### PR TITLE
Fase C: Data Liquidity — manifest, extractor y saneo de contenidos MIHM

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ meta/           → docs.json, patterns.json, ecosystem.json, mihm_state.json, m
 python3 generate_docs_json.py
 ```
 
+## Pipeline de procesamiento AGS (Fase C)
+
+```bash
+python3 scripts/extract_ags_metrics.py
+# genera meta/ags_metrics.json usando meta/manifest.json
+```
+
 ## Desarrollo local
 
 ```bash

--- a/_docs/doc-01.md
+++ b/_docs/doc-01.md
@@ -3,18 +3,14 @@ title: "Decisiones que nadie tomó"
 doc_id: "doc-01"
 series: "01 · Fundamentos"
 summary: "Cristalización por acumulación. Zonas grises operativas."
-version: "1.0"
+version: "1.1"
 stability: "alta"
 first_published: "2026-02-02"
 node: "docs"
 mihm_variable: "M_i"
 mihm_equation: "M_i = gap(discurso, función observada)"
 sf_pattern: "decisión-emergente"
-<<<<<<< HEAD
-mihm_note: "La coherencia entre discurso y operación determina estabilidad narrativa."
-=======
 mihm_note: "Cuando el procedimiento institucional declarado no coincide con la resolución operativa repetida, M_i sube."
->>>>>>> main
 patterns:
   - decisión-emergente
   - cristalización-normativa

--- a/_nodo_ags/ags-06.md
+++ b/_nodo_ags/ags-06.md
@@ -12,11 +12,7 @@ doc_type: "cierre-empírico"
 mihm_variable: "ΔIHG"
 mihm_equation: "ΔIHG = IHG_post - IHG_pre"
 sf_pattern: "validación-empírica"
-<<<<<<< HEAD
-mihm_note: "El evento crítico convierte hipótesis en señal medible."
-=======
 mihm_note: "El evento del 22-feb-2026 convierte una hipótesis sistémica en señal cuantificable."
->>>>>>> main
 patterns:
   - entropía-revelada
   - colapso-del-pacto

