### PR TITLE
BLOQUE 1 · Cognitive Closure

### DIFF
--- a/packages/cognitive-runtime/package.json
+++ b/packages/cognitive-runtime/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sfi/cognitive-runtime",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/cognitive-runtime/src/index.ts
+++ b/packages/cognitive-runtime/src/index.ts
@@ -1,0 +1,131 @@
+export type CognitiveThoughtType =
+  | 'CONTRADICTION'
+  | 'CLOSURE'
+  | 'FIELD_NOTE'
+  | 'INHIBITION_CHECK';
+
+export type CognitiveEvidence = {
+  id?: string;
+  type: string;
+  content?: string;
+  confidence?: number;
+  polarity?: 'supports' | 'contradicts' | 'neutral';
+};
+
+export type CognitiveThoughtInput = {
+  thoughtType?: string;
+  claim?: string;
+  evidence?: CognitiveEvidence[];
+  thresholds?: {
+    minEvidenceCount?: number;
+    minEvidenceTypes?: number;
+    minConfidence?: number;
+  };
+};
+
+export type CognitiveClosureResult = {
+  thoughtType: CognitiveThoughtType;
+  claim: string;
+  status: 'closed' | 'inhibited';
+  inhibited: boolean;
+  reason: string | null;
+  confidence: number;
+  evidenceCount: number;
+  evidenceTypes: string[];
+  contradiction: {
+    detected: boolean;
+    score: number;
+    markers: string[];
+  };
+  thresholds: {
+    minEvidenceCount: number;
+    minEvidenceTypes: number;
+    minConfidence: number;
+  };
+};
+
+const contradictionMarkers = [
+  'pero',
+  'aunque',
+  'sin embargo',
+  'no obstante',
+  'contradiccion',
+  'contradicción',
+  'inconsistente',
+  'incompatible',
+];
+
+function clamp01(value: number) {
+  return Math.max(0, Math.min(1, Number.isFinite(value) ? value : 0));
+}
+
+function normalizeType(value: unknown): CognitiveThoughtType {
+  const raw = typeof value === 'string' ? value.trim().toUpperCase() : '';
+  if (raw === 'CONTRADICCION') return 'CONTRADICTION';
+  if (raw === 'CONTRADICTION' || raw === 'CLOSURE' || raw === 'FIELD_NOTE' || raw === 'INHIBITION_CHECK') return raw;
+  return 'FIELD_NOTE';
+}
+
+function normalizeText(value: unknown) {
+  return typeof value === 'string' ? value.trim().replace(/\s+/g, ' ') : '';
+}
+
+function averageConfidence(evidence: CognitiveEvidence[]) {
+  if (evidence.length === 0) return 0;
+  const total = evidence.reduce((sum, item) => sum + clamp01(Number(item.confidence ?? 0.5)), 0);
+  return clamp01(total / evidence.length);
+}
+
+function contradictionFor(claim: string, evidence: CognitiveEvidence[]) {
+  const haystack = [claim, ...evidence.map((item) => item.content ?? '')].join(' ').toLowerCase();
+  const markers = contradictionMarkers.filter((marker) => haystack.includes(marker));
+  const supports = evidence.some((item) => item.polarity === 'supports');
+  const contradicts = evidence.some((item) => item.polarity === 'contradicts');
+  const polarityScore = supports && contradicts ? 0.45 : 0;
+  const markerScore = Math.min(0.55, markers.length * 0.18);
+  const score = clamp01(markerScore + polarityScore);
+
+  return {
+    detected: score >= 0.35,
+    score: Number(score.toFixed(4)),
+    markers,
+  };
+}
+
+export function evaluateCognitiveClosure(input: CognitiveThoughtInput): CognitiveClosureResult {
+  const thoughtType = normalizeType(input.thoughtType);
+  const claim = normalizeText(input.claim);
+  const evidence = Array.isArray(input.evidence)
+    ? input.evidence.filter((item) => item && typeof item.type === 'string' && item.type.trim().length > 0)
+    : [];
+  const evidenceTypes = Array.from(new Set(evidence.map((item) => item.type.trim())));
+  const contradiction = contradictionFor(claim, evidence);
+  const thresholds = {
+    minEvidenceCount: input.thresholds?.minEvidenceCount ?? (thoughtType === 'CONTRADICTION' || contradiction.detected ? 3 : 2),
+    minEvidenceTypes: input.thresholds?.minEvidenceTypes ?? (thoughtType === 'CONTRADICTION' || contradiction.detected ? 2 : 1),
+    minConfidence: input.thresholds?.minConfidence ?? 0.45,
+  };
+  const confidence = Number(averageConfidence(evidence).toFixed(4));
+  const reason = evidence.length < thresholds.minEvidenceCount
+    ? 'insufficient_evidence_count'
+    : evidenceTypes.length < thresholds.minEvidenceTypes
+      ? 'insufficient_evidence_types'
+      : confidence < thresholds.minConfidence
+        ? 'confidence_below_threshold'
+        : claim.length === 0
+          ? 'missing_claim'
+          : null;
+
+  return {
+    thoughtType,
+    claim,
+    status: reason ? 'inhibited' : 'closed',
+    inhibited: Boolean(reason),
+    reason,
+    confidence,
+    evidenceCount: evidence.length,
+    evidenceTypes,
+    contradiction,
+    thresholds,
+  };
+}

