### PR TITLE
Execute SFI tickets #25-#36

### DIFF
--- a/.github/workflows/worldspect-cron.yml
+++ b/.github/workflows/worldspect-cron.yml
@@ -44,11 +44,12 @@ jobs:
           VERCEL_APP_URL: ${{ secrets.VERCEL_APP_URL }}
           WORLDSPECT_INGEST_SECRET: ${{ secrets.WORLDSPECT_INGEST_SECRET }}
         run: |
-          test -n "$VERCEL_APP_URL"
-          test -n "$WORLDSPECT_INGEST_SECRET"
+          test -n "$VERCEL_APP_URL" || (echo "Missing VERCEL_APP_URL secret" && exit 1)
+          test -n "$WORLDSPECT_INGEST_SECRET" || (echo "Missing WORLDSPECT_INGEST_SECRET secret" && exit 1)
 
           curl --fail-with-body -X POST "$VERCEL_APP_URL/api/worldspect/ingest-payload" \
             -H "Authorization: Bearer $WORLDSPECT_INGEST_SECRET" \
+            -H "X-SFI-Ingest-Mode: daily_cron" \
             -H "Content-Type: application/json" \
             --data-binary @world_payload.json
 
@@ -56,4 +57,5 @@ jobs:
         env:
           VERCEL_APP_URL: ${{ secrets.VERCEL_APP_URL }}
         run: |
+          test -n "$VERCEL_APP_URL" || (echo "Missing VERCEL_APP_URL secret" && exit 1)
           curl --fail-with-body "$VERCEL_APP_URL/api/worldspect/real"

--- a/docs/RUNTIME_OWNERSHIP.md
+++ b/docs/RUNTIME_OWNERSHIP.md
@@ -1,0 +1,7 @@
+# Runtime Ownership
+
+Productive runtime lives in `packages/sfi-kernel`, `packages/runtime`, and `services/worker`.
+
+Experimental runtime remains under `experimental/` and must not be imported by production API routes, workers, or packages. Legacy Python adapters remain in `services/python`; `world_cli.py` is callable by scheduled ingestion and the protected WorldSpect diagnostic route only.
+
+UI code consumes read APIs. It must not execute WorldSpect adapters or SFI kernel cycles directly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,11 @@
     "": {
       "name": "system-friction-terminal",
       "version": "1.0.0",
+      "workspaces": [
+        "apps/*",
+        "services/*",
+        "packages/*"
+      ],
       "dependencies": {
         "@headlessui/react": "^2.0.0",
         "@supabase/auth-helpers-nextjs": "^0.15.0",
@@ -33,6 +38,22 @@
         "tailwindcss": "^3.4.16",
         "typescript": "^5.7.2"
       }
+    },
+    "apps/admin": {
+      "name": "@sfi/admin",
+      "version": "0.0.0"
+    },
+    "apps/demo": {
+      "name": "@sfi/demo",
+      "version": "0.0.0"
+    },
+    "apps/observatory": {
+      "name": "@sfi/observatory",
+      "version": "0.0.0"
+    },
+    "apps/terminal": {
+      "name": "@sfi/terminal",
+      "version": "0.0.0"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -920,6 +941,98 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
+    },
+    "node_modules/@sfi/admin": {
+      "resolved": "apps/admin",
+      "link": true
+    },
+    "node_modules/@sfi/agent": {
+      "resolved": "services/agent",
+      "link": true
+    },
+    "node_modules/@sfi/api": {
+      "resolved": "services/api",
+      "link": true
+    },
+    "node_modules/@sfi/api-contracts": {
+      "resolved": "packages/api-contracts",
+      "link": true
+    },
+    "node_modules/@sfi/campo-ob": {
+      "resolved": "packages/campo-ob",
+      "link": true
+    },
+    "node_modules/@sfi/config": {
+      "resolved": "packages/config",
+      "link": true
+    },
+    "node_modules/@sfi/db": {
+      "resolved": "packages/db",
+      "link": true
+    },
+    "node_modules/@sfi/delta": {
+      "resolved": "packages/delta",
+      "link": true
+    },
+    "node_modules/@sfi/demo": {
+      "resolved": "apps/demo",
+      "link": true
+    },
+    "node_modules/@sfi/events": {
+      "resolved": "packages/events",
+      "link": true
+    },
+    "node_modules/@sfi/graph": {
+      "resolved": "packages/graph",
+      "link": true
+    },
+    "node_modules/@sfi/ingestion": {
+      "resolved": "services/ingestion",
+      "link": true
+    },
+    "node_modules/@sfi/mihm-core": {
+      "resolved": "packages/mihm-core",
+      "link": true
+    },
+    "node_modules/@sfi/observatory": {
+      "resolved": "apps/observatory",
+      "link": true
+    },
+    "node_modules/@sfi/policy": {
+      "resolved": "packages/policy",
+      "link": true
+    },
+    "node_modules/@sfi/runtime": {
+      "resolved": "packages/runtime",
+      "link": true
+    },
+    "node_modules/@sfi/security": {
+      "resolved": "packages/security",
+      "link": true
+    },
+    "node_modules/@sfi/sfi-kernel": {
+      "resolved": "packages/sfi-kernel",
+      "link": true
+    },
+    "node_modules/@sfi/sources": {
+      "resolved": "packages/sources",
+      "link": true
+    },
+    "node_modules/@sfi/terminal": {
+      "resolved": "apps/terminal",
+      "link": true
+    },
+    "node_modules/@sfi/testing": {
+      "resolved": "packages/testing",
+      "link": true
+    },
+    "node_modules/@sfi/ui": {
+      "resolved": "packages/ui",
+      "link": true
+    },
+    "node_modules/@sfi/worker": {
+      "resolved": "services/worker",
+      "link": true
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -3402,6 +3515,82 @@
           "optional": true
         }
       }
