### PR TITLE
SFI-WVA-01: Activate World Vector agent cron boundary

### DIFF
--- a/.github/workflows/world-vector-agents.yml
+++ b/.github/workflows/world-vector-agents.yml
@@ -1,0 +1,41 @@
+name: World Vector Agents
+
+on:
+  schedule:
+    - cron: '20 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      job:
+        description: 'Agent job: daily, reports, audit, all'
+        required: false
+        default: 'all'
+
+jobs:
+  run_world_vector_agents:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve Agent Job
+        run: |
+          JOB="${{ github.event.inputs.job }}"
+          if [ -z "$JOB" ]; then JOB="all"; fi
+          echo "WORLD_VECTOR_AGENT_JOB=$JOB" >> "$GITHUB_ENV"
+          echo "World Vector job=$JOB"
+
+      - name: Run World Vector System Actor
+        env:
+          VERCEL_APP_URL: ${{ secrets.VERCEL_APP_URL }}
+          SFI_AGENT_SECRET: ${{ secrets.SFI_AGENT_SECRET }}
+        run: |
+          test -n "$VERCEL_APP_URL" || (echo "Missing VERCEL_APP_URL secret" && exit 1)
+          test -n "$SFI_AGENT_SECRET" || (echo "Missing SFI_AGENT_SECRET secret" && exit 1)
+
+          curl --fail-with-body -X POST "$VERCEL_APP_URL/api/world-vector/agents/system-run?job=$WORLD_VECTOR_AGENT_JOB&persist=true" \
+            -H "Authorization: Bearer $SFI_AGENT_SECRET"
+
+      - name: Read World Vector Health
+        env:
+          VERCEL_APP_URL: ${{ secrets.VERCEL_APP_URL }}
+        run: |
+          test -n "$VERCEL_APP_URL" || (echo "Missing VERCEL_APP_URL secret" && exit 1)
+          curl --fail-with-body "$VERCEL_APP_URL/api/world-vector/agents/health"

--- a/docs/ops/WORLD_VECTOR_WEEKLY_RUNBOOK.md
+++ b/docs/ops/WORLD_VECTOR_WEEKLY_RUNBOOK.md
@@ -1,0 +1,45 @@
+# World Vector Weekly Runbook
+
+## Boundary
+
+World Vector cron is a system actor. It may read WorldSpect snapshots, derive World Vector observations, persist daily memory, persist report drafts and run health checks.
+
+It must not close cycles, approve drafts, publish externally or mutate governed ROOT state.
+
+## Daily loop
+
+Every scheduled run:
+
+1. WorldSpect remains the measurement source.
+2. World Vector system actor calls `/api/world-vector/agents/system-run`.
+3. `dailyObservationAgent` derives and persists the daily observation when memory is ready.
+4. `internalReportAgent` and `publicReportAgent` prepare draft memory when requested.
+5. `persistenceAuditAgent` and `alertAgent` report blockers.
+6. `/api/world-vector/agents/health` exposes operational status.
+
+## Weekly close
+
+Sunday close remains a governed ROOT action.
+
+The system actor may prepare draft material, but it does not close the cycle. Closing the cycle requires the protected close-cycle route and a ROOT session.
+
+## Required secrets
+
+- `VERCEL_APP_URL`
+- `SFI_AGENT_SECRET`
+
+`SFI_AGENT_SECRET` is used only by the World Vector system actor route. It is not a publishing credential and does not grant ROOT.
+
+## Surfaces
+
+- `/world-vector`: minimal observatory dashboard.
+- `/api/world-vector/agents/system-run`: system actor execution endpoint.
+- `/api/world-vector/agents/health`: read-only health endpoint.
+- `/api/world-vector/agents/close-cycle`: ROOT-only close-cycle endpoint.
+
+## Failure modes
+
+- If WorldSpect has no latest snapshot, agents must report `worldspect_snapshot_missing`.
+- If World Vector tables are missing, agents must report `world_vector_tables_not_installed`.
+- If memory is blocked, agents may return interpretation but must not claim persistence.
+- If close-cycle is requested without ROOT, it must remain blocked.

