### PR TITLE
Align MIHM process with real mihm_analyses schema

### DIFF
--- a/src/app/api/mihm/process/route.ts
+++ b/src/app/api/mihm/process/route.ts
@@ -12,6 +12,7 @@ export async function POST(req: Request) {
   const contentType = req.headers.get('content-type') ?? '';
   const input = contentType.includes('application/json') ? await req.json().catch(() => ({})) : await req.text();
   const analysis = analyzeMihmInput(input);
+  const inputKind = contentType.includes('application/json') ? 'json' : 'text';
   const event = await appendOperationalEvent({
     eventName: 'mihm.analysis.created',
     actorId: gate.ctx.user.id,
@@ -21,21 +22,31 @@ export async function POST(req: Request) {
   });
   if (!event.ok) return NextResponse.json(event, { status: 400 });
 
+  const visibleVariables = {
+    detected_dimensions: analysis.detected_dimensions,
+    claims: analysis.claims,
+    evidence: analysis.evidence,
+    source: 'api_mihm_process',
+  };
+  const sensitiveVariables = {
+    tensions: analysis.tensions,
+    risks: analysis.risks,
+    actor_id: gate.ctx.user.id,
+    payload: { input: recordValue(input), contentType },
+  };
+
   const service = createServiceSupabaseClient();
   const { data, error } = await service
     .from('mihm_analyses')
     .insert({
       event_id: event.data.id,
-      actor_id: gate.ctx.user.id,
-      input_hash: analysis.input_hash,
-      detected_dimensions: analysis.detected_dimensions,
-      claims: analysis.claims,
-      evidence: analysis.evidence,
-      tensions: analysis.tensions,
-      risks: analysis.risks,
+      input_kind: inputKind,
+      input_ref: analysis.input_hash,
+      visible_variables: visibleVariables,
+      sensitive_variables: sensitiveVariables,
       confidence: analysis.confidence,
       homeostatic_vector: analysis.homeostatic_vector,
-      payload: { input: recordValue(input), contentType },
+      uncertainty: analysis.confidence >= 0.7 ? 'low' : analysis.confidence >= 0.45 ? 'medium' : 'high',
     })
     .select('*')
     .single();

--- a/src/observatory/field/catalog/mihmRuntimeMatrix.ts
+++ b/src/observatory/field/catalog/mihmRuntimeMatrix.ts
@@ -30,10 +30,13 @@ export function buildMihmRuntimeMatrix(input: {
   const observed = latest(input.mihmAnalyses);
   if (observed) {
     const payload = asRecord(observed.payload || observed.result || observed.analysis);
-    const ihg = pickNumber(observed, ['ihg', 'IHG']) ?? pickNumber(payload, ['ihg', 'IHG']);
-    const nti = pickNumber(observed, ['nti', 'NTI', 'nti_obs']) ?? pickNumber(payload, ['nti', 'NTI', 'NTI_obs']);
-    const ldi = pickNumber(observed, ['ldi', 'LDI', 'ldi_hours']) ?? pickNumber(payload, ['ldi', 'LDI', 'LDI_hours']);
-    const phi = pickNumber(observed, ['phi', 'PHI_SF']) ?? pickNumber(payload, ['phi', 'PHI_SF']);
+    const vector = asRecord(observed.homeostatic_vector || payload.homeostatic_vector || payload.homeostaticVector);
+    const visible = asRecord(observed.visible_variables || payload.visible_variables || payload.visibleVariables);
+    const sensitive = asRecord(observed.sensitive_variables || payload.sensitive_variables || payload.sensitiveVariables);
+    const ihg = pickNumber(observed, ['ihg', 'IHG']) ?? pickNumber(vector, ['ihg', 'IHG']);
+    const nti = pickNumber(observed, ['nti', 'NTI', 'nti_obs']) ?? pickNumber(vector, ['nti', 'NTI', 'NTI_obs']);
+    const ldi = pickNumber(observed, ['ldi', 'LDI', 'ldi_hours']) ?? pickNumber(vector, ['ldi', 'LDI', 'LDI_hours']);
+    const phi = pickNumber(observed, ['phi', 'PHI_SF']) ?? pickNumber(vector, ['phi', 'PHI_SF']);
     return {
       ihg,
       nti,
@@ -41,8 +44,8 @@ export function buildMihmRuntimeMatrix(input: {
       phi,
       regime: stringValue(observed.regime, payload.regime, regimeFrom(ihg, nti, ldi)) ?? regimeFrom(ihg, nti, ldi),
       sourceState: 'observed',
-      contributingNodes: asStringArray(payload.contributingNodes),
-      contributingEvidence: asStringArray(payload.contributingEvidence),
+      contributingNodes: asStringArray(visible.contributingNodes || visible.nodes),
+      contributingEvidence: asStringArray(visible.contributingEvidence || visible.evidence).concat(asStringArray(sensitive.evidence)),
       warnings,
     };
   }


### PR DESCRIPTION
## Summary

Aligns `POST /api/mihm/process` with the actual `public.mihm_analyses` schema currently present in Supabase.

Current production failure:

```txt
mihm_analysis_insert_failed
Could not find the 'actor_id' column of 'mihm_analyses' in the schema cache
```

Actual table columns observed:

```txt
id
node_id
worldspect_snapshot_id
kernel_cycle_id
event_id
input_kind
input_ref
visible_variables
sensitive_variables
homeostatic_vector
confidence
uncertainty
created_at
```

## Changes

- Updates `src/app/api/mihm/process/route.ts` so MIHM inserts use the real schema:
  - `event_id`
  - `input_kind`
  - `input_ref`
  - `visible_variables`
  - `sensitive_variables`
  - `homeostatic_vector`
  - `confidence`
  - `uncertainty`

- Updates `src/observatory/field/catalog/mihmRuntimeMatrix.ts` so runtime reads observed MIHM state from:
  - `homeostatic_vector`
  - `visible_variables`
  - `sensitive_variables`

## Expected result after deploy

After running the browser console POST to `/api/mihm/process`:

```txt
/api/mihm/state
analyses.Count >= 1
runtime.sourceState = observed
warnings no longer include mihm_analyses_empty_derived_from_field
```

## Validation required

Please run before merge:

```bash
npm run typecheck
npm run build
npm run check:boundaries
```

No Supabase migration is required for this fix. The code now adapts to the table that already exists.