+    },
+    "packages/api-contracts": {
+      "name": "@sfi/api-contracts",
+      "version": "0.0.0"
+    },
+    "packages/campo-ob": {
+      "name": "@sfi/campo-ob",
+      "version": "0.0.0"
+    },
+    "packages/config": {
+      "name": "@sfi/config",
+      "version": "0.0.0"
+    },
+    "packages/db": {
+      "name": "@sfi/db",
+      "version": "0.0.0"
+    },
+    "packages/delta": {
+      "name": "@sfi/delta",
+      "version": "0.0.0"
+    },
+    "packages/events": {
+      "name": "@sfi/events",
+      "version": "0.0.0"
+    },
+    "packages/graph": {
+      "name": "@sfi/graph",
+      "version": "0.0.0"
+    },
+    "packages/mihm-core": {
+      "name": "@sfi/mihm-core",
+      "version": "0.0.0"
+    },
+    "packages/policy": {
+      "name": "@sfi/policy",
+      "version": "0.0.0"
+    },
+    "packages/runtime": {
+      "name": "@sfi/runtime",
+      "version": "0.0.0"
+    },
+    "packages/security": {
+      "name": "@sfi/security",
+      "version": "0.0.0"
+    },
+    "packages/sfi-kernel": {
+      "name": "@sfi/sfi-kernel",
+      "version": "0.0.0"
+    },
+    "packages/sources": {
+      "name": "@sfi/sources",
+      "version": "0.0.0"
+    },
+    "packages/testing": {
+      "name": "@sfi/testing",
+      "version": "0.0.0"
+    },
+    "packages/ui": {
+      "name": "@sfi/ui",
+      "version": "0.0.0"
+    },
+    "services/agent": {
+      "name": "@sfi/agent",
+      "version": "0.0.0"
+    },
+    "services/api": {
+      "name": "@sfi/api",
+      "version": "0.0.0"
+    },
+    "services/ingestion": {
+      "name": "@sfi/ingestion",
+      "version": "0.0.0"
+    },
+    "services/worker": {
+      "name": "@sfi/worker",
+      "version": "0.0.0"
     }
   }
 }

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -89,9 +89,14 @@ export type LogEntryDTO = {
 };
 
 export type SourceHealthDTO = {
+  key?: string;
   sourceId: string;
-  status: 'healthy' | 'degraded' | 'unavailable' | 'unknown';
+  status: 'healthy' | 'degraded' | 'missing' | 'simulated' | 'unavailable' | 'unknown';
   kind?: 'webhook' | 'oauth' | 'manual' | 'cron' | 'fixture' | 'public-api';
+  nti?: number | null;
+  simulated?: boolean;
+  last_ok?: string | null;
+  last_error?: string | null;
   lastObservedAt?: string;
   checkedAt?: string;
   confidence: number;
@@ -209,3 +214,4 @@ export type EvaluationResponse = {
 export type { NodeBootstrapResponseV1 } from './node-bootstrap';
 export { normalizeNodeBootstrapResponse } from './node-bootstrap';
 export * from './terminal-read-model';
+export * from './worldspect';

--- a/packages/api-contracts/src/worldspect.ts
+++ b/packages/api-contracts/src/worldspect.ts
@@ -1,0 +1,74 @@
+export type WorldSpectSourceState = 'observed' | 'degraded' | 'missing';
+
+export type WorldSpectEvidenceLevel = 'direct' | 'none';
+
+export type WorldSpectIngestMode = 'daily_cron' | 'manual' | 'diagnostic' | 'fallback_runtime';
+
+export type WorldSpectSource = {
+  key: string;
+  label?: string;
+  value: number | null;
+  raw?: unknown;
+  unit?: string;
+  nti?: number;
+  nti_base?: number;
+  weight?: number;
+  mihm_var?: string;
+  simulated?: boolean;
+  ts?: string;
+  error?: string;
+};
+
+export type WorldSpectSourceHealthStatus = 'healthy' | 'degraded' | 'missing' | 'simulated' | 'unavailable' | 'unknown';
+
+export type WorldSpectSourceHealth = {
+  key: string;
+  sourceId: string;
+  status: WorldSpectSourceHealthStatus;
+  kind?: 'webhook' | 'oauth' | 'manual' | 'cron' | 'fixture' | 'public-api';
+  nti: number | null;
+  simulated: boolean;
+  last_ok: string | null;
+  last_error: string | null;
+  lastObservedAt?: string;
+  checkedAt?: string;
+  confidence: number;
+  message?: string;
+};
+
+export type WorldSpectFieldStateSignal = {
+  sourceState: Exclude<WorldSpectSourceState, 'missing'>;
+  evidenceLevel: 'direct';
+  confidence: number;
+  metrics: {
+    wsi: number;
+    nti: number;
+  };
+  observedAt: string;
+  sourceIds: string[];
+} | null;
+
+export type WorldSpectSnapshotMeta = {
+  id: string;
+  observedAt: string;
+  createdAt: string;
+  ingestMode: WorldSpectIngestMode;
+  adapterStatus: string;
+  adapterError: string | null;
+  snapshotHash: string;
+  persisted: boolean;
+};
+
+export type WorldSpectResponse = {
+  sourceState: WorldSpectSourceState;
+  evidenceLevel: WorldSpectEvidenceLevel;
+  confidence: number;
+  wsi: number | null;
+  nti: number | null;
+  ts: string;
+  sources: WorldSpectSource[];
+  degraded_sources: string[];
+  sourceHealth: WorldSpectSourceHealth[];
+  fieldStateSignal: WorldSpectFieldStateSignal;
+  snapshot?: WorldSpectSnapshotMeta;
+};

--- a/packages/campo-ob/src/index.ts
+++ b/packages/campo-ob/src/index.ts
@@ -84,3 +84,145 @@ export type SourceHealth = CanonicalEvidence & {
   lastObservedAt?: string;
   message?: string;
 };
+
+export type CampoNodeType =
+  | 'BIO'
+  | 'ECO'
+  | 'ECON'
+  | 'INST'
+  | 'DIG'
+  | 'ALG'
+  | 'AGT'
+  | 'CYB'
+  | 'CULT'
+  | 'ENE'
+  | 'INF'
+  | 'PERC';
+
+export type CampoWorldSpectSource = {
+  key: string;
+  value: number | null;
+  nti?: number;
+  weight?: number;
+  mihm_var?: string;
+  simulated?: boolean;
+  error?: string;
+};
+
+export type CampoWorldSpectSnapshot = {
+  sourceState: 'observed' | 'degraded' | 'missing';
+  evidenceLevel: 'direct' | 'none';
+  confidence: number;
+  wsi: number | null;
+  nti: number | null;
+  ts: string;
+  sources: CampoWorldSpectSource[];
+  degraded_sources: string[];
+};
+
+export type CampoObNode = {
+  id: string;
+  type: CampoNodeType;
+  sourceKey: string;
+  weight: number;
+  value: number | null;
+  nti: number | null;
+  simulated: boolean;
+  ontologyDistance: number;
+};
+
+export type CampoObState = {
+  snapshotHashInput: string;
+  observedAt: string;
+  sourceState: 'observed' | 'degraded' | 'missing';
+  confidence: number;
+  nodes: CampoObNode[];
+  aggregateWeights: Record<CampoNodeType, number>;
+};
+
+const sourceTypeRules: Array<[string, CampoNodeType]> = [
+  ['energy', 'ENE'],
+  ['climate', 'ECO'],
+  ['ecology', 'ECO'],
+  ['market', 'ECON'],
+  ['econom', 'ECON'],
+  ['institution', 'INST'],
+  ['govern', 'INST'],
+  ['digital', 'DIG'],
+  ['cyber', 'CYB'],
+  ['algorithm', 'ALG'],
+  ['agent', 'AGT'],
+  ['culture', 'CULT'],
+  ['media', 'INF'],
+  ['news', 'INF'],
+  ['perception', 'PERC'],
+  ['health', 'BIO'],
+  ['bio', 'BIO'],
+];
+
+const initialWeights: Record<CampoNodeType, number> = {
+  BIO: 0.08,
+  ECO: 0.1,
+  ECON: 0.1,
+  INST: 0.12,
+  DIG: 0.08,
+  ALG: 0.08,
+  AGT: 0.07,
+  CYB: 0.07,
+  CULT: 0.08,
+  ENE: 0.08,
+  INF: 0.09,
+  PERC: 0.05,
+};
+
+function nodeTypeForSource(source: CampoWorldSpectSource): CampoNodeType {
+  const key = `${source.key} ${source.mihm_var ?? ''}`.toLowerCase();
+  return sourceTypeRules.find(([needle]) => key.includes(needle))?.[1] ?? 'INF';
+}
+
+function clampWeight(value: unknown, fallback: number) {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(0, Math.min(1, parsed));
+}
+
+export function mapWorldSpectToCampo(snapshot: CampoWorldSpectSnapshot): CampoObState {
+  const nodes = snapshot.sources.map((source) => {
+    const type = nodeTypeForSource(source);
+    const degraded = snapshot.degraded_sources.includes(source.key) || Boolean(source.error) || source.simulated === true;
+    const baseWeight = clampWeight(source.weight, initialWeights[type]);
+
+    return {
+      id: `worldspect:${source.key}`,
+      type,
+      sourceKey: source.key,
+      weight: degraded ? Number((baseWeight * 0.5).toFixed(4)) : baseWeight,
+      value: source.value,
+      nti: typeof source.nti === 'number' && Number.isFinite(source.nti) ? source.nti : null,
+      simulated: source.simulated === true,
+      ontologyDistance: 0,
+    };
+  });
+
+  const aggregateWeights = Object.keys(initialWeights).reduce<Record<CampoNodeType, number>>((acc, key) => {
+    const type = key as CampoNodeType;
+    acc[type] = Number(nodes.filter((node) => node.type === type).reduce((sum, node) => sum + node.weight, 0).toFixed(4));
+    return acc;
+  }, {} as Record<CampoNodeType, number>);
+
+  return {
+    snapshotHashInput: JSON.stringify({
+      sourceState: snapshot.sourceState,
+      confidence: snapshot.confidence,
+      wsi: snapshot.wsi,
+      nti: snapshot.nti,
+      ts: snapshot.ts,
+      sources: snapshot.sources.map((source) => source.key).sort(),
+    }),
+    observedAt: snapshot.ts,
+    sourceState: snapshot.sourceState,
+    confidence: snapshot.confidence,
+    nodes,
+    aggregateWeights,
+  };
+}

--- a/packages/delta/package.json
+++ b/packages/delta/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sfi/delta",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/delta/src/index.ts
+++ b/packages/delta/src/index.ts
@@ -1,0 +1,55 @@
+export type DeltaVector = {
+  confidence: number;
+  sourceDegradation: number;
+  ontologySpread: number;
+  ntiPressure: number;
+};
+
+export type DeltaInput = {
+  confidence: number;
+  sourceState: 'observed' | 'degraded' | 'missing';
+  nodes: Array<{ weight: number; nti: number | null; ontologyDistance: number; simulated: boolean }>;
+};
+
+export type DeltaResult = {
+  vector: DeltaVector;
+  score: number;
+  trace: string[];
+};
+
+function clamp01(value: number) {
+  return Math.max(0, Math.min(1, Number.isFinite(value) ? value : 0));
+}
+
+function average(values: number[]) {
+  return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
+}
+
+export function computeDelta(input: DeltaInput): DeltaResult {
+  const confidenceGap = 1 - clamp01(input.confidence);
+  const sourceDegradation = input.sourceState === 'missing'
+    ? 1
+    : input.sourceState === 'degraded'
+      ? 0.55
+      : 0;
+  const ontologySpread = clamp01(average(input.nodes.map((node) => node.ontologyDistance)));
+  const ntiPressure = clamp01(average(input.nodes.map((node) => node.nti ?? 0)) + (input.nodes.some((node) => node.simulated) ? 0.15 : 0));
+  const vector = {
+    confidence: Number(confidenceGap.toFixed(4)),
+    sourceDegradation: Number(sourceDegradation.toFixed(4)),
+    ontologySpread: Number(ontologySpread.toFixed(4)),
+    ntiPressure: Number(ntiPressure.toFixed(4)),
+  };
+  const score = clamp01((vector.confidence * 0.25) + (vector.sourceDegradation * 0.35) + (vector.ontologySpread * 0.15) + (vector.ntiPressure * 0.25));
+
+  return {
+    vector,
+    score: Number(score.toFixed(4)),
+    trace: [
+      `confidence_gap=${vector.confidence}`,
+      `source_degradation=${vector.sourceDegradation}`,
+      `ontology_spread=${vector.ontologySpread}`,
+      `nti_pressure=${vector.ntiPressure}`,
+    ],
+  };
+}

--- a/packages/events/src/schema.ts
+++ b/packages/events/src/schema.ts
@@ -23,6 +23,15 @@ export type SFIEvent<TPayload = unknown> = {
   uncertainty?: string;
 };
 
+export type EpistemicEventRecord<TPayload = unknown> = SFIEvent<TPayload> & {
+  id?: string;
+  logbookId: string;
+  schemaVersion: string;
+  hashPrev: string | null;
+  hashSelf: string;
+  createdAt: string;
+};
+
 const epistemicClasses: EpistemicClass[] = [
   'observed',
   'declared',
@@ -65,4 +74,16 @@ export function validateEpistemicEventShape(event: unknown): boolean {
     if (event.source.sourceType !== undefined && typeof event.source.sourceType !== 'string') return false;
   }
   return true;
+}
+
+export function canonicalizeEventPayload(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalizeEventPayload);
+  if (!value || typeof value !== 'object') return value;
+
+  return Object.keys(value as Record<string, unknown>)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, key) => {
+      acc[key] = canonicalizeEventPayload((value as Record<string, unknown>)[key]);
+      return acc;
+    }, {});
 }

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sfi/graph",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,0 +1,45 @@
+export type GraphNodeRecord = {
+  nodeId: string;
+  label: string;
+  ontologyType: string;
+  lineage: string[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type GraphEdgeRecord = {
+  edgeId: string;
+  sourceNodeId: string;
+  targetNodeId: string;
+  relation: string;
+  weight: number;
+  lineage: string[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export function canonicalGraphNode(input: Partial<GraphNodeRecord> & { nodeId: string }): GraphNodeRecord {
+  const now = new Date().toISOString();
+  return {
+    nodeId: input.nodeId,
+    label: input.label ?? input.nodeId,
+    ontologyType: input.ontologyType ?? 'unknown',
+    lineage: Array.isArray(input.lineage) ? input.lineage : [],
+    createdAt: input.createdAt ?? now,
+    updatedAt: input.updatedAt ?? now,
+  };
+}
+
+export function canonicalGraphEdge(input: Partial<GraphEdgeRecord> & { edgeId: string; sourceNodeId: string; targetNodeId: string }): GraphEdgeRecord {
+  const now = new Date().toISOString();
+  return {
+    edgeId: input.edgeId,
+    sourceNodeId: input.sourceNodeId,
+    targetNodeId: input.targetNodeId,
+    relation: input.relation ?? 'related_to',
+    weight: Math.max(0, Math.min(1, Number(input.weight ?? 0))),
+    lineage: Array.isArray(input.lineage) ? input.lineage : [],
+    createdAt: input.createdAt ?? now,
+    updatedAt: input.updatedAt ?? now,
+  };
+}

--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sfi/policy",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -1,0 +1,53 @@
+export type PolicyEpistemicClass = 'observed' | 'declared' | 'derived' | 'inferred' | 'simulated' | 'fixture' | 'missing';
+
+export type PolicyThresholds = {
+  minConfidence: number;
+  maxDelta: number;
+  allowSimulated: boolean;
+};
+
+export type PolicyDecision = {
+  allowed: boolean;
+  reason: string;
+  thresholds: PolicyThresholds;
+  trace: string[];
+};
+
+const defaultThresholds: Record<PolicyEpistemicClass, PolicyThresholds> = {
+  observed: { minConfidence: 0.55, maxDelta: 0.7, allowSimulated: false },
+  declared: { minConfidence: 0.5, maxDelta: 0.7, allowSimulated: false },
+  derived: { minConfidence: 0.45, maxDelta: 0.65, allowSimulated: false },
+  inferred: { minConfidence: 0.6, maxDelta: 0.5, allowSimulated: false },
+  simulated: { minConfidence: 0.8, maxDelta: 0.35, allowSimulated: true },
+  fixture: { minConfidence: 1, maxDelta: 0, allowSimulated: false },
+  missing: { minConfidence: 1, maxDelta: 0, allowSimulated: false },
+};
+
+export function evaluatePolicy(input: {
+  epistemicClass: PolicyEpistemicClass;
+  confidence: number;
+  deltaScore: number;
+  hasSimulatedSources?: boolean;
+  thresholds?: Partial<PolicyThresholds>;
+}): PolicyDecision {
+  const thresholds = { ...defaultThresholds[input.epistemicClass], ...input.thresholds };
+  const trace = [
+    `epistemic_class=${input.epistemicClass}`,
+    `confidence=${input.confidence}`,
+    `delta=${input.deltaScore}`,
+  ];
+
+  if (input.confidence < thresholds.minConfidence) {
+    return { allowed: false, reason: 'confidence_below_threshold', thresholds, trace };
+  }
+
+  if (input.deltaScore > thresholds.maxDelta) {
+    return { allowed: false, reason: 'delta_above_threshold', thresholds, trace };
+  }
+
+  if (input.hasSimulatedSources && !thresholds.allowSimulated) {
+    return { allowed: false, reason: 'simulated_sources_blocked', thresholds, trace };
+  }
+
+  return { allowed: true, reason: 'policy_allowed', thresholds, trace };
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sfi/runtime",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,0 +1,13 @@
+export type RuntimeHealth = {
+  status: 'idle' | 'running' | 'degraded';
+  lastCycleAt: string | null;
+  failures: number;
+};
+
+export function runtimeHealth(input: { running: boolean; lastCycleAt: string | null; failures: number }): RuntimeHealth {
+  return {
+    status: input.failures > 0 ? 'degraded' : input.running ? 'running' : 'idle',
+    lastCycleAt: input.lastCycleAt,
+    failures: input.failures,
+  };
+}

--- a/packages/sfi-kernel/package.json
+++ b/packages/sfi-kernel/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sfi/sfi-kernel",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/sfi-kernel/src/bootstrap.ts
+++ b/packages/sfi-kernel/src/bootstrap.ts
@@ -1,0 +1,6 @@
+import { createSfiKernelRuntime } from './runtime';
+import type { SfiKernelAdapters } from './state';
+
+export function bootstrapSfiKernel(adapters: SfiKernelAdapters) {
+  return createSfiKernelRuntime(adapters);
+}

--- a/packages/sfi-kernel/src/cycle.ts
+++ b/packages/sfi-kernel/src/cycle.ts
@@ -1,0 +1,39 @@
+import { mapWorldSpectToCampo } from '../../campo-ob/src';
+import { computeDelta } from '../../delta/src';
+import { evaluatePolicy } from '../../policy/src';
+import type { SfiKernelAdapters, SfiKernelCycleResult } from './state';
+
+export async function cycle(adapters: SfiKernelAdapters): Promise<SfiKernelCycleResult> {
+  const worldSpect = await adapters.readWorldSpect();
+  const campo = mapWorldSpectToCampo(worldSpect);
+  const delta = computeDelta({
+    confidence: campo.confidence,
+    sourceState: campo.sourceState,
+    nodes: campo.nodes,
+  });
+  const policy = evaluatePolicy({
+    epistemicClass: campo.sourceState === 'missing' ? 'missing' : 'derived',
+    confidence: campo.confidence,
+    deltaScore: delta.score,
+    hasSimulatedSources: campo.nodes.some((node) => node.simulated),
+  });
+
+  if (policy.allowed) {
+    await adapters.appendEvent({
+      eventName: 'sfi.kernel.cycle',
+      epistemicClass: 'derived',
+      confidence: campo.confidence,
+      payload: { campo, delta, policy },
+      occurredAt: campo.observedAt,
+      logbookId: 'sfi-kernel',
+    });
+  }
+
+  return {
+    observedAt: campo.observedAt,
+    campo,
+    delta,
+    policy,
+    emitted: policy.allowed,
+  };
+}

--- a/packages/sfi-kernel/src/index.ts
+++ b/packages/sfi-kernel/src/index.ts
@@ -1,0 +1,4 @@
+export { bootstrapSfiKernel } from './bootstrap';
+export { cycle } from './cycle';
+export { createSfiKernelRuntime } from './runtime';
+export type { SfiKernelAdapters, SfiKernelCycleResult, SfiKernelRuntimeState } from './state';

--- a/packages/sfi-kernel/src/runtime.ts
+++ b/packages/sfi-kernel/src/runtime.ts
@@ -1,0 +1,28 @@
+import { cycle } from './cycle';
+import type { SfiKernelAdapters, SfiKernelRuntimeState } from './state';
+
+export function createSfiKernelRuntime(adapters: SfiKernelAdapters) {
+  const state: SfiKernelRuntimeState = {
+    running: false,
+    lastCycleAt: null,
+    lastResult: null,
+    failures: 0,
+  };
+
+  return {
+    state,
+    async tick() {
+      state.running = true;
+      try {
+        state.lastResult = await cycle(adapters);
+        state.lastCycleAt = new Date().toISOString();
+        return state.lastResult;
+      } catch (error) {
+        state.failures += 1;
+        throw error;
+      } finally {
+        state.running = false;
+      }
+    },
+  };
+}

--- a/packages/sfi-kernel/src/state.ts
+++ b/packages/sfi-kernel/src/state.ts
@@ -1,0 +1,31 @@
+import type { CampoObState, CampoWorldSpectSnapshot } from '../../campo-ob/src';
+import type { DeltaResult } from '../../delta/src';
+import type { PolicyDecision } from '../../policy/src';
+
+export type SfiKernelAdapters = {
+  readWorldSpect: () => Promise<CampoWorldSpectSnapshot>;
+  appendEvent: (event: {
+    eventName: string;
+    epistemicClass: 'observed' | 'derived' | 'missing';
+    confidence: number;
+    payload: unknown;
+    occurredAt: string;
+    logbookId: string;
+    lineage?: string[];
+  }) => Promise<unknown>;
+};
+
+export type SfiKernelCycleResult = {
+  observedAt: string;
+  campo: CampoObState;
+  delta: DeltaResult;
+  policy: PolicyDecision;
+  emitted: boolean;
+};
+
+export type SfiKernelRuntimeState = {
+  running: boolean;
+  lastCycleAt: string | null;
+  lastResult: SfiKernelCycleResult | null;
+  failures: number;
+};

--- a/services/worker/src/index.ts
+++ b/services/worker/src/index.ts
@@ -1,0 +1,24 @@
+let shuttingDown = false;
+
+function log(message: string, extra: Record<string, unknown> = {}) {
+  console.log(JSON.stringify({ service: 'sfi-worker', message, ...extra, ts: new Date().toISOString() }));
+}
+
+process.on('SIGINT', () => {
+  shuttingDown = true;
+  log('shutdown_requested', { signal: 'SIGINT' });
+});
+
+process.on('SIGTERM', () => {
+  shuttingDown = true;
+  log('shutdown_requested', { signal: 'SIGTERM' });
+});
+
+export async function workerLoop(tick: () => Promise<unknown>, intervalMs = 60_000) {
+  while (!shuttingDown) {
+    const startedAt = Date.now();
+    await tick();
+    const waitMs = Math.max(0, intervalMs - (Date.now() - startedAt));
+    await new Promise((resolve) => setTimeout(resolve, waitMs));
+  }
+}

--- a/src/app/api/events/append/route.ts
+++ b/src/app/api/events/append/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { appendEpistemicEvent } from '@/lib/events/eventStore';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const result = await appendEpistemicEvent(body);
+  return NextResponse.json(result, { status: result.ok ? 201 : 400 });
+}

--- a/src/app/api/events/stream/route.ts
+++ b/src/app/api/events/stream/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { streamEpistemicEvents } from '@/lib/events/eventStore';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const logbookId = request.nextUrl.searchParams.get('logbookId') ?? 'default';
+  const limit = Number(request.nextUrl.searchParams.get('limit') ?? 100);
+  const result = await streamEpistemicEvents(logbookId, limit);
+  return NextResponse.json(result, { status: result.ok ? 200 : 502 });
+}

--- a/src/app/api/events/verify/route.ts
+++ b/src/app/api/events/verify/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyEpistemicEventChain } from '@/lib/events/eventStore';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const logbookId = request.nextUrl.searchParams.get('logbookId') ?? 'default';
+  const limit = Number(request.nextUrl.searchParams.get('limit') ?? 100);
+  const result = await verifyEpistemicEventChain(logbookId, limit);
+  return NextResponse.json(result, { status: result.ok ? 200 : 409 });
+}

--- a/src/app/api/runtime/health/route.ts
+++ b/src/app/api/runtime/health/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return NextResponse.json({
+    status: 'idle',
+    service: 'sfi-runtime',
+    checkedAt: new Date().toISOString(),
+    metrics: {
+      cycles: 0,
+      failures: 0,
+    },
+  });
+}