--- a/src/app/api/world-vector/agents/daily/route.ts
+++ b/src/app/api/world-vector/agents/daily/route.ts
@@ -6,7 +6,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function POST(request: Request) {
-  const gate = await requireWorldVectorAgentActor('daily');
+  const gate = await requireWorldVectorAgentActor('daily', { allowSystemActor: true });
   if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
 
   const url = new URL(request.url);

--- a/src/app/api/world-vector/agents/health/route.ts
+++ b/src/app/api/world-vector/agents/health/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { getWorldVectorStatus, getWorldVectorToday } from '@/lib/world-vector/readModel';
+import { readLatestWorldVectorReport } from '@/lib/world-vector/persistence';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const [status, today, internalReport, externalReport] = await Promise.all([
+    getWorldVectorStatus(),
+    getWorldVectorToday(),
+    readLatestWorldVectorReport({ reportType: 'internal_daily', targetAudience: 'founder' }),
+    readLatestWorldVectorReport({ reportType: 'public_weekly', targetAudience: 'linkedin' }),
+  ]);
+
+  const blocked = [
+    !status.pulse.latest_snapshot_available ? 'worldspect_snapshot_missing' : null,
+    !status.memory.enabled ? status.memory.reason : null,
+    today.observation.status === 'failed' ? 'world_vector_observation_failed' : null,
+  ].filter((item): item is string => Boolean(item));
+
+  return NextResponse.json({
+    ok: blocked.length === 0,
+    pulse: status.pulse,
+    memory: status.memory,
+    current_cycle_day: status.current_cycle_day,
+    cycle_range: today.cycle_range,
+    observation: {
+      observed_at: today.observation.observed_at,
+      sector: today.observation.sector,
+      day_of_week: today.observation.day_of_week,
+      status: today.observation.status,
+      confidence: today.observation.confidence,
+      dominant_signal: today.observation.dominant_signal,
+      warnings: today.observation.warnings,
+    },
+    reports: {
+      internal_daily: internalReport.ok ? Boolean(internalReport.data) : false,
+      public_weekly: externalReport.ok ? Boolean(externalReport.data) : false,
+    },
+    blocked,
+    warnings: status.warnings,
+  });
+}

--- a/src/app/api/world-vector/agents/system-run/route.ts
+++ b/src/app/api/world-vector/agents/system-run/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { requireWorldVectorSystemActor } from '@/lib/world-vector/systemActorAuth';
+import {
+  runAlertAgent,
+  runDailyObservationAgent,
+  runInternalReportAgent,
+  runPersistenceAuditAgent,
+  runPublicReportAgent,
+} from '@/lib/world-vector/agents';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type SystemRunJob = 'daily' | 'reports' | 'audit' | 'all';
+
+function resolveJob(request: Request): SystemRunJob {
+  const url = new URL(request.url);
+  const job = url.searchParams.get('job');
+  if (job === 'daily' || job === 'reports' || job === 'audit' || job === 'all') return job;
+  return 'all';
+}
+
+export async function POST(request: Request) {
+  const job = resolveJob(request);
+  const gate = await requireWorldVectorSystemActor(job === 'all' ? 'daily' : job);
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  const url = new URL(request.url);
+  const persist = url.searchParams.get('persist') !== 'false';
+  const result: Record<string, unknown> = {
+    ok: true,
+    actor: 'world-vector-system-agent',
+    job,
+    persist,
+  };
+
+  if (job === 'daily' || job === 'all') {
+    result.daily = await runDailyObservationAgent({ persist });
+  }
+
+  if (job === 'reports' || job === 'all') {
+    const internal = await runInternalReportAgent({ persist });
+    const external = await runPublicReportAgent({ persist });
+    result.reports = { internal, external };
+  }
+
+  if (job === 'audit' || job === 'all') {
+    const persistence = await runPersistenceAuditAgent();
+    const alerts = await runAlertAgent();
+    result.audit = { persistence, alerts };
+  }
+
+  return NextResponse.json(result);
+}

