### PR TITLE
MACROPHASE C · Kernel Loop Runtime

### DIFF
--- a/packages/campo-ob/src/index.ts
+++ b/packages/campo-ob/src/index.ts
@@ -118,6 +118,11 @@ export type CampoWorldSpectSnapshot = {
   ts: string;
   sources: CampoWorldSpectSource[];
   degraded_sources: string[];
+  snapshot?: {
+    id?: string;
+    snapshotHash?: string;
+    observedAt?: string;
+  };
 };
 
 export type CampoObNode = {

--- a/packages/delta-engine/package.json
+++ b/packages/delta-engine/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sfi/delta-engine",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/delta-engine/src/index.ts
+++ b/packages/delta-engine/src/index.ts
@@ -1,0 +1,81 @@
+export type KernelDeltaInput = {
+  campo: {
+    confidence: number;
+    sourceState: 'observed' | 'degraded' | 'missing';
+    nodes: Array<{ ontologyDistance: number; nti: number | null; simulated: boolean }>;
+  };
+  mihm: {
+    confidence: number;
+    degradation: number;
+    operationalCapacity: number;
+    vector: { nti: number; ldi: number; phi?: number };
+    warnings: string[];
+  };
+};
+
+export type KernelDeltaResult = {
+  vector: {
+    confidenceGap: number;
+    sourceDegradation: number;
+    ontologySpread: number;
+    ntiPressure: number;
+    mihmDegradation: number;
+    capacityGap: number;
+  };
+  score: number;
+  trace: string[];
+};
+
+function clamp01(value: number) {
+  return Math.max(0, Math.min(1, Number.isFinite(value) ? value : 0));
+}
+
+function average(values: number[]) {
+  return values.length > 0 ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
+}
+
+export function computeKernelDelta(input: KernelDeltaInput): KernelDeltaResult {
+  const confidenceGap = 1 - clamp01((input.campo.confidence + input.mihm.confidence) / 2);
+  const sourceDegradation = input.campo.sourceState === 'missing'
+    ? 1
+    : input.campo.sourceState === 'degraded'
+      ? 0.55
+      : 0;
+  const ontologySpread = clamp01(average(input.campo.nodes.map((node) => node.ontologyDistance)));
+  const ntiPressure = clamp01(
+    average(input.campo.nodes.map((node) => node.nti ?? 0))
+    + (input.campo.nodes.some((node) => node.simulated) ? 0.15 : 0)
+    + (input.mihm.vector.nti * 0.2),
+  );
+  const mihmDegradation = clamp01(input.mihm.degradation + (input.mihm.vector.ldi * 0.2));
+  const capacityGap = clamp01(1 - input.mihm.operationalCapacity);
+  const vector = {
+    confidenceGap: Number(confidenceGap.toFixed(4)),
+    sourceDegradation: Number(sourceDegradation.toFixed(4)),
+    ontologySpread: Number(ontologySpread.toFixed(4)),
+    ntiPressure: Number(ntiPressure.toFixed(4)),
+    mihmDegradation: Number(mihmDegradation.toFixed(4)),
+    capacityGap: Number(capacityGap.toFixed(4)),
+  };
+  const score = clamp01(
+    (vector.confidenceGap * 0.18)
+    + (vector.sourceDegradation * 0.22)
+    + (vector.ontologySpread * 0.1)
+    + (vector.ntiPressure * 0.18)
+    + (vector.mihmDegradation * 0.18)
+    + (vector.capacityGap * 0.14),
+  );
+
+  return {
+    vector,
+    score: Number(score.toFixed(4)),
+    trace: [
+      `confidence_gap=${vector.confidenceGap}`,
+      `source_degradation=${vector.sourceDegradation}`,
+      `ontology_spread=${vector.ontologySpread}`,
+      `nti_pressure=${vector.ntiPressure}`,
+      `mihm_degradation=${vector.mihmDegradation}`,
+      `capacity_gap=${vector.capacityGap}`,
+    ],
+  };
+}

--- a/packages/delta/src/index.ts
+++ b/packages/delta/src/index.ts
@@ -53,3 +53,6 @@ export function computeDelta(input: DeltaInput): DeltaResult {
     ],
   };
 }
