### PR TITLE
Connect AMV observatory state across ROOT, ScoreFriction, Logbook and WSV

### DIFF
--- a/docs/amv/AMV_DASHBOARD_GENERATION_POLICY.md
+++ b/docs/amv/AMV_DASHBOARD_GENERATION_POLICY.md
@@ -1,0 +1,35 @@
+# AMV Dashboard Generation Policy
+
+Un dashboard AMV solo puede generarse como UI cuando el contrato trae:
+
+- scope;
+- pregunta ontologica;
+- objeto observable;
+- EvidenceTrust permitido;
+- fuentes;
+- emptyState honesto;
+- outputModes;
+- ArchiveLayer;
+- prohibiciones;
+- criterio de cierre.
+
+Endpoint: `POST /api/amv/dashboard/generate`.
+
+Si falta algo, la respuesta debe ser `spec_only`. No se genera UI.
+
+Ejemplo de prueba:
+
+```json
+{
+  "scope": "scorefriction",
+  "ontologicalQuestion": "Que patron cultural persiste?",
+  "observableObject": "cultural_wave_case",
+  "evidenceTrust": ["verified", "declared"],
+  "sources": ["scorefriction_observations"],
+  "emptyState": "Contrato observable disponible. Sin estado vivo suficiente.",
+  "outputModes": ["dashboard"],
+  "archiveLayer": "living_observatory",
+  "prohibitions": ["No fingir observacion"],
+  "closureCriteria": "Existe observacion, vector y evento de bitacora."
+}
+```

--- a/docs/observatories/SFI_OBSERVATORY_CONNECTION_AUDIT.md
+++ b/docs/observatories/SFI_OBSERVATORY_CONNECTION_AUDIT.md
@@ -1,0 +1,98 @@
+# SFI Observatory Connection Audit
+
+Fecha: 2026-06-08
+
+## 1. Que existe ya
+
+- AMV core: runtime scoped, specs, EvidenceTrust, ArchiveLayer, FieldOperators, OutputModes y registry por scope.
+- Scopes AMV: `root`, `scorefriction`, `governance-reality`, `cluster-atlas`, `signal-vane`, `cognitive-twin-engine`.
+- Dashboards contractuales: `ScopedDashboardShell` y `AmvPanelRenderer`.
+- ScoreFriction: ingestion real, normalizacion, vectores, prototipos, verificaciones y eventos epistemicos.
+- ROOT: consola operativa, VISOR, twin state, WSV/MIHM translators y attractor/field state translators.
+
+## 2. Que esta solo como contrato/spec
+
+- Governance Reality, Cluster Atlas, Signal Vane, Cognitive Twin Engine y Root AMV tienen dashboard spec pero no conector vivo por scope.
+- Dashboard generation policy existia conceptualmente; ahora queda en `dashboardGenerationPolicy.ts` y `dashboardFactory.ts`.
+
+## 3. Que ya tiene endpoint
+
+- AMV runtime: `/api/amv`.
+- AMV state: `/api/amv/state`.
+- ScoreFriction ingest/evaluate/observe/propose/verify/evidence/audio.
+- ScoreFriction state: `/api/scorefriction/state`.
+- Twin state: `/api/twin/state`.
+- WorldSpect state: `/api/worldspect/state`.
+
+## 4. Que ya lee base de datos
+
+- ScoreFriction state lee `scorefriction_observations`, `scorefriction_vectors`, `scorefriction_prototypes`, `scorefriction_verifications` y `epistemic_events`.
+- WSV state lee `worldspect_snapshots`.
+- Twin state conserva su lectura existente y ahora agrega overview AMV.
+
+## 5. Que solo pinta plantilla
+
+- Scopes AMV sin conector vivo siguen mostrando contrato observable con estado degradado.
+- Los paneles AMV ya no dicen activo si no hay lectura viva.
+
+## 6. Que llega a ROOT
+
+- `/api/twin/state` incluye `amvScopes`.
+- `RootObservatoryIndex` muestra scopes, evidencia, degradacion, sandbox, regimen, atractor y warnings.
+
+## 7. Que no llega a ROOT
+
+- WSV llega como translator existente y endpoint independiente, pero no se promueve automaticamente a regimen.
+- Scopes sin conector no llegan como vivos; llegan como degradados.
+
+## 8. Que llega a bitacora
+
+- ScoreFriction ingest ya registra eventos en `epistemic_events` con `logbookId = SCOREFRICTION`.
+- `saveAmvReadingToLogbook` permite guardar lectura AMV por scope con routing policy.
+
+## 9. Que no llega a bitacora
+
+- La UI de `RootLogbookConsole` todavia no escribe entradas desde botones productivos.
+- VISOR no persiste registros y no debe hacerlo.
+
+## 10. Que esta degradado
+
+- Cualquier scope sin conector vivo.
+- WSV sin snapshot con fecha, fuente y confianza.
+- ScoreFriction si faltan observaciones, vectores o evento de bitacora.
+
+## 11. Que puede alimentar regimen
+
+- ScoreFriction solo si existe observacion real y source coverage mayor a cero.
+- Otros scopes no alimentan regimen hasta tener conector vivo.
+
+## 12. Que debe quedarse en sandbox
+
+- Simulated/sandbox evidence.
+- Dashboard generation requests que no cumplan contrato AMV completo.
+- Scopes sin fuentes reales.
+
+## 13. Archivos cambiados para cerrar el flujo
+
+- `src/lib/amv/core/amvScopeStateTypes.ts`
+- `src/lib/amv/core/amvStateBuilder.ts`
+- `src/app/api/amv/state/route.ts`
+- `src/lib/amv/scopes/scorefriction/scorefrictionStateConnector.ts`
+- `src/app/api/scorefriction/state/route.ts`
+- `src/observatory/components/amv/ScopedDashboardShell.tsx`
+- `src/observatory/components/amv/AmvPanelRenderer.tsx`
+- `src/lib/root/rootScopeOverview.ts`
+- `src/observatory/components/root/RootObservatoryIndex.tsx`
+- `src/app/api/twin/state/route.ts`
+- `src/lib/amv/core/logbookRoutingPolicy.ts`
+- `src/lib/amv/core/saveAmvReadingToLogbook.ts`
+- `src/observatory/components/root/RootLogbookConsole.tsx`
+- `src/lib/worldspect/worldspectStateBuilder.ts`
+- `src/app/api/worldspect/state/route.ts`
+- `src/lib/amv/scopes/root/rootWsvConnector.ts`
+- `src/app/(observatory)/observatories/page.tsx`
+- `src/observatory/components/amv/ObservatoryOfObservatories.tsx`
+- `src/observatory/components/amv/ObservatoryScopeCard.tsx`
+- `src/lib/amv/core/dashboardGenerationPolicy.ts`
+- `src/lib/amv/core/dashboardFactory.ts`
+- `src/app/api/amv/dashboard/generate/route.ts`

--- a/docs/observatories/SFI_TOTAL_OBSERVATORY_PLAN.md
+++ b/docs/observatories/SFI_TOTAL_OBSERVATORY_PLAN.md
@@ -1,0 +1,28 @@
+# SFI Total Observatory Plan
+
+El observatorio total no reemplaza ROOT. Observa scopes AMV y declara si estan vivos, degradados, en sandbox o incompletos.
+
+Ruta: `/observatories`.
+
+Reglas:
+
+- No declarar vivo un scope sin evidencia.
+- No permitir regimen si no hay fuente y coverage suficiente.
+- No fortalecer atractor sin evidencia verificada.
+- Mostrar deuda como warning operativo.
+- Dejar scopes sin conector como degradados.
+
+Pruebas manuales:
+
+1. Abrir `/api/amv/state`.
+2. Confirmar que devuelve todos los scopes.
+3. Abrir `/api/amv/state?scope=scorefriction`.
+4. Confirmar que ScoreFriction muestra `live` solo si hay observacion real.
+5. Abrir `/observatories`.
+6. Confirmar que los scopes degradados no dicen "Observatorio activo".
+7. Abrir `/api/twin/state`.
+8. Confirmar `data.amvScopes`.
+
+Siguiente fase recomendada:
+
+- Crear conectores vivos para Governance Reality y Signal Vane antes de promover mas dashboards.

