### PR TITLE
HOTFIX · Fix WorldSpect global Supabase import

### DIFF
--- a/src/observatory/worldspect/globalWorldSpect.ts
+++ b/src/observatory/worldspect/globalWorldSpect.ts
@@ -1,4 +1,4 @@
-import { createServiceSupabaseClient } from '@/lib/supabase/server';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
 
 export type GlobalWorldSpectSnapshot = {
   id?: string;


### PR DESCRIPTION
Fixes broken import path in `src/observatory/worldspect/globalWorldSpect.ts`.

Replaces:

```ts
@/lib/supabase/server
```

with:

```ts
@/runtime/supabase/server
```

This restores production builds after removal of the unsafe compatibility bridge.