+
+export { computeKernelDelta } from '../../delta-engine/src';
+export type { KernelDeltaInput, KernelDeltaResult } from '../../delta-engine/src';

--- a/packages/mihm-core/src/index.ts
+++ b/packages/mihm-core/src/index.ts
@@ -35,6 +35,36 @@ export type MihmComputationResult = {
   warnings: string[];
 };
 
+export type ReducedMihmCampoInput = {
+  confidence: number;
+  sourceState: 'observed' | 'degraded' | 'missing';
+  nodes: Array<{
+    type: string;
+    weight: number;
+    value: number | null;
+    nti: number | null;
+    simulated: boolean;
+  }>;
+};
+
+export type ReducedMihmGraphInput = {
+  sourceState: 'observed' | 'degraded' | 'missing';
+  nodes: unknown[];
+  edges: Array<{ weight?: number | null }>;
+};
+
+export type ReducedMihmInput = {
+  observedAt: string;
+  campo: ReducedMihmCampoInput;
+  graph: ReducedMihmGraphInput;
+};
+
+export type ReducedMihmResult = MihmComputationResult & {
+  sourceIds: string[];
+  degradation: number;
+  operationalCapacity: number;
+};
+
 export function clamp01(value: number) {
   if (!Number.isFinite(value)) return 0;
   return Math.min(1, Math.max(0, value));
@@ -98,4 +128,59 @@ export function deriveRegime(
   if (p < 0.25 || d >= 0.75 || co < 0.25) return 'critical';
   if (p < 0.5 || d >= 0.45 || co < 0.5) return 'watch';
   return 'stable';
+}
+
+function average(values: number[]) {
+  return values.length > 0 ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
+}
+
+export function computeReducedMihm(input: ReducedMihmInput): ReducedMihmResult {
+  const campoNodes = input.campo.nodes;
+  const graphNodeCount = input.graph.nodes.length;
+  const graphEdgeCount = input.graph.edges.length;
+  const totalGraph = Math.max(1, graphNodeCount + graphEdgeCount);
+  const graphDensity = clamp01(graphEdgeCount / totalGraph);
+  const avgWeight = clamp01(average(campoNodes.map((node) => node.weight)));
+  const avgValue = clamp01(average(campoNodes.map((node) => typeof node.value === 'number' ? node.value : 0)));
+  const avgNti = clamp01(average(campoNodes.map((node) => typeof node.nti === 'number' ? node.nti : 0)));
+  const simulatedRatio = clamp01(campoNodes.filter((node) => node.simulated).length / Math.max(1, campoNodes.length));
+  const sourcePenalty = input.campo.sourceState === 'missing'
+    ? 1
+    : input.campo.sourceState === 'degraded'
+      ? 0.45
+      : 0;
+  const graphPenalty = input.graph.sourceState === 'observed' && graphEdgeCount > 0 ? 0 : 0.35;
+
+  const ihg = clamp01((input.campo.confidence * 0.45) + (avgWeight * 0.25) + (graphDensity * 0.2) + (avgValue * 0.1));
+  const nti = clamp01((avgNti * 0.55) + (sourcePenalty * 0.25) + (simulatedRatio * 0.2));
+  const ldi = clamp01((sourcePenalty * 0.45) + (graphPenalty * 0.25) + ((1 - input.campo.confidence) * 0.2) + (simulatedRatio * 0.1));
+  const phi = clamp01(ihg * (1 - ldi) * (1 - (nti * 0.35)));
+  const qualified = qualifyNode({
+    id: 'sfi.kernel',
+    type: 'field',
+    vector: { ihg, nti, ldi, phi },
+    weight: avgWeight,
+  });
+  const degradation = degradeNode(qualified, 0.35, 1, ldi * 0.25);
+  const operationalCapacityValue = operationalCapacity(qualified, degradation, avgWeight, graphDensity);
+  const warnings = [
+    ...(input.campo.sourceState === 'observed' ? [] : [`campo_${input.campo.sourceState}`]),
+    ...(input.graph.sourceState === 'observed' && graphEdgeCount > 0 ? [] : ['graph_not_observed']),
+    ...(simulatedRatio > 0 ? ['simulated_sources_present'] : []),
+  ];
+
+  return {
+    regime: deriveRegime(phi, degradation, operationalCapacityValue),
+    vector: {
+      ihg: Number(ihg.toFixed(4)),
+      nti: Number(nti.toFixed(4)),
+      ldi: Number(ldi.toFixed(4)),
+      phi: Number(phi.toFixed(4)),
+    },
+    confidence: Number(clamp01(input.campo.confidence * (1 - (sourcePenalty * 0.3)) * (1 - (graphPenalty * 0.2))).toFixed(4)),
+    warnings,
+    sourceIds: campoNodes.map((node) => node.type),
+    degradation: Number(degradation.toFixed(4)),
+    operationalCapacity: Number(operationalCapacityValue.toFixed(4)),
+  };
 }

--- a/packages/policy-runtime/package.json
+++ b/packages/policy-runtime/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sfi/policy-runtime",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/policy-runtime/src/index.ts
+++ b/packages/policy-runtime/src/index.ts
@@ -1,0 +1,55 @@
+export type KernelPolicyDecision = {
+  allowed: boolean;
+  status: 'committed' | 'degraded' | 'blocked';
+  reason: string;
+  thresholds: {
+    minConfidence: number;
+    maxDelta: number;
+    minOperationalCapacity: number;
+  };
+  trace: string[];
+};
+
+export function evaluateKernelPolicy(input: {
+  sourceState: 'observed' | 'degraded' | 'missing';
+  confidence: number;
+  deltaScore: number;
+  operationalCapacity: number;
+  hasSimulatedSources?: boolean;
+  warnings?: string[];
+}): KernelPolicyDecision {
+  const thresholds = {
+    minConfidence: input.sourceState === 'observed' ? 0.45 : 0.55,
+    maxDelta: input.sourceState === 'observed' ? 0.72 : 0.55,
+    minOperationalCapacity: 0.25,
+  };
+  const trace = [
+    `source_state=${input.sourceState}`,
+    `confidence=${input.confidence}`,
+    `delta=${input.deltaScore}`,
+    `operational_capacity=${input.operationalCapacity}`,
+    ...(input.warnings ?? []).map((warning) => `warning=${warning}`),
+  ];
+
+  if (input.sourceState === 'missing') {
+    return { allowed: false, status: 'blocked', reason: 'worldspect_missing', thresholds, trace };
+  }
+
+  if (input.confidence < thresholds.minConfidence) {
+    return { allowed: false, status: 'blocked', reason: 'confidence_below_threshold', thresholds, trace };
+  }
+
+  if (input.deltaScore > thresholds.maxDelta) {
+    return { allowed: true, status: 'degraded', reason: 'delta_above_observed_band', thresholds, trace };
+  }
+
+  if (input.operationalCapacity < thresholds.minOperationalCapacity) {
+    return { allowed: true, status: 'degraded', reason: 'capacity_below_operational_band', thresholds, trace };
+  }
+
+  if (input.hasSimulatedSources) {
+    return { allowed: true, status: 'degraded', reason: 'simulated_sources_present', thresholds, trace };
+  }
+
+  return { allowed: true, status: 'committed', reason: 'policy_allowed', thresholds, trace };
+}

--- a/packages/policy/src/index.ts
+++ b/packages/policy/src/index.ts
@@ -51,3 +51,6 @@ export function evaluatePolicy(input: {
 
   return { allowed: true, reason: 'policy_allowed', thresholds, trace };
 }
+
+export { evaluateKernelPolicy } from '../../policy-runtime/src';
+export type { KernelPolicyDecision } from '../../policy-runtime/src';

--- a/packages/sfi-kernel/src/cycle.ts
+++ b/packages/sfi-kernel/src/cycle.ts
@@ -1,39 +1,104 @@
 import { mapWorldSpectToCampo } from '../../campo-ob/src';
-import { computeDelta } from '../../delta/src';
-import { evaluatePolicy } from '../../policy/src';
-import type { SfiKernelAdapters, SfiKernelCycleResult } from './state';
+import { computeReducedMihm } from '../../mihm-core/src';
+import { computeKernelDelta } from '../../delta-engine/src';
+import { evaluateKernelPolicy } from '../../policy-runtime/src';
+import type { SfiKernelAdapters, SfiKernelCycleRecord, SfiKernelCycleResult } from './state';
+
+function cycleIdFor(observedAt: string) {
+  return `kernel:${observedAt}:${Math.random().toString(36).slice(2, 10)}`;
+}
 
 export async function cycle(adapters: SfiKernelAdapters): Promise<SfiKernelCycleResult> {
   const worldSpect = await adapters.readWorldSpect();
+  const graph = await adapters.readGraph();
   const campo = mapWorldSpectToCampo(worldSpect);
-  const delta = computeDelta({
-    confidence: campo.confidence,
-    sourceState: campo.sourceState,
-    nodes: campo.nodes,
-  });
-  const policy = evaluatePolicy({
-    epistemicClass: campo.sourceState === 'missing' ? 'missing' : 'derived',
-    confidence: campo.confidence,
-    deltaScore: delta.score,
-    hasSimulatedSources: campo.nodes.some((node) => node.simulated),
-  });
-
-  if (policy.allowed) {
-    await adapters.appendEvent({
-      eventName: 'sfi.kernel.cycle',
-      epistemicClass: 'derived',
-      confidence: campo.confidence,
-      payload: { campo, delta, policy },
-      occurredAt: campo.observedAt,
-      logbookId: 'sfi-kernel',
-    });
-  }
-
-  return {
+  const mihm = computeReducedMihm({
     observedAt: campo.observedAt,
     campo,
+    graph: {
+      sourceState: graph.sourceState === 'observed' ? 'observed' : 'degraded',
+      nodes: graph.nodes,
+      edges: graph.edges,
+    },
+  });
+  const delta = computeKernelDelta({
+    campo,
+    mihm,
+  });
+  const policy = evaluateKernelPolicy({
+    sourceState: campo.sourceState,
+    confidence: mihm.confidence,
+    deltaScore: delta.score,
+    operationalCapacity: mihm.operationalCapacity,
+    hasSimulatedSources: campo.nodes.some((node) => node.simulated),
+    warnings: [
+      ...mihm.warnings,
+      ...(graph.degradedReason ? [graph.degradedReason] : []),
+    ],
+  });
+  const observedAt = campo.observedAt;
+  const cycleId = cycleIdFor(observedAt);
+  const event = await adapters.appendEvent({
+    eventName: 'kernel.cycle.executed',
+    epistemicClass: campo.sourceState === 'observed' && graph.sourceState === 'observed' ? 'observed' : 'derived',
+    confidence: mihm.confidence,
+    payload: {
+      cycleId,
+      sourceState: campo.sourceState,
+      graph: {
+        sourceState: graph.sourceState,
+        nodeCount: graph.nodes.length,
+        edgeCount: graph.edges.length,
+        degradedReason: graph.degradedReason,
+      },
+      campo,
+      mihm,
+      delta,
+      policy,
+    },
+    occurredAt: observedAt,
+    logbookId: 'BR',
+    lineage: [
+      worldSpect.snapshot?.snapshotHash ?? campo.snapshotHashInput,
+      graph.loadedAt,
+    ],
+  });
+  const eventId = event?.id ?? null;
+
+  const cycleRecord: SfiKernelCycleRecord = {
+    cycleId,
+    observedAt,
+    status: policy.status,
+    sourceState: campo.sourceState,
+    confidence: mihm.confidence,
+    worldspectSnapshotId: worldSpect.snapshot?.id ?? null,
+    graphNodeCount: graph.nodes.length,
+    graphEdgeCount: graph.edges.length,
+    campo,
+    mihm,
     delta,
     policy,
-    emitted: policy.allowed,
+    epistemicEventId: eventId,
+  };
+  await adapters.persistCycle(cycleRecord);
+
+  return {
+    cycleId,
+    observedAt,
+    sourceState: campo.sourceState,
+    confidence: mihm.confidence,
+    campo,
+    graph: {
+      sourceState: graph.sourceState,
+      nodeCount: graph.nodes.length,
+      edgeCount: graph.edges.length,
+      degradedReason: graph.degradedReason,
+    },
+    mihm,
+    delta,
+    policy,
+    persisted: true,
+    eventId,
+    emitted: Boolean(eventId),
   };
 }

--- a/packages/sfi-kernel/src/index.ts
+++ b/packages/sfi-kernel/src/index.ts
@@ -1,4 +1,4 @@
 export { bootstrapSfiKernel } from './bootstrap';
 export { cycle } from './cycle';
 export { createSfiKernelRuntime } from './runtime';
-export type { SfiKernelAdapters, SfiKernelCycleResult, SfiKernelRuntimeState } from './state';
+export type { SfiKernelAdapters, SfiKernelCycleRecord, SfiKernelCycleResult, SfiKernelRuntimeState } from './state';

--- a/packages/sfi-kernel/src/state.ts
+++ b/packages/sfi-kernel/src/state.ts
@@ -1,9 +1,12 @@
 import type { CampoObState, CampoWorldSpectSnapshot } from '../../campo-ob/src';
-import type { DeltaResult } from '../../delta/src';
-import type { PolicyDecision } from '../../policy/src';
+import type { CanonicalGraphState } from '../../graph/src';
+import type { ReducedMihmResult } from '../../mihm-core/src';
+import type { KernelDeltaResult } from '../../delta-engine/src';
+import type { KernelPolicyDecision } from '../../policy-runtime/src';
 
 export type SfiKernelAdapters = {
   readWorldSpect: () => Promise<CampoWorldSpectSnapshot>;
+  readGraph: () => Promise<CanonicalGraphState>;
   appendEvent: (event: {
     eventName: string;
     epistemicClass: 'observed' | 'derived' | 'missing';
@@ -12,14 +15,43 @@ export type SfiKernelAdapters = {
     occurredAt: string;
     logbookId: string;
     lineage?: string[];
-  }) => Promise<unknown>;
+  }) => Promise<{ id: string } | null>;
+  persistCycle: (cycle: SfiKernelCycleRecord) => Promise<unknown>;
+};
+
+export type SfiKernelCycleRecord = {
+  cycleId: string;
+  observedAt: string;
+  status: 'committed' | 'degraded' | 'blocked';
+  sourceState: 'observed' | 'degraded' | 'missing';
+  confidence: number;
+  worldspectSnapshotId: string | null;
+  graphNodeCount: number;
+  graphEdgeCount: number;
+  campo: CampoObState;
+  mihm: ReducedMihmResult;
+  delta: KernelDeltaResult;
+  policy: KernelPolicyDecision;
+  epistemicEventId?: string | null;
 };
 
 export type SfiKernelCycleResult = {
+  cycleId: string;
   observedAt: string;
+  sourceState: 'observed' | 'degraded' | 'missing';
+  confidence: number;
   campo: CampoObState;
-  delta: DeltaResult;
-  policy: PolicyDecision;
+  graph: {
+    sourceState: CanonicalGraphState['sourceState'];
+    nodeCount: number;
+    edgeCount: number;
+    degradedReason: string | null;
+  };
+  mihm: ReducedMihmResult;
+  delta: KernelDeltaResult;
+  policy: KernelPolicyDecision;
+  persisted: boolean;
+  eventId: string | null;
   emitted: boolean;
 };
 

--- a/src/app/api/kernel/cycle/route.ts
+++ b/src/app/api/kernel/cycle/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { getServerUserContext } from '@/lib/server/productionBackend';
+import { runKernelCycle } from '@/lib/kernel/runKernelCycle';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  const ctx = await getServerUserContext();
+
+  if (!ctx.user) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const result = await runKernelCycle();
+
+  if (!result.ok) {
+    return NextResponse.json(result, { status: 409 });
+  }
+
+  return NextResponse.json(result);
+}

--- a/src/app/api/runtime/bootstrap/route.ts
+++ b/src/app/api/runtime/bootstrap/route.ts
@@ -4,6 +4,7 @@ import { getEntitlements } from '@/lib/licensing/entitlements';
 import { parseGraphProfile, readCanonicalGraphState } from '@/lib/graph/canonicalGraph';
 import { getLatestWorldSpectSnapshot, snapshotRowToApiData } from '@/lib/worldspect/snapshotStore';
 import { missingWorldSpectResponse } from '@/lib/worldspect/contract';
+import { getLatestKernelCycle } from '@/lib/kernel/kernelCycleStore';
 
 export const dynamic = 'force-dynamic';
 
@@ -41,9 +42,10 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ ok: false, error: nodeError ?? 'node_not_found' }, { status: nodeError ? 500 : 404 });
   }
 