--- a/docs/root/ROOT_OPERATION_GUIDE.md
+++ b/docs/root/ROOT_OPERATION_GUIDE.md
@@ -1,0 +1,35 @@
+# ROOT Operation Guide
+
+ROOT coordina observatorios; no los absorbe.
+
+Flujo objetivo:
+
+```txt
+ingestion -> evidence -> vector -> event -> logbook -> AMV state -> live dashboard -> ROOT scope overview -> decision or closure
+```
+
+Pruebas manuales:
+
+1. `POST /api/scorefriction/ingest`.
+2. Confirmar registro en `scorefriction_observations`.
+3. Confirmar vector en `scorefriction_vectors`.
+4. Confirmar evento en `epistemic_events` con `logbook_id = SCOREFRICTION`.
+5. Confirmar `/api/scorefriction/state`.
+6. Confirmar `/api/amv/state?scope=scorefriction`.
+7. Confirmar `/scorefriction` mostrando estado vivo o degraded honesto.
+8. Confirmar ROOT mostrando scope ScoreFriction en el panel Root.
+9. Confirmar VISOR apagable con "Salir de VISOR" y apagado al entrar en control.
+10. Confirmar `/api/worldspect/state` degraded si no hay fuente suficiente.
+
+Queda degraded a proposito:
+
+- Scopes AMV sin conector vivo.
+- WSV sin snapshot valido.
+- Cualquier lectura sin evidencia o source coverage.
+
+No se toco:
+
+- Migraciones Supabase.
+- Permisos productivos.
+- Nuevo chat.
+- Rediseño estetico de ROOT.

--- a/src/app/(observatory)/observatories/page.tsx
+++ b/src/app/(observatory)/observatories/page.tsx
@@ -1,0 +1,7 @@
+import { buildAllAmvScopeStates } from '@/lib/amv/core/amvStateBuilder'
+import { ObservatoryOfObservatories } from '@/observatory/components/amv/ObservatoryOfObservatories'
+
+export default async function ObservatoriesPage() {
+  const scopes = await buildAllAmvScopeStates()
+  return <ObservatoryOfObservatories scopes={scopes} />
+}

--- a/src/app/api/amv/dashboard/generate/route.ts
+++ b/src/app/api/amv/dashboard/generate/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+import { createDashboardContract } from '@/lib/amv/core/dashboardFactory'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}))
+  return NextResponse.json(createDashboardContract(body && typeof body === 'object' ? body : {}))
+}

--- a/src/app/api/amv/state/route.ts
+++ b/src/app/api/amv/state/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import { buildAllAmvScopeStates, buildAmvScopeState } from '@/lib/amv/core/amvStateBuilder'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const scope = searchParams.get('scope')
+  if (!scope) {
+    const scopes = await buildAllAmvScopeStates()
+    return NextResponse.json({ ok: true, scopes })
+  }
+
+  const state = await buildAmvScopeState(scope)
+  return NextResponse.json(state, { status: state.ok ? 200 : 404 })
+}

--- a/src/app/api/scorefriction/state/route.ts
+++ b/src/app/api/scorefriction/state/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { buildScoreFrictionScopeState } from '@/lib/amv/scopes/scorefriction/scorefrictionStateConnector'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  return NextResponse.json(await buildScoreFrictionScopeState())
+}

--- a/src/app/api/twin/state/route.ts
+++ b/src/app/api/twin/state/route.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from 'next/server';
 import { readTwinSelfObservation } from '@/lib/operational/twinState';
+import { buildRootScopeOverview } from '@/lib/root/rootScopeOverview';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  const state = await readTwinSelfObservation();
-  return NextResponse.json({ ok: true, data: state });
+  const [state, amvScopes] = await Promise.all([
+    readTwinSelfObservation(),
+    buildRootScopeOverview(),
+  ]);
+
+  return NextResponse.json({ ok: true, data: { ...state, amvScopes } });
 }

--- a/src/app/api/worldspect/state/route.ts
+++ b/src/app/api/worldspect/state/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { buildWorldSpectState } from '@/lib/worldspect/worldspectStateBuilder'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  return NextResponse.json({ ok: true, data: await buildWorldSpectState() })
+}

--- a/src/app/scorefriction/page.tsx
+++ b/src/app/scorefriction/page.tsx
@@ -1,11 +1,14 @@
 import { ScoreFrictionPanel, ScoreFrictionShell } from '@/scorefriction/components/ScoreFrictionShell';
 import { scorefrictionDashboardSpec } from '@/lib/amv/scopes/scorefriction/scorefrictionDashboardSpec';
 import { ScopedDashboardShell } from '@/observatory/components/amv/ScopedDashboardShell';
+import { buildScoreFrictionScopeState } from '@/lib/amv/scopes/scorefriction/scorefrictionStateConnector';
 