--- a/src/app/world-vector/page.tsx
+++ b/src/app/world-vector/page.tsx
@@ -1,0 +1,92 @@
+import { getWorldVectorStatus, getWorldVectorToday } from '@/lib/world-vector/readModel';
+
+function formatMetric(value: number | null | undefined) {
+  return typeof value === 'number' ? value.toFixed(2) : 'n/a';
+}
+
+export default async function WorldVectorPage() {
+  const [status, today] = await Promise.all([
+    getWorldVectorStatus(),
+    getWorldVectorToday(),
+  ]);
+
+  const observation = today.observation;
+  const dominant = observation.domain_values[0];
+
+  return (
+    <main className="min-h-screen bg-[#060605] px-6 py-10 text-[#d8d2c2]">
+      <div className="mx-auto max-w-6xl space-y-8">
+        <header className="border border-[#2f2a1e] bg-[#0b0b09] p-6">
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#c8a951]">System Friction Institute</p>
+          <h1 className="mt-4 text-4xl font-semibold text-[#f5eedc]">World Vector Observatory</h1>
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-[#9f9788]">
+            Lectura diaria derivada de WorldSpect. Esta superficie muestra pulso, memoria, vector dominante e interpretacion operativa.
+          </p>
+        </header>
+
+        <section className="grid gap-3 md:grid-cols-5">
+          <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#8f8878]">Pulse</div>
+            <div className="mt-2 text-lg text-[#f5eedc]">{status.pulse.latest_snapshot_available ? 'ACTIVE' : 'MISSING'}</div>
+          </div>
+          <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#8f8878]">Last Snapshot</div>
+            <div className="mt-2 text-sm text-[#f5eedc]">{status.pulse.latest_observed_at ?? 'none'}</div>
+          </div>
+          <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#8f8878]">Dominant</div>
+            <div className="mt-2 text-lg text-[#f5eedc]">{dominant?.domain ?? 'unresolved'}</div>
+          </div>
+          <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#8f8878]">Confidence</div>
+            <div className="mt-2 text-lg text-[#f5eedc]">{formatMetric(observation.confidence)}</div>
+          </div>
+          <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#8f8878]">Memory</div>
+            <div className="mt-2 text-lg text-[#f5eedc]">{status.memory.enabled ? 'READY' : 'BLOCKED'}</div>
+          </div>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+          <div className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Domain Vector</div>
+            <div className="mt-5 space-y-3">
+              {observation.domain_values.map((item) => (
+                <div key={item.domain} className="grid gap-2 md:grid-cols-[220px_1fr_70px] md:items-center">
+                  <div className="font-mono text-xs text-[#d8d2c2]">{item.domain}</div>
+                  <div className="h-2 bg-[#1e1c17]">
+                    <div
+                      className="h-2 bg-[#c8a951]"
+                      style={{ width: `${Math.max(0, Math.min(1, item.value ?? 0)) * 100}%` }}
+                    />
+                  </div>
+                  <div className="font-mono text-xs text-[#8f8878]">{formatMetric(item.value)}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Agent Interpretation</div>
+            <p className="mt-5 text-sm leading-7 text-[#d8d2c2]">{observation.interpretation}</p>
+            <div className="mt-5 border-t border-[#2f2a1e] pt-4 font-mono text-[11px] uppercase tracking-[0.12em] text-[#8f8878]">
+              status={observation.status} · sector={observation.sector} · signal={observation.dominant_signal ?? 'none'}
+            </div>
+          </div>
+        </section>
+
+        <section className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
+          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Lineage</div>
+          <div className="mt-5 grid gap-3 font-mono text-xs text-[#d8d2c2] md:grid-cols-2">
+            <div>snapshot_id: {observation.source_snapshot_id ?? 'none'}</div>
+            <div>observed_at: {observation.observed_at ?? 'none'}</div>
+            <div>cycle_start: {today.cycle_range.cycle_start_date}</div>
+            <div>cycle_end: {today.cycle_range.cycle_end_date}</div>
+            <div>memory: {status.memory.reason}</div>
+            <div>warnings: {status.warnings.length ? status.warnings.join(', ') : 'none'}</div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/world-vector/auth.ts
+++ b/src/lib/world-vector/auth.ts
@@ -1,7 +1,14 @@
 import 'server-only';
 import { requireGovernedActor } from '@/lib/operational/common';
+import { requireWorldVectorSystemActor } from './systemActorAuth';
 
-export async function requireWorldVectorAgentActor(action: string) {
+export async function requireWorldVectorAgentActor(action: string, options: { allowSystemActor?: boolean } = {}) {
+  if (options.allowSystemActor) {
+    const systemGate = await requireWorldVectorSystemActor(action);
+    if (systemGate.ok) return systemGate;
+    if (systemGate.status !== 403) return systemGate;
+  }
+
   const gate = await requireGovernedActor(`world_vector.agent.${action}`);
   if (!gate.ok) return gate;
   if (!gate.ctx.isRoot) {

--- a/src/lib/world-vector/systemActorAuth.ts
+++ b/src/lib/world-vector/systemActorAuth.ts
@@ -1,0 +1,66 @@
+import 'server-only';
+import crypto from 'crypto';
+import { headers } from 'next/headers';
+
+export type WorldVectorSystemActorAction = 'daily' | 'reports' | 'audit' | 'health';
+
+const ALLOWED_SYSTEM_ACTIONS = new Set<WorldVectorSystemActorAction>([
+  'daily',
+  'reports',
+  'audit',
+  'health',
+]);
+
+function safeEqual(a: string, b: string) {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  if (left.length !== right.length) return false;
+  return crypto.timingSafeEqual(left, right);
+}
+
+export async function requireWorldVectorSystemActor(action: string) {
+  if (!ALLOWED_SYSTEM_ACTIONS.has(action as WorldVectorSystemActorAction)) {
+    return {
+      ok: false as const,
+      status: 403,
+      body: { ok: false, error: 'system_actor_action_not_allowed', action },
+    };
+  }
+
+  const expected = process.env.SFI_AGENT_SECRET || process.env.WORLD_VECTOR_AGENT_SECRET;
+  if (!expected) {
+    return {
+      ok: false as const,
+      status: 503,
+      body: { ok: false, error: 'system_actor_secret_not_configured' },
+    };
+  }
+
+  const headerStore = await headers();
+  const authorization = headerStore.get('authorization') ?? '';
+  const token = authorization.startsWith('Bearer ') ? authorization.slice('Bearer '.length).trim() : '';
+
+  if (!token || !safeEqual(token, expected)) {
+    return {
+      ok: false as const,
+      status: 401,
+      body: { ok: false, error: 'system_actor_unauthorized' },
+    };
+  }
+
+  return {
+    ok: true as const,
+    ctx: {
+      user: {
+        id: 'world-vector-system-agent',
+        email: 'world-vector-agent@systemfriction.local',
+      },
+      profile: {
+        role: 'system',
+        alias: 'world-vector-agent',
+      },
+      isRoot: false,
+      isSystemActor: true,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Implements the first operational activation layer for World Vector agents without granting ROOT authority to cron.

### Added

- `src/lib/world-vector/systemActorAuth.ts`
  - Server-only system actor gate using `SFI_AGENT_SECRET` or `WORLD_VECTOR_AGENT_SECRET`.
  - Allows only non-ROOT World Vector system jobs: `daily`, `reports`, `audit`, `health`.

- `src/app/api/world-vector/agents/system-run/route.ts`
  - New system actor endpoint for scheduled execution.
  - Supports `job=daily`, `job=reports`, `job=audit`, `job=all`.
  - Runs daily observation, report draft generation, persistence audit and alerts.
  - Does not close cycles.

- `src/app/api/world-vector/agents/health/route.ts`
  - Read-only health endpoint for pulse, memory, current observation, report presence, warnings and blockers.

- `.github/workflows/world-vector-agents.yml`
  - Scheduled GitHub Actions workflow every 6 hours.
  - Calls the system-run endpoint with `SFI_AGENT_SECRET`.
  - Reads health after execution.

- `/world-vector`
  - Minimal dashboard surface for World Vector pulse, domain vector, interpretation and lineage.

- `docs/ops/WORLD_VECTOR_WEEKLY_RUNBOOK.md`
  - Operational boundary and weekly loop documentation.

### Changed

- `src/lib/world-vector/auth.ts`
  - Adds optional system actor path while preserving ROOT requirement as default.

- `src/app/api/world-vector/agents/daily/route.ts`
  - Allows system actor for daily observation.

## Boundary

Cron can breathe and persist operational memory.
ROOT still owns closure, approval and any external action.

## Required secret

Add repository/environment secret:

```txt
SFI_AGENT_SECRET=<strong random value>
```

`VERCEL_APP_URL` is already used by the existing WorldSpect workflow.

## Not done

- No visual polish.
- No ROOT approval UI yet.
- No automatic publishing.
- No cycle closing from cron.

## Validation

Static repository patch only. I could not run the build from the connector.