--- a/meta/ags_metrics.json
+++ b/meta/ags_metrics.json
@@ -1,0 +1,119 @@
+{
+  "node": "nodo-ags",
+  "manifest_version": "1.1",
+  "generated_at": "2026-02-23T23:30:14.126037Z",
+  "documents": [
+    {
+      "doc_id": "ags-01",
+      "source": "_nodo_ags/ags-01.md",
+      "version": "1.1",
+      "first_published": "2026-02-15",
+      "mihm_variable": "ΔU",
+      "sf_pattern": "distancia-umbrales",
+      "time_score": 4,
+      "opacity_score": 14,
+      "evidence": [
+        "idades que nadie asignó y soluciones que nadie tiene.  ## Lo que no se mide en el Nodo  * Años reales hasta que pozos clave dejen de operar por profundidad * Tiempo real de resolución",
+        "idades que nadie asignó y soluciones que nadie tiene.  ## Lo que no se mide en el Nodo  * Años reales hasta que pozos clave dejen de operar por profundidad * Tiempo real de resolución",
+        "se mide en el Nodo  * Años reales hasta que pozos clave dejen de operar por profundidad * Tiempo real de resolución de trámites federales cuando hay presión política * Fecha estimada de",
+        "odo  * Años reales hasta que pozos clave dejen de operar por profundidad * Tiempo real de resolución de trámites federales cuando hay presión política * Fecha estimada de ruptura del equilib",
+        "sf_pattern: \"distancia-umbrales\" mihm_note: \"La distancia entre umbrales determina riesgo oculto del nodo.\" patterns:   - umbral-real   - distancia-umbrales   - fricción-política   - zon"
+      ],
+      "vhpd_status": "ok",
+      "vhpd_notes": []
+    },
+    {
+      "doc_id": "ags-02",
+      "source": "_nodo_ags/ags-02.md",
+      "version": "1.1",
+      "first_published": "2026-02-15",
+      "mihm_variable": "LDI",
+      "sf_pattern": "latencia-politizada",
+      "time_score": 21,
+      "opacity_score": 4,
+      "evidence": [
+        "--- layout: default title: \"El costo de la latencia\" doc_id: \"ags-02\" series: \"ags-02 · Nodo Aguascalientes\" summary: \"Cuando el tiempo de re",
+        "2026-02-15\" stability: \"alta\" node: \"nodo-ags\" mihm_variable: \"LDI\" mihm_equation: \"LDI = latencia_resolución_trámite\" sf_pattern: \"latencia-politizada\" mihm_note: \"La latencia institucion",
+        "ags\" mihm_variable: \"LDI\" mihm_equation: \"LDI = latencia_resolución_trámite\" sf_pattern: \"latencia-politizada\" mihm_note: \"La latencia institucional funciona como mecanismo de control.\" pa",
+        "ion: \"LDI = latencia_resolución_trámite\" sf_pattern: \"latencia-politizada\" mihm_note: \"La latencia institucional funciona como mecanismo de control.\" patterns:   - latencia-política   - di",
+        "mihm_note: \"La latencia institucional funciona como mecanismo de control.\" patterns:   - latencia-política   - distancia-umbrales   - responsabilidad-difusa   - costo-diferido ---  # El c"
+      ],
+      "vhpd_status": "ok",
+      "vhpd_notes": []
+    },
+    {
+      "doc_id": "ags-03",
+      "source": "_nodo_ags/ags-03.md",
+      "version": "1.1",
+      "first_published": "2026-02-15",
+      "mihm_variable": "E_p",
+      "sf_pattern": "extracción-proxy",
+      "time_score": 1,
+      "opacity_score": 2,
+      "evidence": [
+        "público  El Acuífero Valle de Aguascalientes (Clave 0101) tiene un déficit de −95.75 hm³/año. La recarga es 249.6. La extracción concesionada es 342.95. Eso está publicado en registr",
+        "n: \"E_p = extracción_proxy_energía\" sf_pattern: \"extracción-proxy\" mihm_note: \"El recurso oculto se vuelve visible vía energía consumida.\" patterns:   - derecho-vs-recurso   - pérdida-no",
+        "ero eso no se puede medir sin desagregar quién realmente opera cada concesión.  ## Lo que no se documenta  * Cruce entre titulares de concesión y beneficiarios reales * Volumen de agua rentada a"
+      ],
+      "vhpd_status": "ok",
+      "vhpd_notes": []
+    },
+    {
+      "doc_id": "ags-04",
+      "source": "_nodo_ags/ags-04.md",
+      "version": "1.1",
+      "first_published": "2026-02-15",
+      "mihm_variable": "F_i",
+      "sf_pattern": "ficción-institucional",
+      "time_score": 2,
+      "opacity_score": 14,
+      "evidence": [
+        "elocidad real de degradación del acuífero y costo creciente de extracción * Costo real de latencia federal medido en inversión diferida y empleos no generados * Fragilidad real de los equi",
+        "bilidad del corredor  ## El riesgo  Cuando la ficción institucional se sostiene demasiado tiempo, el sistema pierde capacidad de respuesta. No por incompetencia. Porque la información ne",
+        "a siga funcionando. Pero también impide que se corrijan las causas.  ## Lo que la ficción oculta  * Velocidad real de degradación del acuífero y costo creciente de extracción * Costo rea",
+        "--- layout: default title: \"La ficción institucional\" doc_id: \"ags-04\" series: \"ags-04 · Nodo Aguascalientes\" summary: \"Métricas",
+        "mihm_variable: \"F_i\" mihm_equation: \"F_i = fricción_institucional compuesta\" sf_pattern: \"ficción-institucional\" mihm_note: \"Estabilidad reportada sin respaldo operativo aumenta fricción."
+      ],
+      "vhpd_status": "ok",
+      "vhpd_notes": []
+    },
+    {
+      "doc_id": "ags-05",
+      "source": "_nodo_ags/ags-05.md",
+      "version": "1.1",
+      "first_published": "2026-02-15",
+      "mihm_variable": "U_p",
+      "sf_pattern": "pacto-implícito",
+      "time_score": 1,
+      "opacity_score": 6,
+      "evidence": [
+        "s que necesitan que el corredor opere.  Ese equilibrio:  * No se firma * No se negocia en mesas oficiales * No tiene plazo * Tiene condiciones que nadie explicita  Mientras las condic",
+        "información existe en conversaciones que no se graban, en acuerdos que no se escriben, en silencios que no se interpretan.  Documentarla sería poner en un registro lo que necesita permanec",
+        "información existe en conversaciones que no se graban, en acuerdos que no se escriben, en silencios que no se interpretan.  Documentarla sería poner en un registro lo que necesita permanece",
+        "es operativos. Cuando se rompen, el corredor se desregula.  ## Variable implícita  Lo que no se documenta:  * Cuáles son las condiciones * Quién las monitorea * Qué pasa cuando alguien deja de cu",
+        "Nodo Aguascalientes\" summary: \"Equilibrio implícito: estabilidad operativa con variables no documentadas.\" version: \"1.1\" first_published: \"2026-02-15\" stability: \"alta\" node: \"nodo-ags\" mihm_v"
+      ],
+      "vhpd_status": "ok",
+      "vhpd_notes": []
+    },
+    {
+      "doc_id": "ags-06",
+      "source": "_nodo_ags/ags-06.md",
+      "version": "1.1",
+      "first_published": "2026-02-23",
+      "mihm_variable": "ΔIHG",
+      "sf_pattern": "validación-empírica",
+      "time_score": 5,
+      "opacity_score": 11,
+      "evidence": [
+        "endógena del sistema. El agua, los permisos y la estabilidad del corredor industrial dependían de una función de utilidad ($U_P$) que acaba de cambiar de signo.  El ecosistema no requ",
+        "IHG_{post} - IHG_{pre}$). La fricción ahora es medible a través de fuentes públicas:  * **Latencia Institucional (LDI) post-evento:** Variación en los tiempos de resolución de trámites (CO",
+        "és de fuentes públicas:  * **Latencia Institucional (LDI) post-evento:** Variación en los tiempos de resolución de trámites (CONAGUA, CFE, REPDA) antes y después de la ruptura logística.",
+        "o.  **Límite de aplicación:** Este documento registra una transición de fase sistémica en tiempo real utilizando datos de dominio público surgidos a partir del 22 de febrero de 2026. No",
+        "es públicas:  * **Latencia Institucional (LDI) post-evento:** Variación en los tiempos de resolución de trámites (CONAGUA, CFE, REPDA) antes y después de la ruptura logística. La burocracia"
+      ],
+      "vhpd_status": "ok",
+      "vhpd_notes": []
+    }
+  ]
+}

