### PR TITLE
Visor: convertir VISOR en interlocutor operativo ROOT y habilitar proveedores IA externos

### DIFF
--- a/src/observatory/ai/aiProviderRouter.ts
+++ b/src/observatory/ai/aiProviderRouter.ts
@@ -26,11 +26,121 @@ export function resolveAiProvider(preferredProvider?: AiProvider): AiProvider {
   return configured?.provider || 'local_stub';
 }
 
+function stringifyContext(context?: Record<string, unknown>) {
+  if (!context) return '';
+  return JSON.stringify(context, null, 2).slice(0, 24000);
+}
+
+function systemInstruction(request: AiProviderRequest) {
+  const context = stringifyContext(request.context);
+  return [
+    'Responde en español claro, directo y útil.',
+    request.mode === 'sfi_visor_companion'
+      ? 'Actúa como VISOR ROOT, interlocutor operativo de SystemFriction Institute. No ejecutes acciones, no crees registros, no inventes evidencia y separa registro, inferencia, hipótesis y conocimiento general.'
+      : `Tarea: ${request.task}.`,
+    context ? `Contexto visible:\n${context}` : '',
+  ].filter(Boolean).join('\n\n');
+}
+
+async function parseJsonResponse(response: Response) {
+  const payload = await response.json().catch(() => null) as Record<string, unknown> | null;
+  if (!response.ok) {
+    const message = typeof payload?.error === 'object' && payload.error && 'message' in payload.error
+      ? String((payload.error as { message?: unknown }).message)
+      : `provider_http_${response.status}`;
+    throw new Error(message);
+  }
+  return payload;
+}
+
+async function callOpenAi(request: AiProviderRequest, apiKey: string) {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: systemInstruction(request) },
+        { role: 'user', content: request.input },
+      ],
+      temperature: 0.4,
+    }),
+  });
+  const payload = await parseJsonResponse(response);
+  const choice = Array.isArray(payload?.choices) ? payload.choices[0] as Record<string, unknown> | undefined : undefined;
+  const message = choice?.message as Record<string, unknown> | undefined;
+  return {
+    text: typeof message?.content === 'string' ? message.content : '',
+    usage: typeof payload?.usage === 'object' && payload.usage ? payload.usage as Record<string, unknown> : undefined,
+  };
+}
+
+async function callAnthropic(request: AiProviderRequest, apiKey: string) {
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: process.env.ANTHROPIC_MODEL || 'claude-3-5-haiku-latest',
+      max_tokens: 1200,
+      system: systemInstruction(request),
+      messages: [{ role: 'user', content: request.input }],
+    }),
+  });
+  const payload = await parseJsonResponse(response);
+  const content = Array.isArray(payload?.content) ? payload.content : [];
+  const text = content.map((item) => {
+    if (item && typeof item === 'object' && 'text' in item) return String((item as { text?: unknown }).text || '');
+    return '';
+  }).filter(Boolean).join('\n');
+  return {
+    text,
+    usage: typeof payload?.usage === 'object' && payload.usage ? payload.usage as Record<string, unknown> : undefined,
+  };
+}
+
+async function callGroqCompatible(request: AiProviderRequest, apiKey: string, provider: 'groq' | 'deepseek') {
+  const endpoint = provider === 'groq' ? 'https://api.groq.com/openai/v1/chat/completions' : 'https://api.deepseek.com/chat/completions';
+  const model = provider === 'groq'
+    ? process.env.GROQ_MODEL || 'llama-3.1-8b-instant'
+    : process.env.DEEPSEEK_MODEL || 'deepseek-chat';
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      messages: [
+        { role: 'system', content: systemInstruction(request) },
+        { role: 'user', content: request.input },
+      ],
+      temperature: 0.35,
+    }),
+  });
+  const payload = await parseJsonResponse(response);
+  const choice = Array.isArray(payload?.choices) ? payload.choices[0] as Record<string, unknown> | undefined : undefined;
+  const message = choice?.message as Record<string, unknown> | undefined;
+  return {
+    text: typeof message?.content === 'string' ? message.content : '',
+    usage: typeof payload?.usage === 'object' && payload.usage ? payload.usage as Record<string, unknown> : undefined,
+  };
+}
+
 export async function runAiTask(request: AiProviderRequest): Promise<AiProviderResponse> {
   const provider = resolveAiProvider(request.providerPreference || request.preferredProvider || process.env.DEFAULT_AI_PROVIDER as AiProvider | undefined);
 
   if (provider === 'local_stub') {
-    const output = 'Motor IA externo no configurado.';
+    const output = request.mode === 'sfi_visor_companion'
+      ? 'VISOR sin proveedor externo configurado; usar fallback local.'
+      : 'Motor IA externo no configurado.';
     return {
       ok: false,
       provider,
@@ -43,15 +153,48 @@ export async function runAiTask(request: AiProviderRequest): Promise<AiProviderR
     };
   }
 
-  const output = 'Proveedor IA detectado, pero la ejecucion externa permanece deshabilitada en esta fase.';
-  return {
-    ok: false,
-    provider,
-    task: request.task,
-    output,
-    text: output,
-    external: false,
-    reason: 'external_execution_disabled',
-    error: 'external_execution_disabled',
-  };
+  const apiKey = process.env[providerEnv[provider]];
+  if (!apiKey) {
+    return {
+      ok: false,
+      provider: 'local_stub',
+      task: request.task,
+      output: 'Motor IA externo no configurado.',
+      text: 'Motor IA externo no configurado.',
+      external: false,
+      reason: 'missing_provider_key',
+      error: 'missing_provider_key',
+    };
+  }
+
+  try {
+    const result = provider === 'openai'
+      ? await callOpenAi(request, apiKey)
+      : provider === 'anthropic'
+        ? await callAnthropic(request, apiKey)
+        : await callGroqCompatible(request, apiKey, provider);
+    const output = result.text.trim();
+    if (!output) throw new Error('empty_provider_response');
+    return {
+      ok: true,
+      provider,
+      task: request.task,
+      output,
+      text: output,
+      external: true,
+      usage: result.usage,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'provider_request_failed';
+    return {
+      ok: false,
+      provider,
+      task: request.task,
+      output: message,
+      text: message,
+      external: true,
+      reason: 'provider_request_failed',
+      error: message,
+    };
+  }
 }

--- a/src/observatory/components/root/RootDashboardClient.tsx
+++ b/src/observatory/components/root/RootDashboardClient.tsx
@@ -173,8 +173,8 @@ export function RootDashboardClient() {
         </div>
       </header>
 
-      <main className={`relative grid h-screen grid-cols-1 bg-[#080808] pt-9 lg:grid-cols-[minmax(0,1fr)_380px] ${visor.enabled ? 'grayscale' : ''}`}>
-        <section className="relative min-h-0 overflow-hidden border-r border-[#1e1c17]">
+      <main className="relative grid h-screen grid-cols-1 bg-[#080808] pt-9 lg:grid-cols-[minmax(0,1fr)_380px]">
+        <section className={`relative min-h-0 overflow-hidden border-r border-[#1e1c17] ${visor.enabled ? 'grayscale' : ''}`}>
           <div className="absolute left-3 top-3 z-20 flex flex-col gap-2">
             {FIELD_TOOLS.map((tool) => (
               <FieldToolButton key={tool.id} tool={tool} active={activeTool === tool.id} onClick={() => {
@@ -216,7 +216,7 @@ export function RootDashboardClient() {
           </div>
         </section>
 
-        <aside className="min-h-0 overflow-hidden bg-[#0e0d0b]">
+        <aside className={`min-h-0 overflow-hidden bg-[#0e0d0b] ${visor.enabled ? 'grayscale' : ''}`}>
           <div className="flex h-full flex-col">
             <Accordion title="Chat Twin" open={openPanel === 'chat'} onClick={() => setOpenPanel(openPanel === 'chat' ? 'propuestas' : 'chat')}>
               <TwinInteractionPanel compact selectedNodeLabel={selectedNodeLabel} onArtifactIntent={() => setOpenPanel('artefactos')} />
@@ -238,7 +238,7 @@ export function RootDashboardClient() {
             </Accordion>
           </div>
         </aside>
-        <VisorMode enabled={visor.enabled} twin={twin} />
+        <VisorMode enabled={visor.enabled} twin={twin} onEnable={() => visor.setEnabled(true)} />
       </main>
     </div>
   );

--- a/src/observatory/components/root/VisorChat.tsx
+++ b/src/observatory/components/root/VisorChat.tsx
@@ -33,7 +33,7 @@ export function VisorChat({
       <header className="border-b border-white/10 px-4 py-3">
         <div className="flex items-start justify-between gap-3">
           <div>
-            <h2 className="font-mono text-[11px] uppercase tracking-[0.22em] text-[#d4af37]">SFI Visor Chat</h2>
+            <h2 className="font-mono text-[11px] uppercase tracking-[0.22em] text-[#d4af37]">ROOT VISOR / Chat operativo</h2>
             <p className="mt-1 font-mono text-[9px] uppercase tracking-[0.12em] text-white/35">{context.label} / {context.description}</p>
           </div>
           <button type="button" onClick={onClose} className="font-mono text-[10px] uppercase tracking-[0.14em] text-white/45 hover:text-white">
@@ -58,7 +58,7 @@ export function VisorChat({
         {loading ? (
           <div className="border-l border-[#d4af37]/35 bg-white/[0.02] px-3 py-2 font-mono text-[11px] leading-5 text-white/40">
             <div className="mb-1 text-[8px] uppercase tracking-[0.18em] text-white/25">visor</div>
-            leyendo el campo...
+            leyendo memoria visible...
           </div>
         ) : null}
       </div>
@@ -72,11 +72,11 @@ export function VisorChat({
               void submit();
             }
           }}
-          placeholder={`Pregunta libre sobre ${context.label}...`}
+          placeholder={`Pregunta libre a ROOT VISOR desde ${context.label}...`}
           className="h-24 w-full resize-none border border-white/10 bg-white/[0.025] p-3 font-mono text-[11px] leading-5 text-white/75 outline-none placeholder:text-white/20 focus:border-[#d4af37]/45"
         />
         <div className="mt-2 flex items-center justify-between">
-          <span className="font-mono text-[8px] uppercase tracking-[0.14em] text-white/25">voz del sistema / no ejecuta</span>
+          <span className="font-mono text-[8px] uppercase tracking-[0.14em] text-white/25">interlocutor operativo / no ejecuta</span>
           <button type="button" disabled={loading} onClick={() => void submit()} className="border border-[#d4af37]/45 px-3 py-1.5 font-mono text-[9px] uppercase tracking-[0.16em] text-[#d4af37] hover:bg-[#d4af37]/10 disabled:opacity-40">
             preguntar
           </button>

--- a/src/observatory/components/root/VisorGoldenNode.tsx
+++ b/src/observatory/components/root/VisorGoldenNode.tsx
@@ -3,19 +3,23 @@
 export function VisorGoldenNode({
   label,
   onClick,
+  dormant = false,
 }: {
   label: string;
   onClick: () => void;
+  dormant?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="absolute left-1/2 top-1/2 z-[90] grid h-32 w-32 -translate-x-1/2 -translate-y-1/2 place-items-center rounded-full border border-[#d4af37]/80 bg-[#d4af37]/12 shadow-[0_0_70px_rgba(212,175,55,0.28)] outline-none transition hover:bg-[#d4af37]/18 focus-visible:ring-1 focus-visible:ring-[#d4af37]"
+      className={`pointer-events-auto absolute top-1/2 z-[90] grid -translate-x-1/2 -translate-y-1/2 place-items-center rounded-full border border-[#d4af37]/80 bg-[#d4af37]/12 shadow-[0_0_70px_rgba(212,175,55,0.28)] outline-none transition hover:bg-[#d4af37]/18 focus-visible:ring-1 focus-visible:ring-[#d4af37] ${
+        dormant ? 'left-[calc((100%_-_380px)/2)] h-28 w-28 max-lg:left-1/2' : 'left-1/2 h-32 w-32'
+      }`}
       aria-label="Open SFI Visor Chat"
     >
       <span className="absolute h-16 w-16 rounded-full border border-[#d4af37]/40 bg-[#d4af37]/20" />
-      <span className="relative font-mono text-[10px] uppercase tracking-[0.2em] text-[#f4d77a]">
+      <span className="relative text-center font-mono text-[10px] uppercase tracking-[0.2em] text-[#f4d77a]">
         {label}
       </span>
     </button>

--- a/src/observatory/components/root/VisorMode.tsx
+++ b/src/observatory/components/root/VisorMode.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useMemo } from 'react';
 import { VisorChat } from './VisorChat';
 import { VisorGoldenNode } from './VisorGoldenNode';
 import { useVisorChat, useVisorContext } from './visorHooks';
@@ -18,17 +19,129 @@ type TwinState = {
   };
 };
 
+type LogbookEntry = {
+  id: string;
+  actor: 'Usuario' | 'Sistema' | 'Agente' | 'Evento';
+  timestamp?: string;
+  summary: string;
+};
+
+function valueText(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function actorFor(event: Record<string, unknown>): LogbookEntry['actor'] {
+  const source = `${valueText(event.actor) || valueText(event.source) || valueText(event.role) || valueText(event.type) || ''}`.toLowerCase();
+  if (source.includes('user') || source.includes('usuario')) return 'Usuario';
+  if (source.includes('agent') || source.includes('agente')) return 'Agente';
+  if (source.includes('system') || source.includes('sistema')) return 'Sistema';
+  return 'Evento';
+}
+
+function summaryFor(event: unknown) {
+  if (typeof event === 'string') return event;
+  if (!event || typeof event !== 'object') return undefined;
+  const record = event as Record<string, unknown>;
+  return valueText(record.summary)
+    || valueText(record.message)
+    || valueText(record.description)
+    || valueText(record.title)
+    || valueText(record.label)
+    || valueText(record.event)
+    || valueText(record.type);
+}
+
+function timestampFor(event: unknown) {
+  if (!event || typeof event !== 'object') return undefined;
+  const record = event as Record<string, unknown>;
+  return valueText(record.timestamp) || valueText(record.createdAt) || valueText(record.created_at) || valueText(record.time) || valueText(record.date);
+}
+
+function mapLogbookEntries(events: unknown[] | undefined): LogbookEntry[] {
+  if (!Array.isArray(events)) return [];
+  return events.map((event, index) => {
+    const record = event && typeof event === 'object' ? event as Record<string, unknown> : {};
+    const summary = summaryFor(event);
+    if (!summary) return null;
+    return {
+      id: valueText(record.id) || `event-${index}`,
+      actor: actorFor(record),
+      timestamp: timestampFor(event),
+      summary,
+    };
+  }).filter((entry): entry is LogbookEntry => Boolean(entry));
+}
+
+function VisorLogbookPanel({
+  entries,
+  onAsk,
+}: {
+  entries: LogbookEntry[];
+  onAsk: (entry: LogbookEntry) => void;
+}) {
+  return (
+    <section className="absolute bottom-6 left-6 z-[88] max-h-[42vh] w-[min(380px,calc(100vw-32px))] overflow-hidden border border-white/10 bg-black/80 shadow-2xl">
+      <header className="border-b border-white/10 px-3 py-2">
+        <h3 className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#d4af37]">Bitácora visible</h3>
+        <p className="mt-1 font-mono text-[8px] uppercase tracking-[0.12em] text-white/30">recentEvents / sólo lectura</p>
+      </header>
+      <div className="max-h-[34vh] overflow-y-auto p-3">
+        {entries.length === 0 ? (
+          <p className="border-l border-white/15 px-3 py-2 font-mono text-[11px] leading-5 text-white/45">
+            Bitácora sin entradas legibles. Falta mapear recentEvents/logbook a entradas Usuario/Sistema/Agente.
+          </p>
+        ) : entries.map((entry) => (
+          <article key={entry.id} className="mb-3 border border-white/10 bg-white/[0.025] p-3 last:mb-0">
+            <div className="mb-2 flex items-center justify-between gap-3 font-mono text-[8px] uppercase tracking-[0.16em]">
+              <span className="text-[#d4af37]">{entry.actor}</span>
+              {entry.timestamp ? <time className="text-white/25">{entry.timestamp}</time> : null}
+            </div>
+            <p className="font-mono text-[11px] leading-5 text-white/60">{entry.summary}</p>
+            <button
+              type="button"
+              onClick={() => onAsk(entry)}
+              className="mt-3 border border-[#d4af37]/35 px-2 py-1 font-mono text-[8px] uppercase tracking-[0.14em] text-[#d4af37] hover:bg-[#d4af37]/10"
+            >
+              preguntar sobre esta entrada
+            </button>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function VisorMode({
   enabled,
   twin,
+  onEnable,
 }: {
   enabled: boolean;
   twin: TwinState | null;
+  onEnable: () => void;
 }) {
-  const { contextKey, context, setContextKey } = useVisorContext('nodes');
+  const { contextKey, context, setContextKey } = useVisorContext('bitacoras');
   const chat = useVisorChat(contextKey, twin);
+  const logbookEntries = useMemo(() => mapLogbookEntries(twin?.data?.seed?.recentEvents), [twin]);
 
-  if (!enabled) return null;
+  const { setOpen } = chat;
+
+  useEffect(() => {
+    if (enabled) setOpen(true);
+  }, [enabled, setOpen]);
+
+  function activateVisor() {
+    onEnable();
+    chat.setOpen(true);
+  }
+
+  if (!enabled) {
+    return (
+      <div className="pointer-events-none absolute inset-0 z-30">
+        <VisorGoldenNode label="ROOT VISOR" onClick={activateVisor} dormant />
+      </div>
+    );
+  }
 
   return (
     <div className="absolute inset-0 z-[70] overflow-hidden bg-[#030303]/96 text-white">
@@ -45,7 +158,17 @@ export function VisorMode({
         chat.setOpen(true);
       }} />
 
-      <VisorGoldenNode label={context.label.toUpperCase()} onClick={() => chat.setOpen(true)} />
+      <VisorGoldenNode label="ROOT VISOR" onClick={() => chat.setOpen(true)} />
+
+      {contextKey === 'bitacoras' ? (
+        <VisorLogbookPanel
+          entries={logbookEntries}
+          onAsk={(entry) => {
+            chat.setOpen(true);
+            void chat.submit(`Pregunta sobre esta entrada de bitácora (${entry.actor}${entry.timestamp ? ` / ${entry.timestamp}` : ''}): ${entry.summary}`);
+          }}
+        />
+      ) : null}
 
       <div className="absolute bottom-6 left-1/2 z-[85] -translate-x-1/2 text-center font-mono text-[9px] uppercase tracking-[0.18em] text-white/30">
         observer / {context.description}

--- a/src/observatory/components/root/visorHooks.ts
+++ b/src/observatory/components/root/visorHooks.ts
@@ -16,18 +16,67 @@ type TwinState = {
   };
 };
 
-type VisorIntent = 'site' | 'attractor' | 'theory' | 'explain' | 'support' | 'closure' | 'reading' | 'personal_unknown' | 'open';
+type VisorIntent = 'site' | 'attractor' | 'theory' | 'explain' | 'support' | 'closure' | 'reading' | 'personal_unknown' | 'logbook' | 'memory' | 'observatory_gap' | 'open';
 
-const SFI_FREE_VISOR_CONTEXT = [
-  'VISOR MODE es una capa de observación conversacional libre dentro de SystemFriction Institute.',
-  'Debe responder como chat abierto: explicar, interpretar, preguntar, teorizar, reconocer límites y orientar búsqueda interna.',
-  'No está obligado a convertir todo en nodos, evidencias o registros. Puede hablar de forma natural si la pregunta es abierta.',
-  'Marco interno: SFI observa fricción sistémica, trazabilidad de decisiones, evidencias, bitácoras, atlas, atractores, patrones, nodos y cambios de régimen.',
-  'Un atractor se entiende como una dirección, configuración o cuenca de coherencia hacia la que el sistema tiende o que el usuario declara para orientar observación y acción.',
-  'Si el usuario pregunta qué es el sitio, explicar el sitio libremente: observatorio, laboratorio y sistema de lectura/registro de fricción, decisiones, evidencia, patrones y dirección operativa.',
-  'Si el usuario pregunta por algo no registrado, no inventar. Decir que no está registrado como nodo y pedir contexto de forma abierta.',
-  'Si falta evidencia, separar dato conectado, inferencia razonable y hueco no observado.',
-].join('\n');
+const SFI_VISOR_ROOT_PROMPT = `Eres VISOR ROOT, interlocutor operativo de SystemFriction Institute.
+
+No eres una base de datos con chat.
+No eres un inventario de nodos.
+Eres el observador conversacional del instituto.
+
+Tienes acceso al contexto visible del instituto:
+nodos, documentos, evidencias, patrones, propuestas, bitácoras, atlas, workbook, ledger y eventos recientes.
+
+Tu función:
+ayudar al usuario root a entender, usar y consolidar SFI.
+
+Puedes:
+- explicar
+- teorizar
+- inferir
+- proponer rutas
+- diseñar módulos
+- traducir bitácoras
+- orientar uso del observatorio
+- sugerir nuevos observatorios
+- detectar huecos
+- generar prompts para Codex
+- responder preguntas generales con conocimiento amplio
+
+No puedes:
+- ejecutar acciones
+- crear registros
+- aprobar decisiones
+- fingir que algo está registrado si no está
+- inventar evidencia
+
+Regla crítica:
+No abras respuestas con conteos de nodos.
+Sólo menciona conteos si el usuario pide inventario, estado o auditoría.
+
+Si algo está registrado:
+usa el registro.
+
+Si algo no está registrado:
+di “No lo veo registrado en SFI.”
+Luego ofrece:
+- inferencia
+- explicación general
+- hipótesis
+- ruta de observación
+
+Toda respuesta debe acercar SFI a:
+- más claridad
+- mejor arquitectura
+- mejor uso del observatorio
+- mejor decisión
+- mejor consolidación
+
+Tono:
+claro, simple, directo.
+Sin tecnicismos innecesarios.
+No imitar al usuario.
+Conocer su fricción desde la memoria visible, pero responder estable.`;
 
 function count(value: unknown[] | undefined) {
   return Array.isArray(value) ? value.length : 0;
@@ -42,10 +91,6 @@ function readSnapshot(twin: TwinState | null): VisorSnapshot {
     patterns: count(seed?.patternCatalog),
     events: count(seed?.recentEvents),
   };
-}
-
-function hasConnectedData(snapshot: VisorSnapshot) {
-  return snapshot.proposals + snapshot.nodes + snapshot.documents + snapshot.patterns + snapshot.events > 0;
 }
 
 function contextDataAvailable(contextKey: VisorContextKey, snapshot: VisorSnapshot) {
@@ -64,6 +109,9 @@ function normalize(input: string) {
 
 function intentFor(prompt: string): VisorIntent {
   const normalized = normalize(prompt);
+  if (normalized.includes('bitacora') || normalized.includes('logbook') || normalized.includes('recent event')) return 'logbook';
+  if (normalized.includes('que sabes de mi') || normalized.includes('memoria visible') || normalized.includes('sobre mi') || normalized.includes('en el instituto')) return 'memory';
+  if (normalized.includes('observatorio falta') || normalized.includes('que observatorio') || normalized.includes('nuevo observatorio') || normalized.includes('modulo falta')) return 'observatory_gap';
   if (normalized.includes('que es el sitio') || normalized.includes('que es este sitio') || normalized.includes('que hace el sitio') || normalized.includes('systemfriction') || normalized.includes('system friction')) return 'site';
   if (normalized.includes('perro') || normalized.includes('mascota') || normalized.includes('mi gato') || normalized.includes('mi familia') || normalized.includes('mi casa')) return 'personal_unknown';
   if (normalized.includes('atractor') || normalized.includes('direccion de atractor') || normalized.includes('cuenca')) return 'attractor';
@@ -75,103 +123,124 @@ function intentFor(prompt: string): VisorIntent {
   return 'open';
 }
 
-function inventoryText(snapshot: VisorSnapshot) {
-  return `Tengo a la vista: ${snapshot.nodes} nodos, ${snapshot.documents} documentos/evidencias, ${snapshot.patterns} patrones, ${snapshot.proposals} propuestas y ${snapshot.events} eventos recientes.`;
-}
-
 function lensText(contextKey: VisorContextKey, snapshot: VisorSnapshot) {
   const context = findVisorContext(contextKey);
   const contextHasData = contextDataAvailable(contextKey, snapshot);
   return contextHasData
-    ? `Para ${context.label}, sí hay señal conectada.`
-    : `Para ${context.label}, no veo una fuente directa conectada todavía. Puedo responder desde el marco SFI y declarar cuando algo sea inferencia.`;
+    ? `Registro visible: en la capa ${context.label} hay señal conectada que puede orientar la lectura.`
+    : `No lo veo registrado en SFI para la capa ${context.label}. Sin embargo puedo inferir, explicar o proponerte una ruta de observación sin fingir registro.`;
+}
+
+function readableList(value: unknown[] | undefined, label: string) {
+  if (!Array.isArray(value) || value.length === 0) return `${label}: sin entradas visibles.`;
+  return `${label}: ${value.slice(0, 4).map((item) => {
+    if (item && typeof item === 'object') {
+      const record = item as Record<string, unknown>;
+      return String(record.title || record.label || record.name || record.summary || record.type || record.id || 'entrada visible');
+    }
+    return String(item);
+  }).join('; ')}.`;
+}
+
+function visibleMemory(twin: TwinState | null) {
+  const seed = twin?.data?.seed;
+  return [
+    readableList(seed?.nodeCatalog, 'Nodos'),
+    readableList(seed?.documentCatalog, 'Documentos/evidencias'),
+    readableList(seed?.patternCatalog, 'Patrones'),
+    readableList(twin?.data?.proposals, 'Propuestas'),
+    readableList(seed?.recentEvents, 'Eventos recientes'),
+  ].join('\n');
 }
 
 function localCompanionResponse(contextKey: VisorContextKey, prompt: string, twin: TwinState | null) {
   const context = findVisorContext(contextKey);
   const snapshot = readSnapshot(twin);
-  const connected = hasConnectedData(snapshot);
   const intent = intentFor(prompt);
-  const inventory = inventoryText(snapshot);
   const lensLimit = lensText(contextKey, snapshot);
 
   if (intent === 'site') {
+    return 'SystemFriction Institute es el campo donde estás convirtiendo fricción, memoria, evidencia y decisión en un sistema observable. No es sólo un sitio: es una herramienta para operar bitácoras, atlas, nodos, atractores, propuestas, decisiones, observatorios y rutas de ejecución.';
+  }
+
+  if (intent === 'personal_unknown') {
+    return 'No lo veo registrado en SFI. Aun así puedo conversar sobre eso. Cuéntame qué pasa y lo observamos sin forzarlo a nodo: conducta, contexto, señal, repetición y qué te preocupa.';
+  }
+
+  if (intent === 'logbook') {
     return [
-      'SystemFriction Institute es un sitio-observatorio: no sólo presenta información, organiza una forma de mirar sistemas.',
-      'Su función es permitir que el usuario observe fricción, decisiones, bitácoras, evidencia, nodos, patrones, atractores y cambios de estado sin mover el sistema accidentalmente.',
-      connected ? inventory : 'En este momento no necesito datos conectados para responder esto: hablo desde el marco del sitio.',
-      'En términos simples: el sitio intenta convertir ruido operativo en trazabilidad; y trazabilidad en dirección de acción.',
+      'La bitácora en VISOR debe funcionar como memoria viva: qué pasó, qué se repitió, qué quedó abierto y qué pide cierre.',
+      snapshot.events > 0
+        ? 'Registro visible: hay eventos recientes conectados. Úsalos como entradas Usuario/Sistema/Agente antes de convertirlos en conclusión.'
+        : 'Bitácora sin entradas legibles. Falta mapear recentEvents/logbook a entradas Usuario/Sistema/Agente.',
+      'Ruta útil: leer la entrada, separar registro/inferencia/hipótesis, decidir si requiere evidencia y sólo después proponer una ruta de registro o cierre.',
+    ].join('\n\n');
+  }
+
+  if (intent === 'memory') {
+    return [
+      'Puedo leer la memoria visible que llega al VISOR: nodos, documentos/evidencias, patrones, propuestas y eventos recientes. No leo capas privadas que no estén conectadas a este contexto.',
+      visibleMemory(twin),
+      'Inferencia: si una capa aparece vacía, no significa que no exista en tu historia; significa que no está visible para SFI en esta vista. Puedo ayudarte a decidir qué conviene registrar y qué conviene dejar como conversación.',
+    ].join('\n\n');
+  }
+
+  if (intent === 'observatory_gap') {
+    return [
+      'Hipótesis operativa: puede faltar un observatorio de traducción entre bitácora y ejecución mínima.',
+      'Ruta propuesta: 1) detectar entrada repetida, 2) exigir evidencia mínima, 3) formular perturbación MOP-H de bajo riesgo, 4) declarar criterio de cierre, 5) registrar sólo si el resultado deja rastro verificable.',
+      'También pueden faltar observatorios por ecosistema digital: identidad/acceso, publicaciones, ventas, soporte, comunidad, automatizaciones y deuda técnica. Puedo convertir cualquiera en mapa de señales, riesgos y próximos pasos.',
     ].join('\n\n');
   }
 
   if (intent === 'attractor') {
     return [
-      inventory,
+      'Un atractor en SFI es una dirección de convergencia: no ordena por sí mismo, pero permite observar si decisiones, evidencias y acciones se alinean o se dispersan.',
       lensLimit,
-      'Dirección de atractor: es la orientación hacia la que el sistema busca estabilizar lectura, decisión o acción. No es una orden mágica; es una hipótesis de convergencia.',
-      '¿Por qué atractores? Porque en teoría de sistemas dinámicos un atractor describe regiones hacia las que ciertas trayectorias tienden. En SFI se usa como lenguaje operativo: una dirección declarada que permite observar si las acciones, evidencias y decisiones convergen o se dispersan.',
-      'Si me pides el atractor actual y no está registrado, debo decirlo. Puedo inferir una dirección probable desde el contexto, pero no la presento como dato conectado.',
-    ].join('\n\n');
-  }
-
-  if (intent === 'personal_unknown') {
-    return [
-      'No lo tengo registrado como nodo visible en este contexto.',
-      'Cuéntame de ello y puedo ayudarte a observarlo sin forzarlo al sistema: qué es, por qué importa, qué relación tiene contigo y si conviene registrarlo o sólo conversarlo.',
+      'Inferencia útil: si la misma fricción vuelve, hay patrón posible; si el patrón arrastra decisiones hacia una misma forma, hay atractor probable; si falta evidencia, queda como hipótesis y no como registro cerrado.',
     ].join('\n\n');
   }
 
   if (intent === 'theory') {
     return [
-      connected ? inventory : 'No hay inventario conectado suficiente para afirmar un dato interno específico.',
+      'Puedo teorizar, pero separando capas: registro, inferencia e hipótesis.',
       lensLimit,
-      'Lectura teórica: puedo formular hipótesis dentro del marco SFI, pero debo separar lo observado de lo inferido.',
-      'Si aparece residuo, puede ser una relación sin cierre entre evidencia, decisión y destino. Si aparece repetición, puede ser patrón. Si aparece dirección persistente, puede leerse como atractor provisional.',
-      'No infiero como verdad. Propongo lectura, declaro límite y señalo qué evidencia faltaría.',
+      'Conocimiento general: en sistemas complejos importa más la repetición que la intensidad aislada. En SFI eso se traduce en observar rastros, no sólo sensaciones fuertes.',
     ].join('\n\n');
   }
 
   if (intent === 'explain') {
     return [
-      connected ? inventory : 'No hay datos conectados suficientes para este lente, pero puedo responder desde el marco general.',
+      `Lectura desde ${context.label}: ${context.description}`,
       lensLimit,
-      `Lectura corta: ${context.description} Visor no está aquí para mover nada; está para mirar, explicar y ordenar sin ruido.`,
-      'Si algo no cuadra, separo tres capas: dato conectado, inferencia razonable y hueco sin evidencia.',
+      'Si lo que preguntas no está en SFI, no lo convierto en dato. Puedo explicarlo con conocimiento general o proponerte cómo observarlo sin crear registros desde el chat.',
     ].join('\n\n');
   }
 
   if (intent === 'support') {
     return [
-      connected ? inventory : 'No necesito un nodo conectado para acompañar esta pregunta.',
-      'Estoy en modo observación. No ejecuto, no apruebo, no escribo registros.',
-      'Dime el residuo o la duda en una frase. La convierto en una pregunta verificable o en una lectura tentativa, según corresponda.',
+      'Sí. Puedo acompañar la pregunta sin ejecutar nada ni crear registros.',
+      'Dime el residuo en una frase. Yo lo devuelvo como: registro visible si existe, inferencia si hay base, hipótesis si falta evidencia, y ruta mínima si conviene observarlo.',
     ].join('\n\n');
   }
 
   if (intent === 'closure') {
     return [
-      connected ? inventory : 'No veo todavía inventario suficiente para cerrar algo con certeza.',
+      'Para cerrar algo en SFI hace falta una cadena mínima: qué pasó, qué evidencia lo sostiene, qué patrón toca, qué decisión pide y qué criterio permite decir “cerrado”.',
       lensLimit,
-      'Para cerrar algo, se requiere cadena mínima: qué existe, por qué existe, qué evidencia lo sostiene y qué destino correcto tiene.',
-      'Si falta una pieza, no lo cierres como verdad. Déjalo como pendiente, hipótesis, workbook o pregunta abierta.',
+      'Si falta una pieza, no conviene cerrarlo. Conviene dejarlo como hipótesis, pendiente de workbook o ruta de observación.',
     ].join('\n\n');
   }
 
   if (intent === 'reading') {
     return [
-      connected ? inventory : 'Sin datos conectados puedo dar una guía de lectura, no un dictamen interno.',
+      'Lectura operativa: busca repetición, no dramatismo. Una fricción pequeña pero recurrente suele pesar más que una señal intensa y aislada.',
       lensLimit,
-      'Lectura: busca repetición, no intensidad. Una fricción repetida vale más que una alarma fuerte pero aislada.',
-      'Puedo comparar patrones, eventos y propuestas visibles. Si no existen, puedo ayudarte a definir qué observar primero.',
+      'Puedo ayudarte a convertir esa lectura en pregunta observable, bitácora legible o ruta de perturbación mínima sin ejecutar cambios desde el chat.',
     ].join('\n\n');
   }
 
-  return [
-    connected ? inventory : 'No hay datos conectados suficientes para este lente. Eso no bloquea la conversación.',
-    lensLimit,
-    'Puedo responder libremente dentro del marco SFI: explicar el sitio, pensar atractores, ordenar dudas, teorizar, hacer preguntas, detectar huecos y decir “no sé” cuando no haya base.',
-    'Límite: no ejecuto acciones, no creo registros y no presento inferencias como datos.',
-  ].join('\n\n');
+  return 'Sí. Puedo dialogar libremente contigo desde VISOR. Uso SFI como memoria y marco cuando aplica, y conocimiento general cuando la pregunta lo requiere. Mi límite es no mentir: no invento registros ni ejecuto cambios. Puedo ayudarte a pensar, traducir, proyectar, diseñar rutas y consolidar el instituto.';
 }
 
 async function llmCompanionResponse(contextKey: VisorContextKey, prompt: string, twin: TwinState | null) {
@@ -187,15 +256,14 @@ async function llmCompanionResponse(contextKey: VisorContextKey, prompt: string,
       context: {
         visor_context: context,
         system_snapshot: snapshot,
-        rule: [
-          SFI_FREE_VISOR_CONTEXT,
-          'Tono: clínico, directo, estable. Precisión antes que dramatización.',
-          'Responder libremente como chat conversacional de VISOR MODE, no como formulario de nodos.',
-          'Puede contestar preguntas generales sobre el sitio, SFI, atractores, bitácoras, atlas, workbook, evidencia y dirección.',
-          'Si pregunta por un objeto no registrado —por ejemplo un perro, una persona o una historia personal— decir que no está registrado como nodo y pedir contexto sin bloquear la conversación.',
-          'No encadenar todo a evidencia si la pregunta es conceptual. Sí declarar límites cuando falte dato conectado.',
-          'No ejecutar acciones, no crear registros, no aprobar decisiones y no fingir acceso a datos inexistentes.',
-        ].join('\n'),
+        visible_memory: {
+          nodes: twin?.data?.seed?.nodeCatalog ?? [],
+          documents: twin?.data?.seed?.documentCatalog ?? [],
+          patterns: twin?.data?.seed?.patternCatalog ?? [],
+          proposals: twin?.data?.proposals ?? [],
+          recentEvents: twin?.data?.seed?.recentEvents ?? [],
+        },
+        rule: SFI_VISOR_ROOT_PROMPT,
       },
     }),
   }).catch(() => null);
@@ -215,7 +283,7 @@ export function useVisorMode() {
   };
 }
 
-export function useVisorContext(initial: VisorContextKey = 'nodes') {
+export function useVisorContext(initial: VisorContextKey = 'bitacoras') {
   const [contextKey, setContextKey] = useState<VisorContextKey>(initial);
   const context = useMemo(() => findVisorContext(contextKey), [contextKey]);
   return { contextKey, context, setContextKey };
@@ -225,7 +293,7 @@ export function useVisorChat(contextKey: VisorContextKey, twin: TwinState | null
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [messages, setMessages] = useState<VisorChatMessage[]>([
-    { role: 'visor', text: 'Estoy en Visor Mode. Puedes preguntarme libremente. Observo el contexto de SystemFriction Institute, pero no estoy encadenado a nodos: si falta dato, lo digo; si la pregunta es conceptual, respondo desde el marco.' },
+    { role: 'visor', text: 'Soy VISOR ROOT. Puedo dialogar contigo desde la memoria visible de SFI y desde conocimiento general cuando aplique. No ejecuto acciones, no creo registros y no invento evidencia.' },
   ]);
 
   async function submit(prompt: string) {


### PR DESCRIPTION
### Motivation
- Reorientar VISOR para que deje de comportarse como inventario de nodos y pase a ser el interlocutor operativo (VISOR ROOT) del instituto, usando memoria visible y diferenciando registro/inferencia/hipótesis.
- Permitir uso real de motores externos cuando haya claves configuradas y mantener un fallback local útil cuando no las haya.
- Mejorar la experiencia de activación visual del VISOR con un nodo dorado persistente e introducir una vista útil de bitácora en VISOR.

### Description
- Habilita ruteo real a proveedores IA y fallbacks en `src/observatory/ai/aiProviderRouter.ts`, añadiendo llamadas a OpenAI, Anthropic y endpoints compatibles (Groq/DeepSeek), construyendo instrucciones de sistema y usando la clave del proveedor si existe; cuando no hay clave devuelve un `local_stub` o fallback específico para `sfi_visor_companion` según el modo.
- Reemplaza y refuerza el prompt interno de VISOR con el nuevo `SFI_VISOR_ROOT_PROMPT` en `src/observatory/components/root/visorHooks.ts`, y convierte las respuestas locales en mensajes operativos que no abren con conteos ni inventan registros, además de pasar la `visible_memory` al endpoint AI.
- Mejora el comportamiento visual y de activación en `src/observatory/components/root/VisorMode.tsx`, `src/observatory/components/root/VisorGoldenNode.tsx` y `src/observatory/components/root/RootDashboardClient.tsx` para mostrar un nodo dorado persistente (`ROOT VISOR`) que activa el chat al hacer clic y establece `bitacoras` como contexto por defecto; añade un panel de bitácora de sólo lectura mapeando `recentEvents` con actor/timestamp/resumen y acción “preguntar sobre esta entrada”.
- Ajusta la UI de chat en `src/observatory/components/root/VisorChat.tsx` para enmarcar VISOR como “interlocutor operativo” que lee la memoria visible pero no ejecuta acciones, y actualiza textos y placeholders coherentes con la nueva función.

### Testing
- Ejecuté `npm run build`, el comando falló por ausencia del binario `next` en el entorno (resultado: failed). 
- Ejecuté `npx tsc --noEmit --pretty false`, la ejecución se detuvo en la advertencia de deprecación de `baseUrl` en `tsconfig.json` (resultado: failed). 
- Ejecuté `npx tsc --noEmit --pretty false --ignoreDeprecations 6.0`, el typecheck corrió pero falló debido a dependencias/decl. de tipos ausentes y errores TypeScript a nivel de repo (resultado: failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a201b9b7478832f97b519a757473905)