-export default function ScoreFrictionPage() {
+export default async function ScoreFrictionPage() {
+  const state = await buildScoreFrictionScopeState();
+
   return (
     <div className="grid gap-4">
-      <ScopedDashboardShell spec={scorefrictionDashboardSpec} />
+      <ScopedDashboardShell spec={scorefrictionDashboardSpec} state={state} />
       <ScoreFrictionShell
         title="Observatorio"
         subtitle="Observa fuentes culturales imperfectas, declara su friccion, normaliza senal y verifica si un protoatractor cultural adquiere forma."

--- a/src/app/scorefriction/wave/page.tsx
+++ b/src/app/scorefriction/wave/page.tsx
@@ -1,5 +1,13 @@
 import CulturalVectorDashboard from '@/scorefriction/components/CulturalVectorDashboard';
+import { ScoreFrictionStateBanner } from '@/scorefriction/components/ScoreFrictionStateBanner';
+import { buildScoreFrictionScopeState } from '@/lib/amv/scopes/scorefriction/scorefrictionStateConnector';
 
-export default function ScoreFrictionWavePage() {
-  return <CulturalVectorDashboard />;
+export default async function ScoreFrictionWavePage() {
+  const state = await buildScoreFrictionScopeState();
+  return (
+    <>
+      <ScoreFrictionStateBanner state={state} />
+      <CulturalVectorDashboard />
+    </>
+  );
 }

--- a/src/app/scorefriction/wide/page.tsx
+++ b/src/app/scorefriction/wide/page.tsx
@@ -1,5 +1,13 @@
 import { ScoreFrictionWideClient } from '@/scorefriction/components/ScoreFrictionWideClient';
+import { ScoreFrictionStateBanner } from '@/scorefriction/components/ScoreFrictionStateBanner';
+import { buildScoreFrictionScopeState } from '@/lib/amv/scopes/scorefriction/scorefrictionStateConnector';
 
-export default function ScoreFrictionWidePage() {
-  return <ScoreFrictionWideClient />;
+export default async function ScoreFrictionWidePage() {
+  const state = await buildScoreFrictionScopeState();
+  return (
+    <>
+      <ScoreFrictionStateBanner state={state} />
+      <ScoreFrictionWideClient />
+    </>
+  );
 }

--- a/src/lib/amv/core/amvScopeStateTypes.ts
+++ b/src/lib/amv/core/amvScopeStateTypes.ts
@@ -1,0 +1,64 @@
+import type { AmvArchiveLayer } from './archiveLayerPolicy'
+import type { AmvDashboardSpec } from './dashboardSpecTypes'
+import type { AmvEvidenceTrust } from './evidenceTypes'
+import type { AmvTrustLevel } from './amvTypes'
+
+export type AmvScopeLiveState = 'live' | 'degraded' | 'sandbox' | 'missing'
+
+export type AmvLatestReading = {
+  id?: string
+  label: string
+  observedAt?: string
+  summary: string
+  trust: AmvEvidenceTrust
+  source?: string
+  payload?: unknown
+}
+
+export type AmvEvidenceSummary = {
+  count: number
+  verified: number
+  declared: number
+  derived: number
+  degraded: number
+  sandbox: number
+  sourceCoverage: number
+  latestObservedAt?: string
+}
+
+export type AmvRecentEvent = {
+  id?: string
+  label: string
+  occurredAt?: string
+  trust: AmvEvidenceTrust
+  summary?: string
+}
+
+export type AmvArchiveLayerSummary = {
+  layer: AmvArchiveLayer
+  count: number
+  canFeedRegime: boolean
+}
+
+export type AmvScopeState = {
+  ok: true
+  scope: string
+  label: string
+  state: AmvScopeLiveState
+  dashboardSpec?: AmvDashboardSpec
+  latestReading: AmvLatestReading | null
+  sourceTrust: AmvTrustLevel
+  evidenceSummary: AmvEvidenceSummary
+  recentEvents: AmvRecentEvent[]
+  archiveLayerSummary: AmvArchiveLayerSummary[]
+  warnings: string[]
+  canFeedRegime: boolean
+  canSupportAttractor: boolean
+  selectedContext?: unknown
+}
+
+export type AmvScopeStateError = {
+  ok: false
+  error: string
+  availableScopes?: string[]
+}

--- a/src/lib/amv/core/amvStateBuilder.ts
+++ b/src/lib/amv/core/amvStateBuilder.ts
@@ -1,0 +1,63 @@
+import { getAmvDashboardByScope, listAmvDashboards } from '../registry/dashboardRegistry'
+import { getAmvScope, listAmvScopes } from '../registry/scopeRegistry'
+import { buildScoreFrictionScopeState } from '../scopes/scorefriction/scorefrictionStateConnector'
+import type { AmvScopeState, AmvScopeStateError } from './amvScopeStateTypes'
+
+function labelForScope(scope: string) {
+  return scope.split('-').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
+}
+
+export function buildDegradedAmvScopeState(scope: string, warning?: string): AmvScopeState {
+  const dashboardSpec = getAmvDashboardByScope(scope)
+  return {
+    ok: true,
+    scope,
+    label: dashboardSpec?.title ?? labelForScope(scope),
+    state: 'degraded',
+    dashboardSpec,
+    latestReading: null,
+    sourceTrust: 'degraded',
+    evidenceSummary: {
+      count: 0,
+      verified: 0,
+      declared: 0,
+      derived: 0,
+      degraded: 1,
+      sandbox: 0,
+      sourceCoverage: 0,
+    },
+    recentEvents: [],
+    archiveLayerSummary: [
+      { layer: 'technical_audit', count: 1, canFeedRegime: false },
+      { layer: 'living_observatory', count: 0, canFeedRegime: false },
+      { layer: 'sandbox', count: 0, canFeedRegime: false },
+    ],
+    warnings: [warning ?? 'Contrato observable disponible. Sin estado vivo suficiente.'],
+    canFeedRegime: false,
+    canSupportAttractor: false,
+  }
+}
+
+export async function buildAmvScopeState(scopeInput: string): Promise<AmvScopeState | AmvScopeStateError> {
+  const scope = scopeInput.trim().toLowerCase()
+  if (!scope) return { ok: false, error: 'missing_scope', availableScopes: listAmvScopes() }
+  if (!getAmvScope(scope)) return { ok: false, error: 'unknown_scope', availableScopes: listAmvScopes() }
+  if (scope === 'scorefriction') return buildScoreFrictionScopeState()
+  return buildDegradedAmvScopeState(scope)
+}
+
+export async function buildAllAmvScopeStates() {
+  const scopes = listAmvScopes()
+  const states = await Promise.all(scopes.map((scope) => buildAmvScopeState(scope)))
+  return states.filter((state): state is AmvScopeState => state.ok)
+}
+
+export function listAmvDashboardContracts() {
+  return listAmvDashboards().map((dashboard) => ({
+    scope: dashboard.scope,
+    title: dashboard.title,
+    panels: dashboard.panels.length,
+    lanes: dashboard.lanes,
+    hasStateConnector: dashboard.scope === 'scorefriction',
+  }))
+}

--- a/src/lib/amv/core/dashboardFactory.ts
+++ b/src/lib/amv/core/dashboardFactory.ts
@@ -1,0 +1,33 @@
+import { validateDashboardGeneration, type DashboardGenerationInput } from './dashboardGenerationPolicy'
+
+export function createDashboardContract(input: DashboardGenerationInput) {
+  const validation = validateDashboardGeneration(input)
+  if (!validation.ok) {
+    return {
+      ok: false as const,
+      validation,
+      specDraft: {
+        scope: input.scope ?? 'missing',
+        status: 'spec_only',
+        missing: validation.missing,
+      },
+    }
+  }
+
+  return {
+    ok: true as const,
+    validation,
+    dashboard: {
+      scope: input.scope,
+      ontologicalQuestion: input.ontologicalQuestion,
+      observableObject: input.observableObject,
+      evidenceTrust: input.evidenceTrust,
+      sources: input.sources,
+      emptyState: input.emptyState,
+      outputModes: input.outputModes,
+      archiveLayer: input.archiveLayer,
+      prohibitions: input.prohibitions,
+      closureCriteria: input.closureCriteria,
+    },
+  }
+}

--- a/src/lib/amv/core/dashboardGenerationPolicy.ts
+++ b/src/lib/amv/core/dashboardGenerationPolicy.ts
@@ -1,0 +1,38 @@
+import type { AmvArchiveLayer } from './archiveLayerPolicy'
+import type { AmvEvidenceTrust } from './evidenceTypes'
+import type { AmvOutputMode } from './outputModeTypes'
+
+export type DashboardGenerationInput = {
+  scope?: string
+  ontologicalQuestion?: string
+  observableObject?: string
+  evidenceTrust?: AmvEvidenceTrust[]
+  sources?: string[]
+  emptyState?: string
+  outputModes?: AmvOutputMode[]
+  archiveLayer?: AmvArchiveLayer
+  prohibitions?: string[]
+  closureCriteria?: string
+}
+
+export function validateDashboardGeneration(input: DashboardGenerationInput) {
+  const missing = [
+    ['scope', input.scope],
+    ['ontologicalQuestion', input.ontologicalQuestion],
+    ['observableObject', input.observableObject],
+    ['evidenceTrust', input.evidenceTrust?.length],
+    ['sources', input.sources?.length],
+    ['emptyState', input.emptyState],
+    ['outputModes', input.outputModes?.length],
+    ['archiveLayer', input.archiveLayer],
+    ['prohibitions', input.prohibitions?.length],
+    ['closureCriteria', input.closureCriteria],
+  ].filter(([, value]) => !value).map(([key]) => key)
+
+  return {
+    ok: missing.length === 0,
+    missing,
+    action: missing.length === 0 ? 'generate_dashboard' : 'create_spec_only',
+    warning: missing.length === 0 ? null : 'No generar UI: faltan campos de contrato AMV.',
+  }
+}

--- a/src/lib/amv/core/logbookRoutingPolicy.ts
+++ b/src/lib/amv/core/logbookRoutingPolicy.ts
@@ -1,0 +1,70 @@
+import type { AmvArchiveLayer } from './archiveLayerPolicy'
+import type { AmvEvidenceDecisionSupport, AmvEvidenceTrust } from './evidenceTypes'
+
+export type AmvLogbookRoute = {
+  layer: AmvArchiveLayer | 'not_promoted'
+  decisionSupport: AmvEvidenceDecisionSupport
+  canPromote: boolean
+  reason: string
+}
+
+export function routeAmvReadingToLogbook(input: {
+  trust: AmvEvidenceTrust | 'derived' | 'degraded'
+  hasOperator?: boolean
+  hasTimestamp?: boolean
+  closesLoop?: boolean
+  changesRoute?: boolean
+}): AmvLogbookRoute {
+  if (input.trust === 'verified') {
+    return {
+      layer: input.closesLoop || input.changesRoute ? 'attractor' : 'living_observatory',
+      decisionSupport: input.closesLoop || input.changesRoute ? 'strong_decision' : 'operational_reading',
+      canPromote: true,
+      reason: 'Evidencia verificada con criterio suficiente para lectura fuerte.',
+    }
+  }
+
+  if (input.trust === 'declared') {
+    const canPromote = Boolean(input.hasOperator && input.hasTimestamp)
+    return {
+      layer: canPromote ? 'living_observatory' : 'technical_audit',
+      decisionSupport: canPromote ? 'operational_reading' : 'audit_only',
+      canPromote,
+      reason: canPromote ? 'Declaracion con operador y fecha.' : 'Declaracion incompleta; falta operador o timestamp.',
+    }
+  }
+
+  if (input.trust === 'inferred' || input.trust === 'derived') {
+    return {
+      layer: 'technical_audit',
+      decisionSupport: 'route_risk_closure_only',
+      canPromote: false,
+      reason: 'Inferencia util para auditoria o lectura operativa, no para decision fuerte.',
+    }
+  }
+
+  if (input.trust === 'simulated' || input.trust === 'sandbox') {
+    return {
+      layer: 'sandbox',
+      decisionSupport: 'excluded_from_regime',
+      canPromote: false,
+      reason: 'Sandbox o simulacion; no alimenta regimen.',
+    }
+  }
+
+  if (input.trust === 'audit' || input.trust === 'degraded') {
+    return {
+      layer: 'technical_audit',
+      decisionSupport: 'audit_only',
+      canPromote: false,
+      reason: 'Estado degradado o tecnico; queda en auditoria.',
+    }
+  }
+
+  return {
+    layer: 'not_promoted',
+    decisionSupport: 'not_promoted',
+    canPromote: false,
+    reason: 'Trust desconocido; no se promueve.',
+  }
+}

--- a/src/lib/amv/core/saveAmvReadingToLogbook.ts
+++ b/src/lib/amv/core/saveAmvReadingToLogbook.ts
@@ -1,0 +1,45 @@
+import { appendEpistemicEvent } from '@/lib/events/eventStore'
+import { routeAmvReadingToLogbook } from './logbookRoutingPolicy'
+import type { AmvEvidenceTrust } from './evidenceTypes'
+
+export async function saveAmvReadingToLogbook(input: {
+  scope: string
+  trust: AmvEvidenceTrust
+  summary: string
+  operator?: string
+  observedAt?: string
+  payload?: unknown
+  closesLoop?: boolean
+  changesRoute?: boolean
+}) {
+  const route = routeAmvReadingToLogbook({
+    trust: input.trust,
+    hasOperator: Boolean(input.operator),
+    hasTimestamp: Boolean(input.observedAt),
+    closesLoop: input.closesLoop,
+    changesRoute: input.changesRoute,
+  })
+
+  if (route.layer === 'not_promoted') {
+    return { ok: false as const, error: 'amv_reading_not_promoted', route }
+  }
+
+  const event = await appendEpistemicEvent({
+    eventName: `amv.${input.scope}.reading.saved`,
+    epistemicClass: input.trust === 'verified' ? 'observed' : input.trust === 'declared' ? 'declared' : 'derived',
+    confidence: input.trust === 'verified' ? 0.8 : input.trust === 'declared' ? 0.58 : 0.42,
+    payload: {
+      scope: input.scope,
+      summary: input.summary,
+      route,
+      operator: input.operator ?? null,
+      observedAt: input.observedAt ?? null,
+      payload: input.payload ?? null,
+    },
+    source: { sourceId: 'AMV', sourceType: 'scope_reading' },
+    logbookId: `AMV:${input.scope.toUpperCase()}`,
+    lineage: [input.scope],
+  })
+
+  return { ...event, route }
+}

--- a/src/lib/amv/scopes/root/rootWsvConnector.ts
+++ b/src/lib/amv/scopes/root/rootWsvConnector.ts
@@ -1,0 +1,11 @@
+import { buildWorldSpectState } from '@/lib/worldspect/worldspectStateBuilder'
+
+export async function buildRootWsvContext() {
+  const state = await buildWorldSpectState()
+  return {
+    source: 'worldspect',
+    canOrientExternalContext: Boolean(state.observed_at && state.sources.length > 0 && state.confidence > 0),
+    state,
+    warnings: state.warnings,
+  }
+}

--- a/src/lib/amv/scopes/scorefriction/scorefrictionStateConnector.ts
+++ b/src/lib/amv/scopes/scorefriction/scorefrictionStateConnector.ts
@@ -1,0 +1,161 @@
+import { createServiceSupabaseClient } from '@/runtime/supabase/server'
+import type { AmvScopeState } from '@/lib/amv/core/amvScopeStateTypes'
+import type { AmvEvidenceTrust } from '@/lib/amv/core/evidenceTypes'
+import type { AmvTrustLevel } from '@/lib/amv/core/amvTypes'
+import { scorefrictionDashboardSpec } from './scorefrictionDashboardSpec'
+
+type Row = Record<string, unknown>
+
+function asRows(data: unknown): Row[] {
+  return Array.isArray(data) ? data.filter((item): item is Row => !!item && typeof item === 'object' && !Array.isArray(item)) : []
+}
+
+function str(value: unknown, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}
+
+function num(value: unknown, fallback = 0) {
+  const parsed = Number(value ?? fallback)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {}
+}
+
+function trustFromEvent(row: Row): AmvEvidenceTrust {
+  const klass = str(row.epistemic_class)
+  if (klass === 'observed') return 'verified'
+  if (klass === 'declared') return 'declared'
+  if (klass === 'derived' || klass === 'inferred') return 'inferred'
+  if (klass === 'simulated' || klass === 'fixture') return 'sandbox'
+  return 'unknown'
+}
+
+function latestLabel(row: Row | undefined) {
+  if (!row) return 'Sin lectura viva'
+  const normalized = record(row.normalized_payload)
+  const raw = record(row.raw_payload)
+  return str(normalized.title) || str(raw.title) || str(row.case_id) || 'Observacion ScoreFriction'
+}
+
+async function queryRows(table: string, select = '*', order = 'created_at', limit = 25, eq?: { column: string; value: string }) {
+  const service = createServiceSupabaseClient()
+  let query = service.from(table).select(select).order(order, { ascending: false }).limit(limit)
+  if (eq) query = query.eq(eq.column, eq.value)
+  const { data, error } = await query
+  return { rows: asRows(data), warning: error ? `${table}: ${error.message}` : null }
+}
+
+export async function buildScoreFrictionSelectedContext() {
+  const warnings: string[] = []
+
+  let observations: Row[] = []
+  let vectors: Row[] = []
+  let prototypes: Row[] = []
+  let verifications: Row[] = []
+  let events: Row[] = []
+
+  try {
+    const [obs, vec, proto, ver, evt] = await Promise.all([
+      queryRows('scorefriction_observations'),
+      queryRows('scorefriction_vectors'),
+      queryRows('scorefriction_prototypes'),
+      queryRows('scorefriction_verifications', '*', 'verified_at'),
+      queryRows('epistemic_events', '*', 'created_at', 25, { column: 'logbook_id', value: 'SCOREFRICTION' }),
+    ])
+
+    observations = obs.rows
+    vectors = vec.rows
+    prototypes = proto.rows
+    verifications = ver.rows
+    events = evt.rows
+    warnings.push(...[obs.warning, vec.warning, proto.warning, ver.warning, evt.warning].filter((item): item is string => Boolean(item)))
+  } catch (error) {
+    warnings.push(error instanceof Error ? error.message : 'scorefriction_state_unavailable')
+  }
+
+  const latestObservation = observations[0]
+  const latestVectors = vectors.find((row) => str(row.observation_id) === str(latestObservation?.id)) ?? vectors[0] ?? null
+  const latestEvent = events[0] ?? null
+  const evidenceCount = observations.length + verifications.length
+  const sourceCoverage = observations.reduce((sum, row) => sum + num(row.source_coverage_contribution, 0), 0)
+  const latestReliability = num(latestObservation?.reliability_score, 0)
+  const trust: AmvTrustLevel = evidenceCount === 0 ? 'degraded' : latestReliability >= 0.7 || verifications.length > 0 ? 'observed' : 'derived'
+
+  if (!latestObservation) warnings.push('scorefriction_state_degraded: no hay observaciones reales registradas')
+  if (vectors.length === 0) warnings.push('scorefriction_vectors_missing')
+  if (events.length === 0) warnings.push('scorefriction_logbook_missing')
+
+  return {
+    case_id: str(latestObservation?.case_id) || null,
+    latest_observation: latestObservation ?? null,
+    latest_vectors: latestVectors,
+    evidence_count: evidenceCount,
+    source_coverage: sourceCoverage,
+    latest_event: latestEvent,
+    warnings,
+    trust,
+    tables: {
+      observations: observations.length,
+      vectors: vectors.length,
+      prototypes: prototypes.length,
+      verifications: verifications.length,
+      events: events.length,
+    },
+  }
+}
+
+export async function buildScoreFrictionScopeState(): Promise<AmvScopeState> {
+  const selectedContext = await buildScoreFrictionSelectedContext()
+  const latestObservation = record(selectedContext.latest_observation)
+  const latestEvent = record(selectedContext.latest_event)
+  const latestObservedAt = str(latestObservation.created_at) || str(latestEvent.created_at) || undefined
+  const liveEnough = selectedContext.evidence_count > 0 && Boolean(selectedContext.latest_observation)
+  const verified = selectedContext.trust === 'observed' ? 1 : 0
+  const derived = liveEnough && selectedContext.trust !== 'observed' ? 1 : 0
+
+  return {
+    ok: true,
+    scope: 'scorefriction',
+    label: 'ScoreFriction',
+    state: liveEnough ? 'live' : 'degraded',
+    dashboardSpec: scorefrictionDashboardSpec,
+    latestReading: liveEnough ? {
+      id: str(latestObservation.id) || undefined,
+      label: latestLabel(latestObservation),
+      observedAt: latestObservedAt,
+      summary: `Caso ${str(latestObservation.case_id, 'sin caso')} con ${selectedContext.evidence_count} piezas de evidencia conectadas.`,
+      trust: selectedContext.trust === 'observed' ? 'verified' : 'inferred',
+      source: str(latestObservation.source_name, 'scorefriction'),
+      payload: selectedContext,
+    } : null,
+    sourceTrust: selectedContext.trust,
+    evidenceSummary: {
+      count: selectedContext.evidence_count,
+      verified,
+      declared: 0,
+      derived,
+      degraded: liveEnough ? 0 : 1,
+      sandbox: 0,
+      sourceCoverage: selectedContext.source_coverage,
+      latestObservedAt,
+    },
+    recentEvents: latestEvent ? [{
+      id: str(latestEvent.event_id) || str(latestEvent.id) || undefined,
+      label: str(latestEvent.event_name, 'scorefriction.event'),
+      occurredAt: str(latestEvent.occurred_at) || str(latestEvent.created_at) || undefined,
+      trust: trustFromEvent(latestEvent),
+      summary: str(latestEvent.uncertainty) || undefined,
+    }] : [],
+    archiveLayerSummary: [
+      { layer: liveEnough ? 'living_observatory' : 'technical_audit', count: selectedContext.evidence_count, canFeedRegime: liveEnough },
+      { layer: 'attractor', count: verified, canFeedRegime: verified > 0 },
+      { layer: 'sandbox', count: 0, canFeedRegime: false },
+    ],
+    warnings: selectedContext.warnings,
+    canFeedRegime: liveEnough && selectedContext.source_coverage > 0,
+    canSupportAttractor: verified > 0,
+    selectedContext,
+  }
+}

--- a/src/lib/root/rootScopeOverview.ts
+++ b/src/lib/root/rootScopeOverview.ts
@@ -1,0 +1,17 @@
+import { buildAllAmvScopeStates } from '@/lib/amv/core/amvStateBuilder'
+
+export async function buildRootScopeOverview() {
+  const scopes = await buildAllAmvScopeStates()
+
+  return scopes.map((scope) => ({
+    scope: scope.scope,
+    label: scope.label,
+    state: scope.state,
+    sourceTrust: scope.sourceTrust,
+    latestReading: scope.latestReading,
+    evidenceCount: scope.evidenceSummary.count,
+    canFeedRegime: scope.canFeedRegime,
+    canSupportAttractor: scope.canSupportAttractor,
+    warnings: scope.warnings,
+  }))
+}

--- a/src/lib/worldspect/worldspectStateBuilder.ts
+++ b/src/lib/worldspect/worldspectStateBuilder.ts
@@ -1,0 +1,77 @@
+import { getLatestWorldSpectSnapshot } from './snapshotStore'
+
+export type WorldSpectState = {
+  observed_at: string | null
+  source_state: 'observed' | 'degraded' | 'missing'
+  confidence: number
+  sources: unknown[]
+  source_health: unknown[]
+  degraded_sources: string[]
+  field_state_signal: unknown
+  territory: string
+  time_window: string
+  dominant_external_pressures: string[]
+  relevance_to_sfi: string
+  warnings: string[]
+}
+
+function rawString(value: unknown, fallback: string) {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}
+
+export async function buildWorldSpectState(): Promise<WorldSpectState> {
+  try {
+    const latest = await getLatestWorldSpectSnapshot()
+    if (!latest) {
+      return {
+        observed_at: null,
+        source_state: 'missing',
+        confidence: 0,
+        sources: [],
+        source_health: [],
+        degraded_sources: [],
+        field_state_signal: null,
+        territory: 'unknown',
+        time_window: 'unknown',
+        dominant_external_pressures: [],
+        relevance_to_sfi: 'WSV no orienta contexto externo sin fuente, fecha y confianza.',
+        warnings: ['worldspect_state_missing'],
+      }
+    }
+
+    const raw = latest.raw_payload && typeof latest.raw_payload === 'object' ? latest.raw_payload as Record<string, unknown> : {}
+    const valid = Boolean(latest.observed_at && latest.sources.length > 0 && latest.confidence > 0)
+
+    return {
+      observed_at: latest.observed_at,
+      source_state: valid ? latest.source_state : 'degraded',
+      confidence: latest.confidence,
+      sources: latest.sources,
+      source_health: latest.source_health,
+      degraded_sources: latest.degraded_sources,
+      field_state_signal: latest.field_state_signal,
+      territory: rawString(raw.territory, 'global'),
+      time_window: rawString(raw.time_window, 'latest_snapshot'),
+      dominant_external_pressures: Array.isArray(raw.dominant_external_pressures)
+        ? raw.dominant_external_pressures.filter((item): item is string => typeof item === 'string')
+        : [],
+      relevance_to_sfi: rawString(raw.relevance_to_sfi, valid ? 'Contexto externo disponible para lectura SFI.' : 'WSV degradado; no orienta decision fuerte.'),
+      warnings: valid ? [] : ['worldspect_state_degraded: falta fuente, fecha o confianza suficiente'],
+    }
+  } catch (error) {
+    return {
+      observed_at: null,
+      source_state: 'degraded',
+      confidence: 0,
+      sources: [],
+      source_health: [],
+      degraded_sources: [],
+      field_state_signal: null,
+      territory: 'unknown',
+      time_window: 'unknown',
+      dominant_external_pressures: [],
+      relevance_to_sfi: 'WSV degradado por error de lectura.',
+      warnings: [error instanceof Error ? error.message : 'worldspect_state_unavailable'],
+    }
+  }
+}

--- a/src/observatory/components/amv/AmvPanelRenderer.tsx
+++ b/src/observatory/components/amv/AmvPanelRenderer.tsx
@@ -1,10 +1,14 @@
 import type { AmvDashboardPanelSpec } from '@/lib/amv/core/dashboardSpecTypes'
+import type { AmvScopeState } from '@/lib/amv/core/amvScopeStateTypes'
 
 function joinOrEmpty(values: string[], fallback: string) {
   return values.length ? values.join(' / ') : fallback
 }
 
-export function AmvPanelRenderer({ panel }: { panel: AmvDashboardPanelSpec }) {
+export function AmvPanelRenderer({ panel, state }: { panel: AmvDashboardPanelSpec; state?: AmvScopeState }) {
+  const hasLiveState = Boolean(state?.latestReading)
+  const warning = state?.warnings[0]
+
   return (
     <section className="border border-[#1e1c17] bg-[#0b0a08] p-3">
       <div className="flex items-start justify-between gap-3">
@@ -35,7 +39,34 @@ export function AmvPanelRenderer({ panel }: { panel: AmvDashboardPanelSpec }) {
           <dd className="mt-1 text-[#8f8678]">{panel.minimumEvidence}</dd>
         </div>
       </dl>
-      <p className="mt-3 border-t border-[#1e1c17] pt-3 text-[11px] leading-5 text-[#6f685c]">{panel.emptyState}</p>
+      <div className="mt-3 border-t border-[#1e1c17] pt-3 text-[11px] leading-5 text-[#6f685c]">
+        {hasLiveState ? (
+          <div className="space-y-2">
+            <p className="text-[#b8ad98]">{state?.latestReading?.summary}</p>
+            <dl className="grid grid-cols-2 gap-2 font-mono text-[8px] uppercase tracking-[0.1em]">
+              <div>
+                <dt className="text-[#3f3a32]">Trust</dt>
+                <dd className="mt-1 text-[#c8a951]">{state?.sourceTrust}</dd>
+              </div>
+              <div>
+                <dt className="text-[#3f3a32]">Evidencia</dt>
+                <dd className="mt-1 text-[#c8a951]">{state?.evidenceSummary.count}</dd>
+              </div>
+              <div>
+                <dt className="text-[#3f3a32]">Regimen</dt>
+                <dd className="mt-1 text-[#8f8678]">{state?.canFeedRegime ? 'permitido' : 'no'}</dd>
+              </div>
+              <div>
+                <dt className="text-[#3f3a32]">Atractor</dt>
+                <dd className="mt-1 text-[#8f8678]">{state?.canSupportAttractor ? 'puede sostener' : 'no sostiene'}</dd>
+              </div>
+            </dl>
+            {warning ? <p className="text-[#c87060]">{warning}</p> : null}
+          </div>
+        ) : (
+          <p>Contrato observable disponible. Sin estado vivo suficiente. {panel.emptyState}</p>
+        )}
+      </div>
     </section>
   )
 }

--- a/src/observatory/components/amv/ObservatoryOfObservatories.tsx
+++ b/src/observatory/components/amv/ObservatoryOfObservatories.tsx
@@ -1,0 +1,29 @@
+import type { AmvScopeState } from '@/lib/amv/core/amvScopeStateTypes'
+import { ObservatoryScopeCard } from './ObservatoryScopeCard'
+
+export function ObservatoryOfObservatories({ scopes }: { scopes: AmvScopeState[] }) {
+  const live = scopes.filter((scope) => scope.state === 'live').length
+  const degraded = scopes.filter((scope) => scope.state === 'degraded').length
+
+  return (
+    <main className="min-h-screen bg-[#070706] text-[#d8d0bd]">
+      <header className="border-b border-[#26221b] bg-[#0c0b09]">
+        <div className="mx-auto max-w-6xl px-5 py-6">
+          <p className="font-mono text-[10px] uppercase tracking-[0.26em] text-[#b8924b]">SFI / observatorios</p>
+          <h1 className="mt-2 font-serif text-3xl text-[#ead8aa]">Observatorio de observatorios</h1>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-[#918877]">
+            Observatories observa los scopes AMV. ROOT decide. Ningun scope degradado alimenta regimen ni atractor.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-3 font-mono text-[9px] uppercase tracking-[0.14em] text-[#8f8678]">
+            <span className="border border-[#26221b] px-3 py-2">vivos {live}</span>
+            <span className="border border-[#26221b] px-3 py-2">degradados {degraded}</span>
+            <span className="border border-[#26221b] px-3 py-2">scopes {scopes.length}</span>
+          </div>
+        </div>
+      </header>
+      <section className="mx-auto grid max-w-6xl gap-4 px-5 py-6 md:grid-cols-2 xl:grid-cols-3">
+        {scopes.map((scope) => <ObservatoryScopeCard key={scope.scope} scope={scope} />)}
+      </section>
+    </main>
+  )
+}

--- a/src/observatory/components/amv/ObservatoryScopeCard.tsx
+++ b/src/observatory/components/amv/ObservatoryScopeCard.tsx
@@ -1,0 +1,36 @@
+import type { AmvScopeState } from '@/lib/amv/core/amvScopeStateTypes'
+
+function stateClass(state: string) {
+  if (state === 'live') return 'text-[#6ab88a]'
+  if (state === 'sandbox') return 'text-[#c8a951]'
+  return 'text-[#c87060]'
+}
+
+export function ObservatoryScopeCard({ scope }: { scope: AmvScopeState }) {
+  const debt = scope.warnings.length ? scope.warnings[0] : scope.latestReading ? 'Sin deuda critica declarada.' : 'Falta estado vivo.'
+
+  return (
+    <article className="border border-[#252119] bg-[#0c0b09] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#7a7568]">{scope.scope}</div>
+          <h2 className="mt-1 text-base font-semibold text-[#ead8aa]">{scope.label}</h2>
+        </div>
+        <span className={`font-mono text-[9px] uppercase tracking-[0.14em] ${stateClass(scope.state)}`}>{scope.state}</span>
+      </div>
+      <p className="mt-3 min-h-12 text-sm leading-6 text-[#a99f8d]">
+        {scope.latestReading?.summary ?? 'Contrato observable disponible. Sin estado vivo suficiente.'}
+      </p>
+      <dl className="mt-4 grid grid-cols-2 gap-3 font-mono text-[9px] uppercase tracking-[0.11em] text-[#6f685c]">
+        <div><dt className="text-[#3f3a32]">Evidencia</dt><dd className="mt-1 text-[#c8a951]">{scope.evidenceSummary.count}</dd></div>
+        <div><dt className="text-[#3f3a32]">Regimen</dt><dd className="mt-1 text-[#c8a951]">{scope.canFeedRegime ? 'permitido' : 'no'}</dd></div>
+        <div><dt className="text-[#3f3a32]">Atractor</dt><dd className="mt-1 text-[#c8a951]">{scope.canSupportAttractor ? 'si' : 'no'}</dd></div>
+        <div><dt className="text-[#3f3a32]">Eyectores</dt><dd className="mt-1 text-[#c87060]">{scope.state === 'degraded' ? 'deuda de evidencia' : '-'}</dd></div>
+      </dl>
+      <div className="mt-4 border-t border-[#252119] pt-3 text-[11px] leading-5 text-[#8f8678]">
+        <p><span className="font-mono uppercase tracking-[0.12em] text-[#4d4639]">Deuda:</span> {debt}</p>
+        <p className="mt-1"><span className="font-mono uppercase tracking-[0.12em] text-[#4d4639]">Ruta unica:</span> {scope.canFeedRegime ? 'mantener observacion y verificar cierre' : 'conectar evidencia antes de promover'}</p>
+      </div>
+    </article>
+  )
+}

--- a/src/observatory/components/amv/ScopedDashboardShell.tsx
+++ b/src/observatory/components/amv/ScopedDashboardShell.tsx
@@ -1,8 +1,10 @@
 import type { AmvDashboardSpec } from '@/lib/amv/core/dashboardSpecTypes'
+import type { AmvScopeState } from '@/lib/amv/core/amvScopeStateTypes'
 import { AmvPanelRenderer } from './AmvPanelRenderer'
 
-export function ScopedDashboardShell({ spec }: { spec: AmvDashboardSpec }) {
+export function ScopedDashboardShell({ spec, state }: { spec: AmvDashboardSpec; state?: AmvScopeState }) {
   const panels = [...spec.panels].sort((a, b) => a.order - b.order)
+  const hasLiveState = Boolean(state?.latestReading)
 
   return (
     <div className="min-h-0 bg-[#060605] text-[#ccc8bc]">
@@ -12,10 +14,23 @@ export function ScopedDashboardShell({ spec }: { spec: AmvDashboardSpec }) {
         </div>
         <h2 className="mt-1 text-lg font-semibold text-[#d7cdb8]">{spec.title}</h2>
         <p className="mt-2 max-w-3xl text-xs leading-5 text-[#8f8678]">{spec.instrument.ontologicalQuestion}</p>
+        <div className="mt-3 grid gap-2 font-mono text-[9px] uppercase tracking-[0.12em] text-[#6f685c] md:grid-cols-4">
+          <div className="border border-[#1e1c17] px-2 py-2">
+            Estado <span className={hasLiveState ? 'text-[#6ab88a]' : 'text-[#c87060]'}>{state?.state ?? 'degraded'}</span>
+          </div>
+          <div className="border border-[#1e1c17] px-2 py-2">Trust <span className="text-[#c8a951]">{state?.sourceTrust ?? 'degraded'}</span></div>
+          <div className="border border-[#1e1c17] px-2 py-2">Evidencia <span className="text-[#c8a951]">{state?.evidenceSummary.count ?? 0}</span></div>
+          <div className="border border-[#1e1c17] px-2 py-2">Regimen <span className="text-[#c8a951]">{state?.canFeedRegime ? 'si' : 'no'}</span></div>
+        </div>
+        {!hasLiveState ? (
+          <p className="mt-3 border-l border-[#c87060] pl-3 text-xs leading-5 text-[#c87060]">
+            Contrato observable disponible. Sin estado vivo suficiente.
+          </p>
+        ) : null}
       </header>
       <div className="grid gap-3 p-4 md:grid-cols-2 xl:grid-cols-3">
         {panels.map((panel) => (
-          <AmvPanelRenderer key={panel.id} panel={panel} />
+          <AmvPanelRenderer key={panel.id} panel={panel} state={state} />
         ))}
       </div>
     </div>

--- a/src/observatory/components/root/RootDashboardClient.tsx
+++ b/src/observatory/components/root/RootDashboardClient.tsx
@@ -12,6 +12,8 @@ import { AcpFieldRegimeView } from '@/observatory/components/root/AcpFieldRegime
 import { AcpFreeNodesView } from '@/observatory/components/root/AcpFreeNodesView';
 import { AcpAttractorFieldView } from '@/observatory/components/root/AcpAttractorFieldView';
 import { RootOperationsConsole } from '@/observatory/components/root/RootOperationsConsole';
+import { RootObservatoryIndex } from '@/observatory/components/root/RootObservatoryIndex';
+import { RootLogbookConsole } from '@/observatory/components/root/RootLogbookConsole';
 import { VisorMode } from '@/observatory/components/root/VisorMode';
 import { useVisorMode } from '@/observatory/components/root/visorHooks';
 import { buildRootAttractorState } from '@/lib/root/rootAttractorState';
@@ -28,6 +30,17 @@ type TwinState = {
     mihmRuntimeMatrix?: unknown;
     kernel?: unknown;
     proposals?: unknown[];
+    amvScopes?: Array<{
+      scope: string;
+      label: string;
+      state: string;
+      sourceTrust: string;
+      latestReading?: { label?: string; summary?: string; observedAt?: string } | null;
+      evidenceCount: number;
+      canFeedRegime: boolean;
+      canSupportAttractor: boolean;
+      warnings: string[];
+    }>;
     warnings?: string[];
     seed?: {
       nodeCatalog?: unknown[];
@@ -148,7 +161,12 @@ export function RootDashboardClient() {
 
   useEffect(() => {
     window.sessionStorage.setItem('root:open-panel', openPanel);
+    if (openPanel === 'control') visor.setEnabled(false);
   }, [openPanel]);
+
+  useEffect(() => {
+    return () => visor.setEnabled(false);
+  }, []);
 
   useEffect(() => {
     const navigation = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
@@ -284,6 +302,10 @@ export function RootDashboardClient() {
               <AcpAgentRegistryPanel compact />
             </Accordion>
             <Accordion title="Root" open={openPanel === 'control'} onClick={() => setOpenPanel(openPanel === 'control' ? 'chat' : 'control')}>
+              <RootObservatoryIndex scopes={twin?.data?.amvScopes} />
+              <div className="mt-3">
+                <RootLogbookConsole />
+              </div>
               <RootOperationsConsole />
               <div className="mt-3">
                 <SystemOverridePanel />
@@ -291,7 +313,7 @@ export function RootDashboardClient() {
             </Accordion>
           </div>
         </aside>
-        <VisorMode enabled={visor.enabled} twin={twin} onEnable={() => visor.setEnabled(true)} />
+        <VisorMode enabled={visor.enabled} twin={twin} onEnable={() => visor.setEnabled(true)} onDisable={() => visor.setEnabled(false)} />
       </main>
     </div>
   );

--- a/src/observatory/components/root/RootLogbookConsole.tsx
+++ b/src/observatory/components/root/RootLogbookConsole.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+const LAYERS = [
+  ['Registro', 'Entrada con fuente, fecha y objeto observado.'],
+  ['Evidencia', 'Origen y confianza que sostienen la lectura.'],
+  ['Inferencia', 'Lectura derivada; no sostiene decision fuerte por si sola.'],
+  ['Hipotesis', 'Ruta posible cuando falta evidencia suficiente.'],
+  ['Decision', 'Solo aparece cuando hay soporte para promover.'],
+  ['Cierre', 'Criterio verificable para declarar terminado.'],
+]
+
+export function RootLogbookConsole() {
+  return (
+    <section className="border border-[#1e1c17] bg-[#0b0a08] p-3">
+      <h3 className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Bitacora AMV</h3>
+      <p className="mt-2 text-[11px] leading-5 text-[#8f8678]">
+        Registro separado de VISOR y Twin. No es chat; clasifica lectura, evidencia, inferencia, hipotesis, decision y cierre.
+      </p>
+      <div className="mt-3 grid gap-2">
+        {LAYERS.map(([label, detail]) => (
+          <div key={label} className="border-l border-[#1e1c17] pl-3">
+            <div className="font-mono text-[8px] uppercase tracking-[0.14em] text-[#7a7568]">{label}</div>
+            <p className="mt-1 text-[11px] leading-5 text-[#9d927f]">{detail}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/observatory/components/root/RootObservatoryIndex.tsx
+++ b/src/observatory/components/root/RootObservatoryIndex.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+type RootScopeOverviewItem = {
+  scope: string
+  label: string
+  state: string
+  sourceTrust: string
+  latestReading?: { label?: string; summary?: string; observedAt?: string } | null
+  evidenceCount: number
+  canFeedRegime: boolean
+  canSupportAttractor: boolean
+  warnings: string[]
+}
+
+function tone(state: string) {
+  if (state === 'live') return 'text-[#6ab88a]'
+  if (state === 'sandbox') return 'text-[#c8a951]'
+  return 'text-[#c87060]'
+}
+
+export function RootObservatoryIndex({ scopes }: { scopes?: RootScopeOverviewItem[] }) {
+  const items = Array.isArray(scopes) ? scopes : []
+
+  return (
+    <section className="space-y-3">
+      <div className="border-l border-[#8a7035] pl-3">
+        <h3 className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Observatorios AMV</h3>
+        <p className="mt-2 text-[11px] leading-5 text-[#8f8678]">
+          ROOT coordina scopes; no los absorbe. Un scope sin evidencia queda degradado y no alimenta regimen.
+        </p>
+      </div>
+      {items.length === 0 ? (
+        <p className="text-[11px] leading-5 text-[#c87060]">Sin indice de observatorios conectado.</p>
+      ) : items.map((item) => (
+        <article key={item.scope} className="border border-[#1e1c17] bg-[#0b0a08] p-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="font-mono text-[8px] uppercase tracking-[0.16em] text-[#7a7568]">{item.scope}</div>
+              <h4 className="mt-1 text-sm font-semibold text-[#d7cdb8]">{item.label}</h4>
+            </div>
+            <span className={`font-mono text-[9px] uppercase tracking-[0.14em] ${tone(item.state)}`}>{item.state}</span>
+          </div>
+          <p className="mt-2 text-[11px] leading-5 text-[#9d927f]">
+            {item.latestReading?.summary ?? 'Contrato observable disponible. Sin estado vivo suficiente.'}
+          </p>
+          <dl className="mt-3 grid grid-cols-2 gap-2 font-mono text-[8px] uppercase tracking-[0.1em] text-[#6f685c]">
+            <div><dt className="text-[#3f3a32]">Evidencia</dt><dd className="mt-1 text-[#c8a951]">{item.evidenceCount}</dd></div>
+            <div><dt className="text-[#3f3a32]">Trust</dt><dd className="mt-1 text-[#c8a951]">{item.sourceTrust}</dd></div>
+            <div><dt className="text-[#3f3a32]">Regimen</dt><dd className="mt-1 text-[#8f8678]">{item.canFeedRegime ? 'puede alimentar' : 'no alimenta'}</dd></div>
+            <div><dt className="text-[#3f3a32]">Atractor</dt><dd className="mt-1 text-[#8f8678]">{item.canSupportAttractor ? 'sostiene' : 'no sostiene'}</dd></div>
+          </dl>
+          {item.warnings.length ? <p className="mt-3 text-[11px] leading-5 text-[#c87060]">{item.warnings[0]}</p> : null}
+        </article>
+      ))}
+    </section>
+  )
+}

--- a/src/observatory/components/root/VisorMode.tsx
+++ b/src/observatory/components/root/VisorMode.tsx
@@ -93,10 +93,12 @@ export function VisorMode({
   enabled,
   twin,
   onEnable,
+  onDisable,
 }: {
   enabled: boolean;
   twin: TwinState | null;
   onEnable: () => void;
+  onDisable: () => void;
 }) {
   const { contextKey, context, setContextKey } = useVisorContext('bitacoras');
   const chat = useVisorChat(contextKey, twin);
@@ -129,6 +131,13 @@ export function VisorMode({
       <div className="absolute left-1/2 top-4 z-[85] -translate-x-1/2 border border-white/10 bg-black/75 px-3 py-1.5 font-mono text-[9px] uppercase tracking-[0.24em] text-white/45">
         AMV ROOT / lectura libre
       </div>
+      <button
+        type="button"
+        onClick={onDisable}
+        className="absolute right-4 top-4 z-[86] border border-[#d4af37]/40 bg-black/75 px-3 py-1.5 font-mono text-[9px] uppercase tracking-[0.16em] text-[#d4af37] hover:bg-[#d4af37]/10"
+      >
+        Salir de VISOR
+      </button>
 
       <VisorSidebar activeContext={contextKey} onSelect={(nextContext) => {
         setContextKey(nextContext);

--- a/src/observatory/components/root/visorHooks.ts
+++ b/src/observatory/components/root/visorHooks.ts
@@ -450,17 +450,11 @@ async function amvRootResponse(prompt: string) {
 }
 
 export function useVisorMode() {
-  const [enabled, setEnabledState] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    return window.sessionStorage.getItem('root:visor-enabled') === 'true';
-  });
+  const [enabled, setEnabledState] = useState(false);
 
   function setEnabled(next: boolean | ((current: boolean) => boolean)) {
     setEnabledState((current) => {
       const value = typeof next === 'function' ? next(current) : next;
-      if (typeof window !== 'undefined') {
-        window.sessionStorage.setItem('root:visor-enabled', value ? 'true' : 'false');
-      }
       return value;
     });
   }

--- a/src/scorefriction/components/ScoreFrictionStateBanner.tsx
+++ b/src/scorefriction/components/ScoreFrictionStateBanner.tsx
@@ -1,0 +1,21 @@
+import type { AmvScopeState } from '@/lib/amv/core/amvScopeStateTypes'
+
+export function ScoreFrictionStateBanner({ state }: { state: AmvScopeState }) {
+  const live = Boolean(state.latestReading)
+
+  return (
+    <section className="border-b border-[#26221b] bg-[#0c0b09] text-[#d8d0bd]">
+      <div className="mx-auto flex max-w-6xl flex-col gap-2 px-5 py-3 font-mono text-[9px] uppercase tracking-[0.12em] md:flex-row md:items-center md:justify-between">
+        <span className={live ? 'text-[#6ab88a]' : 'text-[#c87060]'}>
+          ScoreFriction state: {state.state}
+        </span>
+        <span className="text-[#8f8678]">
+          evidencia {state.evidenceSummary.count} / trust {state.sourceTrust} / regimen {state.canFeedRegime ? 'permitido' : 'no'}
+        </span>
+        <span className="text-[#8f8678]">
+          {state.latestReading?.label ?? 'Contrato observable disponible. Sin estado vivo suficiente.'}
+        </span>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

Connects the AMV observatory contract to explicit live/degraded state across ScoreFriction, ROOT, WSV, logbook policy, and the total observatory index.

## Files changed

- Added AMV scope state types/builders and `/api/amv/state`.
- Added ScoreFriction live state connector and `/api/scorefriction/state`.
- Updated AMV dashboard rendering to accept live state and honest empty/degraded states.
- Added ROOT AMV scope overview, `RootObservatoryIndex`, `RootLogbookConsole`, and `amvScopes` in `/api/twin/state`.
- Adjusted VISOR so it is not persisted indefinitely and can be exited explicitly.
- Added WSV state builder and `/api/worldspect/state`.
- Added `/observatories` with total scope cards.
- Added governed dashboard generation policy and `/api/amv/dashboard/generate`.
- Added audit and operation docs.

## New routes

- `GET /api/amv/state`
- `GET /api/amv/state?scope=scorefriction`
- `GET /api/scorefriction/state`
- `GET /api/worldspect/state`
- `POST /api/amv/dashboard/generate`
- `GET /observatories`

## How to test

- `npm run typecheck`
- `npm run check:boundaries`
- `npm run build`
- `GET /api/amv/state?scope=scorefriction`
- `GET /api/scorefriction/state`
- `GET /api/worldspect/state`
- Open `/observatories`
- Open `/scorefriction`, `/scorefriction/wave`, `/scorefriction/wide`
- Open ROOT and confirm the AMV scope index appears in the Root panel

## Degraded on purpose

- AMV scopes without real connectors return degraded state.
- ScoreFriction returns degraded if Supabase/tables are unavailable or no observations exist.
- WSV returns missing/degraded unless a snapshot has timestamp, source, and confidence.
- Dashboard generation returns spec-only when required AMV contract fields are missing.

## Not touched

- No Supabase migrations.
- No productive permission changes.
- No new chat.
- No aesthetic redesign.
- No fake metrics or mock live observations.

## Risks

- Local state depends on Supabase availability; unavailable Supabase is represented as degraded warnings.
- Only ScoreFriction has a real AMV state connector in this PR.
- Root logbook UI is separated, but productive write controls are still intentionally minimal.

## Recommended next phase

Add live connectors for Governance Reality and Signal Vane, then promote only scopes with observed evidence into regime/attractor support.