--- a/meta/manifest.json
+++ b/meta/manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifest_version": "1.1",
+  "node": "nodo-ags",
+  "source_glob": "_nodo_ags/ags-*.md",
+  "normalization": {
+    "version_target": "1.1",
+    "time_keywords": {
+      "days": ["día", "días", "day", "days"],
+      "weeks": ["semana", "semanas", "week", "weeks"],
+      "months": ["mes", "meses", "month", "months"],
+      "years": ["año", "años", "year", "years"],
+      "latency": ["latencia", "tiempo", "retraso", "resolución"]
+    },
+    "opacity_keywords": {
+      "opacity": ["opacidad", "oculta", "oculto", "silencio", "silencios"],
+      "narrative_gap": ["ficción", "narrativa", "no se documenta", "no documentada"],
+      "institutional_gap": ["umbral oficial", "umbral real", "distancia", "zona gris"]
+    }
+  },
+  "vhpd_validation": {
+    "required_fields": ["doc_id", "version", "first_published", "mihm_variable", "sf_pattern"],
+    "evidence_window": 180,
+    "block_if_missing_evidence": true
+  }
+}

--- a/mihm.md
+++ b/mihm.md
@@ -8,16 +8,11 @@ permalink: /mihm/
   <div class="doc-container">
     <div class="doc-label">MIHM · Integración operativa</div>
     <h1>Motor de validación<br>System Friction ↔ evidencia</h1>
-<<<<<<< HEAD
-    <p>Fase 2 en curso: panel operativo con snapshots versionados por nodo y lectura pública del estado del sistema.</p>
-=======
-    <p>Esta capa no explica el MIHM. Expone su estado operacional para lectura pública trazable desde los documentos y nodos del ecosistema.</p>
->>>>>>> main
+    <p>Fase C en curso: panel operativo con snapshots versionados por nodo, señales extraídas desde AGS y lectura pública trazable.</p>
 
     <div class="mihm-grid">
       <div class="mihm-card">
         <h3>IHG agregado</h3>