--- a/src/app/api/runtime/bootstrap/route.ts
+++ b/src/app/api/runtime/bootstrap/route.ts
@@ -7,6 +7,7 @@ import { missingWorldSpectResponse } from '@/lib/worldspect/contract';
 import { getLatestKernelCycle } from '@/lib/kernel/kernelCycleStore';
 import { readGovernanceRuntime } from '@/lib/governance/governanceRuntime';
 import { readRecentThoughtInhibitions } from '@/lib/governance/thoughtInhibition';
+import { readRecentThoughtClosures } from '@/lib/cognitive/thoughtClosure';
 
 export const dynamic = 'force-dynamic';
 
@@ -32,12 +33,13 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ ok: false, error: nodeError ?? 'node_not_found' }, { status: nodeError ? 500 : 404 });
   }
 
-  const [graph, latestWorldSpect, latestKernelCycle, governance, recentThoughtInhibitions, entitlements] = await Promise.all([
+  const [graph, latestWorldSpect, latestKernelCycle, governance, recentThoughtInhibitions, recentThoughtClosures, entitlements] = await Promise.all([
     readCanonicalGraphState(profile),
     getLatestWorldSpectSnapshot(),
     getLatestKernelCycle(),
     readGovernanceRuntime(),
     readRecentThoughtInhibitions(),
+    readRecentThoughtClosures(),
     ctx.isRoot ? Promise.resolve(ROOT_ENTITLEMENTS) : getEntitlements(ctx.user.id),
   ]);
 
@@ -96,6 +98,7 @@ export async function GET(request: NextRequest) {
       governance,
       governanceRuntime: {
         recentThoughtInhibitions,
+        recentThoughtClosures,
       },
       entitlements,
       loadedAt: now,

--- a/src/app/api/thoughts/evaluate/route.ts
+++ b/src/app/api/thoughts/evaluate/route.ts
@@ -12,17 +12,11 @@ export async function POST(req: Request) {
   }
 
   const body = await req.json().catch(() => ({}));
-
   const result = await evaluateThoughtClosure({
     actorId: ctx.user.id,
     thoughtType: body?.thoughtType,
     claim: body?.claim,
-    evidence: Array.isArray(body?.evidence)
-      ? body.evidence
-      : Array.from({ length: Number(body?.evidenceCount ?? 0) }, (_, index) => ({
-        type: Array.isArray(body?.evidenceTypes) ? body.evidenceTypes[index] ?? 'declared' : 'declared',
-        confidence: 0.5,
-      })),
+    evidence: Array.isArray(body?.evidence) ? body.evidence : [],
     payload: body?.payload && typeof body.payload === 'object' ? body.payload : {},
   });
 

--- a/src/lib/cognitive/thoughtClosure.ts
+++ b/src/lib/cognitive/thoughtClosure.ts
@@ -1,0 +1,97 @@
+import { appendEpistemicEvent } from '@/lib/events/eventStore';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { evaluateThoughtInhibition } from '@/lib/governance/thoughtInhibition';
+import { evaluateCognitiveClosure, type CognitiveEvidence } from '../../../packages/cognitive-runtime/src';
+
+type ThoughtClosureInput = {
+  actorId: string;
+  thoughtType?: string;
+  claim?: string;
+  evidence?: CognitiveEvidence[];
+  payload?: Record<string, unknown>;
+};
+
+function inhibitionType(thoughtType: string) {
+  return thoughtType === 'CONTRADICTION' ? 'CONTRADICCION' : thoughtType;
+}
+
+export async function evaluateThoughtClosure(input: ThoughtClosureInput) {
+  const closure = evaluateCognitiveClosure({
+    thoughtType: input.thoughtType,
+    claim: input.claim,
+    evidence: input.evidence,
+  });
+  const evidenceTypes = closure.evidenceTypes;
+
+  if (closure.inhibited) {
+    const inhibition = await evaluateThoughtInhibition({
+      actorId: input.actorId,
+      thoughtType: inhibitionType(closure.thoughtType),
+      evidenceCount: closure.evidenceCount,
+      evidenceTypes,
+      reason: closure.reason ?? 'thought_inhibited',
+      payload: {
+        claim: closure.claim,
+        closure,
+        ...(input.payload ?? {}),
+      },
+    });
+
+    return {
+      ok: inhibition.ok,
+      data: closure,
+      inhibition,
+    };
+  }
+
+  const event = await appendEpistemicEvent({
+    eventName: 'cognitive.thought.closed',
+    epistemicClass: 'derived',
+    confidence: closure.confidence,
+    payload: {
+      closure,
+      evidence: input.evidence ?? [],
+      ...(input.payload ?? {}),
+    },
+    occurredAt: new Date().toISOString(),
+    source: {
+      sourceId: 'SYSTEM_FRICTION_INSTITUTE',
+      sourceType: 'cognitive_runtime',
+    },
+    logbookId: 'BR',
+    lineage: evidenceTypes,
+  });
+
+  if (!event.ok) {
+    return {
+      ok: false as const,
+      error: event.error,
+      details: 'details' in event ? event.details : undefined,
+      data: closure,
+    };
+  }
+
+  return {
+    ok: true as const,
+    data: {
+      ...closure,
+      eventId: event.data.id,
+    },
+  };
+}
+
+export async function readRecentThoughtClosures(limit = 5) {
+  const service = createServiceSupabaseClient();
+  const { data, error } = await service
+    .from('epistemic_events')
+    .select('id,event_id,event_name,confidence,payload,occurred_at,created_at')
+    .eq('event_name', 'cognitive.thought.closed')
+    .order('occurred_at', { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    return [];
+  }
+
+  return Array.isArray(data) ? data : [];
+}


### PR DESCRIPTION
Closes #41

## Scope
- Implements System Friction Institute cognitive closure for thought evaluation.
- Adds `packages/cognitive-runtime` with evidence thresholds, contradiction detection, and inhibition decisions.
- Adds `POST /api/thoughts/evaluate`.
- Routes the existing governance thought evaluation endpoint through the same closure flow.
- Persists closed thoughts as `cognitive.thought.closed` epistemic events only when evidence thresholds pass.
- Keeps insufficient evidence in the inhibition path.
- Exposes recent closed thoughts in `GET /api/runtime/bootstrap`.

## Constraints honored
- Did not advance #42 or #43.
- Did not create campaigns.
- Did not change UI design.
- Did not add schema.

## Validation
- `npx tsc --noEmit --pretty false --incremental false` passed.
- `npm run check:boundaries` passed.
- `npm run build` passed.
- Pure evaluator smoke test passed for closed and inhibited cases.
