### PR TITLE
Phase 02 live prediction registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Base Next.js App Router construida alrededor de `systemprompt.html` como contrat
 - `/world-vector` observatorio World Vector build-safe con panel runtime
 - `/field` frontera publica de captura
 - `/root/agents` frontera ROOT para agentes pasivos
+- `/root/predictions` registro privado de predicciones gobernado por ROOT
+- `/root/predictions/new` captura de hipotesis antes de perturbacion
 - `/terminal` terminal principal con auditoria, AMV, patrones, hard stop y memoria
 - `/llms.txt` protocolo legible para agentes
 - `/api/audit` auditoria operacional
@@ -39,6 +41,8 @@ La app funciona sin variables de entorno usando memoria local de runtime. Con `G
 Cron breathes. Field captures. Library formalizes. World Vector contextualizes. Prediction Registry preserves evidence. Atlas accumulates longitudinal memory. Agents compare and propose. ROOT decides.
 
 Phase 01 agents are deterministic and passive. They may expose health, integrity, blockers and structured proposals. They must not publish, close cycles, mutate governed ROOT state, rewrite protocols, rewrite phenotypes, promote Atlas entries or expose private evidence.
+
+Phase 02 adds a private Prediction Registry. ROOT can register hypotheses before perturbation and update 72h, 7d, 30d and 90d returns. Agents classify evidence state and pending return windows only; Atlas promotion and publication remain out of scope.
 
 
 

--- a/docs/ops/SFI_PREDICTION_REGISTRY_PHASE.md
+++ b/docs/ops/SFI_PREDICTION_REGISTRY_PHASE.md
@@ -4,6 +4,22 @@
 
 Prediction Registry is planned as governed hypothesis memory. Phase 01 defines the type contract and operational boundary only. It does not create database writes, automatic publication, Atlas promotion, protocol mutation or phenotype mutation.
 
+## Phase 02 implementation status
+
+Phase 02 creates the first live ROOT-governed Prediction Registry layer:
+
+- table: `public.sfi_prediction_entries`
+- migration: `supabase/migrations/20260629100000_create_sfi_prediction_entries.sql`
+- health API: `/api/sfi/predictions/health`
+- ROOT list/create API: `/api/sfi/predictions`
+- ROOT detail API: `/api/sfi/predictions/[hypothesisId]`
+- ROOT returns API: `/api/sfi/predictions/[hypothesisId]/returns`
+- ROOT UI: `/root/predictions`
+- ROOT create UI: `/root/predictions/new`
+- ROOT detail UI: `/root/predictions/[hypothesisId]`
+
+The implementation is private by default. It does not add public prediction browsing, participant DB writes, Atlas promotion or automatic publication.
+
 ## Core rule
 
 A prediction must be registered before perturbation to count as predictive evidence. If the prediction is added after perturbation, it is retrospective observation, not predictive evidence.

--- a/docs/ops/SFI_PREDICTION_REGISTRY_RUNBOOK.md
+++ b/docs/ops/SFI_PREDICTION_REGISTRY_RUNBOOK.md
@@ -1,0 +1,80 @@
+# SFI Prediction Registry Runbook
+
+## Purpose
+
+Prediction Registry preserves ROOT-governed hypotheses as timestamped evidence memory. Its core rule is: without a prediction registered before perturbation, the result is not predictive evidence; it is retrospective observation.
+
+## Table
+
+The live table is `public.sfi_prediction_entries`, created by `supabase/migrations/20260629100000_create_sfi_prediction_entries.sql`.
+
+Direct table access is revoked from `anon` and `authenticated`. RLS is enabled and service-role access is the only direct database policy. Application routes must still enforce ROOT before writes or private reads.
+
+## APIs
+
+- `GET /api/sfi/predictions/health`: non-sensitive health, table availability, counts when safe, blocker reasons and agent status.
+- `GET /api/sfi/predictions`: ROOT-only private list.
+- `POST /api/sfi/predictions`: ROOT-only create.
+- `GET /api/sfi/predictions/[hypothesisId]`: ROOT-only private detail.
+- `PATCH /api/sfi/predictions/[hypothesisId]/returns`: ROOT-only return-window update.
+
+## ROOT flow
+
+1. Operator captures signal through WB-001 or `/operator/field`.
+2. ROOT opens `/root/predictions/new`.
+3. ROOT registers the explicit prediction before perturbation.
+4. Perturbation is applied.
+5. ROOT records returns at 72h, 7d, 30d and 90d.
+6. Agents classify evidence state and return windows.
+7. Atlas waits until evidence matures.
+
+## Evidence rule
+
+If `perturbation_applied_at` is absent or later than `prediction_registered_at`, the entry is classified as:
+
+- `estado_observacion = registrada_pre_perturbacion`
+- `is_predictive_evidence = true`
+- `evidence_state = PENDING`
+
+If the prediction is registered after perturbation, the entry is classified as:
+
+- `estado_observacion = retrospective_observation`
+- `is_predictive_evidence = false`
+- `evidence_state = OBSERVED` when supporting evidence exists, otherwise `UNCERTAIN`
+
+Retrospective entries must never be labeled predictive evidence.
+
+## Evidence states
+
+Allowed evidence states are `PENDING`, `OBSERVED`, `VERIFIED`, `DEGRADED`, `UNCERTAIN` and `ARCHIVED`.
+
+Allowed observation states are `pendiente`, `registrada_pre_perturbacion`, `retrospective_observation`, `observed`, `verified`, `degraded`, `uncertain` and `archived`.
+
+No claim should be stronger than its evidence state.
+
+## Return windows
+
+Return windows are `72h`, `7d`, `30d` and `90d`. The Return Window Agent detects pending, due, complete and overdue windows. It does not auto-fill results.
+
+## Agent boundaries
+
+Evidence State Agent may compute predictive versus retrospective classification, prediction matched, prediction failed, evidence degraded and requires refinement.
+
+Return Window Agent may compute pending, due, complete and overdue windows.
+
+Agents must not rewrite phenotypes, rewrite protocols, promote Atlas entries, publish claims, close cycles or act as ROOT.
+
+## What Phase 02 does not do
+
+- no public prediction browsing
+- no participant-submitted DB writes
+- no automatic publishing
+- no Atlas promotion
+- no protocol mutation
+- no phenotype mutation
+- no self-modifying agents
+- no diagnosis tooling
+
+## Next phase
+
+Phase 03 can prepare Atlas learning and refinement proposal agents. Those agents may propose Atlas candidates or protocol refinements, but ROOT must approve any promotion or mutation.

--- a/src/app/api/sfi/predictions/[hypothesisId]/returns/route.ts
+++ b/src/app/api/sfi/predictions/[hypothesisId]/returns/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { requireRootActor } from '@/lib/root/server';
+import {
+  normalizeUpdatePredictionReturnInput,
+  updatePredictionReturn,
+} from '@/lib/sfi/predictions/service';
+import { runEvidenceStateAgent, runReturnWindowAgent } from '@/lib/sfi/predictions/agents';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: Promise<{ hypothesisId: string }> | { hypothesisId: string };
+};
+
+async function routeHypothesisId(ctx: RouteContext) {
+  const params = await Promise.resolve(ctx.params);
+  return typeof params.hypothesisId === 'string' && params.hypothesisId.trim().length > 0
+    ? decodeURIComponent(params.hypothesisId.trim())
+    : null;
+}
+
+async function requireRoot(action: string) {
+  try {
+    return await requireRootActor(action);
+  } catch (error) {
+    return {
+      ok: false as const,
+      status: 503,
+      body: {
+        ok: false,
+        error: 'root_auth_unavailable',
+        details: error instanceof Error ? error.message : 'unknown_root_auth_error',
+      },
+    };
+  }
+}
+
+export async function PATCH(request: Request, ctx: RouteContext) {
+  const gate = await requireRoot('sfi.predictions.returns.update');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  const hypothesisId = await routeHypothesisId(ctx);
+  if (!hypothesisId) return NextResponse.json({ ok: false, error: 'missing_hypothesis_id' }, { status: 400 });
+
+  const normalized = normalizeUpdatePredictionReturnInput(await request.json().catch(() => ({})));
+  if (!normalized.ok) return NextResponse.json(normalized, { status: normalized.status ?? 400 });
+
+  const result = await updatePredictionReturn(hypothesisId, normalized.data);
+  if (!result.ok) return NextResponse.json(result, { status: result.status ?? 400 });
+
+  return NextResponse.json({
+    ok: true,
+    entry: result.data,
+    agents: {
+      evidenceStateAgent: runEvidenceStateAgent(result.data),
+      returnWindowAgent: runReturnWindowAgent(result.data),
+    },
+    private: true,
+  });
+}

--- a/src/app/api/sfi/predictions/[hypothesisId]/route.ts
+++ b/src/app/api/sfi/predictions/[hypothesisId]/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { requireRootActor } from '@/lib/root/server';
+import { getPredictionEntry } from '@/lib/sfi/predictions/service';
+import { runEvidenceStateAgent, runReturnWindowAgent } from '@/lib/sfi/predictions/agents';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: Promise<{ hypothesisId: string }> | { hypothesisId: string };
+};
+
+async function routeHypothesisId(ctx: RouteContext) {
+  const params = await Promise.resolve(ctx.params);
+  return typeof params.hypothesisId === 'string' && params.hypothesisId.trim().length > 0
+    ? decodeURIComponent(params.hypothesisId.trim())
+    : null;
+}
+
+async function requireRoot(action: string) {
+  try {
+    return await requireRootActor(action);
+  } catch (error) {
+    return {
+      ok: false as const,
+      status: 503,
+      body: {
+        ok: false,
+        error: 'root_auth_unavailable',
+        details: error instanceof Error ? error.message : 'unknown_root_auth_error',
+      },
+    };
+  }
+}
+
+export async function GET(_request: Request, ctx: RouteContext) {
+  const gate = await requireRoot('sfi.predictions.read');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  const hypothesisId = await routeHypothesisId(ctx);
+  if (!hypothesisId) return NextResponse.json({ ok: false, error: 'missing_hypothesis_id' }, { status: 400 });
+
+  const result = await getPredictionEntry(hypothesisId);
+  if (!result.ok) return NextResponse.json(result, { status: result.status ?? 400 });
+
+  return NextResponse.json({
+    ok: true,
+    entry: result.data,
+    agents: {
+      evidenceStateAgent: runEvidenceStateAgent(result.data),
+      returnWindowAgent: runReturnWindowAgent(result.data),
+    },
+    private: true,
+  });
+}

--- a/src/app/api/sfi/predictions/health/route.ts
+++ b/src/app/api/sfi/predictions/health/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getPredictionRegistryHealth } from '@/lib/sfi/predictions/service';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const health = await getPredictionRegistryHealth();
+  return NextResponse.json(health, { status: health.table_available ? 200 : 200 });
+}

--- a/src/app/api/sfi/predictions/route.ts
+++ b/src/app/api/sfi/predictions/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { requireRootActor } from '@/lib/root/server';
+import {
+  createPredictionEntry,
+  listPredictionEntries,
+  normalizeCreatePredictionInput,
+} from '@/lib/sfi/predictions/service';
+import { runEvidenceStateAgent, runReturnWindowAgent } from '@/lib/sfi/predictions/agents';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+async function requireRoot(action: string) {
+  try {
+    return await requireRootActor(action);
+  } catch (error) {
+    return {
+      ok: false as const,
+      status: 503,
+      body: {
+        ok: false,
+        error: 'root_auth_unavailable',
+        details: error instanceof Error ? error.message : 'unknown_root_auth_error',
+      },
+    };
+  }
+}
+
+export async function GET() {
+  const gate = await requireRoot('sfi.predictions.list');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  const result = await listPredictionEntries({ limit: 100 });
+  if (!result.ok) return NextResponse.json(result, { status: result.status ?? 400 });
+
+  return NextResponse.json({
+    ok: true,
+    entries: result.data.entries,
+    count: result.data.count,
+    private: true,
+  });
+}
+
+export async function POST(request: Request) {
+  const gate = await requireRoot('sfi.predictions.create');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  const normalized = normalizeCreatePredictionInput(await request.json().catch(() => ({})));
+  if (!normalized.ok) return NextResponse.json(normalized, { status: normalized.status ?? 400 });
+
+  const result = await createPredictionEntry({
+    ...normalized.data,
+    created_by: gate.ctx.user.id,
+  });
+  if (!result.ok) return NextResponse.json(result, { status: result.status ?? 400 });
+
+  return NextResponse.json({
+    ok: true,
+    entry: result.data,
+    agents: {
+      evidenceStateAgent: runEvidenceStateAgent(result.data),
+      returnWindowAgent: runReturnWindowAgent(result.data),
+    },
+  }, { status: 201 });
+}

--- a/src/app/field/page.tsx
+++ b/src/app/field/page.tsx
@@ -12,6 +12,7 @@ export default function FieldPage() {
           <p className="mt-3 max-w-3xl text-sm leading-6 text-[#9f9788]">
             Field is the future capture surface. In Phase 01 it routes participants and operators to the correct workbook
             boundary without storing private observations, diagnosing anyone or interpreting phenotype patterns publicly.
+            In Phase 02, operator capture may lead to a ROOT-governed Prediction Registry entry.
           </p>
         </header>
 
@@ -44,6 +45,9 @@ export default function FieldPage() {
               <Link href="/operator/field" className="border border-[#c8a95166] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951]">
                 Operator Field
               </Link>
+              <Link href="/root/predictions/new" className="border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
+                ROOT Prediction
+              </Link>
               <Link href="/library/SFI-WB-001_Operator_Workbook.html" className="border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
                 WB-001
               </Link>
@@ -55,7 +59,8 @@ export default function FieldPage() {
           <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Operational position</div>
           <p className="mt-4 text-sm leading-6 text-[#9f9788]">
             Library formalizes the method. World Vector contextualizes the world. Field captures signal.
-            Prediction Registry stores hypotheses. Atlas stores longitudinal memory. ROOT decides.
+            Prediction Registry stores ROOT-timestamped hypotheses. Atlas stores longitudinal memory later.
+            ROOT decides what becomes evidence, archive, Atlas candidate or public output.
           </p>
         </section>
       </div>

--- a/src/app/field/participant/page.tsx
+++ b/src/app/field/participant/page.tsx
@@ -11,7 +11,7 @@ export default function ParticipantFieldPage() {
           <h1 className="mt-4 text-4xl font-semibold text-[#f5eedc]">72-hour marks without technical interpretation.</h1>
           <p className="mt-3 text-sm leading-6 text-[#9f9788]">
             This Phase 01 route is a public-safe placeholder for WB-002-aligned capture. It explains the future boundary
-            and links to the workbook; it does not collect private data yet.
+            and links to the workbook; it does not collect private data or submit DB writes yet.
           </p>
         </header>
 
@@ -22,6 +22,7 @@ export default function ParticipantFieldPage() {
             <li>Reflect on what changed, what was noticed, what was avoided and what was yours.</li>
             <li>Do not receive phenotype interpretation, diagnosis or operator inference by default.</li>
             <li>Keep observation low-friction and privacy-preserving until a governed capture layer exists.</li>
+            <li>Technical interpretation remains operator/ROOT governed.</li>
           </ul>
           <Link href="/library/SFI-WB-002_Participant_Workbook.html" className="mt-5 inline-block border border-[#c8a95166] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951]">
             Open WB-002

--- a/src/app/operator/field/page.tsx
+++ b/src/app/operator/field/page.tsx
@@ -26,7 +26,8 @@ export default function OperatorFieldPage() {
           <h1 className="mt-4 text-4xl font-semibold text-[#f5eedc]">Capture before claim, prediction before perturbation.</h1>
           <p className="mt-3 max-w-3xl text-sm leading-6 text-[#9f9788]">
             This Phase 01 route aligns to WB-001 and names the capture contract. It does not write to Supabase,
-            close cycles, publish, diagnose or mutate protocols.
+            close cycles, publish, diagnose or mutate protocols. Phase 02 uses this capture boundary before ROOT
+            registers a live prediction.
           </p>
         </header>
 
@@ -43,8 +44,12 @@ export default function OperatorFieldPage() {
           <p className="mt-4 text-sm leading-6 text-[#9f9788]">
             Operator capture can support future Prediction Registry entries only when source, timestamp, operator note,
             EP_estado and SSP context are present. ROOT remains responsible for governed approvals and Atlas promotion.
+            Prediction registration must happen before perturbation to count as predictive evidence.
           </p>
           <div className="mt-5 flex flex-wrap gap-3">
+            <Link href="/root/predictions/new" className="border border-[#c8a95166] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951]">
+              ROOT Prediction
+            </Link>
             <Link href="/library/SFI-WB-001_Operator_Workbook.html" className="border border-[#c8a95166] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951]">
               Open WB-001
             </Link>

--- a/src/app/root/agents/page.tsx
+++ b/src/app/root/agents/page.tsx
@@ -3,8 +3,13 @@ import WorldVectorRuntimePanel from '@/components/world-vector/WorldVectorRuntim
 
 export const dynamic = 'force-static';
 
-const futureRoutes = [
-  { label: 'Future Prediction Registry', href: '/root/predictions' },
+const rootAgentRoutes = [
+  { label: 'Prediction Registry health', href: '/api/sfi/predictions/health' },
+  { label: 'Prediction Registry', href: '/root/predictions' },
+  { label: 'Register prediction', href: '/root/predictions/new' },
+  { label: 'Pending return windows', href: '/root/predictions' },
+  { label: 'Evidence State Agent', href: '/api/sfi/predictions/health' },
+  { label: 'Return Window Agent', href: '/api/sfi/predictions/health' },
   { label: 'Future Atlas', href: '/root/atlas' },
 ];
 
@@ -16,8 +21,8 @@ export default function RootAgentsPage() {
           <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#c8a951]">ROOT Agents Boundary</p>
           <h1 className="mt-4 text-4xl font-semibold text-[#f5eedc]">Agents compare and propose. ROOT decides.</h1>
           <p className="mt-3 max-w-3xl text-sm leading-6 text-[#9f9788]">
-            This Phase 01 dashboard is a safe ROOT placeholder. It exposes read-only health links and boundaries,
-            with no mutation buttons, no automatic publishing and no cron authority to close cycles.
+            This ROOT dashboard exposes read-only health links and governed routes. It does not publish,
+            promote Atlas entries or grant cron authority to close cycles.
           </p>
         </header>
 
@@ -34,8 +39,8 @@ export default function RootAgentsPage() {
           <Link href="/api/sfi/library/health" className="border border-[#2f2a1e] bg-[#0b0b09] p-4 text-sm text-[#d8d2c2]">
             Library health API
           </Link>
-          {futureRoutes.map((route) => (
-            <Link key={route.href} href={route.href} className="border border-[#2f2a1e] bg-[#0b0b09] p-4 text-sm text-[#8f8878]">
+          {rootAgentRoutes.map((route) => (
+            <Link key={`${route.href}:${route.label}`} href={route.href} className="border border-[#2f2a1e] bg-[#0b0b09] p-4 text-sm text-[#8f8878]">
               {route.label}
             </Link>
           ))}
@@ -48,6 +53,10 @@ export default function RootAgentsPage() {
           <p className="mt-4 text-sm leading-6 text-[#9f9788]">
             Protocol mutation, phenotype mutation, Atlas promotion, publication and cycle close require governed ROOT
             approval. System actor credentials are not ROOT credentials.
+          </p>
+          <p className="mt-3 text-sm leading-6 text-[#9f9788]">
+            Prediction agents classify evidence state and return windows only. They do not fill results, rewrite protocols
+            or mutate phenotype definitions.
           </p>
         </section>
       </div>

--- a/src/app/root/predictions/[hypothesisId]/page.tsx
+++ b/src/app/root/predictions/[hypothesisId]/page.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+import PredictionDetailPanel from '@/components/root/predictions/PredictionDetailPanel';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  params: Promise<{ hypothesisId: string }> | { hypothesisId: string };
+};
+
+export default async function RootPredictionDetailPage({ params }: PageProps) {
+  const resolved = await Promise.resolve(params);
+  const hypothesisId = decodeURIComponent(resolved.hypothesisId);
+
+  return (
+    <main className="min-h-screen bg-[#060605] px-6 py-10 text-[#d8d2c2]">
+      <div className="mx-auto max-w-6xl space-y-8">
+        <header className="border border-[#2f2a1e] bg-[#0b0b09] p-6">
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#c8a951]">Prediction Detail</p>
+          <h1 className="mt-4 break-words text-4xl font-semibold text-[#f5eedc]">{hypothesisId}</h1>
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-[#9f9788]">
+            Review evidence classification and record return windows. Atlas promotion and publication are still out of scope.
+          </p>
+          <Link href="/root/predictions" className="mt-5 inline-block border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
+            Back to registry
+          </Link>
+        </header>
+
+        <PredictionDetailPanel hypothesisId={hypothesisId} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/root/predictions/new/page.tsx
+++ b/src/app/root/predictions/new/page.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import NewPredictionForm from '@/components/root/predictions/NewPredictionForm';
+
+export const dynamic = 'force-static';
+
+export default function NewRootPredictionPage() {
+  return (
+    <main className="min-h-screen bg-[#060605] px-6 py-10 text-[#d8d2c2]">
+      <div className="mx-auto max-w-5xl space-y-8">
+        <header className="border border-[#2f2a1e] bg-[#0b0b09] p-6">
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#c8a951]">New Prediction</p>
+          <h1 className="mt-4 text-4xl font-semibold text-[#f5eedc]">Register before perturbation.</h1>
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-[#9f9788]">
+            This governed form creates a private Prediction Registry entry. It does not publish, diagnose,
+            promote to Atlas or mutate the phenotype registry.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3">
+            <Link href="/root/predictions" className="border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
+              Registry
+            </Link>
+            <Link href="/library/SFI-WB-001_Operator_Workbook.html" className="border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
+              WB-001
+            </Link>
+          </div>
+        </header>
+
+        <NewPredictionForm />
+      </div>
+    </main>
+  );
+}

--- a/src/app/root/predictions/page.tsx
+++ b/src/app/root/predictions/page.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import PredictionRegistryPanel from '@/components/root/predictions/PredictionRegistryPanel';
+
+export const dynamic = 'force-static';
+
+export default function RootPredictionsPage() {
+  return (
+    <main className="min-h-screen bg-[#060605] px-6 py-10 text-[#d8d2c2]">
+      <div className="mx-auto max-w-6xl space-y-8">
+        <header className="border border-[#2f2a1e] bg-[#0b0b09] p-6">
+          <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#c8a951]">Prediction Registry</p>
+          <h1 className="mt-4 text-4xl font-semibold text-[#f5eedc]">ROOT-governed hypothesis memory.</h1>
+          <p className="mt-3 max-w-3xl text-sm leading-6 text-[#9f9788]">
+            ROOT registers hypotheses before perturbation, records return windows and reviews evidence state.
+            No public browsing, Atlas promotion or automatic publication happens here.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3">
+            <Link href="/root/predictions/new" className="border border-[#c8a95166] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951]">
+              New prediction
+            </Link>
+            <Link href="/library/phenotypes" className="border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
+              Phenotypes
+            </Link>
+            <Link href="/field" className="border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
+              Field
+            </Link>
+            <Link href="/operator/field" className="border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
+              Operator Field
+            </Link>
+          </div>
+        </header>
+
+        <PredictionRegistryPanel />
+      </div>
+    </main>
+  );
+}

--- a/src/components/root/predictions/NewPredictionForm.tsx
+++ b/src/components/root/predictions/NewPredictionForm.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { FormEvent, useState } from 'react';
+import { getSfiPhenotypeRegistry } from '@/lib/sfi/phenotypes/registry';
+
+type SubmitState =
+  | { status: 'idle'; message: null }
+  | { status: 'submitting'; message: null }
+  | { status: 'error'; message: string }
+  | { status: 'created'; message: string };
+
+function textFromForm(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function optionalIsoFromForm(formData: FormData, key: string) {
+  const value = textFromForm(formData, key);
+  if (!value) return null;
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? new Date(time).toISOString() : null;
+}
+
+const PHENOTYPES = getSfiPhenotypeRegistry();
+
+export default function NewPredictionForm() {
+  const router = useRouter();
+  const [state, setState] = useState<SubmitState>({ status: 'idle', message: null });
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const probability = Number(textFromForm(formData, 'probabilidad_estimativa'));
+
+    setState({ status: 'submitting', message: null });
+
+    const response = await fetch('/api/sfi/predictions', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        case_id: textFromForm(formData, 'case_id'),
+        hypothesis_id: textFromForm(formData, 'hypothesis_id'),
+        case_label: textFromForm(formData, 'case_label'),
+        operator_mode: textFromForm(formData, 'operator_mode'),
+        fenotipo_estimado: textFromForm(formData, 'fenotipo_estimado'),
+        ep_estado_inicial: textFromForm(formData, 'ep_estado_inicial'),
+        ssp_esperada: textFromForm(formData, 'ssp_esperada'),
+        perturbacion_tipo: textFromForm(formData, 'perturbacion_tipo'),
+        perturbacion_aplicada: textFromForm(formData, 'perturbacion_aplicada'),
+        prediccion_explicita: textFromForm(formData, 'prediccion_explicita'),
+        probabilidad_estimativa: probability,
+        perturbation_applied_at: optionalIsoFromForm(formData, 'perturbation_applied_at'),
+      }),
+    });
+    const body = await response.json().catch(() => null) as { entry?: { hypothesis_id?: string }; error?: string; details?: unknown } | null;
+
+    if (!response.ok || !body?.entry?.hypothesis_id) {
+      setState({
+        status: 'error',
+        message: body?.error ?? `prediction_create_failed_${response.status}`,
+      });
+      return;
+    }
+
+    setState({ status: 'created', message: 'Prediction registered.' });
+    router.push(`/root/predictions/${encodeURIComponent(body.entry.hypothesis_id)}`);
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6">
+      <section className="border border-[#5f4a18] bg-[#151108] p-5">
+        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Core rule</div>
+        <p className="mt-3 text-sm leading-6 text-[#f5eedc]">
+          Prediction must be registered before perturbation to count as predictive evidence.
+        </p>
+        <p className="mt-2 text-xs leading-5 text-[#9f9788]">
+          If the prediction is registered after perturbation, the registry stores it as retrospective observation.
+        </p>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <label className="grid gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">case_id</span>
+          <input required name="case_id" className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+        </label>
+        <label className="grid gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">hypothesis_id</span>
+          <input required name="hypothesis_id" className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+        </label>
+        <label className="grid gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">case_label</span>
+          <input name="case_label" className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+        </label>
+        <label className="grid gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">operator_mode</span>
+          <input name="operator_mode" className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+        </label>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <label className="grid gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">fenotipo_estimado</span>
+          <select required name="fenotipo_estimado" className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]">
+            <option value="">Select phenotype</option>
+            {PHENOTYPES.map((phenotype) => (
+              <option key={phenotype.id} value={phenotype.id}>{phenotype.id} - {phenotype.label}</option>
+            ))}
+          </select>
+        </label>
+        <label className="grid gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">probabilidad_estimativa</span>
+          <input required name="probabilidad_estimativa" type="number" min="0" max="1" step="0.01" className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+        </label>
+        <label className="grid gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">ep_estado_inicial</span>
+          <input required name="ep_estado_inicial" className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+        </label>
+        <label className="grid gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">ssp_esperada</span>
+          <input required name="ssp_esperada" className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+        </label>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <label className="grid gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">perturbacion_tipo</span>
+          <input required name="perturbacion_tipo" className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+        </label>
+        <label className="grid gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">perturbacion_aplicada</span>
+          <input required name="perturbacion_aplicada" className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+        </label>
+        <label className="grid gap-2 md:col-span-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">perturbation_applied_at optional</span>
+          <input name="perturbation_applied_at" type="datetime-local" className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+        </label>
+      </section>
+
+      <label className="grid gap-2">
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">prediccion_explicita</span>
+        <textarea required name="prediccion_explicita" className="min-h-32 border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+      </label>
+
+      <section className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
+        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Phenotype boundary</div>
+        <p className="mt-3 text-sm leading-6 text-[#9f9788]">
+          Phenotypes are hypothesis support only. They are not identity, blame, pathology or diagnosis.
+          Required before use: EP_estado, SSP, evidence source, timestamp and operator note.
+        </p>
+        <Link href="/library/phenotypes" className="mt-4 inline-block border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
+          Open phenotype registry
+        </Link>
+      </section>
+
+      {state.status === 'error' ? <p className="border border-[#5f2f28] bg-[#170d0b] p-3 text-sm text-[#d69a8b]">{state.message}</p> : null}
+      {state.status === 'created' ? <p className="border border-[#314d2a] bg-[#0d170b] p-3 text-sm text-[#a8d69a]">{state.message}</p> : null}
+
+      <button
+        type="submit"
+        disabled={state.status === 'submitting'}
+        className="border border-[#c8a951] bg-[#c8a951] px-5 py-3 font-mono text-[11px] uppercase tracking-[0.16em] text-[#060605] disabled:opacity-60"
+      >
+        {state.status === 'submitting' ? 'Registering' : 'Register prediction'}
+      </button>
+    </form>
+  );
+}

--- a/src/components/root/predictions/PredictionDetailPanel.tsx
+++ b/src/components/root/predictions/PredictionDetailPanel.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import Link from 'next/link';
+import { FormEvent, useEffect, useState } from 'react';
+import type {
+  SfiPredictionEntry,
+  SfiPredictionEvidenceAgentResult,
+  SfiPredictionReturnWindowAgentResult,
+} from '@/lib/sfi/predictions/types';
+import { SFI_PREDICTION_EVIDENCE_STATES, SFI_PREDICTION_OBSERVATION_STATES } from '@/lib/sfi/predictions/types';
+
+type DetailBody = {
+  entry?: SfiPredictionEntry;
+  agents?: {
+    evidenceStateAgent?: SfiPredictionEvidenceAgentResult;
+    returnWindowAgent?: SfiPredictionReturnWindowAgentResult;
+  };
+  error?: string;
+};
+
+type DetailState =
+  | { status: 'loading'; error: null; body: null }
+  | { status: 'ready'; error: null; body: DetailBody }
+  | { status: 'blocked'; error: string; body: DetailBody | null };
+
+function textFromForm(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export default function PredictionDetailPanel({ hypothesisId }: { hypothesisId: string }) {
+  const [state, setState] = useState<DetailState>({ status: 'loading', error: null, body: null });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    const controller = new AbortController();
+
+    async function run() {
+      try {
+        const response = await fetch(`/api/sfi/predictions/${encodeURIComponent(hypothesisId)}`, {
+          cache: 'no-store',
+          credentials: 'include',
+          signal: controller.signal,
+        });
+        const body = await response.json().catch(() => null) as DetailBody | null;
+
+        if (!active) return;
+        if (!response.ok || !body?.entry) {
+          setState({
+            status: 'blocked',
+            error: body?.error ?? `prediction_detail_blocked_${response.status}`,
+            body,
+          });
+          return;
+        }
+
+        setState({ status: 'ready', error: null, body });
+      } catch {
+        if (!active) return;
+        setState({ status: 'blocked', error: 'prediction_detail_fetch_failed', body: null });
+      }
+    }
+
+    void run();
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [hypothesisId]);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    setSaving(true);
+
+    const cpDiasValue = textFromForm(formData, 'cp_dias');
+    const response = await fetch(`/api/sfi/predictions/${encodeURIComponent(hypothesisId)}/returns`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        resultado_72h: textFromForm(formData, 'resultado_72h'),
+        resultado_7d: textFromForm(formData, 'resultado_7d'),
+        resultado_30d: textFromForm(formData, 'resultado_30d'),
+        resultado_90d: textFromForm(formData, 'resultado_90d'),
+        ssp_observada: textFromForm(formData, 'ssp_observada'),
+        friccion_respuesta_campo: textFromForm(formData, 'friccion_respuesta_campo'),
+        ep_t_registrada: textFromForm(formData, 'ep_t_registrada'),
+        cp_dias: cpDiasValue ? Number(cpDiasValue) : null,
+        fallo_hipotesis: textFromForm(formData, 'fallo_hipotesis'),
+        refinamiento: textFromForm(formData, 'refinamiento'),
+        evidence_state: textFromForm(formData, 'evidence_state'),
+        estado_observacion: textFromForm(formData, 'estado_observacion'),
+      }),
+    });
+    const body = await response.json().catch(() => null) as DetailBody | null;
+    setSaving(false);
+
+    if (!response.ok || !body?.entry) {
+      setState({
+        status: 'blocked',
+        error: body?.error ?? `prediction_return_update_failed_${response.status}`,
+        body,
+      });
+      return;
+    }
+
+    setState({ status: 'ready', error: null, body });
+  }
+
+  if (state.status === 'loading') {
+    return <div className="border border-[#2f2a1e] bg-[#0b0b09] p-5 text-sm text-[#8f8878]">Loading prediction entry.</div>;
+  }
+
+  if (state.status === 'blocked' || !state.body?.entry) {
+    return (
+      <section className="border border-[#5f2f28] bg-[#170d0b] p-5">
+        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#d69a8b]">Blocked</div>
+        <p className="mt-3 text-sm text-[#d69a8b]">{state.error}</p>
+        <Link href="/root/predictions" className="mt-4 inline-block border border-[#5f2f28] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d69a8b]">
+          Back to registry
+        </Link>
+      </section>
+    );
+  }
+
+  const entry = state.body.entry;
+  const evidenceAgent = state.body.agents?.evidenceStateAgent;
+  const returnAgent = state.body.agents?.returnWindowAgent;
+
+  return (
+    <div className="space-y-6">
+      <section className="grid gap-3 md:grid-cols-4">
+        <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">Classification</div>
+          <div className="mt-2 text-lg text-[#f5eedc]">{entry.is_predictive_evidence ? 'predictive' : 'retrospective'}</div>
+        </div>
+        <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">Evidence</div>
+          <div className="mt-2 text-lg text-[#f5eedc]">{entry.evidence_state}</div>
+        </div>
+        <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">Observation</div>
+          <div className="mt-2 text-lg text-[#f5eedc]">{entry.estado_observacion}</div>
+        </div>
+        <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">Pending windows</div>
+          <div className="mt-2 text-lg text-[#f5eedc]">{returnAgent?.pending_count ?? 'unknown'}</div>
+        </div>
+      </section>
+
+      <section className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
+        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">{entry.hypothesis_id}</div>
+        <h2 className="mt-2 text-2xl font-semibold text-[#f5eedc]">{entry.case_label || entry.case_id}</h2>
+        <p className="mt-4 text-sm leading-6 text-[#d8d2c2]">{entry.prediccion_explicita}</p>
+        <div className="mt-5 grid gap-3 font-mono text-[11px] uppercase tracking-[0.12em] text-[#8f8878] md:grid-cols-2">
+          <div>phenotype={entry.fenotipo_estimado}</div>
+          <div>probability={entry.probabilidad_estimativa}</div>
+          <div>registered_at={entry.prediction_registered_at}</div>
+          <div>perturbation_at={entry.perturbation_applied_at ?? 'not_applied'}</div>
+        </div>
+      </section>
+
+      <section className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
+        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Agents</div>
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          <div className="border border-[#2f2a1e] bg-[#060605] p-4 text-sm text-[#d8d2c2]">
+            evidence: matched={String(evidenceAgent?.prediction_matched ?? 'unknown')} failed={String(evidenceAgent?.prediction_failed ?? 'unknown')} retrospective={String(evidenceAgent?.retrospective_only ?? 'unknown')}
+          </div>
+          <div className="border border-[#2f2a1e] bg-[#060605] p-4 text-sm text-[#d8d2c2]">
+            returns: due={returnAgent?.due_count ?? 'unknown'} overdue={returnAgent?.overdue_count ?? 'unknown'} complete={returnAgent?.complete_count ?? 'unknown'}
+          </div>
+        </div>
+      </section>
+
+      <form onSubmit={onSubmit} className="space-y-4 border border-[#2f2a1e] bg-[#0b0b09] p-5">
+        <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Update returns</div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {(['resultado_72h', 'resultado_7d', 'resultado_30d', 'resultado_90d'] as const).map((field) => (
+            <label key={field} className="grid gap-2">
+              <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">{field}</span>
+              <textarea name={field} defaultValue={entry[field] ?? ''} className="min-h-24 border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+            </label>
+          ))}
+          <label className="grid gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">ssp_observada</span>
+            <input name="ssp_observada" defaultValue={entry.ssp_observada ?? ''} className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+          </label>
+          <label className="grid gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">friccion_respuesta_campo</span>
+            <input name="friccion_respuesta_campo" defaultValue={entry.friccion_respuesta_campo ?? ''} className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+          </label>
+          <label className="grid gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">ep_t_registrada</span>
+            <input name="ep_t_registrada" defaultValue={entry.ep_t_registrada ?? ''} className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+          </label>
+          <label className="grid gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">cp_dias</span>
+            <input name="cp_dias" type="number" defaultValue={entry.cp_dias ?? ''} className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+          </label>
+          <label className="grid gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">fallo_hipotesis</span>
+            <input name="fallo_hipotesis" defaultValue={entry.fallo_hipotesis ?? ''} className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+          </label>
+          <label className="grid gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">evidence_state</span>
+            <select name="evidence_state" defaultValue={entry.evidence_state} className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]">
+              {SFI_PREDICTION_EVIDENCE_STATES.map((stateValue) => <option key={stateValue} value={stateValue}>{stateValue}</option>)}
+            </select>
+          </label>
+          <label className="grid gap-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">estado_observacion</span>
+            <select name="estado_observacion" defaultValue={entry.estado_observacion} className="border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]">
+              {SFI_PREDICTION_OBSERVATION_STATES.map((stateValue) => <option key={stateValue} value={stateValue}>{stateValue}</option>)}
+            </select>
+          </label>
+          <label className="grid gap-2 md:col-span-2">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">refinamiento</span>
+            <textarea name="refinamiento" defaultValue={entry.refinamiento ?? ''} className="min-h-24 border border-[#2f2a1e] bg-[#060605] px-3 py-3 text-sm text-[#f5eedc]" />
+          </label>
+        </div>
+        <p className="text-xs leading-5 text-[#8f8878]">This update records returns only. It does not publish, promote to Atlas, mutate protocols or mutate phenotypes.</p>
+        <button disabled={saving} className="border border-[#c8a951] bg-[#c8a951] px-5 py-3 font-mono text-[11px] uppercase tracking-[0.16em] text-[#060605] disabled:opacity-60">
+          {saving ? 'Saving' : 'Save returns'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/root/predictions/PredictionRegistryPanel.tsx
+++ b/src/components/root/predictions/PredictionRegistryPanel.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import type { SfiPredictionEntry, SfiPredictionHealth } from '@/lib/sfi/predictions/types';
+
+type ListState =
+  | { status: 'loading'; error: null; health: null; entries: [] }
+  | { status: 'ready'; error: null; health: SfiPredictionHealth | null; entries: SfiPredictionEntry[] }
+  | { status: 'blocked'; error: string; health: SfiPredictionHealth | null; entries: SfiPredictionEntry[] };
+
+export default function PredictionRegistryPanel() {
+  const [state, setState] = useState<ListState>({
+    status: 'loading',
+    error: null,
+    health: null,
+    entries: [],
+  });
+
+  useEffect(() => {
+    let active = true;
+    const controller = new AbortController();
+
+    async function loadRegistry() {
+      try {
+        const [healthResponse, listResponse] = await Promise.all([
+          fetch('/api/sfi/predictions/health', { cache: 'no-store', signal: controller.signal }),
+          fetch('/api/sfi/predictions', { cache: 'no-store', credentials: 'include', signal: controller.signal }),
+        ]);
+        const health = await healthResponse.json().catch(() => null) as SfiPredictionHealth | null;
+        const listBody = await listResponse.json().catch(() => null) as { entries?: SfiPredictionEntry[]; error?: string } | null;
+
+        if (!active) return;
+        if (!listResponse.ok) {
+          setState({
+            status: 'blocked',
+            error: listBody?.error ?? `prediction_registry_blocked_${listResponse.status}`,
+            health,
+            entries: [],
+          });
+          return;
+        }
+
+        setState({
+          status: 'ready',
+          error: null,
+          health,
+          entries: listBody?.entries ?? [],
+        });
+      } catch {
+        if (!active) return;
+        setState({
+          status: 'blocked',
+          error: 'prediction_registry_fetch_failed',
+          health: null,
+          entries: [],
+        });
+      }
+    }
+
+    void loadRegistry();
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, []);
+
+  const health = state.health;
+
+  return (
+    <div className="space-y-6">
+      <section className="grid gap-3 md:grid-cols-4">
+        <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">Table</div>
+          <div className="mt-2 text-lg text-[#f5eedc]">{health?.table_available ? 'available' : 'blocked'}</div>
+        </div>
+        <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">Entries</div>
+          <div className="mt-2 text-lg text-[#f5eedc]">{health?.entries_count ?? 'unknown'}</div>
+        </div>
+        <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">Pending returns</div>
+          <div className="mt-2 text-lg text-[#f5eedc]">{health?.pending_returns_count ?? 'unknown'}</div>
+        </div>
+        <div className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#8f8878]">Agents</div>
+          <div className="mt-2 text-lg text-[#f5eedc]">{health?.agents.evidenceStateAgent.ok && health.agents.returnWindowAgent.ok ? 'ready' : 'blocked'}</div>
+        </div>
+      </section>
+
+      {state.status === 'blocked' ? (
+        <section className="border border-[#5f2f28] bg-[#170d0b] p-5">
+          <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#d69a8b]">Blocked</div>
+          <p className="mt-3 text-sm text-[#d69a8b]">{state.error}</p>
+          <div className="mt-3 space-y-1 font-mono text-[11px] text-[#c8a951]">
+            {(health?.blocked ?? []).map((item) => <div key={item}>{item}</div>)}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">ROOT Registry</div>
+            <h2 className="mt-2 text-2xl font-semibold text-[#f5eedc]">Prediction entries</h2>
+          </div>
+          <Link href="/root/predictions/new" className="border border-[#c8a95166] px-4 py-2 text-center font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951]">
+            New prediction
+          </Link>
+        </div>
+
+        <div className="mt-5 space-y-3">
+          {state.status === 'loading' ? <div className="text-sm text-[#8f8878]">Loading private registry state.</div> : null}
+          {state.entries.length === 0 && state.status !== 'loading' ? <div className="text-sm text-[#8f8878]">No prediction entries available to this ROOT session.</div> : null}
+          {state.entries.map((entry) => (
+            <Link
+              key={entry.hypothesis_id}
+              href={`/root/predictions/${encodeURIComponent(entry.hypothesis_id)}`}
+              className="grid gap-3 border border-[#2f2a1e] bg-[#060605] p-4 text-sm text-[#d8d2c2] md:grid-cols-[1fr_180px_140px]"
+            >
+              <div>
+                <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-[#c8a951]">{entry.hypothesis_id}</div>
+                <div className="mt-1 text-[#f5eedc]">{entry.case_label || entry.case_id}</div>
+                <div className="mt-2 text-xs leading-5 text-[#8f8878]">{entry.prediccion_explicita}</div>
+              </div>
+              <div className="font-mono text-[11px] uppercase tracking-[0.12em] text-[#8f8878]">
+                phenotype={entry.fenotipo_estimado}
+              </div>
+              <div className="font-mono text-[11px] uppercase tracking-[0.12em] text-[#8f8878]">
+                {entry.is_predictive_evidence ? 'predictive' : 'retrospective'}<br />
+                {entry.evidence_state}
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/lib/sfi/predictions/agents/evidenceStateAgent.ts
+++ b/src/lib/sfi/predictions/agents/evidenceStateAgent.ts
@@ -1,0 +1,57 @@
+import type { SfiPredictionEntry, SfiPredictionEvidenceAgentResult } from '../types';
+
+function timeValue(value: string | null | undefined) {
+  if (!value) return null;
+  const time = Date.parse(value);
+  return Number.isFinite(time) ? time : null;
+}
+
+function parseFailure(value: string | null) {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+  if (['false', 'no', '0', 'matched', 'confirmada', 'confirmed'].includes(normalized)) return false;
+  if (['true', 'si', 'yes', '1', 'failed', 'fallo', 'falla'].includes(normalized)) return true;
+  return null;
+}
+
+function hasReturnEvidence(entry: SfiPredictionEntry) {
+  return Boolean(
+    entry.resultado_72h
+    || entry.resultado_7d
+    || entry.resultado_30d
+    || entry.resultado_90d
+    || entry.ssp_observada
+    || entry.friccion_respuesta_campo
+  );
+}
+
+export function runEvidenceStateAgent(entry: SfiPredictionEntry): SfiPredictionEvidenceAgentResult {
+  const registeredAt = timeValue(entry.prediction_registered_at);
+  const perturbationAt = timeValue(entry.perturbation_applied_at);
+  const predictionRegisteredBeforePerturbation = Boolean(
+    registeredAt !== null && (perturbationAt === null || perturbationAt > registeredAt)
+  );
+  const failure = parseFailure(entry.fallo_hipotesis);
+  const evidenceDegraded = entry.evidence_state === 'DEGRADED' || entry.estado_observacion === 'degraded';
+  const warnings = [
+    !predictionRegisteredBeforePerturbation ? 'retrospective_only_not_predictive_evidence' : null,
+    entry.evidence_state === 'VERIFIED' && !hasReturnEvidence(entry) ? 'verified_without_return_evidence' : null,
+  ].filter((item): item is string => Boolean(item));
+
+  return {
+    agent: 'evidenceStateAgent',
+    mode: 'passive_deterministic',
+    ok: true,
+    hypothesis_id: entry.hypothesis_id,
+    blocked: [],
+    warnings,
+    root_approval_required: true,
+    prediction_registered_before_perturbation: predictionRegisteredBeforePerturbation,
+    prediction_matched: failure === false ? true : null,
+    prediction_failed: failure === true ? true : null,
+    evidence_degraded: evidenceDegraded,
+    requires_refinement: failure === true || evidenceDegraded || Boolean(entry.refinamiento),
+    retrospective_only: !predictionRegisteredBeforePerturbation || !entry.is_predictive_evidence,
+  };
+}

--- a/src/lib/sfi/predictions/agents/index.ts
+++ b/src/lib/sfi/predictions/agents/index.ts
@@ -1,0 +1,2 @@
+export { runEvidenceStateAgent } from './evidenceStateAgent';
+export { runReturnWindowAgent } from './returnWindowAgent';

--- a/src/lib/sfi/predictions/agents/returnWindowAgent.ts
+++ b/src/lib/sfi/predictions/agents/returnWindowAgent.ts
@@ -1,0 +1,65 @@
+import type {
+  SfiPredictionEntry,
+  SfiPredictionReturnWindow,
+  SfiPredictionReturnWindowAgentResult,
+  SfiPredictionReturnWindowStatus,
+} from '../types';
+
+const WINDOW_CONFIG: Array<{
+  window: SfiPredictionReturnWindow;
+  field: SfiPredictionReturnWindowStatus['field'];
+  days: number;
+}> = [
+  { window: '72h', field: 'resultado_72h', days: 3 },
+  { window: '7d', field: 'resultado_7d', days: 7 },
+  { window: '30d', field: 'resultado_30d', days: 30 },
+  { window: '90d', field: 'resultado_90d', days: 90 },
+];
+
+function timeValue(value: string | null | undefined) {
+  if (!value) return null;
+  const time = Date.parse(value);
+  return Number.isFinite(time) ? time : null;
+}
+
+function textComplete(value: string | null) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function runReturnWindowAgent(entry: SfiPredictionEntry, now = new Date()): SfiPredictionReturnWindowAgentResult {
+  const baseTime = timeValue(entry.perturbation_applied_at) ?? timeValue(entry.prediction_registered_at);
+  const blocked = baseTime === null ? ['return_window_base_time_unavailable'] : [];
+  const nowMs = now.getTime();
+
+  const windows = WINDOW_CONFIG.map<SfiPredictionReturnWindowStatus>((config) => {
+    const dueAtMs = baseTime === null ? null : baseTime + config.days * 24 * 60 * 60 * 1000;
+    const due = dueAtMs !== null && nowMs >= dueAtMs;
+    const overdue = dueAtMs !== null && nowMs > dueAtMs + 24 * 60 * 60 * 1000;
+    const complete = textComplete(entry[config.field]);
+
+    return {
+      window: config.window,
+      field: config.field,
+      due_at: dueAtMs === null ? null : new Date(dueAtMs).toISOString(),
+      complete,
+      pending: !complete,
+      due: due && !complete,
+      overdue: overdue && !complete,
+    };
+  });
+
+  return {
+    agent: 'returnWindowAgent',
+    mode: 'passive_deterministic',
+    ok: blocked.length === 0,
+    hypothesis_id: entry.hypothesis_id,
+    blocked,
+    warnings: [],
+    root_approval_required: true,
+    windows,
+    pending_count: windows.filter((window) => window.pending).length,
+    complete_count: windows.filter((window) => window.complete).length,
+    due_count: windows.filter((window) => window.due).length,
+    overdue_count: windows.filter((window) => window.overdue).length,
+  };
+}

--- a/src/lib/sfi/predictions/service.ts
+++ b/src/lib/sfi/predictions/service.ts
@@ -1,0 +1,449 @@
+import 'server-only';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { runEvidenceStateAgent, runReturnWindowAgent } from './agents';
+import {
+  SFI_PREDICTION_EVIDENCE_STATES,
+  SFI_PREDICTION_OBSERVATION_STATES,
+  type CreateSfiPredictionInput,
+  type SfiPredictionEntry,
+  type SfiPredictionEvidenceState,
+  type SfiPredictionHealth,
+  type SfiPredictionObservationState,
+  type UpdateSfiPredictionReturnInput,
+} from './types';
+
+type ServiceResult<T> =
+  | { ok: true; data: T; warnings?: string[] }
+  | { ok: false; error: string; status?: number; details?: unknown; blocked?: string[]; warnings?: string[] };
+
+type PredictionClassification = {
+  estado_observacion: SfiPredictionObservationState;
+  is_predictive_evidence: boolean;
+  evidence_state: SfiPredictionEvidenceState;
+  prediction_registered_before_perturbation: boolean;
+  retrospective_only: boolean;
+};
+
+const TABLE = 'sfi_prediction_entries';
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function textValue(value: unknown) {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function nullableText(value: unknown) {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function numberValue(value: unknown) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function booleanValue(value: unknown) {
+  return value === true;
+}
+
+function isoOrNull(value: unknown) {
+  const text = textValue(value);
+  if (!text) return null;
+  const time = Date.parse(text);
+  return Number.isFinite(time) ? new Date(time).toISOString() : null;
+}
+
+function serviceClient() {
+  try {
+    return { ok: true as const, client: createServiceSupabaseClient() };
+  } catch (error) {
+    return {
+      ok: false as const,
+      error: error instanceof Error ? error.message : 'supabase_service_unavailable',
+      blocked: ['supabase_service_unavailable'],
+    };
+  }
+}
+
+function evidenceState(value: unknown): SfiPredictionEvidenceState | null {
+  return SFI_PREDICTION_EVIDENCE_STATES.includes(value as SfiPredictionEvidenceState)
+    ? value as SfiPredictionEvidenceState
+    : null;
+}
+
+function observationState(value: unknown): SfiPredictionObservationState | null {
+  return SFI_PREDICTION_OBSERVATION_STATES.includes(value as SfiPredictionObservationState)
+    ? value as SfiPredictionObservationState
+    : null;
+}
+
+function hasEvidencePayload(input: {
+  ssp_observada?: string | null;
+  friccion_respuesta_campo?: string | null;
+  resultado_72h?: string | null;
+  resultado_7d?: string | null;
+  resultado_30d?: string | null;
+  resultado_90d?: string | null;
+}) {
+  return Boolean(
+    input.ssp_observada
+    || input.friccion_respuesta_campo
+    || input.resultado_72h
+    || input.resultado_7d
+    || input.resultado_30d
+    || input.resultado_90d
+  );
+}
+
+export function normalizeCreatePredictionInput(raw: unknown): ServiceResult<CreateSfiPredictionInput> {
+  const record = asRecord(raw);
+  const required = {
+    case_id: textValue(record.case_id),
+    hypothesis_id: textValue(record.hypothesis_id),
+    fenotipo_estimado: textValue(record.fenotipo_estimado),
+    ep_estado_inicial: textValue(record.ep_estado_inicial),
+    ssp_esperada: textValue(record.ssp_esperada),
+    perturbacion_tipo: textValue(record.perturbacion_tipo),
+    perturbacion_aplicada: textValue(record.perturbacion_aplicada),
+    prediccion_explicita: textValue(record.prediccion_explicita),
+    probabilidad_estimativa: numberValue(record.probabilidad_estimativa),
+  };
+  const missing = Object.entries(required)
+    .filter(([, value]) => value === null)
+    .map(([key]) => key);
+
+  if (missing.length > 0) {
+    return { ok: false, error: 'missing_required_prediction_fields', status: 400, details: { missing } };
+  }
+
+  if (required.probabilidad_estimativa === null || required.probabilidad_estimativa < 0 || required.probabilidad_estimativa > 1) {
+    return { ok: false, error: 'probabilidad_estimativa_out_of_range', status: 400 };
+  }
+
+  const perturbationAppliedAt = record.perturbation_applied_at ? isoOrNull(record.perturbation_applied_at) : null;
+  if (record.perturbation_applied_at && !perturbationAppliedAt) {
+    return { ok: false, error: 'invalid_perturbation_applied_at', status: 400 };
+  }
+
+  return {
+    ok: true,
+    data: {
+      case_id: required.case_id!,
+      hypothesis_id: required.hypothesis_id!,
+      fenotipo_estimado: required.fenotipo_estimado!,
+      ep_estado_inicial: required.ep_estado_inicial!,
+      ssp_esperada: required.ssp_esperada!,
+      perturbacion_tipo: required.perturbacion_tipo!,
+      perturbacion_aplicada: required.perturbacion_aplicada!,
+      prediccion_explicita: required.prediccion_explicita!,
+      probabilidad_estimativa: required.probabilidad_estimativa,
+      case_label: nullableText(record.case_label),
+      operator_mode: nullableText(record.operator_mode),
+      perturbation_applied_at: perturbationAppliedAt,
+      friccion_respuesta_campo: nullableText(record.friccion_respuesta_campo),
+      ssp_observada: nullableText(record.ssp_observada),
+      created_by: nullableText(record.created_by),
+    },
+  };
+}
+
+export function normalizeUpdatePredictionReturnInput(raw: unknown): ServiceResult<UpdateSfiPredictionReturnInput> {
+  const record = asRecord(raw);
+  const cpDias = record.cp_dias === null || record.cp_dias === undefined || record.cp_dias === ''
+    ? null
+    : numberValue(record.cp_dias);
+  if (record.cp_dias !== undefined && record.cp_dias !== null && record.cp_dias !== '' && cpDias === null) {
+    return { ok: false, error: 'invalid_cp_dias', status: 400 };
+  }
+
+  const nextEvidenceState = record.evidence_state === undefined ? undefined : evidenceState(record.evidence_state);
+  if (record.evidence_state !== undefined && !nextEvidenceState) {
+    return { ok: false, error: 'invalid_evidence_state', status: 400 };
+  }
+
+  const nextObservationState = record.estado_observacion === undefined ? undefined : observationState(record.estado_observacion);
+  if (record.estado_observacion !== undefined && !nextObservationState) {
+    return { ok: false, error: 'invalid_estado_observacion', status: 400 };
+  }
+
+  return {
+    ok: true,
+    data: {
+      resultado_72h: record.resultado_72h === undefined ? undefined : nullableText(record.resultado_72h),
+      resultado_7d: record.resultado_7d === undefined ? undefined : nullableText(record.resultado_7d),
+      resultado_30d: record.resultado_30d === undefined ? undefined : nullableText(record.resultado_30d),
+      resultado_90d: record.resultado_90d === undefined ? undefined : nullableText(record.resultado_90d),
+      ssp_observada: record.ssp_observada === undefined ? undefined : nullableText(record.ssp_observada),
+      friccion_respuesta_campo: record.friccion_respuesta_campo === undefined ? undefined : nullableText(record.friccion_respuesta_campo),
+      ep_t_registrada: record.ep_t_registrada === undefined ? undefined : nullableText(record.ep_t_registrada),
+      cp_dias: record.cp_dias === undefined ? undefined : cpDias,
+      fallo_hipotesis: record.fallo_hipotesis === undefined ? undefined : nullableText(record.fallo_hipotesis),
+      refinamiento: record.refinamiento === undefined ? undefined : nullableText(record.refinamiento),
+      evidence_state: nextEvidenceState ?? undefined,
+      estado_observacion: nextObservationState ?? undefined,
+    },
+  };
+}
+
+function predictionEntryFromRow(row: unknown): SfiPredictionEntry {
+  const record = asRecord(row);
+
+  return {
+    id: textValue(record.id) ?? '',
+    case_id: textValue(record.case_id) ?? '',
+    hypothesis_id: textValue(record.hypothesis_id) ?? '',
+    case_label: nullableText(record.case_label),
+    operator_mode: nullableText(record.operator_mode),
+    fenotipo_estimado: textValue(record.fenotipo_estimado) ?? '',
+    ep_estado_inicial: textValue(record.ep_estado_inicial) ?? '',
+    ssp_esperada: textValue(record.ssp_esperada) ?? '',
+    ssp_observada: nullableText(record.ssp_observada),
+    perturbacion_tipo: textValue(record.perturbacion_tipo) ?? '',
+    perturbacion_aplicada: textValue(record.perturbacion_aplicada) ?? '',
+    prediccion_explicita: textValue(record.prediccion_explicita) ?? '',
+    probabilidad_estimativa: numberValue(record.probabilidad_estimativa) ?? 0,
+    friccion_respuesta_campo: nullableText(record.friccion_respuesta_campo),
+    resultado_72h: nullableText(record.resultado_72h),
+    resultado_7d: nullableText(record.resultado_7d),
+    resultado_30d: nullableText(record.resultado_30d),
+    resultado_90d: nullableText(record.resultado_90d),
+    ep_t_registrada: nullableText(record.ep_t_registrada),
+    cp_dias: numberValue(record.cp_dias),
+    fallo_hipotesis: nullableText(record.fallo_hipotesis),
+    refinamiento: nullableText(record.refinamiento),
+    estado_observacion: observationState(record.estado_observacion) ?? 'pendiente',
+    prediction_registered_at: textValue(record.prediction_registered_at) ?? '',
+    perturbation_applied_at: nullableText(record.perturbation_applied_at),
+    is_predictive_evidence: booleanValue(record.is_predictive_evidence),
+    evidence_state: evidenceState(record.evidence_state) ?? 'PENDING',
+    created_by: nullableText(record.created_by),
+    created_at: textValue(record.created_at) ?? '',
+    updated_at: textValue(record.updated_at) ?? '',
+  };
+}
+
+export function classifyPredictionEvidence(entry: {
+  prediction_registered_at: string;
+  perturbation_applied_at?: string | null;
+  ssp_observada?: string | null;
+  friccion_respuesta_campo?: string | null;
+  resultado_72h?: string | null;
+  resultado_7d?: string | null;
+  resultado_30d?: string | null;
+  resultado_90d?: string | null;
+}): PredictionClassification {
+  const registeredAt = Date.parse(entry.prediction_registered_at);
+  const perturbationAt = entry.perturbation_applied_at ? Date.parse(entry.perturbation_applied_at) : null;
+  const predictionRegisteredBeforePerturbation = Number.isFinite(registeredAt)
+    && (perturbationAt === null || (Number.isFinite(perturbationAt) && perturbationAt > registeredAt));
+
+  if (predictionRegisteredBeforePerturbation) {
+    return {
+      estado_observacion: 'registrada_pre_perturbacion',
+      is_predictive_evidence: true,
+      evidence_state: 'PENDING',
+      prediction_registered_before_perturbation: true,
+      retrospective_only: false,
+    };
+  }
+
+  return {
+    estado_observacion: 'retrospective_observation',
+    is_predictive_evidence: false,
+    evidence_state: hasEvidencePayload(entry) ? 'OBSERVED' : 'UNCERTAIN',
+    prediction_registered_before_perturbation: false,
+    retrospective_only: true,
+  };
+}
+
+export async function createPredictionEntry(input: CreateSfiPredictionInput): Promise<ServiceResult<SfiPredictionEntry>> {
+  const client = serviceClient();
+  if (!client.ok) return { ok: false, error: client.error, status: 503, blocked: client.blocked };
+
+  const registeredAt = new Date().toISOString();
+  const classification = classifyPredictionEvidence({
+    prediction_registered_at: registeredAt,
+    perturbation_applied_at: input.perturbation_applied_at ?? null,
+    ssp_observada: input.ssp_observada ?? null,
+    friccion_respuesta_campo: input.friccion_respuesta_campo ?? null,
+  });
+
+  const { data, error } = await client.client
+    .from(TABLE)
+    .insert({
+      case_id: input.case_id,
+      hypothesis_id: input.hypothesis_id,
+      case_label: input.case_label ?? null,
+      operator_mode: input.operator_mode ?? null,
+      fenotipo_estimado: input.fenotipo_estimado,
+      ep_estado_inicial: input.ep_estado_inicial,
+      ssp_esperada: input.ssp_esperada,
+      ssp_observada: input.ssp_observada ?? null,
+      perturbacion_tipo: input.perturbacion_tipo,
+      perturbacion_aplicada: input.perturbacion_aplicada,
+      prediccion_explicita: input.prediccion_explicita,
+      probabilidad_estimativa: input.probabilidad_estimativa,
+      friccion_respuesta_campo: input.friccion_respuesta_campo ?? null,
+      estado_observacion: classification.estado_observacion,
+      prediction_registered_at: registeredAt,
+      perturbation_applied_at: input.perturbation_applied_at ?? null,
+      is_predictive_evidence: classification.is_predictive_evidence,
+      evidence_state: classification.evidence_state,
+      created_by: input.created_by ?? null,
+    })
+    .select('*')
+    .single();
+
+  if (error) return { ok: false, error: 'prediction_insert_failed', status: 400, details: error.message };
+  return { ok: true, data: predictionEntryFromRow(data) };
+}
+
+export async function listPredictionEntries(options: { limit?: number } = {}): Promise<ServiceResult<{ entries: SfiPredictionEntry[]; count: number | null }>> {
+  const client = serviceClient();
+  if (!client.ok) return { ok: false, error: client.error, status: 503, blocked: client.blocked };
+  const limit = Math.max(1, Math.min(100, options.limit ?? 50));
+
+  const { data, error, count } = await client.client
+    .from(TABLE)
+    .select('*', { count: 'exact' })
+    .order('prediction_registered_at', { ascending: false })
+    .limit(limit);
+
+  if (error) return { ok: false, error: 'prediction_list_failed', status: 400, details: error.message };
+  return { ok: true, data: { entries: (data ?? []).map(predictionEntryFromRow), count: count ?? null } };
+}
+
+export async function getPredictionEntry(hypothesisId: string): Promise<ServiceResult<SfiPredictionEntry>> {
+  const client = serviceClient();
+  if (!client.ok) return { ok: false, error: client.error, status: 503, blocked: client.blocked };
+
+  const { data, error } = await client.client
+    .from(TABLE)
+    .select('*')
+    .eq('hypothesis_id', hypothesisId)
+    .maybeSingle();
+
+  if (error) return { ok: false, error: 'prediction_lookup_failed', status: 400, details: error.message };
+  if (!data) return { ok: false, error: 'prediction_not_found', status: 404 };
+  return { ok: true, data: predictionEntryFromRow(data) };
+}
+
+export async function updatePredictionReturn(hypothesisId: string, updates: UpdateSfiPredictionReturnInput): Promise<ServiceResult<SfiPredictionEntry>> {
+  const client = serviceClient();
+  if (!client.ok) return { ok: false, error: client.error, status: 503, blocked: client.blocked };
+
+  const patch = Object.fromEntries(
+    Object.entries(updates).filter(([, value]) => value !== undefined)
+  );
+
+  if (Object.keys(patch).length === 0) {
+    return { ok: false, error: 'empty_prediction_return_update', status: 400 };
+  }
+
+  const { data, error } = await client.client
+    .from(TABLE)
+    .update(patch)
+    .eq('hypothesis_id', hypothesisId)
+    .select('*')
+    .single();
+
+  if (error) return { ok: false, error: 'prediction_return_update_failed', status: 400, details: error.message };
+  return { ok: true, data: predictionEntryFromRow(data) };
+}
+
+export async function getPredictionRegistryHealth(): Promise<SfiPredictionHealth> {
+  const client = serviceClient();
+  if (!client.ok) {
+    return {
+      ok: false,
+      table_available: false,
+      entries_count: null,
+      pending_returns_count: null,
+      blocked: client.blocked,
+      warnings: [client.error],
+      agents: {
+        evidenceStateAgent: { ok: false, checked: 0, blocked: client.blocked, warnings: [] },
+        returnWindowAgent: { ok: false, checked: 0, pending_returns_count: 0, overdue_returns_count: 0, blocked: client.blocked, warnings: [] },
+      },
+    };
+  }
+
+  const countResult = await client.client.from(TABLE).select('id', { count: 'exact', head: true });
+  if (countResult.error) {
+    return {
+      ok: false,
+      table_available: false,
+      entries_count: null,
+      pending_returns_count: null,
+      blocked: ['sfi_prediction_entries_unavailable'],
+      warnings: [countResult.error.message],
+      agents: {
+        evidenceStateAgent: { ok: false, checked: 0, blocked: ['sfi_prediction_entries_unavailable'], warnings: [] },
+        returnWindowAgent: { ok: false, checked: 0, pending_returns_count: 0, overdue_returns_count: 0, blocked: ['sfi_prediction_entries_unavailable'], warnings: [] },
+      },
+    };
+  }
+
+  const rowsResult = await client.client
+    .from(TABLE)
+    .select('*')
+    .order('prediction_registered_at', { ascending: false })
+    .limit(200);
+
+  if (rowsResult.error) {
+    return {
+      ok: false,
+      table_available: true,
+      entries_count: countResult.count ?? null,
+      pending_returns_count: null,
+      blocked: ['sfi_prediction_entries_read_failed'],
+      warnings: [rowsResult.error.message],
+      agents: {
+        evidenceStateAgent: { ok: false, checked: 0, blocked: ['sfi_prediction_entries_read_failed'], warnings: [] },
+        returnWindowAgent: { ok: false, checked: 0, pending_returns_count: 0, overdue_returns_count: 0, blocked: ['sfi_prediction_entries_read_failed'], warnings: [] },
+      },
+    };
+  }
+
+  const entries = (rowsResult.data ?? []).map(predictionEntryFromRow);
+  const evidenceAgents = entries.map(runEvidenceStateAgent);
+  const returnAgents = entries.map((entry) => runReturnWindowAgent(entry));
+  const pendingReturnsCount = returnAgents.reduce((total, result) => total + result.pending_count, 0);
+  const overdueReturnsCount = returnAgents.reduce((total, result) => total + result.overdue_count, 0);
+  const evidenceBlocked = evidenceAgents.flatMap((result) => result.blocked);
+  const returnBlocked = returnAgents.flatMap((result) => result.blocked);
+  const evidenceWarnings = evidenceAgents.flatMap((result) => result.warnings);
+  const returnWarnings = returnAgents.flatMap((result) => result.warnings);
+  const blocked = [...new Set([...evidenceBlocked, ...returnBlocked])];
+  const warnings = [...new Set([...evidenceWarnings, ...returnWarnings])];
+
+  return {
+    ok: blocked.length === 0,
+    table_available: true,
+    entries_count: countResult.count ?? entries.length,
+    pending_returns_count: pendingReturnsCount,
+    blocked,
+    warnings,
+    agents: {
+      evidenceStateAgent: {
+        ok: evidenceBlocked.length === 0,
+        checked: evidenceAgents.length,
+        blocked: [...new Set(evidenceBlocked)],
+        warnings: [...new Set(evidenceWarnings)],
+      },
+      returnWindowAgent: {
+        ok: returnBlocked.length === 0,
+        checked: returnAgents.length,
+        pending_returns_count: pendingReturnsCount,
+        overdue_returns_count: overdueReturnsCount,
+        blocked: [...new Set(returnBlocked)],
+        warnings: [...new Set(returnWarnings)],
+      },
+    },
+  };
+}

--- a/src/lib/sfi/predictions/types.ts
+++ b/src/lib/sfi/predictions/types.ts
@@ -1,37 +1,173 @@
 export type SfiPredictionObservationState =
   | 'pendiente'
   | 'registrada_pre_perturbacion'
+  | 'retrospective_observation'
   | 'observed'
   | 'verified'
   | 'degraded'
   | 'uncertain'
   | 'archived';
 
+export type SfiPredictionEvidenceState =
+  | 'PENDING'
+  | 'OBSERVED'
+  | 'VERIFIED'
+  | 'DEGRADED'
+  | 'UNCERTAIN'
+  | 'ARCHIVED';
+
+export type SfiPredictionReturnWindow = '72h' | '7d' | '30d' | '90d';
+
+export const SFI_PREDICTION_OBSERVATION_STATES: SfiPredictionObservationState[] = [
+  'pendiente',
+  'registrada_pre_perturbacion',
+  'retrospective_observation',
+  'observed',
+  'verified',
+  'degraded',
+  'uncertain',
+  'archived',
+];
+
+export const SFI_PREDICTION_EVIDENCE_STATES: SfiPredictionEvidenceState[] = [
+  'PENDING',
+  'OBSERVED',
+  'VERIFIED',
+  'DEGRADED',
+  'UNCERTAIN',
+  'ARCHIVED',
+];
+
+export const SFI_PREDICTION_RETURN_WINDOWS: SfiPredictionReturnWindow[] = ['72h', '7d', '30d', '90d'];
+
 export interface SfiPredictionEntry {
+  id: string;
   case_id: string;
   hypothesis_id: string;
-  case_label: string;
-  operator_mode: string;
-  fenotipo_estimado: string | null;
-  ep_estado_inicial: string | null;
-  ssp_esperada: string | null;
+  case_label: string | null;
+  operator_mode: string | null;
+  fenotipo_estimado: string;
+  ep_estado_inicial: string;
+  ssp_esperada: string;
   ssp_observada: string | null;
-  perturbacion_tipo: string | null;
-  perturbacion_aplicada: string | null;
+  perturbacion_tipo: string;
+  perturbacion_aplicada: string;
   prediccion_explicita: string;
-  probabilidad_estimativa: number | null;
+  probabilidad_estimativa: number;
   friccion_respuesta_campo: string | null;
   resultado_72h: string | null;
   resultado_7d: string | null;
   resultado_30d: string | null;
   resultado_90d: string | null;
-  ep_t_registrada: string;
+  ep_t_registrada: string | null;
   cp_dias: number | null;
-  fallo_hipotesis: boolean | null;
+  fallo_hipotesis: string | null;
   refinamiento: string | null;
   estado_observacion: SfiPredictionObservationState;
+  prediction_registered_at: string;
+  perturbation_applied_at: string | null;
+  is_predictive_evidence: boolean;
+  evidence_state: SfiPredictionEvidenceState;
+  created_by: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface CreateSfiPredictionInput {
+  case_id: string;
+  hypothesis_id: string;
+  fenotipo_estimado: string;
+  ep_estado_inicial: string;
+  ssp_esperada: string;
+  perturbacion_tipo: string;
+  perturbacion_aplicada: string;
+  prediccion_explicita: string;
+  probabilidad_estimativa: number;
+  case_label?: string | null;
+  operator_mode?: string | null;
+  perturbation_applied_at?: string | null;
+  friccion_respuesta_campo?: string | null;
+  ssp_observada?: string | null;
+  created_by?: string | null;
+}
+
+export interface UpdateSfiPredictionReturnInput {
+  resultado_72h?: string | null;
+  resultado_7d?: string | null;
+  resultado_30d?: string | null;
+  resultado_90d?: string | null;
+  ssp_observada?: string | null;
+  friccion_respuesta_campo?: string | null;
+  ep_t_registrada?: string | null;
+  cp_dias?: number | null;
+  fallo_hipotesis?: string | null;
+  refinamiento?: string | null;
+  evidence_state?: SfiPredictionEvidenceState;
+  estado_observacion?: SfiPredictionObservationState;
+}
+
+export interface SfiPredictionReturnWindowStatus {
+  window: SfiPredictionReturnWindow;
+  field: 'resultado_72h' | 'resultado_7d' | 'resultado_30d' | 'resultado_90d';
+  due_at: string | null;
+  complete: boolean;
+  pending: boolean;
+  due: boolean;
+  overdue: boolean;
+}
+
+export interface SfiPredictionAgentResult {
+  agent: 'evidenceStateAgent' | 'returnWindowAgent';
+  mode: 'passive_deterministic';
+  ok: boolean;
+  hypothesis_id: string | null;
+  blocked: string[];
+  warnings: string[];
+  root_approval_required: true;
+}
+
+export interface SfiPredictionEvidenceAgentResult extends SfiPredictionAgentResult {
+  agent: 'evidenceStateAgent';
+  prediction_registered_before_perturbation: boolean;
+  prediction_matched: boolean | null;
+  prediction_failed: boolean | null;
+  evidence_degraded: boolean;
+  requires_refinement: boolean;
+  retrospective_only: boolean;
+}
+
+export interface SfiPredictionReturnWindowAgentResult extends SfiPredictionAgentResult {
+  agent: 'returnWindowAgent';
+  windows: SfiPredictionReturnWindowStatus[];
+  pending_count: number;
+  complete_count: number;
+  due_count: number;
+  overdue_count: number;
+}
+
+export interface SfiPredictionHealth {
+  ok: boolean;
+  table_available: boolean;
+  entries_count: number | null;
+  pending_returns_count: number | null;
+  blocked: string[];
+  warnings: string[];
+  agents: {
+    evidenceStateAgent: {
+      ok: boolean;
+      checked: number;
+      blocked: string[];
+      warnings: string[];
+    };
+    returnWindowAgent: {
+      ok: boolean;
+      checked: number;
+      pending_returns_count: number;
+      overdue_returns_count: number;
+      blocked: string[];
+      warnings: string[];
+    };
+  };
 }
 
 export interface SfiPredictionAgentComparison {

--- a/supabase/migrations/20260629100000_create_sfi_prediction_entries.sql
+++ b/supabase/migrations/20260629100000_create_sfi_prediction_entries.sql
@@ -1,0 +1,93 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.sfi_prediction_entries (
+  id uuid primary key default gen_random_uuid(),
+  case_id text not null,
+  hypothesis_id text not null unique,
+  case_label text,
+  operator_mode text,
+  fenotipo_estimado text not null,
+  ep_estado_inicial text not null,
+  ssp_esperada text not null,
+  ssp_observada text,
+  perturbacion_tipo text not null,
+  perturbacion_aplicada text not null,
+  prediccion_explicita text not null,
+  probabilidad_estimativa numeric not null check (probabilidad_estimativa >= 0 and probabilidad_estimativa <= 1),
+  friccion_respuesta_campo text,
+  resultado_72h text,
+  resultado_7d text,
+  resultado_30d text,
+  resultado_90d text,
+  ep_t_registrada text,
+  cp_dias integer,
+  fallo_hipotesis text,
+  refinamiento text,
+  estado_observacion text not null default 'pendiente'
+    check (estado_observacion in (
+      'pendiente',
+      'registrada_pre_perturbacion',
+      'retrospective_observation',
+      'observed',
+      'verified',
+      'degraded',
+      'uncertain',
+      'archived'
+    )),
+  prediction_registered_at timestamptz not null default now(),
+  perturbation_applied_at timestamptz,
+  is_predictive_evidence boolean not null default false,
+  evidence_state text not null default 'PENDING'
+    check (evidence_state in ('PENDING', 'OBSERVED', 'VERIFIED', 'DEGRADED', 'UNCERTAIN', 'ARCHIVED')),
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists sfi_prediction_entries_case_id_idx
+  on public.sfi_prediction_entries (case_id);
+
+create index if not exists sfi_prediction_entries_created_at_idx
+  on public.sfi_prediction_entries (created_at desc);
+
+create index if not exists sfi_prediction_entries_evidence_state_idx
+  on public.sfi_prediction_entries (evidence_state);
+
+create index if not exists sfi_prediction_entries_observation_state_idx
+  on public.sfi_prediction_entries (estado_observacion);
+
+create index if not exists sfi_prediction_entries_predictive_idx
+  on public.sfi_prediction_entries (is_predictive_evidence);
+
+create or replace function public.set_sfi_prediction_entries_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_sfi_prediction_entries_updated_at
+on public.sfi_prediction_entries;
+
+create trigger set_sfi_prediction_entries_updated_at
+before update on public.sfi_prediction_entries
+for each row
+execute function public.set_sfi_prediction_entries_updated_at();
+
+alter table public.sfi_prediction_entries enable row level security;
+
+drop policy if exists "sfi prediction entries service role full access"
+on public.sfi_prediction_entries;
+
+create policy "sfi prediction entries service role full access"
+on public.sfi_prediction_entries
+for all
+to service_role
+using (true)
+with check (true);
+
+revoke all on public.sfi_prediction_entries from anon, authenticated;
+grant all on public.sfi_prediction_entries to service_role;


### PR DESCRIPTION
Implements Phase 02: ROOT-governed Live Prediction Registry.

Includes:
- Supabase migration for sfi_prediction_entries
- Prediction contracts and service layer
- Evidence State Agent
- Return Window Agent
- Prediction APIs
- ROOT prediction registry UI
- ROOT prediction creation UI
- ROOT prediction detail/returns UI
- Phenotype registry integration
- Field/operator integration
- ROOT agents integration
- Prediction Registry runbook

Boundary preserved:
- No public prediction list
- No participant DB writes
- No automatic publication
- No Atlas promotion
- No protocol or phenotype mutation
- No self-modifying agents
- No client component imports service-role/server-only code

Validation passed locally:
- git diff --check
- npm run check:boundaries
- npm run typecheck
- npm run build

Operational note:
The migration must be applied to Supabase before live prediction persistence works in production.