-  const [graph, latestWorldSpect, entitlements] = await Promise.all([
+  const [graph, latestWorldSpect, latestKernelCycle, entitlements] = await Promise.all([
     readCanonicalGraphState(profile),
     getLatestWorldSpectSnapshot(),
+    getLatestKernelCycle(),
     ctx.isRoot ? Promise.resolve(ROOT_ENTITLEMENTS) : getEntitlements(ctx.user.id),
   ]);
   const now = new Date().toISOString();
@@ -80,12 +82,25 @@ export async function GET(request: NextRequest) {
       field,
       graph,
       worldspect: latestWorldSpect ? snapshotRowToApiData(latestWorldSpect) : missingWorldSpectResponse(now),
+      kernel: latestKernelCycle
+        ? {
+          status: latestKernelCycle.status,
+          cycleId: latestKernelCycle.cycle_id,
+          observedAt: latestKernelCycle.observed_at,
+          confidence: latestKernelCycle.confidence,
+          sourceState: latestKernelCycle.source_state,
+          graphNodeCount: latestKernelCycle.graph_node_count,
+          graphEdgeCount: latestKernelCycle.graph_edge_count,
+          epistemicEventId: latestKernelCycle.epistemic_event_id,
+        }
+        : null,
       entitlements,
       loadedAt: now,
       warnings: [
         ...(nodeError ? [nodeError] : []),
         ...(graph.degradedReason ? [graph.degradedReason] : []),
         ...(latestWorldSpect ? [] : ['worldspect_snapshot_missing']),
+        ...(latestKernelCycle ? [] : ['kernel_cycle_missing']),
       ],
     },
   });