--- a/src/app/api/worldspect/diagnostic/route.ts
+++ b/src/app/api/worldspect/diagnostic/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildWorldSpectResponse } from '@/lib/worldspect/contract';
+import { runWorldSpectrum } from '@/lib/worldspect/runWorldSpectrum';
+import { upsertWorldSpectSnapshot } from '@/lib/worldspect/snapshotStore';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function isAuthorized(request: NextRequest) {
+  const authHeader = request.headers.get('Authorization');
+  const secret = process.env.WORLDSPECT_INGEST_SECRET;
+  return Boolean(secret && authHeader && authHeader.split(' ')[1] === secret);
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const result = await runWorldSpectrum();
+  const response = buildWorldSpectResponse(result.payload);
+
+  if (response.sourceState === 'missing') {
+    return NextResponse.json({ ok: true, data: response, warnings: ['worldspect_diagnostic_missing'] });
+  }
+
+  const persisted = await upsertWorldSpectSnapshot({
+    sourceState: response.sourceState,
+    evidenceLevel: 'direct',
+    confidence: response.confidence,
+    wsi: response.wsi,
+    nti: response.nti,
+    ts: response.ts,
+    sources: response.sources,
+    degraded_sources: response.degraded_sources,
+    sourceHealth: response.sourceHealth,
+    fieldStateSignal: response.fieldStateSignal,
+    rawPayload: result.payload,
+    adapterStatus: result.ok ? result.status : 'failed',
+    adapterError: result.ok ? null : result.errorCode,
+    ingestMode: 'diagnostic',
+  });
+
+  return NextResponse.json({
+    ok: persisted.ok,
+    data: response,
+    warnings: result.ok ? [] : [result.errorCode],
+    persistence: persisted,
+  }, { status: persisted.ok ? 200 : 502 });
+}

