### PR TITLE
Build ScoreFriction Studio DAW with WebAudio engine and HIMH v3 generation

### DIFF
--- a/apps/web/src/panels/Repositorio.jsx
+++ b/apps/web/src/panels/Repositorio.jsx
@@ -1,112 +1,300 @@
-import React from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useStore, fmt2 } from '../store.jsx'
-import { computeFSoc, computeFractureRisk } from '../socsim.js'
+import { AudioEngine } from '../studio/audio/AudioEngine'
+import { metricsFromSocsim, generationControls } from '../studio/metrics/systemFrictionMetrics'
+import { composeFromPrompt } from '../studio/agent/composerAgent'
+import { quantizeBeat } from '../studio/daw/timeline'
+
+const GRID = 0.25
+const PX_PER_BEAT = 54
+
+const initialTracks = [
+  { id: 'tr-1', name: 'SYNTH', volume: 0.75, pan: 0, sourceType: 'osc', waveform: 'sawtooth' },
+  { id: 'tr-2', name: 'SAMPLER', volume: 0.65, pan: -0.1, sourceType: 'sampler', waveform: 'triangle' },
+]
 
 export default function Repositorio() {
   const { store } = useStore()
-  const { snapshots } = store
+  const audioRef = useRef(new AudioEngine())
+  const schedulerRef = useRef(null)
+  const dragRef = useRef(null)
 
-  const doDownload = (snap) => {
-    const blob = new Blob([JSON.stringify(snap, null, 2)], { type: 'application/json' })
-    const a = document.createElement('a')
-    a.href = URL.createObjectURL(blob)
-    a.download = `sf2-snap-${snap.id}.json`
-    a.click()
+  const [ready, setReady] = useState(false)
+  const [playing, setPlaying] = useState(false)
+  const [playheadBeat, setPlayheadBeat] = useState(0)
+  const [tempo, setTempo] = useState(108)
+  const [tracks, setTracks] = useState(initialTracks)
+  const [clips, setClips] = useState([])
+  const [prompt, setPrompt] = useState('generate melancholic loop')
+  const [fx, setFx] = useState({ filterHz: 12000, delayMix: 0.22, reverbMix: 0.18 })
+
+  const playheadRef = useRef(0)
+  const tempoRef = useRef(tempo)
+  const clipsRef = useRef(clips)
+  const tracksRef = useRef(tracks)
+
+  const metrics = useMemo(() => metricsFromSocsim(store.socsim), [store.socsim])
+  const controls = useMemo(() => generationControls(metrics), [metrics])
+
+
+  useEffect(() => { playheadRef.current = playheadBeat }, [playheadBeat])
+  useEffect(() => { tempoRef.current = tempo }, [tempo])
+  useEffect(() => { clipsRef.current = clips }, [clips])
+  useEffect(() => { tracksRef.current = tracks }, [tracks])
+  useEffect(() => {
+    setTempo(controls.tempo)
+  }, [controls.tempo])
+
+  useEffect(() => {
+    tracks.forEach((track) => audioRef.current.updateTrack(track))
+  }, [tracks])
+
+  useEffect(() => {
+    audioRef.current.setMasterFx(fx)
+  }, [fx])
+
+  useEffect(() => {
+    return () => {
+      if (schedulerRef.current) window.clearInterval(schedulerRef.current)
+    }
+  }, [])
+
+  const initAudio = async () => {
+    await audioRef.current.resume()
+    tracks.forEach((track) => audioRef.current.updateTrack(track))
+    audioRef.current.setMasterFx(fx)
+    setReady(true)
   }
+
+  const buildAndPlaceClip = () => {
+    const trackId = tracks[clips.length % tracks.length].id
+    const clip = composeFromPrompt({
+      prompt,
+      metrics,
+      tempo,
+      trackId,
+    })
+    clip.startBeat = quantizeBeat(playheadBeat, GRID)
+    setClips((prev) => [...prev, clip])
+  }
+
+  const scheduleWindow = () => {
+    const engine = audioRef.current
+    if (!engine.ctx) return
+
+    const now = engine.ctx.currentTime
+    const lookAheadSec = 0.16
+    const currentBeat = playheadRef.current
+    const currentTempo = tempoRef.current
+    const endBeat = currentBeat + (currentTempo / 60) * lookAheadSec
+
+    clipsRef.current.forEach((clip) => {
+      const track = tracksRef.current.find((t) => t.id === clip.trackId)
+      if (!track) return
+      clip.notes.forEach((n) => {
+        const noteBeat = clip.startBeat + n.step / 4
+        if (noteBeat >= currentBeat && noteBeat < endBeat) {
+          const offsetSec = ((noteBeat - currentBeat) * 60) / currentTempo
+          const when = now + Math.max(0, offsetSec)
+          const duration = (n.beats * 60) / currentTempo
+          engine.scheduleNote(track, n, when, duration)
+        }
+      })
+    })
+
+    setPlayheadBeat(endBeat)
+  }
+
+  const startTransport = async () => {
+    await initAudio()
+    if (schedulerRef.current) window.clearInterval(schedulerRef.current)
+    setPlaying(true)
+    schedulerRef.current = window.setInterval(scheduleWindow, 40)
+  }
+
+  const stopTransport = () => {
+    if (schedulerRef.current) window.clearInterval(schedulerRef.current)
+    schedulerRef.current = null
+    setPlaying(false)
+  }
+
+  const updateTrack = (id, patch) => {
+    setTracks((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)))
+  }
+
+  const onClipPointerDown = (event, clipId) => {
+    const clip = clips.find((c) => c.id === clipId)
+    if (!clip) return
+    dragRef.current = {
+      clipId,
+      startX: event.clientX,
+      baseBeat: clip.startBeat,
+      baseTrack: tracks.findIndex((t) => t.id === clip.trackId),
+    }
+    event.currentTarget.setPointerCapture(event.pointerId)
+  }
+
+  const onTimelinePointerMove = (event) => {
+    if (!dragRef.current) return
+    const d = dragRef.current
+    const beatDelta = (event.clientX - d.startX) / PX_PER_BEAT
+    const rawBeat = d.baseBeat + beatDelta
+
+    const trackIndex = Math.max(0, Math.min(tracks.length - 1, d.baseTrack + Math.round(event.movementY / 30)))
+    const newTrackId = tracks[trackIndex].id
+
+    setClips((prev) => prev.map((c) => (c.id === d.clipId
+      ? { ...c, startBeat: Math.max(0, quantizeBeat(rawBeat, GRID)), trackId: newTrackId }
+      : c)))
+  }
+
+  const onTimelinePointerUp = () => {
+    dragRef.current = null
+  }
+
+  const bars = 8
+  const totalBeats = bars * 4
 
   return (
     <>
       <div className="sec">
         <div className="sec-hd">
           <span className="sec-n">01</span>
-          <span className="sec-t">Repositorio de Sesiones</span>
-          <span className="pnl-st" style={{marginLeft:'auto'}}>{snapshots.length} snapshots</span>
+          <span className="sec-t">ScoreFriction STUDIO / DAW</span>
+          <span className="pnl-st" style={{ marginLeft: 'auto' }}>{ready ? 'AUDIO READY' : 'AUDIO LOCKED'}</span>
         </div>
-        <div className="sec-d">
-          Historial de snapshots guardados en el Laboratorio. Cada entrada incluye estado MIHM + Ψ + parámetros.
+        <div className="sec-d">Browser DAW with HIMH v3 generation, live SystemFriction modulation, draggable clips, and real Web Audio routing.</div>
+      </div>
+
+      <div className="studio-grid">
+        <div className="pnl">
+          <div className="pnl-hd"><span className="pnl-lbl">TRANSPORT + AI COMPOSER</span></div>
+          <div className="pnl-body">
+            <div style={{ display: 'flex', gap: 8, marginBottom: 10 }}>
+              <button className="btn" onClick={initAudio}>INIT AUDIO</button>
+              {!playing ? (
+                <button className="btn btn-n" onClick={startTransport} disabled={!ready}>PLAY</button>
+              ) : (
+                <button className="btn btn-r" onClick={stopTransport}>STOP</button>
+              )}
+              <button className="btn btn-g" onClick={() => setPlayheadBeat(0)}>REWIND</button>
+            </div>
+
+            <div className="slider-row">
+              <span className="slider-lbl">TEMPO</span>
+              <input type="range" min="70" max="170" value={tempo} onChange={(e) => setTempo(Number(e.target.value))} />
+              <span className="slider-val">{tempo}</span>
+            </div>
+
+            <div className="slider-row">
+              <span className="slider-lbl">FILTER</span>
+              <input type="range" min="300" max="16000" step="10" value={fx.filterHz} onChange={(e) => setFx((f) => ({ ...f, filterHz: Number(e.target.value) }))} />
+              <span className="slider-val">{fx.filterHz}</span>
+            </div>
+
+            <div className="slider-row">
+              <span className="slider-lbl">DELAY</span>
+              <input type="range" min="0" max="0.95" step="0.01" value={fx.delayMix} onChange={(e) => setFx((f) => ({ ...f, delayMix: Number(e.target.value) }))} />
+              <span className="slider-val">{fx.delayMix.toFixed(2)}</span>
+            </div>
+
+            <div className="slider-row">
+              <span className="slider-lbl">REVERB</span>
+              <input type="range" min="0" max="0.95" step="0.01" value={fx.reverbMix} onChange={(e) => setFx((f) => ({ ...f, reverbMix: Number(e.target.value) }))} />
+              <span className="slider-val">{fx.reverbMix.toFixed(2)}</span>
+            </div>
+
+            <div style={{ marginTop: 12 }}>
+              <label className="inp-lbl">AI PROMPT</label>
+              <input className="inp" value={prompt} onChange={(e) => setPrompt(e.target.value)} />
+              <button className="btn" style={{ marginTop: 8 }} onClick={buildAndPlaceClip} disabled={!ready}>GENERATE CLIP</button>
+            </div>
+          </div>
+        </div>
+
+        <div className="pnl">
+          <div className="pnl-hd"><span className="pnl-lbl">SYSTEMFRICTION METRICS (LIVE)</span></div>
+          <div className="pnl-body">
+            <div className="row3">
+              <div className="cell"><div className="cell-lbl">COHERENCE (C)</div><div className="cell-v">{fmt2(metrics.C)}</div></div>
+              <div className="cell"><div className="cell-lbl">TENSION (T)</div><div className="cell-v">{fmt2(metrics.T)}</div></div>
+              <div className="cell"><div className="cell-lbl">ACTIVATION (A)</div><div className="cell-v">{fmt2(metrics.A)}</div></div>
+            </div>
+            <div className="row3" style={{ marginTop: 8 }}>
+              <div className="cell"><div className="cell-lbl">TEMPO INFLUENCE</div><div className="cell-v">{controls.tempo}</div></div>
+              <div className="cell"><div className="cell-lbl">DENSITY</div><div className="cell-v">{fmt2(controls.density)}</div></div>
+              <div className="cell"><div className="cell-lbl">HARMONIC VAR.</div><div className="cell-v">{fmt2(controls.harmonicVariation)}</div></div>
+            </div>
+          </div>
         </div>
       </div>
 
-      {snapshots.length === 0 ? (
-        <div className="pnl">
-          <div className="pnl-body">
-            <div className="narr-box">
-              <div className="narr-lbl">VACÍO</div>
-              <div className="narr-txt">
-                No hay snapshots guardados. Ve al Laboratorio y presiona SAVE para guardar el estado actual.
+      <div className="sec" style={{ marginTop: '1rem' }}>
+        <div className="sec-hd"><span className="sec-n">02</span><span className="sec-t">Timeline + Mixer</span></div>
+        <div className="studio-grid">
+          <div className="pnl">
+            <div className="pnl-hd"><span className="pnl-lbl">TIMELINE</span><span className="pnl-st">Playhead: {fmt2(playheadBeat)} beats</span></div>
+            <div className="pnl-body">
+              <div className="timeline" onPointerMove={onTimelinePointerMove} onPointerUp={onTimelinePointerUp}>
+                {Array.from({ length: totalBeats + 1 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className={`timeline-gridline${i % 4 === 0 ? ' bar' : ''}`}
+                    style={{ left: i * PX_PER_BEAT }}
+                  />
+                ))}
+
+                <div className="playhead" style={{ left: playheadBeat * PX_PER_BEAT }} />
+
+                {tracks.map((t, idx) => (
+                  <div key={t.id} className="timeline-lane" style={{ top: idx * 56 }}>
+                    <span className="timeline-lane-name">{t.name}</span>
+                  </div>
+                ))}
+
+                {clips.map((clip) => {
+                  const trackIndex = tracks.findIndex((t) => t.id === clip.trackId)
+                  return (
+                    <button
+                      key={clip.id}
+                      type="button"
+                      className="clip"
+                      style={{
+                        left: clip.startBeat * PX_PER_BEAT,
+                        top: trackIndex * 56 + 22,
+                        width: clip.lengthBeats * PX_PER_BEAT,
+                        borderColor: clip.color,
+                      }}
+                      onPointerDown={(e) => onClipPointerDown(e, clip.id)}
+                    >
+                      {clip.name}
+                    </button>
+                  )
+                })}
               </div>
             </div>
           </div>
-        </div>
-      ) : (
-        <div className="repo-list">
-          {/* Header */}
-          <div className="repo-row" style={{background:'var(--bg2)',borderBottom:'.5px solid var(--bdr2)'}}>
-            {['ID', 'TICK', 'IHG', 'NTI', 'R', 'FSoc', 'FR', ''].map((h, i) => (
-              <span key={i} style={{fontSize:7,letterSpacing:'.12em',fontFamily:'monospace',color:'var(--t3)',flex: i === 7 ? '0 0 60px' : 1}}>
-                {h}
-              </span>
-            ))}
-          </div>
 
-          {snapshots.map((snap, i) => {
-            const fsoc = computeFSoc(snap.psi)
-            const fr   = computeFractureRisk(snap.psi)
-            return (
-              <div key={snap.id} className="repo-row">
-                <div style={{flex:1}}>
-                  <div className="repo-row-main" style={{fontSize:9}}>{snap.id.slice(-8)}</div>
-                  <div className="repo-row-sub">{new Date(snap.t).toLocaleTimeString()}</div>
+          <div className="pnl">
+            <div className="pnl-hd"><span className="pnl-lbl">MIXER</span></div>
+            <div className="pnl-body">
+              {tracks.map((t) => (
+                <div key={t.id} style={{ borderBottom: '0.5px solid var(--bdr)', padding: '8px 0 12px' }}>
+                  <div className="cell-lbl" style={{ marginBottom: 6 }}>{t.name} · {t.sourceType}</div>
+                  <div className="slider-row">
+                    <span className="slider-lbl">VOLUME</span>
+                    <input type="range" min="0" max="1" step="0.01" value={t.volume} onChange={(e) => updateTrack(t.id, { volume: Number(e.target.value) })} />
+                    <span className="slider-val">{t.volume.toFixed(2)}</span>
+                  </div>
+                  <div className="slider-row">
+                    <span className="slider-lbl">PAN</span>
+                    <input type="range" min="-1" max="1" step="0.01" value={t.pan} onChange={(e) => updateTrack(t.id, { pan: Number(e.target.value) })} />
+                    <span className="slider-val">{t.pan.toFixed(2)}</span>
+                  </div>
                 </div>
-                <span className="repo-row-meta" style={{flex:1}}>{snap.tick}</span>
-                <span className="repo-row-meta" style={{flex:1,color: snap.mihm.IHG > 0.4 ? 'var(--verde)' : snap.mihm.IHG > 0 ? 'var(--oro)' : 'var(--rojo)'}}>
-                  {fmt2(snap.mihm.IHG)}
-                </span>
-                <span className="repo-row-meta" style={{flex:1,color: snap.mihm.NTI < 0.3 ? 'var(--verde)' : snap.mihm.NTI < 0.6 ? 'var(--oro)' : 'var(--rojo)'}}>
-                  {fmt2(snap.mihm.NTI)}
-                </span>
-                <span className="repo-row-meta" style={{flex:1,color: snap.mihm.R > 0.6 ? 'var(--verde)' : snap.mihm.R > 0.3 ? 'var(--oro)' : 'var(--rojo)'}}>
-                  {fmt2(snap.mihm.R)}
-                </span>
-                <span className="repo-row-meta" style={{flex:1,color: fsoc < 0.3 ? 'var(--verde)' : fsoc < 0.6 ? 'var(--oro)' : 'var(--rojo)'}}>
-                  {fmt2(fsoc)}
-                </span>
-                <span className="repo-row-meta" style={{flex:1,color: fr < 0.3 ? 'var(--verde)' : fr < 0.6 ? 'var(--oro)' : 'var(--rojo)'}}>
-                  {fmt2(fr)}
-                </span>
-                <button
-                  className="btn btn-g"
-                  style={{flex:'0 0 60px',padding:'3px 8px',fontSize:7}}
-                  onClick={() => doDownload(snap)}
-                >
-                  EXPORT
-                </button>
-              </div>
-            )
-          })}
-        </div>
-      )}
-
-      {/* Current session summary */}
-      <div className="sec" style={{marginTop:'2rem'}}>
-        <div className="sec-hd">
-          <span className="sec-n">02</span>
-          <span className="sec-t">Sesión Actual</span>
-        </div>
-        <div className="row3">
-          {[
-            { l: 'Estado MIHM',  v: store.mihm.status },
-            { l: 'Ticks Ψ',      v: store.socsimTick },
-            { l: 'Timeline pts', v: store.timeline.length },
-            { l: 'Mensajes',     v: store.chat.length },
-            { l: 'Snapshots',    v: snapshots.length },
-            { l: 'Escenarios',   v: store.futureScenarios.length },
-          ].map(k => (
-            <div key={k.l} className="cell">
-              <div className="cell-lbl">{k.l}</div>
-              <div className="cell-v">{k.v}</div>
+              ))}
             </div>
-          ))}
+          </div>
         </div>
       </div>
     </>

--- a/apps/web/src/studio/agent/composerAgent.js
+++ b/apps/web/src/studio/agent/composerAgent.js
@@ -1,0 +1,17 @@
+import { himhV3Generate } from '../himh/generator'
+
+export function composeFromPrompt({ prompt, metrics, tempo, trackId }) {
+  const bars = /long|4 bar/i.test(prompt) ? 4 : 2
+  const generated = himhV3Generate({ prompt, metrics, bars })
+
+  return {
+    id: `clip-${Date.now()}`,
+    name: `${generated.mood} loop`,
+    trackId,
+    startBeat: 0,
+    lengthBeats: bars * 4,
+    notes: generated.notes,
+    color: generated.mood === 'dark' ? '#BE3A3A' : generated.mood === 'melancholic' ? '#C8A951' : '#177A5E',
+    tempo,
+  }
+}

--- a/apps/web/src/studio/audio/AudioEngine.js
+++ b/apps/web/src/studio/audio/AudioEngine.js
@@ -1,0 +1,144 @@
+export class AudioEngine {
+  constructor() {
+    this.ctx = null
+    this.masterGain = null
+    this.masterFilter = null
+    this.masterDelay = null
+    this.delayFeedback = null
+    this.reverb = null
+    this.reverbWet = null
+    this.tracks = new Map()
+    this.samplerBuffer = null
+  }
+
+  async init() {
+    if (this.ctx) return
+    const AudioCtx = window.AudioContext || window.webkitAudioContext
+    this.ctx = new AudioCtx()
+
+    this.masterGain = this.ctx.createGain()
+    this.masterGain.gain.value = 0.8
+
+    this.masterFilter = this.ctx.createBiquadFilter()
+    this.masterFilter.type = 'lowpass'
+    this.masterFilter.frequency.value = 14000
+
+    this.masterDelay = this.ctx.createDelay(2)
+    this.masterDelay.delayTime.value = 0.18
+
+    this.delayFeedback = this.ctx.createGain()
+    this.delayFeedback.gain.value = 0.22
+
+    this.reverb = this.ctx.createConvolver()
+    this.reverb.buffer = this.buildImpulseResponse(2.4)
+
+    this.reverbWet = this.ctx.createGain()
+    this.reverbWet.gain.value = 0.14
+
+    this.masterFilter.connect(this.masterGain)
+    this.masterFilter.connect(this.masterDelay)
+    this.masterDelay.connect(this.delayFeedback)
+    this.delayFeedback.connect(this.masterDelay)
+    this.masterDelay.connect(this.masterGain)
+
+    this.masterFilter.connect(this.reverb)
+    this.reverb.connect(this.reverbWet)
+    this.reverbWet.connect(this.masterGain)
+
+    this.masterGain.connect(this.ctx.destination)
+
+    this.samplerBuffer = this.buildSamplerBuffer()
+  }
+
+  async resume() {
+    await this.init()
+    if (this.ctx.state === 'suspended') {
+      await this.ctx.resume()
+    }
+  }
+
+  buildImpulseResponse(seconds) {
+    const length = Math.floor(this.ctx.sampleRate * seconds)
+    const buffer = this.ctx.createBuffer(2, length, this.ctx.sampleRate)
+    for (let ch = 0; ch < 2; ch++) {
+      const data = buffer.getChannelData(ch)
+      for (let i = 0; i < length; i++) {
+        const decay = Math.pow(1 - i / length, 2.8)
+        data[i] = (Math.random() * 2 - 1) * decay
+      }
+    }
+    return buffer
+  }
+
+  buildSamplerBuffer() {
+    const length = Math.floor(this.ctx.sampleRate * 0.6)
+    const buffer = this.ctx.createBuffer(1, length, this.ctx.sampleRate)
+    const d = buffer.getChannelData(0)
+    for (let i = 0; i < length; i++) {
+      const t = i / this.ctx.sampleRate
+      const env = Math.exp(-7 * t)
+      d[i] = (Math.sin(2 * Math.PI * 220 * t) + 0.5 * Math.sin(2 * Math.PI * 330 * t)) * env
+    }
+    return buffer
+  }
+
+  ensureTrack(track) {
+    if (this.tracks.has(track.id)) return this.tracks.get(track.id)
+
+    const gain = this.ctx.createGain()
+    const pan = this.ctx.createStereoPanner()
+    gain.gain.value = track.volume
+    pan.pan.value = track.pan
+
+    gain.connect(pan)
+    pan.connect(this.masterFilter)
+
+    const node = { gain, pan }
+    this.tracks.set(track.id, node)
+    return node
+  }
+
+  updateTrack(track) {
+    if (!this.ctx) return
+    const node = this.ensureTrack(track)
+    node.gain.gain.setTargetAtTime(track.volume, this.ctx.currentTime, 0.01)
+    node.pan.pan.setTargetAtTime(track.pan, this.ctx.currentTime, 0.01)
+  }
+
+  setMasterFx({ filterHz, delayMix, reverbMix }) {
+    if (!this.ctx) return
+    this.masterFilter.frequency.setTargetAtTime(filterHz, this.ctx.currentTime, 0.01)
+    this.delayFeedback.gain.setTargetAtTime(delayMix * 0.8, this.ctx.currentTime, 0.01)
+    this.reverbWet.gain.setTargetAtTime(reverbMix, this.ctx.currentTime, 0.01)
+  }
+
+  scheduleNote(track, note, when, duration) {
+    const node = this.ensureTrack(track)
+    if (track.sourceType === 'sampler') {
+      const src = this.ctx.createBufferSource()
+      src.buffer = this.samplerBuffer
+      const gain = this.ctx.createGain()
+      gain.gain.value = note.velocity
+      src.connect(gain)
+      gain.connect(node.gain)
+      src.playbackRate.value = note.freq / 220
+      src.start(when)
+      src.stop(when + duration)
+      return
+    }
+
+    const osc = this.ctx.createOscillator()
+    osc.type = track.waveform
+    osc.frequency.value = note.freq
+
+    const env = this.ctx.createGain()
+    env.gain.setValueAtTime(0.0001, when)
+    env.gain.exponentialRampToValueAtTime(Math.max(0.001, note.velocity), when + 0.01)
+    env.gain.exponentialRampToValueAtTime(0.0001, when + duration)
+
+    osc.connect(env)
+    env.connect(node.gain)
+    osc.start(when)
+    osc.stop(when + duration + 0.02)
+  }
+}

--- a/apps/web/src/studio/daw/timeline.js
+++ b/apps/web/src/studio/daw/timeline.js
@@ -1,0 +1,13 @@
+export const BEATS_PER_BAR = 4
+
+export function quantizeBeat(beat, grid = 0.25) {
+  return Math.round(beat / grid) * grid
+}
+
+export function clipEnd(clip) {
+  return clip.startBeat + clip.lengthBeats
+}
+
+export function findClipAt(clips, beat, trackId) {
+  return clips.find((c) => c.trackId === trackId && beat >= c.startBeat && beat <= clipEnd(c))
+}

--- a/apps/web/src/studio/himh/generator.js
+++ b/apps/web/src/studio/himh/generator.js
@@ -1,0 +1,67 @@
+const SCALES = {
+  melancholic: [0, 2, 3, 5, 7, 8, 10],
+  uplifting: [0, 2, 4, 5, 7, 9, 11],
+  dark: [0, 1, 3, 5, 6, 8, 10],
+  neutral: [0, 2, 4, 7, 9],
+}
+
+const clamp = (n, a, b) => Math.max(a, Math.min(b, n))
+
+export function promptToMood(prompt) {
+  const p = prompt.toLowerCase()
+  if (p.includes('melanch')) return 'melancholic'
+  if (p.includes('dark') || p.includes('tense')) return 'dark'
+  if (p.includes('happy') || p.includes('upbeat')) return 'uplifting'
+  return 'neutral'
+}
+
+export function himhV3Generate({ prompt, metrics, bars = 2, seed = Date.now() }) {
+  const mood = promptToMood(prompt)
+  const scale = SCALES[mood]
+
+  let s = seed >>> 0
+  const rand = () => {
+    s = (1664525 * s + 1013904223) >>> 0
+    return s / 2 ** 32
+  }
+
+  const coherence = clamp(metrics.C, 0, 1)
+  const tension = clamp(metrics.T, 0, 1)
+  const activation = clamp(metrics.A, 0, 1)
+
+  const stepsPerBar = 16
+  const totalSteps = bars * stepsPerBar
+  const density = Math.max(2, Math.floor(2 + activation * 10))
+  const varChance = 0.08 + tension * 0.5
+
+  const rootMidi = mood === 'dark' ? 48 : mood === 'melancholic' ? 50 : 52
+  const notes = []
+
+  for (let step = 0; step < totalSteps; step++) {
+    const gate = rand()
+    if (gate > density / 16) continue
+
+    const scalePick = Math.floor(rand() * scale.length)
+    let interval = scale[scalePick]
+
+    if (rand() < varChance) {
+      interval += rand() > 0.5 ? 1 : -1
+    }
+
+    const octaveJump = rand() > 0.84 - tension * 0.2 ? 12 : 0
+    const midi = rootMidi + interval + octaveJump
+    const freq = 440 * 2 ** ((midi - 69) / 12)
+
+    const stepDur = coherence > 0.7 ? 1 : coherence > 0.4 ? (rand() > 0.5 ? 1 : 2) : Math.ceil(rand() * 2)
+    const beats = stepDur / 4
+
+    notes.push({
+      step,
+      beats,
+      freq,
+      velocity: 0.3 + activation * 0.6,
+    })
+  }
+
+  return { mood, notes }
+}

--- a/apps/web/src/studio/metrics/systemFrictionMetrics.js
+++ b/apps/web/src/studio/metrics/systemFrictionMetrics.js
@@ -1,0 +1,15 @@
+const clamp = (n, a = 0, b = 1) => Math.max(a, Math.min(b, n))
+
+export function metricsFromSocsim(psi) {
+  const C = clamp(1 - Math.abs(psi.P - psi.T) * 0.8)
+  const T = clamp((psi.T * 0.6 + psi.X * 0.4))
+  const A = clamp(psi.P * 0.5 + psi.X * 0.5)
+  return { C, T, A }
+}
+
+export function generationControls(metrics) {
+  const tempo = Math.round(82 + metrics.A * 68 - metrics.T * 12)
+  const density = clamp(0.2 + metrics.A * 0.7)
+  const harmonicVariation = clamp(0.1 + metrics.T * 0.8)
+  return { tempo, density, harmonicVariation }
+}

--- a/apps/web/src/styles/eidelon.css
+++ b/apps/web/src/styles/eidelon.css
@@ -255,3 +255,18 @@ input[type=range]{flex:1;accent-color:var(--oro);height:1px}
   .hdr-kpi{display:none}
   .tabs-bar{overflow-x:auto}
 }
+
+/* ── STUDIO DAW ── */
+.studio-grid{display:grid;grid-template-columns:1fr 1fr;gap:.5px;background:var(--bdr);border:.5px solid var(--bdr)}
+.timeline{position:relative;height:130px;background:var(--bg2);border:.5px solid var(--bdr);overflow:hidden}
+.timeline-gridline{position:absolute;top:0;bottom:0;width:.5px;background:rgba(255,255,255,.08)}
+.timeline-gridline.bar{background:rgba(200,169,81,.28)}
+.timeline-lane{position:absolute;left:0;right:0;height:56px;border-bottom:.5px solid rgba(255,255,255,.06)}
+.timeline-lane-name{position:absolute;left:8px;top:4px;font-size:8px;color:var(--t3);font-family:var(--mono)}
+.playhead{position:absolute;top:0;bottom:0;width:1px;background:var(--neon);z-index:8}
+.clip{position:absolute;height:26px;background:rgba(200,169,81,.08);border:.5px solid var(--oro);color:var(--t1);font-size:8px;font-family:var(--mono);letter-spacing:.08em;padding:0 8px;cursor:grab;z-index:10;text-align:left}
+.clip:active{cursor:grabbing}
+
+@media(max-width:900px){
+  .studio-grid{grid-template-columns:1fr}
+}


### PR DESCRIPTION
### Motivation
- Provide a fully functional, browser-based DAW inside ScoreFriction STUDIO that produces real audio (no placeholders) and lets UI actions directly affect audio state. 
- Integrate HIMH v3-style music generation and live SystemFriction metrics so generated material is audibly influenced by coherence/tension/activation. 
- Expose an AI composer workflow that accepts natural-language prompts and creates audible timeline clips that feed the audio engine in real time.

### Description
- Implemented a real Web Audio engine (`apps/web/src/studio/audio/AudioEngine.js`) with explicit graph connections, per-track gain/pan nodes, oscillator and sampler sources, and master FX (filter → delay → reverb → gain → destination). 
- Added HIMH v3-inspired generator (`apps/web/src/studio/himh/generator.js`) and a SystemFriction metrics module (`apps/web/src/studio/metrics/systemFrictionMetrics.js`) that derive `C/T/A` and map those to generation controls like tempo, density and harmonic variation. 
- Added an AI composer agent (`apps/web/src/studio/agent/composerAgent.js`) and timeline utilities (`apps/web/src/studio/daw/timeline.js`), and rewired the Repositorio panel into the ScoreFriction STUDIO DAW (`apps/web/src/panels/Repositorio.jsx`) with transport, scheduler (look-ahead), playhead sync, quantized clip placement, draggable clips, and a mixer whose sliders update real gain/pan nodes. 
- Updated styling for the DAW UI (`apps/web/src/styles/eidelon.css`) and used refs/state syncing (playheadRef, tempoRef, clipsRef, tracksRef) so UI state == audio state at scheduling time.

### Testing
- Ran a production build for the web app with `npm run build --workspace=apps/web`, which completed successfully (Vite build completed and assets generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce697598f0832fb4c678fd15e796db)