--- a/src/lib/kernel/kernelCycleStore.ts
+++ b/src/lib/kernel/kernelCycleStore.ts
@@ -1,0 +1,65 @@
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import type { SfiKernelCycleRecord } from '../../../packages/sfi-kernel/src';
+
+export type KernelCycleRow = {
+  id: string;
+  cycle_id: string;
+  epistemic_event_id: string | null;
+  worldspect_snapshot_id: string | null;
+  observed_at: string;
+  source_state: 'observed' | 'degraded' | 'missing';
+  status: 'committed' | 'degraded' | 'blocked';
+  confidence: number;
+  graph_node_count: number;
+  graph_edge_count: number;
+  campo: unknown;
+  mihm: unknown;
+  delta: unknown;
+  policy: unknown;
+  created_at: string;
+};
+
+export async function persistKernelCycle(record: SfiKernelCycleRecord) {
+  const service = createServiceSupabaseClient();
+  const { data, error } = await service
+    .from('kernel_cycles')
+    .insert({
+      cycle_id: record.cycleId,
+      epistemic_event_id: record.epistemicEventId ?? null,
+      worldspect_snapshot_id: record.worldspectSnapshotId,
+      observed_at: record.observedAt,
+      source_state: record.sourceState,
+      status: record.status,
+      confidence: record.confidence,
+      graph_node_count: record.graphNodeCount,
+      graph_edge_count: record.graphEdgeCount,
+      campo: record.campo,
+      mihm: record.mihm,
+      delta: record.delta,
+      policy: record.policy,
+    })
+    .select('*')
+    .single();
+
+  if (error) {
+    return { ok: false as const, error: 'kernel_cycle_persist_failed', details: error.message };
+  }
+
+  return { ok: true as const, data: data as KernelCycleRow };
+}
+
+export async function getLatestKernelCycle() {
+  const service = createServiceSupabaseClient();
+  const { data, error } = await service
+    .from('kernel_cycles')
+    .select('*')
+    .order('observed_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) {
+    return null;
+  }
+
+  return data as KernelCycleRow;
+}