-<<<<<<< HEAD
         <div id="mihm-ihg" class="mihm-value critical">—</div>
       </div>
       <div class="mihm-card">
@@ -47,14 +42,6 @@ permalink: /mihm/
           <tr><td colspan="6">Cargando snapshot…</td></tr>
         </tbody>
       </table>
-=======
-        <div class="mihm-value critical">-0.47</div>
-      </div>
-      <div class="mihm-card">
-        <h3>NTI (integridad de señal)</h3>
-        <div class="mihm-value">0.61</div>
-      </div>
->>>>>>> main
     </div>
 
     <div class="doc-grid mt-4">
@@ -73,18 +60,15 @@ permalink: /mihm/
       <a href="{{ site.baseurl }}/roadmap/" class="doc-item new">
         <div class="doc-num">MIHM · 03</div>
         <div class="doc-title">Roadmap de integración</div>
-        <div class="doc-sub">Fases 0→3 para completar la convergencia del stack editorial y métrico.</div>
+        <div class="doc-sub">Fases C→D para completar convergencia del stack editorial y métrico.</div>
         <span class="doc-arrow">→</span>
       </a>
     </div>
   </div>
 </main>
-<<<<<<< HEAD
 
 <script
   src="{{ site.baseurl }}/assets/js/mihm-panel.js"
   data-mihm-state="{{ site.baseurl }}/meta/mihm_state.json"
   data-mihm-equations="{{ site.baseurl }}/meta/mihm_equations.json">
 </script>
-=======
->>>>>>> main

--- a/mihm/catalogo.md
+++ b/mihm/catalogo.md
@@ -8,7 +8,6 @@ permalink: /mihm/catalogo/
   <div class="doc-container">
     <div class="doc-label">MIHM · Catálogo</div>
     <h1>Mapeo explícito<br>de patrones a variables</h1>
-<<<<<<< HEAD
     <p class="doc-meta">Versión de ecuaciones: <span id="mihm-equations-version">cargando…</span></p>
 
     <div class="sf-table-wrap">
@@ -16,27 +15,13 @@ permalink: /mihm/catalogo/
         <thead><tr><th>Patrón SF</th><th>Variable MIHM</th><th>Ecuación</th><th>Condición de refutación</th></tr></thead>
         <tbody id="mihm-equations-table">
           <tr><td colspan="4">Cargando catálogo…</td></tr>
-=======
-
-    <div class="sf-table-wrap">
-      <table class="sf-table">
-        <thead><tr><th>Patrón SF</th><th>Variable MIHM</th><th>Lectura</th></tr></thead>
-        <tbody>
-          <tr><td>decisión-emergente</td><td>M_i</td><td>Coherencia entre discurso formal y función real.</td></tr>
-          <tr><td>latencia-politizada</td><td>LDI</td><td>Tiempo institucional como variable de ajuste.</td></tr>
-          <tr><td>validación-empírica</td><td>ΔIHG</td><td>Diferencial antes/después de evento revelador.</td></tr>
-          <tr><td>distancia-umbrales</td><td>NTI</td><td>Integridad de señal oficial frente a estado real.</td></tr>
->>>>>>> main
         </tbody>
       </table>
     </div>
   </div>
 </main>
-<<<<<<< HEAD
 
 <script
   src="{{ site.baseurl }}/assets/js/mihm-panel.js"
   data-mihm-equations="{{ site.baseurl }}/meta/mihm_equations.json">
 </script>
-=======
->>>>>>> main

--- a/mihm/nti.md
+++ b/mihm/nti.md
@@ -8,18 +8,13 @@ permalink: /mihm/nti/
   <div class="doc-container">
     <div class="doc-label">MIHM · NTI</div>
     <h1>El sistema se auto-audita</h1>
-<<<<<<< HEAD
-    <p>Fase 2: cada ciclo publica snapshot de integridad de señal por nodo para comparar narrativa institucional vs estado operativo.</p>
-=======
     <p>NTI evalúa divergencia entre narrativa institucional y señal operativa observable. Es una métrica de integridad del canal, no del recurso físico.</p>
->>>>>>> main
 
     <div class="limit-box" style="border-left-color: var(--accent);">
       <span class="lb-label">criterio mínimo</span>
       NTI debe mantener trazabilidad de fuente, latencia de actualización y método de cálculo por nodo.
     </div>
 
