### PR TITLE
Remove legacy from SFI navigation surface types

### DIFF
--- a/src/lib/navigation/sfiNavigation.ts
+++ b/src/lib/navigation/sfiNavigation.ts
@@ -3,7 +3,6 @@ export type SfiSurfaceStatus =
   | 'protected'
   | 'experimental'
   | 'api'
-  | 'legacy'
   | 'missing';
 
 export type SfiSurfaceArea =
@@ -14,8 +13,7 @@ export type SfiSurfaceArea =
   | 'dashboard'
   | 'api'
   | 'contact'
-  | 'user'
-  | 'legacy';
+  | 'user';
 
 export type SfiNavItem = {
   id: string;


### PR DESCRIPTION
### Motivation
- Harden the SFI navigation contract by removing the obsolete `legacy` member from the exported surface type unions in order to eliminate an unused compatibility value and enforce current surface/status semantics.

### Description
- Modified `src/lib/navigation/sfiNavigation.ts` to remove `'legacy'` from `SfiSurfaceStatus` and `SfiSurfaceArea` and kept the existing `SFI_NAVIGATION` registry unchanged because no entry used the removed values.
- Files changed: `src/lib/navigation/sfiNavigation.ts` (single-file change).
- What was migrated: the navigation type contract was hardened in-place by deleting the obsolete union members (`'legacy'`) from `SfiSurfaceStatus` and `SfiSurfaceArea`.
- Remaining legacy references: runtime/fallback modes and diagnostics still reference legacy concepts (for example `TerminalMode` uses a `legacy` mode, `SfiCognitiveCanvasTerminal` mentions `field/persist legacy`, `root/selfObservability` audits legacy ScoreFriction artifacts, and `packages/events/src/legacy-adapters.ts` remains); these were left as operational diagnostics or adapters and are outside the navigation type contract so they were not removed.
- Archivos o procesos sin uso y por qué aún no se migraron: `src/app/(terminal)/terminal/page.tsx` retains a `legacy` terminal fallback, `src/observatory/components/field/SfiCognitiveCanvasTerminal.tsx` keeps quarantine notes (`field/persist legacy`), `src/lib/root/selfObservability.ts` continues to report legacy/static ScoreFriction checks, and `packages/events/src/legacy-adapters.ts` remains as an adapter for old event formats, and none were migrated because they represent separate runtime or ingestion migrations outside the scope of this type-contract change.

### Testing
- Ran `npm run typecheck` and it passed with no type errors after the change.
- Ran `npm run build` (Next.js production build) and it completed successfully with compiled pages and no runtime/type failures reported.
- Build result: both typecheck and production build succeeded and nothing broke as a result of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f4c8559c0832f94a8e96ceeece793)