--- a/src/lib/kernel/runKernelCycle.ts
+++ b/src/lib/kernel/runKernelCycle.ts
@@ -1,0 +1,44 @@
+import { appendEpistemicEvent } from '@/lib/events/eventStore';
+import { readCanonicalGraphState } from '@/lib/graph/canonicalGraph';
+import { getLatestWorldSpectSnapshot, snapshotRowToApiData } from '@/lib/worldspect/snapshotStore';
+import { cycle } from '../../../packages/sfi-kernel/src';
+import { persistKernelCycle } from './kernelCycleStore';
+
+export async function runKernelCycle() {
+  const latestWorldSpect = await getLatestWorldSpectSnapshot();
+
+  if (!latestWorldSpect) {
+    return { ok: false as const, error: 'worldspect_snapshot_missing' };
+  }
+
+  const result = await cycle({
+    readWorldSpect: async () => snapshotRowToApiData(latestWorldSpect),
+    readGraph: async () => readCanonicalGraphState('sfi'),
+    appendEvent: async (event) => {
+      const appended = await appendEpistemicEvent({
+        ...event,
+        source: {
+          sourceId: 'sfi-kernel',
+          sourceType: 'runtime',
+        },
+      });
+
+      if (!appended.ok) {
+        throw new Error(appended.error);
+      }
+
+      return typeof appended.data.id === 'string' ? { id: appended.data.id } : null;
+    },
+    persistCycle: async (record) => {
+      const persisted = await persistKernelCycle(record);
+
+      if (!persisted.ok) {
+        throw new Error(`${persisted.error}: ${persisted.details}`);
+      }
+
+      return persisted.data;
+    },
+  });
+
+  return { ok: true as const, data: result };
+}