-<<<<<<< HEAD
     <div class="sf-table-wrap">
       <table class="sf-table">
         <thead>
@@ -37,12 +32,3 @@ permalink: /mihm/nti/
   src="{{ site.baseurl }}/assets/js/mihm-panel.js"
   data-mihm-state="{{ site.baseurl }}/meta/mihm_state.json">
 </script>
-=======
-    <ul>
-      <li>Fuente declarada por indicador y fecha de extracción.</li>
-      <li>Regla de cómputo reproducible y auditable.</li>
-      <li>Umbrales de alerta explícitos (estable, tensión, crítico).</li>
-    </ul>
-  </div>
-</main>
->>>>>>> main

--- a/roadmap.md
+++ b/roadmap.md
@@ -6,53 +6,73 @@ permalink: /roadmap/
 
 <main>
   <div class="doc-container">
-    <div class="doc-label">Integración · fases 0→3</div>
-    <h1>Ruta priorizada de ejecución</h1>
-<<<<<<< HEAD
-    <p><strong>Fase actual:</strong> Fase 2 · Integración operativa. <strong>Tarea activa:</strong> snapshots versionados y publicación NTI por ciclo.</p>
+    <div class="doc-label">Integración · fases C→D</div>
+    <h1>Mapa de operaciones prospectivo</h1>
+    <p><strong>Fase actual:</strong> Fase C · Procesamiento (Data Liquidity). <strong>Tarea activa:</strong> extracción AGS + normalización por manifiesto + validación VHpD.</p>
 
-    <h2>Fase 0 · Estabilización ✅ completada</h2>
-=======
-
-    <h2>Fase 0 · Estabilización</h2>
->>>>>>> main
+    <h2>Mapa de errores sistémicos (lo que falta limpiar)</h2>
     <ul>
-      <li>Corregir overflow horizontal en body y habilitar scroll en tablas/pre.</li>
-      <li>Normalizar metadatos en encabezados documentales.</li>
-      <li>Publicar trazabilidad SF ↔ MIHM en documentos críticos.</li>
+      <li><strong>Entropía de versiones:</strong> desalineación entre documentos v1.0 y v1.1 que degrada la trazabilidad.</li>
+      <li><strong>Silencio de datos:</strong> AGS-06 contiene señal empírica, pero sin extracción automática hacia tableros.</li>
+      <li><strong>Acoplamiento de presentación:</strong> mezclar HTML de visualización con contenido fuente aumenta fragilidad editorial.</li>
     </ul>
 
-<<<<<<< HEAD
-    <h2>Fase 1 · Integración editorial ✅ completada</h2>
-=======
-    <h2>Fase 1 · Integración editorial</h2>
->>>>>>> main
+    <h2>Fase C · Procesamiento (Data Liquidity) 🔄 en curso</h2>
     <ul>
