### PR TITLE
Connect Cognitive Twin proposals to field seed evidence

### DIFF
--- a/src/app/api/twin/propose/route.ts
+++ b/src/app/api/twin/propose/route.ts
@@ -4,18 +4,120 @@ import { readTwinSelfObservation } from '@/lib/operational/twinState';
 
 export const dynamic = 'force-dynamic';
 
+function termsFromProposal(value: unknown) {
+  return JSON.stringify(value ?? {})
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .split(/[^a-z0-9_\-]+/)
+    .filter((term) => term.length >= 4);
+}
+
+function intersects(haystack: string[], needles: string[]) {
+  return needles.some((needle) => haystack.includes(needle));
+}
+
+function summarizeSeedEvidence(selfObservation: Awaited<ReturnType<typeof readTwinSelfObservation>>, proposalInput: unknown) {
+  const terms = termsFromProposal(proposalInput);
+  const nodes = selfObservation.seed.nodeCatalog
+    .filter((node) => {
+      const searchable = [node.nodeKey, node.label, node.nodeType, ...node.variables, ...node.patterns, ...node.activationConditions]
+        .join(' ')
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .split(/[^a-z0-9_\-]+/);
+      return terms.length === 0 ? node.runtimeState === 'observed' : intersects(searchable, terms);
+    })
+    .slice(0, 12)
+    .map((node) => ({
+      nodeKey: node.nodeKey,
+      label: node.label,
+      nodeType: node.nodeType,
+      variables: node.variables.slice(0, 6),
+      patterns: node.patterns.slice(0, 6),
+      runtimeState: node.runtimeState,
+    }));
+
+  const patterns = selfObservation.seed.patternCatalog
+    .filter((pattern) => {
+      const searchable = [pattern.patternId, pattern.label, ...pattern.triggerTerms, ...pattern.variables, ...pattern.suggestedExecutions]
+        .join(' ')
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .split(/[^a-z0-9_\-]+/);
+      return terms.length === 0 ? pattern.linkedNodes.length > 0 : intersects(searchable, terms);
+    })
+    .slice(0, 12)
+    .map((pattern) => ({
+      patternId: pattern.patternId,
+      label: pattern.label,
+      linkedNodes: pattern.linkedNodes.slice(0, 8),
+      suggestedExecutions: pattern.suggestedExecutions.slice(0, 6),
+      riskLevel: pattern.riskLevel,
+      evidenceRequirement: pattern.evidenceRequirement,
+    }));
+
+  const documents = selfObservation.seed.documentCatalog
+    .filter((document) => {
+      const searchable = [document.documentId, document.title, document.source, document.status, ...document.linkedNodes, ...document.linkedPatterns, ...document.attractors]
+        .join(' ')
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .split(/[^a-z0-9_\-]+/);
+      return terms.length === 0 ? document.visibility === 'public' : intersects(searchable, terms);
+    })
+    .slice(0, 12)
+    .map((document) => ({
+      documentId: document.documentId,
+      title: document.title,
+      source: document.source,
+      visibility: document.visibility,
+      linkedNodes: document.linkedNodes.slice(0, 8),
+      linkedPatterns: document.linkedPatterns.slice(0, 8),
+      evidenceWeight: document.evidenceWeight,
+      confidence: document.confidence,
+    }));
+
+  return {
+    terms: terms.slice(0, 24),
+    nodes,
+    patterns,
+    documents,
+    mihmRuntimeMatrix: selfObservation.seed.mihmRuntimeMatrix,
+    accessMode: selfObservation.seed.accessMode,
+    catalogCounts: {
+      nodeCatalog: selfObservation.seed.nodeCatalog.length,
+      documentCatalog: selfObservation.seed.documentCatalog.length,
+      patternCatalog: selfObservation.seed.patternCatalog.length,
+      executionCatalog: selfObservation.seed.executionCatalog.length,
+    },
+  };
+}
+
 export async function POST(req: Request) {
   const gate = await requireGovernedActor('twin.propose');
   if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
 
   const body = await req.json().catch(() => ({}));
-  const selfObservation = await readTwinSelfObservation();
+  const selfObservation = await readTwinSelfObservation({
+    user: gate.ctx.user,
+    profile: gate.ctx.profile,
+    accessMode: gate.ctx.isRoot ? 'root' : undefined,
+  });
+  const proposalInput = body.proposal ?? body;
+  const seedEvidence = summarizeSeedEvidence(selfObservation, proposalInput);
   const selfObservationPayload = {
     observed_graph_nodes: selfObservation.observed_graph_nodes,
     observed_graph_edges: selfObservation.observed_graph_edges,
     latest_kernel_status: selfObservation.latest_kernel_status,
     latest_governance_status: selfObservation.latest_governance_status,
     latest_worldspect_state: selfObservation.latest_worldspect_state,
+    access_mode: selfObservation.seed.accessMode,
+    seed_catalog_counts: seedEvidence.catalogCounts,
+    mihm_source_state: selfObservation.seed.mihmRuntimeMatrix.sourceState,
   };
   const observed = await appendOperationalEvent({
     eventName: 'cognitive_twin.self_observed',
@@ -29,8 +131,10 @@ export async function POST(req: Request) {
   const payload = {
     quarantine: true,
     self_observation: selfObservationPayload,
-    proposal: body.proposal ?? body,
-    proposal_hash: sha256(body.proposal ?? body),
+    seed_evidence: seedEvidence,
+    proposal: proposalInput,
+    proposal_hash: sha256(proposalInput),
+    seed_hash: sha256(seedEvidence),
     requires_approval: true,
   };
   const event = await appendOperationalEvent({
@@ -48,6 +152,7 @@ export async function POST(req: Request) {
     graphNodeCount: selfObservation.observed_graph_nodes,
     graphEdgeCount: selfObservation.observed_graph_edges,
     inputVectorHash: sha256(payload.self_observation),
+    specHash: sha256(seedEvidence),
     status: 'proposed',
     eventId: event.data.id,
     payload,

--- a/src/lib/operational/twinState.ts
+++ b/src/lib/operational/twinState.ts
@@ -1,20 +1,74 @@
-import { getLatestKernelCycle } from '@/lib/kernel/kernelCycleStore';
 import { readCanonicalGraphState } from '@/lib/graph/canonicalGraph';
 import { readGovernanceRuntime } from '@/lib/governance/governanceRuntime';
+import { getLatestKernelCycle } from '@/lib/kernel/kernelCycleStore';
+import { latestActionProposals, latestRows } from './common';
 import { getLatestWorldSpectSnapshot, snapshotRowToApiData } from '@/lib/worldspect/snapshotStore';
-import { latestActionProposals } from './common';
+import { buildCognitiveTwinSeed } from '@/observatory/field/catalog/cognitiveTwinSeed';
+import { buildDocumentCatalog } from '@/observatory/field/catalog/sfDocumentCatalog';
+import { buildMihmRuntimeMatrix } from '@/observatory/field/catalog/mihmRuntimeMatrix';
+import { buildNodeCatalog } from '@/observatory/field/catalog/sfNodeCatalog';
+import { buildPatternCatalog } from '@/observatory/field/catalog/patternCatalog';
+import type { FieldAccessMode } from '@/observatory/field/catalog/fieldMatrixBuilder';
 
-export async function readTwinSelfObservation() {
-  const [graph, worldspect, kernel, governance, proposals] = await Promise.all([
+export async function readTwinSelfObservation(input: {
+  user?: unknown;
+  profile?: Record<string, unknown> | null;
+  node?: Record<string, unknown> | null;
+  entitlements?: Record<string, unknown> | null;
+  accessMode?: FieldAccessMode;
+} = {}) {
+  const [graph, worldspect, kernel, governance, proposals, mihmAnalyses, logbookKnowledge, logbookSignals] = await Promise.all([
     readCanonicalGraphState('sfi'),
     getLatestWorldSpectSnapshot(),
     getLatestKernelCycle(),
     readGovernanceRuntime(),
     latestActionProposals(['twin_proposal'], 10),
+    latestRows('mihm_analyses', 10),
+    latestRows('logbook_knowledge', 50),
+    latestRows('logbook_signals', 25),
   ]);
+
   const latestCampoState = kernel?.campo_state && typeof kernel.campo_state === 'object'
     ? kernel.campo_state as Record<string, unknown>
     : null;
+  const worldspectData = worldspect ? snapshotRowToApiData(worldspect) : null;
+  const nodeCatalog = buildNodeCatalog(graph);
+  const documentCatalog = buildDocumentCatalog({ logbookKnowledge: logbookKnowledge.data });
+  const patternCatalog = buildPatternCatalog();
+  const executionCatalog = proposals.data.map((proposal) => ({
+    executionId: String(proposal.id ?? proposal.created_at ?? 'twin_proposal'),
+    title: String(proposal.title ?? 'cognitive_twin.proposal'),
+    applicablePatterns: [],
+    requiredApproval: Boolean(proposal.approval_required ?? true),
+    expectedFieldDelta: proposal.expected_field_delta && typeof proposal.expected_field_delta === 'object'
+      ? proposal.expected_field_delta as Record<string, unknown>
+      : {},
+    riskLevel: String(proposal.risk_level ?? 'medium'),
+    verificationCriterion: 'proposal must remain auditable through action_proposals and epistemic_events',
+    source: 'action_proposals' as const,
+  }));
+  const mihmRuntimeMatrix = buildMihmRuntimeMatrix({
+    mihmAnalyses: mihmAnalyses.data,
+    kernel,
+    worldspect: worldspectData,
+    graph,
+    logbookSignals: logbookSignals.data,
+  });
+  const seed = buildCognitiveTwinSeed({
+    user: input.user,
+    profile: input.profile,
+    node: input.node,
+    entitlements: input.entitlements,
+    accessMode: input.accessMode,
+    nodeCatalog,
+    documentCatalog,
+    patternCatalog,
+    executionCatalog,
+    mihmRuntimeMatrix,
+    recentEvents: logbookSignals.data,
+    recentKernelCycles: kernel ? [kernel] : [],
+    latestWorldSpect: worldspectData,
+  });
 
   return {
     observed_graph_nodes: graph.nodes.length,
@@ -23,7 +77,7 @@ export async function readTwinSelfObservation() {
     latest_governance_status: governance.status,
     latest_worldspect_state: worldspect?.source_state ?? null,
     graph,
-    worldspect: worldspect ? snapshotRowToApiData(worldspect) : null,
+    worldspect: worldspectData,
     kernel: kernel
       ? {
         id: kernel.id,
@@ -33,6 +87,20 @@ export async function readTwinSelfObservation() {
       : null,
     governance,
     proposals: proposals.data,
-    warnings: [graph.degradedReason, governance.warning, proposals.error].filter(Boolean),
+    seed,
+    nodeCatalog,
+    documentCatalog,
+    patternCatalog,
+    executionCatalog,
+    mihmRuntimeMatrix,
+    warnings: [
+      graph.degradedReason,
+      governance.warning,
+      proposals.error,
+      mihmAnalyses.error,
+      logbookKnowledge.error,
+      logbookSignals.error,
+      ...mihmRuntimeMatrix.warnings,
+    ].filter(Boolean),
   };
 }


### PR DESCRIPTION
## Summary

Connects the Cognitive Twin runtime to the existing SFI field seed without creating parallel endpoints or replacing existing components.

Changes:
- Extends `readTwinSelfObservation()` with the existing field seed builders.
- Exposes `seed`, `nodeCatalog`, `documentCatalog`, `patternCatalog`, `executionCatalog`, and `mihmRuntimeMatrix` through Twin state.
- Anchors `/api/twin/propose` payloads to field evidence by selecting related nodes, patterns, and documents from the seed.
- Stores `seed_evidence`, `seed_hash`, access mode, catalog counts, and MIHM source state in the proposal payload.

## Validation

Run locally:

```bash
npm run build
npx tsc --noEmit --pretty false
```

Production state validation already observed:

```txt
/api/twin/state -> ok: true
nodeCatalog: 153
documentCatalog: 120
patternCatalog: 127
mihmRuntimeMatrix.sourceState: observed
```

## Notes

This does not change schema, auth provider, multimedia, or backend architecture. It only connects the Twin proposal path to the existing SFI field seed and audit payload.