--- a/src/app/api/worldspect/global/route.ts
+++ b/src/app/api/worldspect/global/route.ts
@@ -1,21 +1,27 @@
 import { NextResponse } from 'next/server';
-import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import type { ApiResult, WorldSpectResponse } from '../../../../../packages/api-contracts/src';
+import { missingWorldSpectResponse } from '@/lib/worldspect/contract';
+import { getLatestWorldSpectSnapshot, snapshotRowToApiData } from '@/lib/worldspect/snapshotStore';
+
+export const dynamic = 'force-dynamic';
+
+function apiOk<TData>(data: TData, warnings?: string[]) {
+  const result: ApiResult<TData> = { ok: true, data, warnings };
+  return NextResponse.json(result);
+}
 
 export async function GET() {
-  const supabase = createServiceSupabaseClient();
-  const { data, error } = await supabase
-    .from('worldspect_snapshots')
-    .select('*')
-    .order('observed_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
+  const latest = await getLatestWorldSpectSnapshot();
 
-  if (error || !data) {
-    return NextResponse.json(
-      { status: 'stale', reason: 'database_hydration_pending' },
-      { status: 200 }
+  if (!latest) {
+    return apiOk<WorldSpectResponse & { status: 'missing' }>(
+      { ...missingWorldSpectResponse(), status: 'missing' },
+      ['worldspect_snapshot_missing'],
     );
   }
 
-  return NextResponse.json({ status: 'ok', snapshot: data }, { status: 200 });
+  return apiOk<WorldSpectResponse & { status: 'ok' }>({
+    ...snapshotRowToApiData(latest),
+    status: 'ok',
+  });
 }

--- a/src/app/api/worldspect/ingest-payload/route.ts
+++ b/src/app/api/worldspect/ingest-payload/route.ts
@@ -1,8 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createHash } from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import type { WorldSpectIngestMode } from '../../../../../packages/api-contracts/src';
+import {
+  buildWorldSpectResponse,
+  finiteNumberOrNull,
+  toStringArray,
+  toWorldSpectSources,
+} from '@/lib/worldspect/contract';
+import { upsertWorldSpectSnapshot } from '@/lib/worldspect/snapshotStore';
 
 export const dynamic = 'force-dynamic';
 
@@ -128,16 +134,23 @@ function parsePayloadFromBuffer(buf: Buffer): { body: WorldSpectPayload; encodin
 }
 
 function toFiniteNumber(value: unknown): number | null {
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : null;
-}
-
-function toJsonArray(value: unknown): unknown[] {
-  return Array.isArray(value) ? value : [];
+  return finiteNumberOrNull(value);
 }
 
 function isoDateOnly(iso: string): string {
   return new Date(iso).toISOString().slice(0, 10);
+}
+
+function ingestModeFromRequest(request: NextRequest): WorldSpectIngestMode {
+  const header = request.headers.get('X-SFI-Ingest-Mode')?.trim();
+  if (header === 'daily_cron' || header === 'manual' || header === 'diagnostic') return header;
+  return 'daily_cron';
+}
+
+function adapterStatusFor(body: WorldSpectPayload, degradedSources: string[], sources: ReturnType<typeof toWorldSpectSources>) {
+  if (typeof body.adapter_error === 'string' && body.adapter_error.length > 0) return 'failed' as const;
+  if (degradedSources.length > 0 || sources.some((source) => source.error || source.simulated === true)) return 'degraded' as const;
+  return 'observed' as const;
 }
 
 export async function POST(request: NextRequest) {
@@ -203,68 +216,69 @@ export async function POST(request: NextRequest) {
       ? new Date(body.ts).toISOString()
       : new Date().toISOString();
     const observedDate = isoDateOnly(observedAt);
-    const degradedSources = toJsonArray(body.degraded_sources);
-    const sources = toJsonArray(body.sources);
-    const sourceHealth = toJsonArray(body.source_health);
-    const confidence = Math.max(0, Math.min(1, nti));
-    const snapshotHash = createHash('sha256')
-      .update(JSON.stringify({ observedAt, wsi, nti, sources, sourceHealth, degradedSources }))
-      .digest('hex');
-
-    const supabase = createServiceSupabaseClient();
-
-    if (!supabase) {
-      console.error('[worldspect/ingest] createServiceSupabaseClient() returned falsy');
-      const wrote = writeDiagnosticDump(body, { note: 'no supabase client' });
-      return NextResponse.json(
-        {
-          ok: false,
-          stage: 'supabase_insert',
-          error_code: 'NO_SUPABASE_CLIENT',
-          diagnostic_dump_written: wrote,
-        },
-        { status: 502 },
-      );
-    }
-
-    const row = {
+    const degradedSources = toStringArray(body.degraded_sources);
+    const sources = toWorldSpectSources(body.sources);
+    const response = buildWorldSpectResponse({
       wsi,
       nti,
-      source_state: degradedSources.length > 0 ? 'degraded' : 'observed',
-      evidence_level: 'observed',
-      confidence,
-      degraded_sources: degradedSources,
+      ts: observedAt,
       sources,
-      source_health: sourceHealth,
-      raw_payload: body,
-      field_state_signal: body.field_state_signal ?? null,
-      observed_at: observedAt,
-      created_at: new Date().toISOString(),
-      adapter_status: degradedSources.length > 0 ? 'degraded' : 'ok',
-      adapter_error: typeof body.adapter_error === 'string' ? body.adapter_error : null,
-      ingest_mode: 'manual',
-      snapshot_hash: snapshotHash,
-    };
+      degraded_sources: degradedSources,
+      source_health: body.source_health,
+      field_state_signal: body.field_state_signal,
+      adapter_error: body.adapter_error,
+    });
 
-    const { error } = await supabase
-      .from('worldspect_snapshots')
-      .insert([row]);
+    if (response.sourceState === 'missing') {
+      return NextResponse.json(
+        {
+          ok: false,
+          stage: 'validate',
+          error_code: 'MISSING_PAYLOAD',
+          error_message: 'Expected valid WorldSpect metrics or sources',
+        },
+        { status: 400 },
+      );
+    }
 
-    if (error) {
-      console.error('Supabase Ingest Error:', error);
-      const wrote = writeDiagnosticDump(body, { supabase_error: error });
+    const persisted = await upsertWorldSpectSnapshot({
+      sourceState: response.sourceState,
+      evidenceLevel: 'direct',
+      confidence: response.confidence,
+      wsi: response.wsi,
+      nti: response.nti,
+      ts: response.ts,
+      sources: response.sources,
+      degraded_sources: response.degraded_sources,
+      sourceHealth: response.sourceHealth,
+      fieldStateSignal: response.fieldStateSignal,
+      rawPayload: body,
+      adapterStatus: adapterStatusFor(body, degradedSources, sources),
+      adapterError: typeof body.adapter_error === 'string' ? body.adapter_error : null,
+      ingestMode: ingestModeFromRequest(request),
+    });
+
+    if (!persisted.ok) {
+      console.error('Supabase Ingest Error:', persisted);
+      const wrote = writeDiagnosticDump(body, { supabase_error: persisted });
       return NextResponse.json(
         {
           ok: false,
           stage: 'supabase_insert',
-          error_code: normalizeSupabaseError(error),
+          error_code: normalizeSupabaseError(persisted),
           diagnostic_dump_written: wrote,
         },
         { status: 502 },
       );
     }
 
-    return NextResponse.json({ ok: true, observed_date: observedDate, snapshot_hash: snapshotHash });
+    return NextResponse.json({
+      ok: true,
+      observed_date: observedDate,
+      snapshot_hash: typeof persisted.data?.snapshot_hash === 'string' ? persisted.data.snapshot_hash : null,
+      sourceState: response.sourceState,
+      ingestMode: ingestModeFromRequest(request),
+    });
   } catch (err: unknown) {
     console.error('[worldspect/ingest] Exception:', errorStack(err));
     return NextResponse.json(

--- a/src/app/api/worldspect/real/route.ts
+++ b/src/app/api/worldspect/real/route.ts
@@ -1,125 +1,14 @@
 import { NextResponse } from 'next/server';
-import type { ApiResult, SourceHealthDTO } from '../../../../../packages/api-contracts/src';
-import { runWorldSpectrum, type WorldSpectrumCliPayload, type WorldSpectrumSource } from '@/lib/worldspect/runWorldSpectrum';
-import {
-  getLatestWorldSpectSnapshot,
-  snapshotRowToApiData,
-  upsertWorldSpectSnapshot,
-} from '@/lib/worldspect/snapshotStore';
+import type { ApiResult, WorldSpectResponse } from '../../../../../packages/api-contracts/src';
+import { missingWorldSpectResponse } from '@/lib/worldspect/contract';
+import { getLatestWorldSpectSnapshot, snapshotRowToApiData } from '@/lib/worldspect/snapshotStore';
 
 export const runtime = 'nodejs';
-
-type WorldSpectRealSourceState = 'observed' | 'degraded';
-
-type WorldSpectRealResponse = {
-  sourceState: WorldSpectRealSourceState;
-  evidenceLevel: 'direct';
-  confidence: number;
-  wsi: number | null;
-  nti: number | null;
-  ts: string;
-  sources: WorldSpectrumSource[];
-  degraded_sources: string[];
-  sourceHealth: SourceHealthDTO[];
-  fieldStateSignal: {
-    sourceState: WorldSpectRealSourceState;
-    evidenceLevel: 'direct';
-    confidence: number;
-    metrics: {
-      wsi: number;
-      nti: number;
-    };
-    observedAt: string;
-    sourceIds: string[];
-  } | null;
-  snapshot?: {
-    id: string;
-    observedAt: string;
-    createdAt: string;
-    ingestMode: string;
-    adapterStatus: string;
-    adapterError: string | null;
-    snapshotHash: string;
-    persisted: boolean;
-  };
-};
+export const dynamic = 'force-dynamic';
 
 function apiOk<TData>(data: TData, warnings?: string[]) {
   const result: ApiResult<TData> = { ok: true, data, warnings };
   return NextResponse.json(result);
-}
-
-function clamp01(value: number) {
-  return Math.max(0, Math.min(1, value));
-}
-
-function isRealSource(source: WorldSpectrumSource) {
-  return source.value !== null && source.simulated !== true && !source.error;
-}
-
-function sourceStatus(source: WorldSpectrumSource, degradedSources: string[]): SourceHealthDTO['status'] {
-  if (degradedSources.includes(source.key)) return 'degraded';
-  if (source.error || source.simulated === true) return 'degraded';
-  if (source.value === null) return 'unavailable';
-  return 'healthy';
-}
-
-function sourceConfidence(source: WorldSpectrumSource) {
-  if (!isRealSource(source)) return 0;
-  if (typeof source.nti === 'number' && Number.isFinite(source.nti)) return clamp01(source.nti);
-  return 0.7;
-}
-
-function calculateConfidence(payload: WorldSpectrumCliPayload) {
-  if (payload.sources.length === 0) return 0;
-  const realSources = payload.sources.filter(isRealSource);
-  const sourceCoverage = realSources.length / payload.sources.length;
-  const metricCoverage = typeof payload.wsi === 'number' && typeof payload.nti === 'number' ? 1 : 0.65;
-  const degradationPenalty = payload.degraded_sources.length > 0 ? 0.82 : 1;
-  return Number(clamp01(sourceCoverage * metricCoverage * degradationPenalty).toFixed(3));
-}
-
-function toSourceHealth(payload: WorldSpectrumCliPayload): SourceHealthDTO[] {
-  return payload.sources.map((source) => ({
-    sourceId: source.key,
-    status: sourceStatus(source, payload.degraded_sources),
-    kind: 'public-api',
-    lastObservedAt: source.ts,
-    checkedAt: payload.ts,
-    confidence: sourceConfidence(source),
-    message: source.error ? 'source_unavailable' : undefined,
-  }));
-}
-
-function toResponse(payload: WorldSpectrumCliPayload, sourceState: WorldSpectRealSourceState): WorldSpectRealResponse {
-  const confidence = calculateConfidence(payload);
-  const sourceHealth = toSourceHealth(payload);
-  const hasMeasuredMetrics = typeof payload.wsi === 'number' && typeof payload.nti === 'number';
-
-  return {
-    sourceState,
-    evidenceLevel: 'direct',
-    confidence,
-    wsi: payload.wsi,
-    nti: payload.nti,
-    ts: payload.ts,
-    sources: payload.sources,
-    degraded_sources: payload.degraded_sources,
-    sourceHealth,
-    fieldStateSignal: hasMeasuredMetrics
-      ? {
-        sourceState,
-        evidenceLevel: 'direct',
-        confidence,
-        metrics: {
-          wsi: payload.wsi as number,
-          nti: payload.nti as number,
-        },
-        observedAt: payload.ts,
-        sourceIds: payload.sources.filter(isRealSource).map((source) => source.key),
-      }
-      : null,
-  };
 }
 
 export async function GET() {
@@ -129,44 +18,8 @@ export async function GET() {
     return apiOk(snapshotRowToApiData(latest));
   }
 
-  const result = await runWorldSpectrum();
-  const sourceState: WorldSpectRealSourceState = result.status === 'observed' ? 'observed' : 'degraded';
-  const response = toResponse(result.payload, sourceState);
-
-  const persisted = await upsertWorldSpectSnapshot({
-    sourceState: response.sourceState,
-    evidenceLevel: response.evidenceLevel,
-    confidence: response.confidence,
-    wsi: response.wsi,
-    nti: response.nti,
-    ts: response.ts,
-    sources: response.sources,
-    degraded_sources: response.degraded_sources,
-    sourceHealth: response.sourceHealth,
-    fieldStateSignal: response.fieldStateSignal,
-    rawPayload: result.payload,
-    adapterStatus: result.ok ? result.status : 'failed',
-    adapterError: result.ok ? null : result.errorCode,
-    ingestMode: 'fallback_runtime',
-  });
-
-  const warnings = [
-    'worldspect_snapshot_missing_used_runtime_fallback',
-    ...(result.ok ? [] : [result.errorCode]),
-    ...(persisted.ok ? [] : [persisted.error]),
-  ];
-
-  return apiOk({
-    ...response,
-    snapshot: {
-      id: persisted.ok && typeof persisted.data?.id === 'string' ? persisted.data.id : 'unpersisted',
-      observedAt: response.ts,
-      createdAt: new Date().toISOString(),
-      ingestMode: 'fallback_runtime',
-      adapterStatus: result.ok ? result.status : 'failed',
-      adapterError: result.ok ? null : result.errorCode,
-      snapshotHash: persisted.ok && typeof persisted.data?.snapshot_hash === 'string' ? persisted.data.snapshot_hash : 'unpersisted',
-      persisted: persisted.ok,
-    },
-  }, warnings);
+  return apiOk<WorldSpectResponse>(
+    missingWorldSpectResponse(),
+    ['worldspect_snapshot_missing'],
+  );
 }

--- a/src/lib/events/eventStore.ts
+++ b/src/lib/events/eventStore.ts
@@ -1,0 +1,171 @@
+import { createHash, randomUUID } from 'crypto';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import {
+  canonicalizeEventPayload,
+  isEpistemicClass,
+  validateEpistemicEventShape,
+  type EpistemicClass,
+  type EpistemicEventRecord,
+  type SFIEvent,
+} from '../../../packages/events/src/schema';
+
+const schemaVersion = '2026-05-27.epistemic-events.v1';
+const genesisHash = 'GENESIS';
+
+function sha256(value: unknown) {
+  return createHash('sha256').update(JSON.stringify(canonicalizeEventPayload(value))).digest('hex');
+}
+
+function clamp01(value: number) {
+  return Math.max(0, Math.min(1, Number.isFinite(value) ? value : 0));
+}
+
+function normalizeEvent(input: Partial<SFIEvent> & { logbookId?: string; schemaVersion?: string }): Omit<EpistemicEventRecord, 'hashPrev' | 'hashSelf' | 'createdAt'> {
+  const occurredAt = typeof input.occurredAt === 'string' && input.occurredAt.length > 0
+    ? new Date(input.occurredAt).toISOString()
+    : new Date().toISOString();
+  const epistemicClass: EpistemicClass = isEpistemicClass(input.epistemicClass) ? input.epistemicClass as EpistemicClass : 'missing';
+  const payload = input.payload ?? {};
+  const checksum = typeof input.checksum === 'string' && input.checksum.length > 0 ? input.checksum : sha256(payload);
+
+  return {
+    eventId: typeof input.eventId === 'string' && input.eventId.length > 0 ? input.eventId : randomUUID(),
+    eventName: typeof input.eventName === 'string' && input.eventName.length > 0 ? input.eventName : 'epistemic.event',
+    epistemicClass,
+    confidence: clamp01(Number(input.confidence ?? 0)),
+    payload,
+    occurredAt,
+    source: input.source ?? { sourceId: 'unknown', sourceType: 'unknown' },
+    checksum,
+    lineage: Array.isArray(input.lineage) ? input.lineage.filter((item): item is string => typeof item === 'string') : [],
+    uncertainty: typeof input.uncertainty === 'string' ? input.uncertainty : undefined,
+    logbookId: typeof input.logbookId === 'string' && input.logbookId.length > 0 ? input.logbookId : 'default',
+    schemaVersion: typeof input.schemaVersion === 'string' && input.schemaVersion.length > 0 ? input.schemaVersion : schemaVersion,
+  };
+}
+
+function toHashMaterial(event: Omit<EpistemicEventRecord, 'hashSelf' | 'createdAt'>) {
+  return {
+    eventId: event.eventId,
+    eventName: event.eventName,
+    logbookId: event.logbookId,
+    epistemicClass: event.epistemicClass,
+    schemaVersion: event.schemaVersion,
+    source: event.source,
+    confidence: event.confidence,
+    payload: event.payload,
+    checksum: event.checksum,
+    lineage: event.lineage ?? [],
+    uncertainty: event.uncertainty ?? null,
+    occurredAt: event.occurredAt,
+    hashPrev: event.hashPrev,
+  };
+}
+
+export function hashEpistemicEvent(event: Omit<EpistemicEventRecord, 'hashSelf' | 'createdAt'>) {
+  return sha256(toHashMaterial(event));
+}
+
+export async function appendEpistemicEvent(input: Partial<SFIEvent> & { logbookId?: string; schemaVersion?: string }) {
+  const service = createServiceSupabaseClient();
+  const event = normalizeEvent(input);
+
+  if (!validateEpistemicEventShape(event)) {
+    return { ok: false as const, error: 'invalid_epistemic_event' };
+  }
+
+  const { data: latest } = await service
+    .from('epistemic_events')
+    .select('hash_self')
+    .eq('logbook_id', event.logbookId)
+    .order('sequence', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const hashPrev = typeof latest?.hash_self === 'string' ? latest.hash_self : null;
+  const hashSelf = hashEpistemicEvent({ ...event, hashPrev });
+
+  const { data, error } = await service
+    .from('epistemic_events')
+    .insert({
+      event_id: event.eventId,
+      event_name: event.eventName,
+      logbook_id: event.logbookId,
+      epistemic_class: event.epistemicClass,
+      schema_version: event.schemaVersion,
+      source: event.source,
+      confidence: event.confidence,
+      payload: event.payload,
+      checksum: event.checksum,
+      lineage: event.lineage,
+      uncertainty: event.uncertainty ?? null,
+      occurred_at: event.occurredAt,
+      hash_prev: hashPrev,
+      hash_self: hashSelf,
+    })
+    .select('*')
+    .single();
+
+  if (error) return { ok: false as const, error: 'epistemic_event_append_failed', details: error.message };
+  return { ok: true as const, data };
+}
+
+export async function streamEpistemicEvents(logbookId = 'default', limit = 100) {
+  const service = createServiceSupabaseClient();
+  const { data, error } = await service
+    .from('epistemic_events')
+    .select('*')
+    .eq('logbook_id', logbookId)
+    .order('sequence', { ascending: true })
+    .limit(Math.max(1, Math.min(500, limit)));
+
+  if (error) return { ok: false as const, error: 'epistemic_event_stream_failed', details: error.message };
+  return { ok: true as const, data: data ?? [] };
+}
+
+export async function verifyEpistemicEventChain(logbookId = 'default', limit = 100) {
+  const streamed = await streamEpistemicEvents(logbookId, limit);
+  if (!streamed.ok) return streamed;
+
+  let previous: string | null = null;
+  const failures: Array<{ eventId: string; reason: string }> = [];
+
+  for (const row of streamed.data) {
+    const expectedPrev = previous;
+    if ((row.hash_prev ?? null) !== expectedPrev) {
+      failures.push({ eventId: String(row.event_id), reason: 'hash_prev_mismatch' });
+    }
+
+    const recalculated = hashEpistemicEvent({
+      eventId: String(row.event_id),
+      eventName: String(row.event_name),
+      logbookId: String(row.logbook_id),
+      epistemicClass: row.epistemic_class as EpistemicClass,
+      schemaVersion: String(row.schema_version),
+      source: row.source,
+      confidence: Number(row.confidence ?? 0),
+      payload: row.payload,
+      checksum: String(row.checksum),
+      lineage: Array.isArray(row.lineage) ? row.lineage : [],
+      uncertainty: typeof row.uncertainty === 'string' ? row.uncertainty : undefined,
+      occurredAt: new Date(String(row.occurred_at)).toISOString(),
+      hashPrev: row.hash_prev ?? null,
+    });
+
+    if (recalculated !== row.hash_self) {
+      failures.push({ eventId: String(row.event_id), reason: 'hash_self_mismatch' });
+    }
+
+    previous = String(row.hash_self ?? genesisHash);
+  }
+
+  return {
+    ok: failures.length === 0,
+    data: {
+      logbookId,
+      checked: streamed.data.length,
+      valid: failures.length === 0,
+      failures,
+    },
+  } as const;
+}

--- a/src/lib/worldspect/contract.ts
+++ b/src/lib/worldspect/contract.ts
@@ -1,0 +1,209 @@
+import type {
+  WorldSpectFieldStateSignal,
+  WorldSpectResponse,
+  WorldSpectSource,
+  WorldSpectSourceHealth,
+  WorldSpectSourceHealthStatus,
+  WorldSpectSourceState,
+} from '../../../packages/api-contracts/src';
+
+export type WorldSpectCanonicalPayload = {
+  sources: WorldSpectSource[];
+  wsi: number | null;
+  nti: number | null;
+  ts: string;
+  degraded_sources: string[];
+  source_health?: unknown;
+  field_state_signal?: unknown;
+  adapter_error?: unknown;
+};
+
+function clamp01(value: number) {
+  return Math.max(0, Math.min(1, Number.isFinite(value) ? value : 0));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+export function finiteNumberOrNull(value: unknown) {
+  if (value === null || typeof value === 'undefined') return null;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function toWorldSpectSources(value: unknown): WorldSpectSource[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter(isRecord)
+    .map((source) => ({
+      key: typeof source.key === 'string' && source.key.length > 0 ? source.key : 'unknown_source',
+      label: typeof source.label === 'string' ? source.label : undefined,
+      value: finiteNumberOrNull(source.value),
+      raw: source.raw,
+      unit: typeof source.unit === 'string' ? source.unit : undefined,
+      nti: finiteNumberOrNull(source.nti) ?? undefined,
+      nti_base: finiteNumberOrNull(source.nti_base) ?? undefined,
+      weight: finiteNumberOrNull(source.weight) ?? undefined,
+      mihm_var: typeof source.mihm_var === 'string' ? source.mihm_var : undefined,
+      simulated: source.simulated === true,
+      ts: typeof source.ts === 'string' ? source.ts : undefined,
+      error: typeof source.error === 'string' ? source.error : undefined,
+    }));
+}
+
+export function toStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+function isRealSource(source: WorldSpectSource) {
+  return source.value !== null && source.simulated !== true && !source.error;
+}
+
+export function deriveWorldSpectSourceHealth(
+  sources: WorldSpectSource[],
+  degradedSources: string[],
+  checkedAt: string,
+): WorldSpectSourceHealth[] {
+  return sources.map((source) => {
+    const nti = finiteNumberOrNull(source.nti);
+    const simulated = source.simulated === true;
+    const hasError = typeof source.error === 'string' && source.error.length > 0;
+    const status = simulated
+      ? 'simulated'
+      : hasError || degradedSources.includes(source.key)
+        ? 'degraded'
+        : source.value === null
+          ? 'missing'
+          : 'healthy';
+    const lastOk = status === 'healthy' ? source.ts ?? checkedAt : null;
+    const lastError = hasError ? source.error as string : status === 'missing' ? 'source_value_missing' : null;
+
+    return {
+      key: source.key,
+      sourceId: source.key,
+      status,
+      kind: 'public-api',
+      nti,
+      simulated,
+      last_ok: lastOk,
+      last_error: lastError,
+      lastObservedAt: source.ts,
+      checkedAt,
+      confidence: isRealSource(source) ? clamp01(nti ?? 0.7) : 0,
+      message: lastError ?? undefined,
+    };
+  });
+}
+
+export function normalizeWorldSpectSourceHealth(
+  value: unknown,
+  sources: WorldSpectSource[],
+  degradedSources: string[],
+  checkedAt: string,
+): WorldSpectSourceHealth[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    return deriveWorldSpectSourceHealth(sources, degradedSources, checkedAt);
+  }
+
+  const normalized = value.filter(isRecord).map((source): WorldSpectSourceHealth => {
+    const key = typeof source.key === 'string'
+      ? source.key
+      : typeof source.sourceId === 'string'
+        ? source.sourceId
+        : 'unknown_source';
+    const statusValue = typeof source.status === 'string' ? source.status : 'unknown';
+    const status: WorldSpectSourceHealthStatus = statusValue === 'healthy'
+      || statusValue === 'degraded'
+      || statusValue === 'missing'
+      || statusValue === 'simulated'
+      || statusValue === 'unavailable'
+      ? statusValue
+      : 'unknown';
+    const nti = finiteNumberOrNull(source.nti);
+    const simulated = source.simulated === true || status === 'simulated';
+
+    return {
+      key,
+      sourceId: typeof source.sourceId === 'string' ? source.sourceId : key,
+      status,
+      kind: 'public-api' as const,
+      nti,
+      simulated,
+      last_ok: typeof source.last_ok === 'string' ? source.last_ok : typeof source.lastObservedAt === 'string' ? source.lastObservedAt : null,
+      last_error: typeof source.last_error === 'string' ? source.last_error : typeof source.message === 'string' ? source.message : null,
+      lastObservedAt: typeof source.lastObservedAt === 'string' ? source.lastObservedAt : undefined,
+      checkedAt,
+      confidence: clamp01(Number(source.confidence ?? 0)),
+      message: typeof source.message === 'string' ? source.message : undefined,
+    };
+  });
+
+  return normalized.length > 0 ? normalized : deriveWorldSpectSourceHealth(sources, degradedSources, checkedAt);
+}
+
+export function calculateWorldSpectSourceState(payload: Pick<WorldSpectCanonicalPayload, 'sources' | 'wsi' | 'nti' | 'degraded_sources'>): WorldSpectSourceState {
+  const hasMetrics = payload.wsi !== null && payload.nti !== null;
+  if (!hasMetrics && payload.sources.length === 0) return 'missing';
+  if (payload.degraded_sources.length > 0 || payload.sources.some((source) => source.error || source.simulated === true)) return 'degraded';
+  return hasMetrics ? 'observed' : 'missing';
+}
+
+export function calculateWorldSpectConfidence(payload: Pick<WorldSpectCanonicalPayload, 'sources' | 'wsi' | 'nti' | 'degraded_sources'>) {
+  if (payload.wsi === null || payload.nti === null) return 0;
+  if (payload.sources.length === 0) return clamp01(payload.nti);
+  const realSources = payload.sources.filter(isRealSource);
+  const sourceCoverage = realSources.length / payload.sources.length;
+  const degradationPenalty = payload.degraded_sources.length > 0 ? 0.82 : 1;
+  return Number(clamp01(sourceCoverage * clamp01(payload.nti) * degradationPenalty).toFixed(3));
+}
+
+export function buildWorldSpectFieldStateSignal(payload: WorldSpectCanonicalPayload, sourceState: WorldSpectSourceState, confidence: number): WorldSpectFieldStateSignal {
+  if (sourceState === 'missing' || payload.wsi === null || payload.nti === null) return null;
+
+  return {
+    sourceState,
+    evidenceLevel: 'direct',
+    confidence,
+    metrics: {
+      wsi: payload.wsi,
+      nti: payload.nti,
+    },
+    observedAt: payload.ts,
+    sourceIds: payload.sources.filter(isRealSource).map((source) => source.key),
+  };
+}
+
+export function buildWorldSpectResponse(payload: WorldSpectCanonicalPayload): WorldSpectResponse {
+  const sourceState = calculateWorldSpectSourceState(payload);
+  const confidence = calculateWorldSpectConfidence(payload);
+  const sourceHealth = normalizeWorldSpectSourceHealth(payload.source_health, payload.sources, payload.degraded_sources, payload.ts);
+
+  return {
+    sourceState,
+    evidenceLevel: sourceState === 'missing' ? 'none' : 'direct',
+    confidence,
+    wsi: payload.wsi,
+    nti: payload.nti,
+    ts: payload.ts,
+    sources: payload.sources,
+    degraded_sources: payload.degraded_sources,
+    sourceHealth,
+    fieldStateSignal: buildWorldSpectFieldStateSignal(payload, sourceState, confidence),
+  };
+}
+
+export function missingWorldSpectResponse(now = new Date().toISOString()): WorldSpectResponse {
+  return {
+    sourceState: 'missing',
+    evidenceLevel: 'none',
+    confidence: 0,
+    wsi: null,
+    nti: null,
+    ts: now,
+    sources: [],
+    degraded_sources: [],
+    sourceHealth: [],
+    fieldStateSignal: null,
+  };
+}

--- a/src/lib/worldspect/snapshotStore.ts
+++ b/src/lib/worldspect/snapshotStore.ts
@@ -1,23 +1,30 @@
 import { createHash } from 'crypto';
 import { createServiceSupabaseClient } from '../../runtime/supabase/server';
-import type { SourceHealthDTO } from '../../../packages/api-contracts/src';
-import type { WorldSpectrumCliPayload, WorldSpectrumSource } from '@/lib/worldspect/runWorldSpectrum';
+import type {
+  WorldSpectIngestMode,
+  WorldSpectFieldStateSignal,
+  WorldSpectResponse,
+  WorldSpectSource,
+  WorldSpectSourceHealth,
+  WorldSpectSourceState,
+} from '../../../packages/api-contracts/src';
+import type { WorldSpectCanonicalPayload } from './contract';
+import { deriveWorldSpectSourceHealth } from './contract';
 
-export type WorldSpectSourceState = 'observed' | 'degraded';
-export type WorldSpectIngestMode = 'daily_cron' | 'manual' | 'fallback_runtime';
+type PersistedWorldSpectSourceState = Exclude<WorldSpectSourceState, 'missing'>;
 
 export type WorldSpectSnapshotInput = {
-  sourceState: WorldSpectSourceState;
+  sourceState: PersistedWorldSpectSourceState;
   evidenceLevel: 'direct';
   confidence: number;
   wsi: number | null;
   nti: number | null;
   ts: string;
-  sources: WorldSpectrumSource[];
+  sources: WorldSpectSource[];
   degraded_sources: string[];
-  sourceHealth: SourceHealthDTO[];
+  sourceHealth: WorldSpectSourceHealth[];
   fieldStateSignal: Record<string, unknown> | null;
-  rawPayload: WorldSpectrumCliPayload;
+  rawPayload: unknown;
   adapterStatus: 'observed' | 'degraded' | 'failed';
   adapterError?: string | null;
   ingestMode: WorldSpectIngestMode;
@@ -27,16 +34,16 @@ export type WorldSpectSnapshotRow = {
   id: string;
   observed_at: string;
   created_at: string;
-  source_state: WorldSpectSourceState;
+  source_state: PersistedWorldSpectSourceState;
   evidence_level: 'direct';
   confidence: number;
   wsi: number | null;
   nti: number | null;
   degraded_sources: string[];
-  sources: WorldSpectrumSource[];
-  source_health: SourceHealthDTO[];
-  raw_payload: WorldSpectrumCliPayload;
-  field_state_signal: Record<string, unknown> | null;
+  sources: WorldSpectSource[];
+  source_health: WorldSpectSourceHealth[];
+  raw_payload: WorldSpectCanonicalPayload;
+  field_state_signal: WorldSpectFieldStateSignal;
   adapter_status: string;
   adapter_error: string | null;
   ingest_mode: WorldSpectIngestMode;
@@ -85,12 +92,12 @@ function numberOrNull(value: unknown) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function isWorldSpectSourceState(value: unknown): value is WorldSpectSourceState {
+function isWorldSpectSourceState(value: unknown): value is PersistedWorldSpectSourceState {
   return value === 'observed' || value === 'degraded';
 }
 
 function isWorldSpectIngestMode(value: unknown): value is WorldSpectIngestMode {
-  return value === 'daily_cron' || value === 'manual' || value === 'fallback_runtime';
+  return value === 'daily_cron' || value === 'manual' || value === 'diagnostic' || value === 'fallback_runtime';
 }
 
 export async function getLatestWorldSpectSnapshot() {
@@ -118,10 +125,16 @@ export async function getLatestWorldSpectSnapshot() {
     wsi: numberOrNull(data.wsi),
     nti: numberOrNull(data.nti),
     degraded_sources: Array.isArray(data.degraded_sources) ? data.degraded_sources.filter((source: unknown): source is string => typeof source === 'string') : [],
-    sources: Array.isArray(data.sources) ? data.sources as WorldSpectrumSource[] : [],
-    source_health: Array.isArray(data.source_health) ? data.source_health as SourceHealthDTO[] : [],
-    raw_payload: data.raw_payload as WorldSpectrumCliPayload,
-    field_state_signal: data.field_state_signal && typeof data.field_state_signal === 'object' ? data.field_state_signal as Record<string, unknown> : null,
+    sources: Array.isArray(data.sources) ? data.sources as WorldSpectSource[] : [],
+    source_health: Array.isArray(data.source_health) && data.source_health.length > 0
+      ? data.source_health as WorldSpectSourceHealth[]
+      : deriveWorldSpectSourceHealth(
+        Array.isArray(data.sources) ? data.sources as WorldSpectSource[] : [],
+        Array.isArray(data.degraded_sources) ? data.degraded_sources.filter((source: unknown): source is string => typeof source === 'string') : [],
+        String(data.observed_at),
+      ),
+    raw_payload: data.raw_payload as WorldSpectCanonicalPayload,
+    field_state_signal: data.field_state_signal && typeof data.field_state_signal === 'object' ? data.field_state_signal as WorldSpectFieldStateSignal : null,
     adapter_status: String(data.adapter_status ?? 'unknown'),
     adapter_error: typeof data.adapter_error === 'string' ? data.adapter_error : null,
     ingest_mode: ingestMode,
@@ -188,5 +201,5 @@ export function snapshotRowToApiData(row: WorldSpectSnapshotRow) {
       snapshotHash: row.snapshot_hash,
       persisted: true,
     },
-  };
+  } satisfies WorldSpectResponse;
 }

--- a/supabase/migrations/20260527081000_worldspect_diagnostic_ingest_mode.sql
+++ b/supabase/migrations/20260527081000_worldspect_diagnostic_ingest_mode.sql
@@ -1,0 +1,6 @@
+alter table public.worldspect_snapshots
+drop constraint if exists worldspect_snapshots_ingest_mode_check;
+
+alter table public.worldspect_snapshots
+add constraint worldspect_snapshots_ingest_mode_check
+check (ingest_mode in ('daily_cron', 'manual', 'diagnostic', 'fallback_runtime'));

--- a/supabase/migrations/20260527082000_create_epistemic_events.sql
+++ b/supabase/migrations/20260527082000_create_epistemic_events.sql
@@ -1,0 +1,27 @@
+create table if not exists public.epistemic_events (
+  id uuid primary key default gen_random_uuid(),
+  sequence bigint generated always as identity,
+  event_id text not null unique,
+  event_name text not null,
+  logbook_id text not null,
+  epistemic_class text not null check (epistemic_class in ('observed', 'declared', 'derived', 'inferred', 'simulated', 'fixture', 'missing')),
+  schema_version text not null,
+  source jsonb not null default '{}'::jsonb,
+  confidence numeric not null default 0 check (confidence >= 0 and confidence <= 1),
+  payload jsonb not null,
+  checksum text not null,
+  lineage text[] not null default '{}',
+  uncertainty text null,
+  occurred_at timestamptz not null,
+  created_at timestamptz not null default now(),
+  hash_prev text null,
+  hash_self text not null unique
+);
+
+create index if not exists epistemic_events_logbook_sequence_idx
+on public.epistemic_events (logbook_id, sequence);
+
+create index if not exists epistemic_events_created_at_idx
+on public.epistemic_events (created_at desc);
+
+alter table public.epistemic_events enable row level security;

--- a/supabase/migrations/20260527083000_create_graph_nodes_edges.sql
+++ b/supabase/migrations/20260527083000_create_graph_nodes_edges.sql
@@ -1,0 +1,42 @@
+create table if not exists public.graph_nodes (
+  id uuid primary key default gen_random_uuid(),
+  node_id text not null unique,
+  label text not null,
+  ontology_type text not null,
+  lineage text[] not null default '{}',
+  attributes jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.graph_edges (
+  id uuid primary key default gen_random_uuid(),
+  edge_id text not null unique,
+  source_node_id text not null references public.graph_nodes(node_id),
+  target_node_id text not null references public.graph_nodes(node_id),
+  relation text not null,
+  weight numeric not null default 0 check (weight >= 0 and weight <= 1),
+  lineage text[] not null default '{}',
+  attributes jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.graph_history (
+  id uuid primary key default gen_random_uuid(),
+  entity_kind text not null check (entity_kind in ('node', 'edge')),
+  entity_id text not null,
+  operation text not null,
+  payload jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists graph_nodes_ontology_type_idx
+on public.graph_nodes (ontology_type);
+
+create index if not exists graph_edges_source_target_idx
+on public.graph_edges (source_node_id, target_node_id);
+
+alter table public.graph_nodes enable row level security;
+alter table public.graph_edges enable row level security;
+alter table public.graph_history enable row level security;


### PR DESCRIPTION
## Summary

Implements issues #25 through #36 in strict commit order.

- Hardened WorldSpect ingest persistence and canonical hashing/upsert behavior.
- Made `/api/worldspect/real` read-only and moved Python execution to protected `/api/worldspect/diagnostic`.
- Normalized `/api/worldspect/global` around the shared WorldSpect response mapper.
- Added sourceHealth derivation from real sources.
- Added minimal epistemic event store routes and migrations.
- Added CAMPO-OB mapper, SFI kernel/runtime scaffolding, Delta/Policy packages, runtime health, graph persistence, and runtime ownership quarantine docs.

## Validation

- `npm run build`
- `npx tsc --noEmit --pretty false --incremental false`
- `npm run check:boundaries`
- `GET /api/worldspect/real` on local `next start` returned `ok: true` with missing snapshot warning and did not execute Python.
- `GET /api/worldspect/global` on local `next start` returned shared contract shape.
- `python services/python/world_cli.py` output parsed as valid JSON.

Closes #25
Closes #26
Closes #27
Closes #28
Closes #29
Closes #30
Closes #31
Closes #32
Closes #33
Closes #34
Closes #35
Closes #36