-      <li>Completar mapeo en la Serie principal (doc-01 a doc-10).</li>
-      <li>Completar mapeo en Nodo AGS (ags-01 a ags-06).</li>
-      <li>Consolidar catálogo central /mihm/catalogo/.</li>
+      <li><strong>C1 · Extracción:</strong> parser Python para leer <code>_nodo_ags/*.md</code> y extraer variables de tiempo/opacidad.</li>
+      <li><strong>C2 · Normalización:</strong> <code>meta/manifest.json</code> como traductor universal de texto narrativo a métricas numéricas.</li>
+      <li><strong>C3 · Validación VHpD:</strong> control humano de plausibilidad y trazabilidad para bloquear alucinaciones.</li>
     </ul>
 
-<<<<<<< HEAD
-    <h2>Fase 2 · Integración operativa 🔄 en curso</h2>
-=======
-    <h2>Fase 2 · Integración operativa</h2>
->>>>>>> main
+    <h2>Fase D · Visualización (The Mirror) ⏳ pendiente</h2>
     <ul>
-      <li>Conectar panel /mihm/ con snapshots de estado por nodo.</li>
-      <li>Publicar NTI por ciclo de actualización.</li>
-      <li>Versionar ecuaciones y cambios metodológicos.</li>
+      <li><strong>D1 · Interface:</strong> dashboard (React o Streamlit) consumiendo salida estructurada y API de Gemini.</li>
+      <li><strong>D2 · Representación:</strong> mapa de calor de entropía/costo de oportunidad en lugar de barras simples.</li>
     </ul>
 
-<<<<<<< HEAD
-    <h2>Fase 3 · Escalamiento ⏳ pendiente</h2>
-=======
-    <h2>Fase 3 · Escalamiento</h2>
->>>>>>> main
-    <ul>
-      <li>Añadir nuevos nodos territoriales con misma plantilla de trazabilidad.</li>
-      <li>Comparar deltas de IHG entre nodos bajo eventos de estrés.</li>
-      <li>Formalizar auditoría cruzada entre narrativa y cálculo.</li>
-    </ul>
+    <h2>Roadmap 2026</h2>
+    <div class="sf-table-wrap">
+      <table class="sf-table">
+        <thead>
+          <tr>
+            <th>Etapa</th>
+            <th>Acción clave</th>
+            <th>Herramienta</th>
+            <th>Objetivo final</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Sincronización</td>
+            <td>Resolver error 403 y push final B2</td>
+            <td>Git / PAT Token</td>
+            <td>Estabilizar repositorio remoto</td>
+          </tr>
+          <tr>
+            <td>Refactorización</td>
+            <td>Migrar HTML acoplado a assets/js + Markdown limpio</td>
+            <td>JavaScript / Markdown</td>
+            <td>Pureza sistémica (Zero Errors)</td>
+          </tr>
+          <tr>
+            <td>Conjuntado</td>
+            <td>Vincular AGS-06 con trazabilidad-evidencia</td>
+            <td>Manifest + parser</td>
+            <td>Demostrar teoría con evidencia operacional</td>
+          </tr>
+          <tr>
+            <td>Despliegue</td>
+            <td>Lanzar dashboard interactivo</td>
+            <td>Gemini API / Python</td>
+            <td>Mostrar fricción para toma de decisión</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="limit-box" style="border-left-color: var(--accent); margin-top: 1.2rem;">
+      <span class="lb-label">estrategia</span>
+      Conjuntar sin mezclar archivos: el <code>manifest.json</code> funciona como pegamento para incorporar nuevos nodos sin reprogramar el sistema completo. La fricción debe mostrarse como costo de oportunidad (días de retraso y pérdidas operativas), no solo como etiqueta cualitativa.
+    </div>
   </div>
 </main>

--- a/scripts/extract_ags_metrics.py
+++ b/scripts/extract_ags_metrics.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Extrae señales de tiempo/opacidad del Nodo AGS usando meta/manifest.json."""
+
+from __future__ import annotations
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "meta" / "manifest.json"
+OUTPUT_PATH = ROOT / "meta" / "ags_metrics.json"
+
+
+@dataclass
+class DocMetrics:
+    doc_id: str
+    source: str
+    version: str
+    first_published: str
+    mihm_variable: str
+    sf_pattern: str
+    time_score: int
+    opacity_score: int
+    evidence: List[str]
+    vhpd_status: str
+    vhpd_notes: List[str]
+
+
+def parse_front_matter(text: str) -> Dict[str, str]:
+    if not text.startswith("---"):
+        return {}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    front = parts[1]
+    data: Dict[str, str] = {}
+    for raw in front.splitlines():
+        if ":" not in raw:
+            continue
+        k, v = raw.split(":", 1)
+        data[k.strip()] = v.strip().strip('"')
+    return data
+
+
+def tokenize(text: str) -> str:
+    return re.sub(r"\s+", " ", text.lower())
+
+
+def keyword_score(text: str, groups: Dict[str, List[str]]) -> int:
+    score = 0
+    for terms in groups.values():
+        for term in terms:
+            score += len(re.findall(re.escape(term.lower()), text))
+    return score
+
+
+def collect_evidence(text: str, terms: List[str], window: int) -> List[str]:
+    snippets = []
+    lower = text.lower()
+    for term in terms:
+        start = 0
+        while True:
+            idx = lower.find(term.lower(), start)
+            if idx == -1:
+                break
+            a = max(0, idx - window // 2)
+            b = min(len(text), idx + len(term) + window // 2)
+            snippet = text[a:b].replace("\n", " ").strip()
+            snippets.append(snippet)
+            start = idx + len(term)
+            if len(snippets) >= 5:
+                return snippets
+    return snippets
+
+
+def main() -> None:
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    src_glob = manifest["source_glob"]
+    base = ROOT
+    files = sorted(base.glob(src_glob))
+
+    time_groups = manifest["normalization"]["time_keywords"]
+    opacity_groups = manifest["normalization"]["opacity_keywords"]
+    required = set(manifest["vhpd_validation"]["required_fields"])
+    window = int(manifest["vhpd_validation"].get("evidence_window", 180))
+    target_version = manifest["normalization"].get("version_target")
+
+    docs: List[DocMetrics] = []
+    all_terms = [t for g in [*time_groups.values(), *opacity_groups.values()] for t in g]
+
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        front = parse_front_matter(text)
+        body = tokenize(text)
+
+        missing = sorted(list(required - set(front.keys())))
+        notes = []
+        if missing:
+            notes.append(f"Faltan campos requeridos: {', '.join(missing)}")
+        if target_version and front.get("version") != target_version:
+            notes.append(
+                f"Versión fuera de objetivo ({front.get('version', 'N/A')} != {target_version})"
+            )
+
+        evidence = collect_evidence(text, all_terms, window)
+        if not evidence:
+            notes.append("Sin evidencia textual para variables de tiempo/opacidad")
+
+        status = "ok" if not notes else "review"
+
+        docs.append(
+            DocMetrics(
+                doc_id=front.get("doc_id", path.stem),
+                source=str(path.relative_to(ROOT)),
+                version=front.get("version", "N/A"),
+                first_published=front.get("first_published", "N/A"),
+                mihm_variable=front.get("mihm_variable", "N/A"),
+                sf_pattern=front.get("sf_pattern", "N/A"),
+                time_score=keyword_score(body, time_groups),
+                opacity_score=keyword_score(body, opacity_groups),
+                evidence=evidence,
+                vhpd_status=status,
+                vhpd_notes=notes,
+            )
+        )
+
+    payload = {
+        "node": manifest.get("node"),
+        "manifest_version": manifest.get("manifest_version"),
+        "generated_at": __import__("datetime").datetime.utcnow().isoformat() + "Z",
+        "documents": [d.__dict__ for d in docs],
+    }
+    OUTPUT_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"Generated {OUTPUT_PATH.relative_to(ROOT)} with {len(docs)} documents")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Poner en marcha la fase C (Procesamiento / "Data Liquidity") para extraer señales operativas desde los documentos del Nodo AGS y normalizarlas para consumo de un dashboard. 
- Eliminar ruido editorial (conflictos de merge y versiones mixtas) que rompe la trazabilidad y la lectura automática de metadatos. 
- Proveer una salida estructurada (manifest + extractor → JSON) que permita avanzar a Fase D (visualización / mapas de calor de fricción).

### Description

- Reemplacé y reorganicé `roadmap.md` por un "Mapa de Operaciones Prospectivo" que introduce Fase C (extracción/normalización/validación VHpD) y Fase D (visualización). 
- Añadí `meta/manifest.json` como traductor/unificador de normalización (palabras clave de tiempo/opacidad, versión objetivo y reglas VHpD). 
- Implementé `scripts/extract_ags_metrics.py` que parsea `_nodo_ags/ags-*.md`, extrae front matter, calcula `time_score` y `opacity_score`, recoge snippets de evidencia y aplica una validación VHpD básica. 
- Generé `meta/ags_metrics.json` con la salida estructurada; limpié marcadores de conflicto y homogenicé versiones/`mihm_note` en `mihm.md`, `mihm/nti.md`, `mihm/catalogo.md`, `_docs/doc-01.md` y `_nodo_ags/ags-06.md`; actualicé `README.md` con el comando del pipeline.

### Testing

- Ejecuté `python3 scripts/extract_ags_metrics.py` y se generó correctamente `meta/ags_metrics.json` (6 documentos procesados), salida: "Generated meta/ags_metrics.json with 6 documents". ✅
- Instalé dependencias y corrí `bundle exec jekyll build` para validar la generación del sitio y la integración del panel, la build concluyó sin errores. ✅
- Serví `_site` y capturé una captura visual de `/roadmap/` con Playwright para validar la presentación; la captura fue generada correctamente y los marcadores de conflicto fueron removidos (`rg -n "<<<<<<<|>>>>>>>|====="` devolvió limpieza parcial antes del saneo y sin coincidencias tras los cambios). ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce253b5ac832f9a46999370df6e7b)