--- a/supabase/migrations/20260527124000_create_kernel_cycles.sql
+++ b/supabase/migrations/20260527124000_create_kernel_cycles.sql
@@ -1,0 +1,25 @@
+create table if not exists public.kernel_cycles (
+  id uuid primary key default gen_random_uuid(),
+  cycle_id text not null unique,
+  epistemic_event_id uuid null references public.epistemic_events(id),
+  worldspect_snapshot_id uuid null references public.worldspect_snapshots(id),
+  observed_at timestamptz not null,
+  source_state text not null check (source_state in ('observed', 'degraded', 'missing')),
+  status text not null check (status in ('committed', 'degraded', 'blocked')),
+  confidence numeric not null default 0 check (confidence >= 0 and confidence <= 1),
+  graph_node_count integer not null default 0 check (graph_node_count >= 0),
+  graph_edge_count integer not null default 0 check (graph_edge_count >= 0),
+  campo jsonb not null default '{}'::jsonb,
+  mihm jsonb not null default '{}'::jsonb,
+  delta jsonb not null default '{}'::jsonb,
+  policy jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists kernel_cycles_observed_at_idx
+on public.kernel_cycles (observed_at desc);
+
+create index if not exists kernel_cycles_status_idx
+on public.kernel_cycles (status);
+
+alter table public.kernel_cycles enable row level security;


### PR DESCRIPTION
Closes #32

## Scope
- Adds the real kernel cycle path: WorldSpect snapshot -> CAMPO-OB -> reduced MIHM -> Delta Engine -> Policy Runtime -> epistemic event store -> kernel_cycles.
- Adds pure packages for `@sfi/delta-engine` and `@sfi/policy-runtime`, while preserving existing `@sfi/delta` and `@sfi/policy` exports.
- Extends `packages/sfi-kernel` to read graph state, compute MIHM/Delta/Policy, append a kernel epistemic event, and persist the cycle.
- Adds `POST /api/kernel/cycle` as the minimal authenticated runner.
- Exposes latest kernel cycle summary from `GET /api/runtime/bootstrap` when present.
- Adds official `kernel_cycles` persistence table. No frontend logic or UI redesign.

## Validation completed locally
- `npx tsc --noEmit --pretty false --incremental false` passed.
- `npm run check:boundaries` passed.
- `npm run build` passed.

## Pending before merge
- Apply DB migration and run a real kernel cycle in production/preview.
- Verify `kernel_cycles` has at least 1 new row.
- Verify `epistemic_events` has `kernel.cycle.executed`.
- Verify `GET /api/runtime/bootstrap` includes latest kernel status/cycle.

Do not merge until DB and endpoint validations pass.