### PR TITLE
STUDIO Phase 2 real audio extraction engine

### DIFF
--- a/docs/studio/STUDIO_AUDIO_ENGINE_ARCHITECTURE.md
+++ b/docs/studio/STUDIO_AUDIO_ENGINE_ARCHITECTURE.md
@@ -1,0 +1,53 @@
+# Studio Audio Engine Architecture
+
+## Boundary
+
+Studio audio extraction runs inside the Studio API boundary only:
+
+- `POST /api/studio/objects/[id]/analyze`
+- `GET /api/studio/objects/[id]/audio`
+- `src/lib/studio/audio/*`
+- Studio production adapter and shell mappings
+
+The engine does not call Python or ffmpeg from a Next route. The current repo explicitly disables Python execution inside Next bundles, and no deploy-safe audio binary is configured.
+
+## Runtime
+
+- Next.js route runtime: `nodejs`
+- Storage source: Supabase bucket `studio-objects`
+- Input evidence: `studio_objects`, `studio_uploads`, storage bytes
+- Decode profile: RIFF/WAVE PCM or float WAV only
+- Idempotency key: `studio-audio:{objectId}:{sha256}:{engineVersion}`
+
+## Pipeline
+
+1. Authenticate the Studio API caller.
+2. Load the `studio_object` row.
+3. Verify object has audio evidence.
+4. Load latest stored `studio_upload`.
+5. Download bytes from private Supabase storage.
+6. Compute SHA-256 checksum.
+7. Reuse completed job if checksum and engine version match.
+8. Create `studio_analysis_jobs` row.
+9. Decode WAV PCM/float samples.
+10. Extract acoustic features.
+11. Generate waveform peaks, energy segments, silence markers, onsets, and coarse sections.
+12. Persist:
+    - `studio_object_features`
+    - `studio_audio_features`
+    - `studio_time_coordinates`
+    - `studio_evidence_traces`
+    - `studio_analysis_jobs`
+13. Mark object `ready`, `blocked`, or `failed`.
+
+## Unsupported codecs
+
+MP3, AAC/M4A, FLAC, OGG, AIFF, and compressed WAV codecs are not decoded. They return `UNSUPPORTED_CODEC` or `INVALID_AUDIO_CONTAINER` and are stored as blocked jobs. No fallback metrics are generated.
+
+## Playback
+
+The UI uses `GET /api/studio/objects/[id]/audio` as an authenticated private proxy. It returns stored bytes with `Cache-Control: private, no-store` and does not expose Supabase storage paths.
+
+## Security note
+
+The route verifies an authenticated Supabase session. The current Studio schema has no owner or ACL column, so object-level ownership cannot be proven without a schema addition.

--- a/docs/studio/STUDIO_AUDIO_ENGINE_AUDIT.md
+++ b/docs/studio/STUDIO_AUDIO_ENGINE_AUDIT.md
@@ -1,0 +1,81 @@
+# Studio Audio Engine Audit
+
+Date: 2026-07-11
+Branch source: `codex/studio-master-reconstruction`
+Target branch: `codex/studio-audio-extraction-engine`
+
+## Git gate
+
+- `git status --short`: clean before this audit.
+- `git branch --show-current`: `codex/studio-master-reconstruction`.
+- `git fetch origin`: completed.
+- `git rev-list --left-right --count origin/main...HEAD`: `0 6`.
+- Interpretation: the source branch is ahead of `origin/main` because it contains the Studio reconstruction work. The new work was branched from that source branch, not from `main`.
+
+## Existing Studio runtime
+
+| Area | File | Current function | Status | Risk | Decision |
+| --- | --- | --- | --- | --- | --- |
+| Analyze route | `src/app/api/studio/objects/[id]/analyze/route.ts` | Returns blocked analysis when no features exist. | Placeholder orchestration. | Uploads never trigger real extraction. | Replace within Studio scope. |
+| Upload route | `src/app/api/studio/objects/upload/route.ts` | Persists `studio_session`, `studio_object`, `studio_upload`, and Supabase storage object. | Real intake path. | No automatic audio extraction after upload. | Preserve and connect analysis after upload through existing object ID. |
+| Production adapter | `src/lib/studio/production/studioProductionAdapter.ts` | Reads Studio tables and maps rows into UI state. | Real repository adapter with partial audio mapping. | Uses legacy audio metric keys and can render nominal semantics with incomplete extraction. | Extend mapping only for Studio audio outputs. |
+| Production types | `src/lib/studio/production/studioProductionTypes.ts` | Defines Studio state contracts. | Real local contract. | Audio fields are legacy names. | Extend without breaking existing UI. |
+| Production shell | `src/components/studio/production/StudioProductionShell.tsx` | Six-module Studio UI. | Functional but not connected to a real audio extractor. | Measure panels use legacy keys and no persisted audio playback endpoint. | Update Measure and Structure panels within Studio scope. |
+| Supabase schema | `supabase/migrations/20260705090000_create_studio_production_tables.sql` | Creates `studio_*` production tables. | Real migration. | No `partial` or `cancelled` job status in DB checks; no owner column for object access. | Use only allowed DB statuses and store semantic details in payload. |
+| Studio repository | `src/lib/studio/production/studioProductionRepository.ts` | Basic Studio table access and blocked analysis insert. | Real service-role repository. | No audio feature persistence service. | Add dedicated audio persistence module. |
+
+## Existing audio-related code
+
+| Area | File | Current function | Status | Risk | Decision |
+| --- | --- | --- | --- | --- | --- |
+| Python WAV script | `services/audio/analyze.py` | Reads WAV with Python `wave`, samples first 30 seconds, returns duration, normalized energy, ZCR, dynamic range. | Real but minimal and non-Studio. | Not a deploy-safe Next route dependency; not enough feature coverage; uses normalized values that are not Studio MetricValue contracts. | Do not import into Next route. Keep untouched. |
+| Worker skeleton | `services/worker/README.md`, `services/worker/src/index.ts` | Declares future internal job worker boundaries. | Skeleton. | Not wired to Studio jobs or deployment. | Do not depend on it for this phase. |
+| ScoreFriction Python bridge | `src/lib/scorefriction/python/pythonBridge.ts` | Explicitly disables Python execution in Next route bundles. | Real boundary. | Running Python from Studio API route would violate repo boundary and widen tracing. | Respect boundary; use Node-only decode for this phase. |
+| SFI media ffmpeg runtime | `src/lib/sfi/media/sfiMediaRenderRuntime.ts` | Uses local ffmpeg for media rendering paths. | Real but different domain. | Local binary availability is not a Studio extraction guarantee on Vercel. | Do not reuse as Studio audio decoder. |
+
+## Runtime and dependency audit
+
+- `package.json` has no audio decoding, FFT, ffmpeg, or native audio dependencies.
+- Local machine has `ffmpeg.exe` and `ffprobe.exe`, but deployment availability is not guaranteed by repo config.
+- `next.config.js` excludes Python services from output tracing and does not package audio binaries.
+- `vercel.json` does not define Studio audio function memory, duration, or binary setup.
+- Node version observed locally: `v24.14.0`.
+- Python version observed locally: `3.14.3`.
+
+## Supabase table constraints relevant to audio
+
+- `studio_analysis_jobs.status` allows only `queued`, `running`, `complete`, `blocked`, `failed`.
+- `studio_objects.status` allows only `uploaded`, `analyzing`, `ready`, `blocked`, `failed`, `archived`.
+- `studio_uploads.status` allows only `stored`, `missing`, `degraded`, `failed`.
+- `studio_audio_features` has scalar columns for `rms`, `peak`, `clipping_risk`, `dynamic_range`, `lufs`, `spectral_centroid` and JSON payload columns.
+- `studio_object_features.numeric_value` is nullable and can represent unavailable values without substituting zero.
+- There is no owner or ACL column on Studio objects, so authenticated route access can be checked, but row-level object ownership cannot be proven from the current schema.
+
+## Engine decision
+
+The deploy-safe implementation for this phase is a Node-only audio engine that decodes WAV PCM/float files from Supabase storage and explicitly blocks unsupported codecs with a traceable error. The engine must not call Python or ffmpeg from a Next route. Unsupported formats such as MP3, AAC/M4A, FLAC, and OGG must return `UNSUPPORTED_CODEC` instead of mocked measurements.
+
+## Supported evidence in this phase
+
+- Supabase `studio_uploads.storage_path`.
+- Stored bytes from bucket `studio-objects`.
+- SHA-256 checksum of the stored file.
+- WAV RIFF metadata from file header.
+- Decoded PCM samples for supported WAV variants.
+- Derived waveform peaks, spectral summaries, dynamics, stereo metrics, silence regions, onsets, and coarse sections.
+
+## Explicit limitations
+
+- MP3/AAC/FLAC/OGG are not decoded in this phase because no deploy-safe decoder is currently present.
+- Integrated LUFS, true peak, and loudness range are not reported as observed unless a standards-aligned loudness engine is added. RMS and sample peak must not be relabeled as LUFS or true peak.
+- Stem, layer, channel, and mix controls remain blocked unless real multichannel or stem evidence exists.
+- Studio object ownership cannot be enforced beyond authentication because the current Studio schema has no owner column.
+- Browser QA of authenticated `/studio` requires a valid user session and Supabase environment; unauthenticated e2e cannot validate private audio playback.
+
+## Required preservation
+
+- Do not modify MIHM formulas.
+- Do not recalculate WSV during Studio render.
+- Do not alter non-Studio routes.
+- Do not remove existing Studio tables, migrations, upload route, or production adapter.
+- Do not create mocked metrics, fallback zeros, random values, decorative controls, or hrefs to POST endpoints.

--- a/docs/studio/STUDIO_AUDIO_ENGINE_ENV.md
+++ b/docs/studio/STUDIO_AUDIO_ENGINE_ENV.md
@@ -1,0 +1,29 @@
+# Studio Audio Engine Environment
+
+Required existing environment:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+Optional Studio audio limits:
+
+- `STUDIO_AUDIO_MAX_FILE_MB`
+  - Default: `75`
+  - Purpose: maximum downloaded audio size for synchronous analysis.
+
+- `STUDIO_AUDIO_MAX_DURATION_SECONDS`
+  - Default: `1200`
+  - Purpose: maximum decoded duration for synchronous analysis.
+
+Storage:
+
+- Bucket: `studio-objects`
+- Upload route keeps bucket private.
+- Playback route proxies bytes through authenticated Studio API.
+
+Deployment notes:
+
+- No Python runtime is required for this engine.
+- No ffmpeg binary is required for this engine.
+- Codec support is intentionally limited to WAV PCM/float until a deploy-safe decoder is added.

--- a/docs/studio/STUDIO_AUDIO_ENGINE_FEATURES.md
+++ b/docs/studio/STUDIO_AUDIO_ENGINE_FEATURES.md
@@ -1,0 +1,60 @@
+# Studio Audio Engine Features
+
+## Observed from WAV metadata
+
+- `duration_seconds`
+- `sample_rate_hz`
+- `channel_count`
+- `bit_depth`
+
+## Observed from decoded samples
+
+- `rms_dbfs`
+- `peak_dbfs`
+- `peak_amplitude`
+- `clipping_risk`
+- `clipping_sample_count`
+- `dynamic_range_db`
+- `crest_factor_db`
+- `headroom_db`
+- `zero_crossing_rate`
+
+## Spectral and tonal features
+
+- `spectral_centroid_hz`
+- `spectral_rolloff_hz`
+- `spectral_bandwidth_hz`
+- `spectral_flux`
+- `noise_floor_dbfs`
+- `tonal_balance_low`
+- `tonal_balance_mid`
+- `tonal_balance_high`
+- `tonal_balance`
+
+Spectral features use bounded DFT frames. They are real measurements from decoded samples, not prediction metrics.
+
+## Stereo features
+
+- `stereo_width`
+- `phase_correlation`
+- `mid_energy`
+- `side_energy`
+
+Mono objects persist these as `MISSING` with `STEREO_SOURCE_REQUIRED`.
+
+## Segmentation artifacts
+
+- waveform peaks in `studio_audio_features.waveform`
+- short energy segments in `studio_audio_features.energy_segments`
+- silence, onset, and coarse section markers in `studio_time_coordinates`
+
+## Blocked standards features
+
+These are intentionally persisted as `MISSING` until a standards-aligned loudness engine exists:
+
+- `lufs_integrated`
+- `true_peak_dbtp`
+- `loudness_range_lu`
+- `short_term_lufs_summary`
+
+RMS is not labeled as LUFS. Sample peak is not labeled as true peak.

--- a/docs/studio/STUDIO_AUDIO_ENGINE_LIMITATIONS.md
+++ b/docs/studio/STUDIO_AUDIO_ENGINE_LIMITATIONS.md
@@ -1,0 +1,35 @@
+# Studio Audio Engine Limitations
+
+## Codec support
+
+Supported:
+
+- RIFF/WAVE PCM integer: 8, 16, 24, 32 bit
+- RIFF/WAVE float: 32, 64 bit
+
+Blocked:
+
+- MP3
+- AAC/M4A
+- FLAC
+- OGG
+- AIFF
+- compressed WAV codecs
+
+Blocked codecs return an explicit analysis job status and do not generate fallback metrics.
+
+## Loudness standards
+
+The engine does not report observed LUFS, true peak, loudness range, or short-term LUFS. Those values require standards-aligned loudness processing and oversampling. They are represented as `MISSING`.
+
+## Access control
+
+The API checks Supabase authentication. The current Studio schema does not include object owner fields, so row ownership cannot be verified without a future migration.
+
+## Structural audio
+
+Stems, layer dependencies, channel faders, mix masking, and real arrangement controls remain blocked unless actual multichannel, stem, section, or event evidence exists.
+
+## Performance
+
+Spectral analysis uses bounded DFT frames to avoid native dependencies. It is accurate enough for traceable inspection but is not a substitute for a dedicated DSP worker on very large files.

--- a/docs/studio/STUDIO_AUDIO_ENGINE_QA.md
+++ b/docs/studio/STUDIO_AUDIO_ENGINE_QA.md
@@ -1,0 +1,64 @@
+# Studio Audio Engine QA
+
+Date: 2026-07-11
+Branch: `codex/studio-audio-extraction-engine`
+
+## Commands
+
+| Command | Result |
+| --- | --- |
+| `npm install` | Passed. Dependencies already up to date. Reported existing npm audit warnings: 4 moderate vulnerabilities. |
+| `npm run qa:studio-audio` | Passed. Generated in-memory stereo WAV, decoded it, extracted 34 features, produced 128 waveform peaks, verified LUFS remains `MISSING`. |
+| `npm run typecheck` | Passed. |
+| `npm run lint` | Blocked. Existing script `next lint` fails under Next 16 with `Invalid project directory provided, no such directory: D:\system-friction\lint`. No ESLint replacement is configured in `package.json`. |
+| `npm run build` | Passed after stopping an existing `next dev` process that held `.next/studio-dev.log`. |
+| `rg -n 'href=.*api|href=.*(analyze|simulate|build|run|POST)' src/app/studio src/components/studio src/lib/studio src/app/api/studio -S` | Passed. No matches. |
+| `rg -n 'mock|simulated|fake|random|NaN|Infinity|ready\s*=\s*1|partial\s*=\s*0\.46|blocked\s*=\s*0\.08' ...` | Existing non-audio matches remain in prior docs and legacy Studio files. No new audio engine mock metrics, random values, `NaN`, or `Infinity` were added. |
+
+## Local HTTP checks
+
+| Route | Result |
+| --- | --- |
+| `GET http://localhost:3000/studio` | `200` |
+| `POST http://localhost:3000/api/studio/objects/test/analyze` without Supabase session | `401` with `AUTH_REQUIRED` |
+
+The dev server was stopped after verification.
+
+## Files touched
+
+- `src/lib/studio/audio/**`
+- `src/app/api/studio/objects/[id]/analyze/route.ts`
+- `src/app/api/studio/objects/[id]/audio/route.ts`
+- `src/app/api/studio/objects/upload/route.ts`
+- `src/lib/studio/production/studioProductionAdapter.ts`
+- `src/components/studio/production/StudioProductionShell.tsx`
+- `scripts/studio-audio-engine-smoke.cjs`
+- `package.json`
+- `docs/studio/STUDIO_AUDIO_ENGINE_*.md`
+
+## Errors found and corrected
+
+- Analysis route previously returned `feature_extractors_not_connected`; replaced with real audio orchestration.
+- Build initially failed with `EBUSY` because a prior dev server held `.next/studio-dev.log`; stopped the repo-local dev process and reran build successfully.
+- TypeScript rejected Buffer response body in the audio proxy route; corrected by copying bytes into an `ArrayBuffer`.
+- Node smoke test initially could not resolve extensionless TS imports; replaced it with a local TypeScript require hook in a `.cjs` script.
+- Legacy UI metric keys (`rms`, `peak`, `clippingRisk`, `dynamicRange`, `lufs`, `spectralCentroid`) were replaced in Measure with canonical extracted keys.
+- Legacy hypothesis input generation from abstract metrics was gated to real `layer_` or `stem_` evidence only.
+
+## Remaining limitations
+
+- Authenticated browser intake, upload, playback, and analysis e2e was not completed because no authenticated Supabase browser session or test credentials were provided in this run.
+- MP3, AAC/M4A, FLAC, OGG, AIFF, and compressed WAV are blocked by design until a deploy-safe decoder exists.
+- Integrated LUFS, true peak, loudness range, and short-term LUFS remain `MISSING` until a standards-aligned loudness engine is added.
+- Object-level authorization cannot be proven from the current Studio schema because `studio_objects` has no owner/ACL column.
+- `npm run lint` remains blocked by the existing Next 16 incompatible lint script.
+
+## Components blocked by lack of evidence
+
+- Layers and stems.
+- Arrangement dependency controls.
+- Mix faders, mute, solo, masking, panorama, and channel meters.
+- Harmonic stability.
+- Standards-aligned mastering loudness.
+- Cultural prediction from audio.
+- Intervention and simulation from audio-only evidence.

--- a/docs/studio/STUDIO_CURRENT_STATE_AUDIT.md
+++ b/docs/studio/STUDIO_CURRENT_STATE_AUDIT.md
@@ -1,0 +1,103 @@
+# Studio Current State Audit
+
+Date: 2026-07-11
+Branch: codex/studio-master-reconstruction
+Scope: `/studio`, `/api/studio`, `src/components/studio`, `src/lib/studio`, and Studio Supabase artifacts.
+
+## Initial Git Gate
+
+- `git status --short`: clean before audit.
+- `git branch -vv`: local branch started from `main` at `5e79cca`.
+- `git fetch origin`: completed without reported changes.
+- `git rev-list --left-right --count origin/main...HEAD`: `0 0`.
+- Working branch created before edits: `codex/studio-master-reconstruction`.
+
+## Express Confirmation
+
+- Real engines: Supabase-backed Studio persistence in `studioProductionRepository.ts`; upload route with storage bucket verification in `/api/studio/objects/upload`; object/session/features/archive/export read routes; blocked analysis job registration in `/api/studio/objects/[id]/analyze`; WorldSpect/World Vector read adapters in `studioCulturalLens.ts`; existing MIHM/ScoreFriction/WorldSpect adapters in `src/lib/studio/evaluation.ts`; cultural-lab pipeline agents that return trace objects from POST routes.
+- Real but blocked engines: `/api/studio/interventions/simulate` is a POST route but returns `simulation_engine_not_connected`; `/api/studio/objects/[id]/analyze` records `feature_extractors_not_connected` when no persisted features exist.
+- Placeholder views: `StudioOriginLedger.tsx` declares itself a restored placeholder; multiple `src/components/studio/views/*` are legacy cultural-lab trace views not mounted by `/studio`; gold console components are not mounted by `/studio`.
+- Components showing raw or API-like access: `StudioProductionShell.tsx` exposes `/api/studio/sessions`, `/api/studio/archive`, `/api/studio/deliverables`, and `/api/studio/exports/build` as interface links; `StudioFooterTransport.tsx` links to object/state JSON.
+- Broken actions: `StudioRightRail.tsx` links hypotheses to missing `/api/studio/hypotheses/build`; `StudioProductionShell.tsx` links `/api/studio/exports/build`, which has no route; filters `ACTIVE`, `ARCHIVE`, `FAVORITES` have no handlers.
+- Href to POST: `StudioProductionShell.tsx` links `/api/studio/interventions/simulate`; `StudioRightRail.tsx` links `/api/studio/interventions/simulate`; `StudioProductionShell.tsx` links `/api/studio/exports/build` as `POST`.
+- Buttons without real handler: filter buttons in Sessions; display-only buttons in gold components (`VER TODOS`, `TOPOLOGIA`, `90 DIAS`, measurement status buttons) are outside current `/studio` mount but remain risky if remounted.
+- Panels using derived information without source: readiness bars in `StudioProductionShell.tsx`; graph nodes and edges in `studioProductionAdapter.ts`; Pixi fallback points in `StudioPixiStage.tsx`; gold degraded engine values in `studioGoldDegradedState.ts`.
+- Visualizations not tied to real variables: Pixi fallback `missing-vector-*` nodes; `StudioOverviewFieldRenderer` readiness normalization; `SpectralCloudRenderer` fallback values; `NeuralGraphRenderer` default values; `VectorScopeRenderer` fallback stereo value.
+
+## Inventory
+
+| File | Real function | Imports | Consumers | State | Dependency | Risk | Decision |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `src/app/studio/page.tsx` | Loads `readStudioProductionState` and renders production console. | Production console, adapter. | Next `/studio`. | Live. | Server adapter. | Low. | Conserve. |
+| `src/app/api/studio/objects/upload/route.ts` | Uploads file to Supabase storage and persists session/object/upload. | Supabase service, repository. | Intake modal. | Real. | `studio_sessions`, `studio_objects`, `studio_uploads`, storage bucket. | Medium, env and permissions. | Conserve, improve UX only. |
+| `src/app/api/studio/objects/[id]/analyze/route.ts` | Returns persisted features or records blocked analysis job. | Repository. | Should be UI action, not href. | Real blocked contract. | `studio_object_features`, `studio_analysis_jobs`. | Low. | Conserve. |
+| `src/app/api/studio/objects/[id]/features/route.ts` | Reads object features. | Repository. | Not directly mounted. | Real read. | Supabase. | Low. | Conserve. |
+| `src/app/api/studio/objects/[id]/route.ts` | Reads object. | Repository. | Footer href today. | Real read, wrong UI usage. | Supabase. | Low. | Conserve, remove direct UI link. |
+| `src/app/api/studio/objects/route.ts` | Lists objects. | Repository. | Potential Memory/selector. | Real read. | Supabase. | Low. | Conserve. |
+| `src/app/api/studio/sessions/route.ts` | Lists/creates sessions. | Repository. | API link today. | Real. | Supabase. | Low. | Conserve, remove direct UI link. |
+| `src/app/api/studio/sessions/[id]/route.ts` | Reads session. | Repository. | Not mounted. | Real. | Supabase. | Low. | Conserve. |
+| `src/app/api/studio/production/state/route.ts` | Returns full Studio production state. | Adapter. | Potential refresh/read API. | Real read. | Adapter. | Low. | Conserve. |
+| `src/app/api/studio/archive/route.ts` | Lists archive events. | Repository. | API link today. | Real read. | Supabase. | Low. | Conserve, remove direct UI link. |
+| `src/app/api/studio/deliverables/route.ts` | Lists exports. | Repository. | API link today. | Real read. | Supabase. | Medium, no generation. | Conserve as listing only. |
+| `src/app/api/studio/interventions/simulate/route.ts` | POST contract returning blocked when engine absent. | None. | Wrong href today. | Real blocked contract. | None. | Medium if UI claims simulation. | Conserve, show unavailable. |
+| `src/app/api/studio/interventions/apply/route.ts` | POST blocked contract. | None. | Not mounted. | Real blocked contract. | None. | Low. | Conserve. |
+| `src/app/api/studio/pipeline/route.ts` | Runs cultural-lab trace pipeline. | Cultural-lab pipeline. | Legacy intake components. | Real trace engine, not persisted Studio object flow. | Agents. | Medium, can be mistaken for object pipeline. | Conserve as subtool. |
+| `src/app/api/studio/evaluate/route.ts` | Builds Studio evaluation report. | ScoreFriction/WorldSpect/Cultural Wave adapters. | Not mounted in production console. | Real/partial evaluation. | Supabase, WSV, scorefriction. | High if mixed with production metrics. | Conserve, keep separate. |
+| `src/app/api/studio/cultural-lens/route.ts` | Reads/builds cultural lens. | Supabase, cultural lens. | Not mounted. | Real/partial. | World Vector/WorldSpect. | Medium. | Conserve. |
+| `src/app/api/studio/gold/route.ts` | Reads gold state. | Gold adapter. | Gold console or diagnostics. | Real/degraded. | ScoreFriction, operational cycle, WSV. | Medium. | No touch unless needed. |
+| `src/app/api/studio/trace/route.ts` | Trace endpoint. | Unknown lightweight route. | Not mounted. | Read. | Route implementation. | Low. | Conserve. |
+| `src/app/api/studio/simulate/route.ts` | Legacy cultural pipeline simulate POST. | Pipeline. | Not mounted. | Real trace, not production simulation. | Agents. | Medium naming conflict. | Conserve as subtool. |
+| `src/app/api/studio/implement/route.ts` | Legacy cultural pipeline implement POST. | Pipeline. | Not mounted. | Real trace. | Agents. | Medium. | Conserve as subtool. |
+| `src/app/api/studio/debug-upload/route.ts` | Upload diagnostics. | Supabase. | Debug only. | Real diagnostic. | Supabase. | Medium exposure. | Conserve, do not link primary UI. |
+| `src/lib/studio/production/studioProductionTypes.ts` | Production state types. | Hypothesis types. | Adapter and UI. | Live contract but lacks canonical metric semantics. | UI. | High. | Replace/consolidate with canonical contracts. |
+| `src/lib/studio/production/studioProductionAdapter.ts` | Builds Studio state from Supabase plus gold/lens. | Supabase, gold, lens, hypotheses. | `/studio`, state API. | Live but over-derives. | Supabase, ScoreFriction/WSV via gold. | High. | Refactor narrowly; do not alter MIHM formulas. |
+| `src/lib/studio/production/studioProductionRepository.ts` | Supabase repository. | Supabase service. | API routes. | Real. | Tables and storage. | Low. | Conserve, extend read details only if needed. |
+| `src/lib/studio/production/studioProductionDegradedState.ts` | Fallback state. | Types. | Adapter catch path. | Real degraded path. | None. | Medium if uses zero values. | Refactor to missing/null. |
+| `src/lib/studio/production/studioCulturalLens.ts` | Builds Cultural/WSV lens from existing world data. | World Vector, WorldSpect. | Adapter. | Real/degraded. | World data. | Medium. | Conserve. |
+| `src/lib/studio/production/hypothesisEngine.ts` | Hypothesis generation from layer inputs and cultural lens. | MIHM thresholds. | Adapter/pipeline. | Real deterministic engine over supplied layers. | Valid layer inputs. | Medium if fake layers supplied. | Conserve, gate inputs. |
+| `src/lib/studio/production/studioHypotheses.ts` | Alternate hypothesis helpers. | MIHM thresholds. | Search shows no direct production consumer. | Unclear. | None. | Low. | No touch. |
+| `src/lib/studio/production/mihmThresholds.ts` | MIHM threshold helpers. | None. | Hypothesis engines. | Valid formula support. | Fase 1 formulas. | High. | No touch. |
+| `src/lib/studio/evaluation.ts` | Evaluation report using ScoreFriction/WorldSpect/Cultural Wave. | ScoreFriction, WorldSpect. | `/api/studio/evaluate`. | Real/partial. | External adapters. | High if exposed as prediction. | No formula changes. |
+| `src/lib/studio/cultural-lab/*` | Legacy pipeline, agents and adapters. | Agent modules, WorldSpect. | Legacy components and POST routes. | Trace engine/subtool. | Mixed evidence quality. | Medium. | Preserve as subtools. |
+| `src/lib/studio/gold/*` | Gold console state and degraded fallback. | ScoreFriction, operational cycle, WSV. | Gold route/components. | Existing live/degraded surface. | External runtime. | High if rewritten. | No touch except docs. |
+| `src/components/studio/production/StudioProductionConsole.tsx` | Shell wrapper. | Types and shell. | `/studio`. | Live. | Shell. | Low. | Conserve. |
+| `src/components/studio/production/StudioProductionShell.tsx` | Main mounted UI. | State types, sidebar, intake, Pixi, rails. | Production console. | Live but contains broken links and heuristic metrics. | State. | High. | Replace primary structure. |
+| `src/components/studio/production/StudioSidebar.tsx` | Primary nav. | None. | Shell. | Live but too many modules. | Shell state. | Medium. | Replace with six modules. |
+| `src/components/studio/production/StudioObjectIntake.tsx` | File intake POST. | React. | Shell. | Real, UX incomplete. | Upload route. | Medium. | Improve. |
+| `src/components/studio/production/StudioRightRail.tsx` | Global rail. | State types. | Shell. | Live but broken hrefs. | State. | High. | Replace with contextual factual rail. |
+| `src/components/studio/production/StudioFooterTransport.tsx` | Bottom transport. | State types. | Shell. | Live but links JSON. | State. | Medium. | Replace href with status/actions. |
+| `src/components/studio/production/StudioHeader.tsx` | Header. | State types. | Shell. | Live. | State. | Low. | Conserve/adapt copy. |
+| `src/components/studio/production/StudioEvaluationStrip.tsx` | Metric strip. | State types. | Shell. | Live. | State. | Medium if plain values. | Adapt to MetricValue. |
+| `src/components/studio/production/pixi/StudioPixiStage.tsx` | Pixi host and SVG fallback. | Pixi renderers. | Shell. | Live but renders fallback fake nodes. | Browser/Pixi. | High. | Gate renderable nodes. |
+| `src/components/studio/production/pixi/renderers/*` | Visual renderers. | Renderer types. | Pixi stage. | Live but several fallback defaults. | Pixi/state. | High. | Tighten to real values only. |
+| `src/components/studio/gold/*` | Alternate gold console. | Gold state. | Not mounted by `/studio`; gold route possible. | Preserved. | Gold adapter. | Medium. | No touch in this scope. |
+| `src/components/studio/views/*` | Cultural-lab trace views. | Pipeline trace types. | Not mounted by production console. | Preserved subtools. | Trace pipeline. | Low. | No touch. |
+| `src/components/studio/Studio*.tsx` legacy | Legacy cultural intervention lab and trace components. | Cultural-lab types. | Not mounted by `/studio`. | Preserved subtools/placeholders. | Pipeline. | Medium. | No touch unless remounted. |
+| `supabase/migrations/20260705090000_create_studio_production_tables.sql` | Creates Studio tables and indexes. | SQL. | Supabase. | Non-destructive migration. | Postgres. | Low. | No touch. |
+
+## Tables
+
+- `studio_sessions`: real session persistence.
+- `studio_objects`: real object persistence.
+- `studio_uploads`: real upload/storage metadata.
+- `studio_object_features`: generic persisted metrics.
+- `studio_audio_features`, `studio_video_features`, `studio_image_features`, `studio_text_features`, `studio_community_features`, `studio_time_coordinates`: modality feature tables exist but are not read by production adapter yet.
+- `studio_hypotheses`, `studio_interventions`: persistence exists; current adapter mostly derives from gold/hypothesis engine rather than these rows.
+- `studio_evidence_traces`: persistence exists; current adapter does not expose detailed evidence refs.
+- `studio_archive_events`, `studio_exports`, `studio_analysis_jobs`: persistence exists; listing/blocking routes exist.
+
+## Required Preservation
+
+- Do not modify `mihmThresholds.ts` formulas.
+- Do not recalculate WSV in render components.
+- Do not remove gold or cultural-lab components; they are unmounted or subtool candidates.
+- Do not apply SQL migrations in this task.
+- Do not expose API endpoints as primary UI actions.
+
+## Required Replacement
+
+- Primary navigation must be reduced to `OVERVIEW`, `MEASURE`, `STRUCTURE`, `FIELD`, `INTERVENTION`, `MEMORY`.
+- Plain numeric UI must move to `MetricValue` with status/source/confidence/explanation.
+- Heuristic readiness percentages must be removed.
+- Broken POST hrefs and raw API links must be removed.
+- Pixi and graph nodes must render only if explainable from state.

--- a/docs/studio/STUDIO_DATA_PROVENANCE.md
+++ b/docs/studio/STUDIO_DATA_PROVENANCE.md
@@ -1,0 +1,26 @@
+# Studio Data Provenance
+
+## Persisted Studio Sources
+
+- `studio_sessions`: session identity, title, status and timestamps.
+- `studio_objects`: active object identity, source URI, MIME, size, status and metadata.
+- `studio_uploads`: storage verification and upload metadata.
+- `studio_object_features`: generic feature rows shown as observed metrics.
+- `studio_audio_features`, `studio_video_features`, `studio_image_features`, `studio_text_features`, `studio_community_features`, `studio_time_coordinates`: modality-specific feature rows.
+- `studio_hypotheses`: persisted hypotheses.
+- `studio_interventions`: persisted intervention queue.
+- `studio_evidence_traces`: evidence references.
+- `studio_archive_events`: memory/timeline/outcome/learning events.
+- `studio_exports`: deliverable rows and download URLs.
+- `studio_analysis_jobs`: blocked/complete analysis job state.
+
+## Existing Engines Preserved
+
+- MIHM thresholds and Phase 1 formulas are not modified.
+- `readStudioGoldState` is used only as an existing internal signal source for MIHM readout.
+- `buildStudioCulturalLens` reads existing World Vector/WorldSpect sources and is not recalculated by rendering.
+- Cultural-lab pipeline endpoints remain subtools, not the primary mounted Studio flow.
+
+## Missing Evidence Handling
+
+When evidence is absent, Studio renders `MISSING`, `DEGRADED`, `FAILED` or a blocked reason. It does not convert absent values to `0`, `0.5`, percentages, fake graph nodes or animated defaults.

--- a/docs/studio/STUDIO_MASTER_SPEC.md
+++ b/docs/studio/STUDIO_MASTER_SPEC.md
@@ -1,0 +1,37 @@
+# Studio Master Spec
+
+Studio is the System Friction Institute object evaluation laboratory. It is not a DAW, a generic dashboard, or a decorative player.
+
+## Canonical Flow
+
+1. Ingest an object.
+2. Verify persisted session, object and upload rows.
+3. Extract evidence only through real persisted rows or a real browser/runtime analyzer.
+4. Measure internal structure without mixing technical metrics with cultural interpretation.
+5. Read MIHM from existing Phase 1 formulas without modifying them.
+6. Compare with Cultural Vector through `buildStudioCulturalLens`.
+7. Compare timing through the existing WorldSpect/World Vector path; render does not recalculate WSV.
+8. Generate hypotheses only from persisted feature/layer evidence.
+9. Propose minimum perturbation only when a hypothesis exists.
+10. Run simulation only when a real POST engine returns a complete result.
+11. Register reports, intervention, return, outcome and learning through persisted rows.
+12. Preserve longitudinal memory through Studio archive/export/job tables.
+
+## Primary Modules
+
+- `OVERVIEW`: active object, real pipeline, evidence matrix, executive reading, current field and next action.
+- `MEASURE`: live signal, composition, sound design and mastering technical metrics.
+- `STRUCTURE`: layers, arrangements, mix and neural graph, blocked when stems/layers/channels are absent.
+- `FIELD`: internal signal, cultural field, world timing, tensions and hypotheses kept separate.
+- `INTERVENTION`: minimum perturbation, candidate actions, simulation availability, verification and outcome registration.
+- `MEMORY`: sessions, timeline, archives, versions, deliverables and learning.
+
+## Hard Rules Implemented
+
+- No primary navigation items for legacy DAW-like views.
+- No href to POST endpoints.
+- No raw API links as user interface.
+- No readiness heuristics like `ready = 1`, `partial = 0.46`, `blocked = 0.08`.
+- No Pixi nodes without source, status, confidence and explanation.
+- No waveform/spectral/timeline/vector animation without corresponding data.
+- No deliverable generation button until a real generation endpoint exists.

--- a/docs/studio/STUDIO_MIGRATION_NOTES.md
+++ b/docs/studio/STUDIO_MIGRATION_NOTES.md
@@ -1,0 +1,31 @@
+# Studio Migration Notes
+
+## Created
+
+- `src/lib/studio/production/studioContracts.ts`
+- `docs/studio/STUDIO_CURRENT_STATE_AUDIT.md`
+- `docs/studio/STUDIO_MASTER_SPEC.md`
+- `docs/studio/STUDIO_VIEW_CONTRACTS.md`
+- `docs/studio/STUDIO_DATA_PROVENANCE.md`
+- `docs/studio/STUDIO_MIGRATION_NOTES.md`
+- `docs/studio/STUDIO_QA_REPORT.md`
+
+## Changed
+
+- `studioProductionTypes.ts` now exports canonical metric, phase, evidence, view, field graph and next action types.
+- `studioProductionAdapter.ts` now reads Studio persistence tables directly and avoids Gold fallback for object features.
+- `StudioProductionShell.tsx` now mounts six canonical modules and hides unavailable actions.
+- `StudioObjectIntake.tsx` refreshes after upload, closes the modal, disables duplicate submit and preserves real errors.
+- Pixi renderers now show missing states instead of animated fallback data.
+- Legacy/Gold Studio components no longer expose decorative buttons.
+
+## Not Changed
+
+- No SQL migration was edited or applied.
+- No MIHM formula file was changed.
+- No WorldSpect/World Vector formula was changed.
+- No non-Studio route was modified.
+
+## Compatibility
+
+The old production state fields remain present for existing components, while the mounted `/studio` surface consumes the canonical contract fields.

--- a/docs/studio/STUDIO_QA_REPORT.md
+++ b/docs/studio/STUDIO_QA_REPORT.md
@@ -1,0 +1,69 @@
+# Studio QA Report
+
+Date: 2026-07-11
+
+## Commands
+
+| Command | Result |
+| --- | --- |
+| `git status --short` before audit | clean |
+| `git branch -vv` before audit | `main` at `5e79cca`, tracking `origin/main` |
+| `git fetch origin` | success |
+| `git rev-list --left-right --count origin/main...HEAD` | `0 0` |
+| `npm install` | success, up to date; reported 4 moderate audit vulnerabilities and pending install-script approvals |
+| `npm run typecheck` | success |
+| `npm run lint` | failed: `next lint` reports `Invalid project directory provided, no such directory: D:\system-friction\lint` |
+| `npm run build` | success |
+| `Invoke-WebRequest http://127.0.0.1:3000/studio` | HTTP 200 before browser auth flow check |
+| Browser open `http://127.0.0.1:3000/studio` | redirected to `/login?next=%2Fstudio`; no console errors on login page |
+| `Invoke-WebRequest http://127.0.0.1:3000/api/studio/production/state` | HTTP 200 |
+
+## Files Touched
+
+See git history on branch `codex/studio-master-reconstruction`.
+
+## Routes Tested
+
+- `/studio`: server response 200; browser session redirected to login because route is auth-gated.
+- `/api/studio/production/state`: HTTP 200.
+
+## Errors Found
+
+- Broken UI links to raw API and POST endpoints in mounted Studio shell.
+- Display-only filters and buttons in Studio/Gold surfaces.
+- Readiness heuristics converting textual state into fake percentages.
+- Pixi fallback nodes and animations without real variables.
+- `npm run lint` script incompatible with current Next CLI behavior.
+- Browser QA blocked by login gate.
+
+## Errors Corrected
+
+- Removed mounted raw API links and href-to-POST actions.
+- Replaced six-module navigation.
+- Added canonical metric/phase/evidence/view contracts.
+- Reworked adapter to read Studio persistence tables directly.
+- Disabled fake Pixi fallback nodes and missing-data animations.
+- Removed decorative buttons from legacy/Gold Studio components.
+- Intake now disables duplicate submit and refreshes after real upload.
+
+## Limitations Remaining
+
+- Auth-gated `/studio` could not be manually exercised in-browser without credentials.
+- Audio intake could not be completed in browser QA because the page redirected to login.
+- Small/large audio upload tests were not executed for the same auth reason.
+- Simulation remains unavailable because the POST route returns `simulation_engine_not_connected`.
+- Deliverable generation remains blocked because only listing/downloading persisted exports is implemented.
+- Manual marker persistence is not exposed because no Studio marker endpoint exists.
+- Outcome and learning registration controls are hidden because no scoped persistence endpoints were found.
+- `npm run lint` is blocked by project script/tooling, not by Studio code.
+
+## Components Blocked By Missing Evidence
+
+- Structure layers: `MULTILAYER_EVIDENCE_REQUIRED`.
+- Arrangements: stems/layers/sections/events required.
+- Mix controls: real channels required.
+- Mastering technical metrics: persisted mastering feature rows required.
+- World timing snapshot ID/regime: missing unless exposed by current WSV adapter.
+- Field tensions: require real relationships between MIHM, Cultural Vector, WSV, external evidence or declared attractor.
+- Simulation: real simulation engine required.
+- Deliverable generation: real generation endpoint required.

--- a/docs/studio/STUDIO_VIEW_CONTRACTS.md
+++ b/docs/studio/STUDIO_VIEW_CONTRACTS.md
@@ -1,0 +1,39 @@
+# Studio View Contracts
+
+All mounted Studio modules consume `ViewContract` from `src/lib/studio/production/studioContracts.ts`.
+
+| View | Inputs | Outputs | Blocking rule |
+| --- | --- | --- | --- |
+| `overview` | `studio_object`, `studio_uploads`, `studio_object_features`, `studio_analysis_jobs` | object status, pipeline, evidence, next action | `ACTIVE_OBJECT_REQUIRED` |
+| `measure` | audio file, `studio_audio_features`, `studio_object_features` | technical metrics, markers, mastering metrics | `MEASUREMENT_EVIDENCE_REQUIRED` |
+| `structure` | stems, layers, sections, channels, graph | layer table, arrangement dependencies, mix controls, neural graph | `MULTILAYER_EVIDENCE_REQUIRED` |
+| `field` | MIHM, Cultural Vector, WorldSpect snapshot | field tensions, hypotheses | `ACTIVE_OBJECT_REQUIRED` or field evidence missing |
+| `intervention` | hypothesis, intervention row, simulation endpoint | candidate actions, verification window, outcome registration | `HYPOTHESIS_REQUIRED` |
+| `memory` | sessions, archive events, exports, analysis jobs | longitudinal table, timeline, deliverable state | `ACTIVE_OBJECT_REQUIRED` |
+
+## Metric Contract
+
+Every displayed metric must be a `MetricValue`:
+
+- `value: null` with `status: "MISSING"` when evidence is absent.
+- `source` and `evidenceIds` required for observed/derived values.
+- `formulaVersion` required when a formula produced the value.
+- `confidence` must be explicit and bounded from 0 to 1.
+
+## Phase Contract
+
+The mounted pipeline uses these exact phases:
+
+1. OBJECT RECEIVED
+2. STORAGE VERIFIED
+3. METADATA EXTRACTED
+4. FEATURE EXTRACTION
+5. MIHM EVALUATION
+6. CULTURAL VECTOR
+7. WSV TIMING
+8. HYPOTHESIS GENERATION
+9. INTERVENTION DESIGN
+10. REPORT READY
+11. RETURN PENDING
+12. OUTCOME RECORDED
+13. LEARNING REGISTERED

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "qa:sfi-runtime": "node scripts/qa-sfi-runtime.mjs",
         "qa:sfi-convergence": "node scripts/qa-sfi-convergence.mjs",
         "qa:sfi-execution": "node scripts/qa-sfi-execution.js",
+        "qa:studio-audio": "node scripts/studio-audio-engine-smoke.cjs",
         "typecheck": "tsc --noEmit --pretty false --incremental false",
         "phase:verify": "npm run check:boundaries && npm run typecheck",
         "qa:sfi-pipeline": "node scripts/qa-sfi-minimal-pipeline.mjs",

--- a/scripts/studio-audio-engine-smoke.cjs
+++ b/scripts/studio-audio-engine-smoke.cjs
@@ -1,0 +1,103 @@
+const fs = require('node:fs');
+const Module = require('node:module');
+const path = require('node:path');
+const ts = require('typescript');
+
+const originalResolve = Module._resolveFilename;
+Module._resolveFilename = function resolveTs(request, parent, isMain, options) {
+  if (request.startsWith('.') && parent?.filename) {
+    const candidate = path.resolve(path.dirname(parent.filename), request);
+    if (fs.existsSync(`${candidate}.ts`)) return `${candidate}.ts`;
+  }
+  return originalResolve.call(this, request, parent, isMain, options);
+};
+
+require.extensions['.ts'] = function loadTs(module, filename) {
+  const source = fs.readFileSync(filename, 'utf8');
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      esModuleInterop: true,
+      moduleResolution: ts.ModuleResolutionKind.NodeJs,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+    },
+    fileName: filename,
+  }).outputText;
+  module._compile(output, filename);
+};
+
+function writeAscii(buffer, offset, value) {
+  buffer.write(value, offset, value.length, 'ascii');
+}
+
+function createSineWav() {
+  const sampleRate = 44100;
+  const durationSeconds = 1;
+  const channels = 2;
+  const bitsPerSample = 16;
+  const frameCount = sampleRate * durationSeconds;
+  const blockAlign = channels * (bitsPerSample / 8);
+  const byteRate = sampleRate * blockAlign;
+  const dataLength = frameCount * blockAlign;
+  const buffer = Buffer.alloc(44 + dataLength);
+
+  writeAscii(buffer, 0, 'RIFF');
+  buffer.writeUInt32LE(36 + dataLength, 4);
+  writeAscii(buffer, 8, 'WAVE');
+  writeAscii(buffer, 12, 'fmt ');
+  buffer.writeUInt32LE(16, 16);
+  buffer.writeUInt16LE(1, 20);
+  buffer.writeUInt16LE(channels, 22);
+  buffer.writeUInt32LE(sampleRate, 24);
+  buffer.writeUInt32LE(byteRate, 28);
+  buffer.writeUInt16LE(blockAlign, 32);
+  buffer.writeUInt16LE(bitsPerSample, 34);
+  writeAscii(buffer, 36, 'data');
+  buffer.writeUInt32LE(dataLength, 40);
+
+  for (let frame = 0; frame < frameCount; frame += 1) {
+    const sample = Math.round(Math.sin((2 * Math.PI * 440 * frame) / sampleRate) * 0.45 * 32767);
+    const offset = 44 + frame * blockAlign;
+    buffer.writeInt16LE(sample, offset);
+    buffer.writeInt16LE(sample, offset + 2);
+  }
+
+  return buffer;
+}
+
+function assertFiniteFeature(feature) {
+  if (typeof feature.value === 'number' && !Number.isFinite(feature.value)) {
+    throw new Error(`non_finite_feature:${feature.key}`);
+  }
+}
+
+const { decodeStudioAudio } = require('../src/lib/studio/audio/audioDecode.ts');
+const { extractStudioAudioFeatures } = require('../src/lib/studio/audio/features/featureRegistry.ts');
+const { buildWaveformPeaks } = require('../src/lib/studio/audio/segmentation/waveformPeaks.ts');
+const { detectSilenceRegions } = require('../src/lib/studio/audio/segmentation/silenceDetection.ts');
+
+const decoded = decodeStudioAudio(createSineWav(), 5);
+const extraction = extractStudioAudioFeatures(decoded);
+const waveform = buildWaveformPeaks(decoded, 128);
+const silence = detectSilenceRegions(extraction.energySegments);
+
+if (decoded.sampleRate !== 44100) throw new Error('sample_rate_mismatch');
+if (decoded.channels !== 2) throw new Error('channel_count_mismatch');
+if (!extraction.features.some((feature) => feature.key === 'rms_dbfs' && typeof feature.value === 'number')) {
+  throw new Error('rms_feature_missing');
+}
+if (!extraction.features.some((feature) => feature.key === 'lufs_integrated' && feature.status === 'MISSING')) {
+  throw new Error('lufs_missing_contract_missing');
+}
+if (!waveform.length) throw new Error('waveform_missing');
+extraction.features.forEach(assertFiniteFeature);
+
+console.log(JSON.stringify({
+  ok: true,
+  sampleRate: decoded.sampleRate,
+  channels: decoded.channels,
+  featureCount: extraction.features.length,
+  waveformPeaks: waveform.length,
+  silenceRegions: silence.length,
+}));

--- a/src/app/api/studio/objects/[id]/analyze/route.ts
+++ b/src/app/api/studio/objects/[id]/analyze/route.ts
@@ -1,25 +1,38 @@
 import { NextResponse } from 'next/server';
-import { getStudioObjectFeatures, recordStudioAnalysisBlocked } from '@/lib/studio/production/studioProductionRepository';
+import { analyzeStudioAudioObject } from '@/lib/studio/audio/analyzeStudioAudioObject';
+import { isStudioAudioError, toStudioAudioApiError } from '@/lib/studio/audio/audioErrors';
+import { createServerSupabaseClient } from '@/runtime/supabase/server';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 type RouteContext = { params: Promise<{ id: string }> | { id: string } };
 
-export async function POST(_request: Request, ctx: RouteContext) {
+export async function POST(request: Request, ctx: RouteContext) {
   const params = await Promise.resolve(ctx.params);
   const objectId = decodeURIComponent(params.id);
-  const features = await getStudioObjectFeatures(objectId);
-  if (!features.ok) return NextResponse.json(features, { status: features.status });
-  if (!features.data.features.length) {
-    const result = await recordStudioAnalysisBlocked(objectId, 'feature_extractors_not_connected');
-    return NextResponse.json({
-      ok: false,
-      status: 'blocked',
-      reason: 'feature_extractors_not_connected',
-      job: result.ok ? result.data : null,
-      degraded: result.ok ? [] : [result.error],
-    }, { status: 202 });
+
+  try {
+    const supabase = await createServerSupabaseClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({
+        ok: false,
+        error: 'AUTH_REQUIRED',
+        details: authError?.message ?? 'Authenticated Studio session required.',
+      }, { status: 401 });
+    }
+
+    const body = await request.json().catch(() => ({})) as { force?: unknown };
+    const result = await analyzeStudioAudioObject(objectId, {
+      force: body.force === true,
+      requestedByUserId: user.id,
+    });
+
+    return NextResponse.json(result, { status: result.reused ? 200 : 202 });
+  } catch (error) {
+    const body = toStudioAudioApiError(error);
+    const status = isStudioAudioError(error) ? error.status : 500;
+    return NextResponse.json(body, { status });
   }
-  return NextResponse.json({ ok: true, status: 'complete', object: features.data.object, features: features.data.features });
 }

--- a/src/app/api/studio/objects/[id]/audio/route.ts
+++ b/src/app/api/studio/objects/[id]/audio/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { loadStudioAudioBytes } from '@/lib/studio/audio/audioStorage';
+import { isStudioAudioError, toStudioAudioApiError } from '@/lib/studio/audio/audioErrors';
+import { createServerSupabaseClient } from '@/runtime/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type RouteContext = { params: Promise<{ id: string }> | { id: string } };
+
+export async function GET(_request: Request, ctx: RouteContext) {
+  const params = await Promise.resolve(ctx.params);
+  const objectId = decodeURIComponent(params.id);
+
+  try {
+    const supabase = await createServerSupabaseClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({
+        ok: false,
+        error: 'AUTH_REQUIRED',
+        details: authError?.message ?? 'Authenticated Studio session required.',
+      }, { status: 401 });
+    }
+
+    const stored = await loadStudioAudioBytes(objectId, {});
+    const body = new ArrayBuffer(stored.bytes.byteLength);
+    new Uint8Array(body).set(stored.bytes);
+    return new NextResponse(body, {
+      status: 200,
+      headers: {
+        'Content-Type': stored.upload.mime_type ?? stored.object.mime_type ?? 'audio/wav',
+        'Content-Length': String(stored.byteLength),
+        'Cache-Control': 'private, no-store',
+        'X-Studio-Audio-Checksum': stored.checksumSha256,
+      },
+    });
+  } catch (error) {
+    const body = toStudioAudioApiError(error);
+    const status = isStudioAudioError(error) ? error.status : 500;
+    return NextResponse.json(body, { status });
+  }
+}

--- a/src/app/api/studio/objects/upload/route.ts
+++ b/src/app/api/studio/objects/upload/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from 'next/server';
+import { analyzeStudioAudioObject } from '@/lib/studio/audio/analyzeStudioAudioObject';
+import { toStudioAudioApiError } from '@/lib/studio/audio/audioErrors';
 import { createServiceSupabaseClient } from '@/runtime/supabase/server';
 import { createStudioUploadObject } from '@/lib/studio/production/studioProductionRepository';
 
@@ -85,7 +87,18 @@ export async function POST(request: Request) {
       sizeBytes: file.size,
       storagePath,
     });
-    return NextResponse.json(result, { status: result.ok ? 201 : result.status });
+    if (!result.ok) return NextResponse.json(result, { status: result.status });
+
+    const objectId = String(result.data.id ?? '');
+    let analysis: unknown = { ok: false, status: 'not_started', reason: 'non_audio_object' };
+    if (objectType === 'music' && objectId) {
+      analysis = await analyzeStudioAudioObject(objectId, {}).catch((error) => ({
+        ...toStudioAudioApiError(error),
+        status: 'blocked',
+      }));
+    }
+
+    return NextResponse.json({ ...result, analysis }, { status: 201 });
   } catch (error) {
     return NextResponse.json({
       ok: false,

--- a/src/components/studio/StudioOriginLedger.tsx
+++ b/src/components/studio/StudioOriginLedger.tsx
@@ -3,7 +3,7 @@
 export function StudioOriginLedger() {
   return (
     <section className="rounded-[2rem] border border-[#2d2a28] bg-[#080706]/90 p-5 text-sm text-[#b8ad98]">
-      StudioOriginLedger · restored placeholder for Studio laboratory extension.
+      StudioOriginLedger: no origin ledger data is mounted for the current Studio object.
     </section>
   );
 }

--- a/src/components/studio/gold/StudioLeftRail.tsx
+++ b/src/components/studio/gold/StudioLeftRail.tsx
@@ -7,9 +7,9 @@ const intensityLabel = {
 };
 
 const trendGlyph = {
-  up: '↑',
-  down: '↓',
-  stable: '→',
+  up: 'UP',
+  down: 'DOWN',
+  stable: 'STABLE',
 };
 
 function pct(value: number) {
@@ -26,7 +26,7 @@ export function StudioLeftRail({ state }: { state: StudioGoldState }) {
       <section className="sfi-studio-gold__panel sfi-studio-gold__active-case">
         <div className="sfi-studio-gold__panel-title">
           <h2>CASO ACTIVO</h2>
-          <button type="button">VER TODOS</button>
+          <span>LECTURA</span>
         </div>
         <p className="sfi-studio-gold__eyebrow">{state.activeCase.id ?? 'SIN ID OPERATIVO'}</p>
         <h3>{state.activeCase.title}</h3>
@@ -48,7 +48,7 @@ export function StudioLeftRail({ state }: { state: StudioGoldState }) {
       <section className="sfi-studio-gold__panel">
         <div className="sfi-studio-gold__panel-title">
           <h2>OBSERVABLES CLAVE</h2>
-          <button type="button">VER TODOS</button>
+          <span>LECTURA</span>
         </div>
         <div className="sfi-studio-gold__list">
           {state.keyObservables.length ? state.keyObservables.map((item) => (
@@ -64,7 +64,7 @@ export function StudioLeftRail({ state }: { state: StudioGoldState }) {
       <section className="sfi-studio-gold__panel sfi-studio-gold__signals">
         <div className="sfi-studio-gold__panel-title">
           <h2>SENALES PERSISTENTES</h2>
-          <button type="button">VER TODOS</button>
+          <span>LECTURA</span>
         </div>
         <div className="sfi-studio-gold__list">
           {state.persistentSignals.length ? state.persistentSignals.map((signal) => (

--- a/src/components/studio/gold/StudioLowerAnalysisGrid.tsx
+++ b/src/components/studio/gold/StudioLowerAnalysisGrid.tsx
@@ -93,7 +93,7 @@ export function StudioLowerAnalysisGrid({ state }: { state: StudioGoldState }) {
             <h2>OBJETO A EVALUAR</h2>
             <p>PRODUCTOR MUSICAL / PANEL MULTIAGENTICO</p>
           </div>
-          <button type="button">{state.objectEvaluation.measurementState.toUpperCase()}</button>
+          <span>{state.objectEvaluation.measurementState.toUpperCase()}</span>
         </div>
         <div className="sfi-studio-gold__object-head">
           <strong>{state.objectEvaluation.title}</strong>
@@ -159,7 +159,7 @@ export function StudioLowerAnalysisGrid({ state }: { state: StudioGoldState }) {
             <h2>SEGUIMIENTO LONGITUDINAL</h2>
             <p>TRAYECTORIAS DE SENALES</p>
           </div>
-          <button type="button">90 DIAS</button>
+          <span>90 DIAS</span>
         </div>
         <div className="sfi-studio-gold__trajectory-list">
           {state.longitudinalTracking.length ? state.longitudinalTracking.map((item) => (
@@ -170,7 +170,7 @@ export function StudioLowerAnalysisGrid({ state }: { state: StudioGoldState }) {
             </div>
           )) : <p className="sfi-studio-gold__empty">Sin trayectoria longitudinal conectada.</p>}
         </div>
-        <button className="sfi-studio-gold__action" type="button">VER TODAS LAS TRAYECTORIAS →</button>
+        <p className="sfi-studio-gold__action">Trayectorias adicionales no montadas en esta vista.</p>
       </article>
 
       <article className="sfi-studio-gold__panel sfi-studio-gold__synthesis">

--- a/src/components/studio/gold/StudioMainWaveLab.tsx
+++ b/src/components/studio/gold/StudioMainWaveLab.tsx
@@ -25,7 +25,7 @@ export function StudioMainWaveLab({ state }: { state: StudioGoldState }) {
         </div>
         <div className="sfi-studio-gold__wave-controls">
           <span>VISTA:</span>
-          <button type="button">TOPOLOGIA</button>
+          <span>TOPOLOGIA</span>
           <Maximize2 size={15} strokeWidth={1.4} aria-hidden="true" />
         </div>
       </div>

--- a/src/components/studio/production/StudioEvaluationStrip.tsx
+++ b/src/components/studio/production/StudioEvaluationStrip.tsx
@@ -1,26 +1,42 @@
-import type { StudioProductionState } from '@/lib/studio/production/studioProductionTypes';
+import type { MetricValue, StudioProductionState } from '@/lib/studio/production/studioProductionTypes';
 
-function pct(value: number | null) {
-  return value === null ? 'SIN DATO' : `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`;
+function value(metric: MetricValue | null) {
+  if (!metric || metric.value === null) return 'SIN DATO';
+  if (typeof metric.value === 'number') return String(Number(metric.value.toFixed(3)));
+  return metric.value;
 }
 
 export function StudioEvaluationStrip({ state }: { state: StudioProductionState }) {
+  const pick = (key: string) => state.metricValues.find((item) => item.key === key) ?? null;
   const items = [
-    { label: 'OBJECT READINESS', value: state.activeObject.readiness.toUpperCase(), source: state.activeObject.id ?? 'NO_OBJECT' },
-    { label: 'FEATURE LAYERS', value: String(state.objectFeatures.layers.length), source: state.objectFeatures.readiness },
-    { label: 'PROJECT COHERENCE', value: pct(state.mihmReport.score), source: state.mihmReport.source },
-    { label: 'HYPOTHESES', value: String(state.hypotheses?.hypotheses.length ?? 0), source: state.hypotheses ? 'hypothesisEngine' : 'BLOCKED' },
-    { label: 'EVIDENCE TRACE', value: String(state.archive.evidenceTraceCount ?? 0), source: state.archive.integrity },
-    { label: 'EXPORTS', value: String(state.exports.packages.length), source: state.exports.signoffReadiness },
+    pick('active_object'),
+    pick('storage_verified'),
+    pick('feature_coverage'),
+    pick('mihm_activation'),
+    pick('cultural_resonance'),
+    {
+      key: 'exports',
+      label: 'Exports',
+      value: String(state.exports.packages.length),
+      unit: null,
+      status: state.exports.packages.length ? 'OBSERVED' as const : 'MISSING' as const,
+      source: 'studio_exports',
+      evidenceIds: state.exports.packages.map((item) => item.id),
+      confidence: state.exports.packages.length ? 1 : 0,
+      observedAt: null,
+      formulaVersion: null,
+      warnings: state.exports.packages.length ? [] : ['EXPORT_GENERATOR_NOT_CONNECTED'],
+      explanation: 'Count of persisted export rows.',
+    },
   ];
 
   return (
     <footer className="sfi-production__evaluation-strip">
       {items.map((item) => (
-        <div key={item.label}>
-          <span>{item.label}</span>
-          <strong>{item.value}</strong>
-          <em>{item.source}</em>
+        <div key={item?.key ?? 'missing'}>
+          <span>{item?.label ?? 'MISSING'}</span>
+          <strong>{value(item)}</strong>
+          <em>{item ? `${item.status} / ${item.source ?? 'NO_SOURCE'} / ${Number(item.confidence.toFixed(2))}` : 'MISSING'}</em>
         </div>
       ))}
     </footer>

--- a/src/components/studio/production/StudioFooterTransport.tsx
+++ b/src/components/studio/production/StudioFooterTransport.tsx
@@ -2,21 +2,20 @@ import type { StudioProductionState } from '@/lib/studio/production/studioProduc
 
 export function StudioFooterTransport({ state }: { state: StudioProductionState }) {
   const hasObject = Boolean(state.activeObject.id);
-  const analyzeHref = hasObject ? `/api/studio/objects/${state.activeObject.id}` : '/api/studio/production/state';
 
   return (
     <section className="sfi-production__transport">
       <div>
         <span>TRANSPORT</span>
-        <strong>PLAY · PAUSE · STOP · +10S · {hasObject ? 'TIMELINE READY' : 'NO TIMELINE'}</strong>
+        <strong>{hasObject && state.audioFeatures.waveform.length ? 'AUDIO BUFFER OBSERVED' : 'NO PLAYBACK BUFFER'}</strong>
       </div>
       <div>
-        <span>AUDIO CONTROLS</span>
-        <strong>{hasObject ? 'CURSOR AVAILABLE AFTER ANALYSIS' : 'WAITING_OBJECT'}</strong>
+        <span>PHASE EVENTS</span>
+        <strong>{state.phaseStates.filter((item) => item.status === 'FAILED' || item.status === 'MISSING').length} BLOCKED / MISSING</strong>
       </div>
       <div>
         <span>ANALYSIS JOB</span>
-        <a href={analyzeHref}>{state.activeObject.status.toUpperCase()}</a>
+        <strong>{state.activeObject.analysisStatus}</strong>
       </div>
     </section>
   );

--- a/src/components/studio/production/StudioHeader.tsx
+++ b/src/components/studio/production/StudioHeader.tsx
@@ -7,7 +7,7 @@ export function StudioHeader({ state }: { state: StudioProductionState }) {
     <header className="sfi-production__header">
       <div>
         <span>SYSTEM FRICTION INSTITUTE</span>
-        <strong>STUDIO / PRODUCTION ENVIRONMENT</strong>
+        <strong>STUDIO / OBJECT EVALUATION LAB</strong>
       </div>
       <div className="sfi-production__header-object">
         <span>ACTIVE OBJECT</span>
@@ -18,9 +18,6 @@ export function StudioHeader({ state }: { state: StudioProductionState }) {
         <strong>{state.systemState.toUpperCase()}</strong>
         <em>{time} UTC</em>
       </div>
-      <style jsx global>{`
-        .sfi-overview__blocked { display: none !important; }
-      `}</style>
     </header>
   );
 }

--- a/src/components/studio/production/StudioObjectIntake.tsx
+++ b/src/components/studio/production/StudioObjectIntake.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useRef, useState } from 'react';
 
 export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const router = useRouter();
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [status, setStatus] = useState<'idle' | 'uploading' | 'complete' | 'blocked'>('idle');
   const [message, setMessage] = useState('Carga un objeto real: audio, video, imagen, texto, comunidad o coordenada temporal.');
@@ -23,7 +25,9 @@ export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: 
       return;
     }
     setStatus('complete');
-    setMessage('Objeto registrado. Recarga Studio para leer el estado persistido.');
+    setMessage(`Objeto registrado: ${body?.data?.id ?? 'studio_object_created'}`);
+    router.refresh();
+    window.setTimeout(onClose, 450);
   }
 
   return (
@@ -37,7 +41,7 @@ export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: 
           const file = event.currentTarget.files?.[0];
           if (file) void upload(file);
         }} />
-        <button type="button" onClick={() => inputRef.current?.click()}>
+        <button type="button" onClick={() => inputRef.current?.click()} disabled={status === 'uploading'}>
           SELECCIONAR OBJETO
         </button>
         <em>{status.toUpperCase()}</em>

--- a/src/components/studio/production/StudioProductionShell.tsx
+++ b/src/components/studio/production/StudioProductionShell.tsx
@@ -75,6 +75,20 @@ function MetricCard({ metric }: { metric: MetricValue }) {
   );
 }
 
+function AudioPlayback({ state }: { state: StudioProductionState }) {
+  const canPlay = Boolean(state.activeObject.id && state.activeObject.type === 'music' && state.activeObject.storageStatus === 'OBSERVED');
+  if (!canPlay) {
+    return <p>Playback unavailable: an audio object with verified storage is required.</p>;
+  }
+
+  return (
+    <div className="sfi-production__audio-player">
+      <span>AUDIO PLAYBACK</span>
+      <audio controls preload="metadata" src={`/api/studio/objects/${encodeURIComponent(state.activeObject.id as string)}/audio`} />
+    </div>
+  );
+}
+
 function PhaseList({ phases }: { phases: PhaseState[] }) {
   return (
     <ol className="sfi-production__phase-list">
@@ -262,25 +276,26 @@ function Overview({ state, onOpenIntake }: { state: StudioProductionState; onOpe
 }
 
 function Measure({ state }: { state: StudioProductionState }) {
-  const technicalKeys = ['rms', 'peak', 'clippingRisk', 'spectralCentroid', 'dynamicRange', 'lufs'];
+  const technicalKeys = ['rms_dbfs', 'peak_dbfs', 'clipping_risk', 'spectral_centroid_hz', 'dynamic_range_db', 'crest_factor_db', 'headroom_db'];
   const technicalMetrics = technicalKeys.map((key) => metricByKey(state, key)).filter((metric): metric is MetricValue => Boolean(metric));
   const hasAudioData = state.audioFeatures.waveform.length > 0 || technicalMetrics.some((metric) => metric.status !== 'MISSING');
 
   return (
     <div className="sfi-production__module">
       <Panel title="LIVE SIGNAL">
+        <AudioPlayback state={state} />
         {hasAudioData ? <StudioPixiStage state={state} variant="waveform" label="Live signal waveform" /> : <p>No animar waveform: no hay audio analizable persistido ni buffer Web Audio activo.</p>}
         <div className="sfi-production__metric-grid">
           {technicalMetrics.length ? technicalMetrics.map((metric) => <MetricCard key={metric.key} metric={metric} />) : <MetricCard metric={{ key: 'live_signal_missing', label: 'Live Signal', value: null, unit: null, status: 'MISSING', source: null, evidenceIds: [], confidence: 0, observedAt: null, formulaVersion: null, warnings: ['AUDIO_EVIDENCE_REQUIRED'], explanation: 'No persisted audio features or active browser audio analysis are available.' }} />}
         </div>
       </Panel>
       <Panel title="COMPOSITION">
-        <p>{state.textFeatures.sections === null ? 'Segmentation unavailable. Manual markers require a persistence endpoint before controls are shown.' : `${state.textFeatures.sections} sections observed.`}</p>
+        <p>{state.timeCoordinateFeatures.placeLabel ? `Persisted ${state.timeCoordinateFeatures.placeLabel} marker at ${state.timeCoordinateFeatures.timeRange ?? 'MISSING_TIME_RANGE'}.` : 'Segmentation unavailable. Manual markers require a persistence endpoint before controls are shown.'}</p>
         {state.textFeatures.motifs.map((item) => <p key={item}>{item}</p>)}
       </Panel>
       <Panel title="SOUND DESIGN">
         <div className="sfi-production__metric-grid">
-          {['spectralCentroid', 'spectral_rolloff', 'spectral_flux', 'noise_floor', 'dynamicRange', 'harmonic_stability', 'percussive_load', 'transient_density', 'stereo_width'].map((key) => metricByKey(state, key) ?? {
+          {['spectral_centroid_hz', 'spectral_rolloff_hz', 'spectral_flux', 'noise_floor_dbfs', 'dynamic_range_db', 'harmonic_stability', 'percussive_load', 'transient_density', 'stereo_width'].map((key) => metricByKey(state, key) ?? {
             key,
             label: key.replace(/_/g, ' ').toUpperCase(),
             value: null,
@@ -298,7 +313,7 @@ function Measure({ state }: { state: StudioProductionState }) {
       </Panel>
       <Panel title="MASTERING TECHNICAL">
         <div className="sfi-production__metric-grid">
-          {['lufs', 'true_peak', 'loudness_range', 'crest_factor', 'clippingRisk', 'headroom', 'stereo_width', 'tonal_balance'].map((key) => metricByKey(state, key) ?? {
+          {['lufs_integrated', 'true_peak_dbtp', 'loudness_range_lu', 'crest_factor_db', 'clipping_risk', 'headroom_db', 'stereo_width', 'tonal_balance'].map((key) => metricByKey(state, key) ?? {
             key,
             label: key.replace(/_/g, ' ').toUpperCase(),
             value: null,
@@ -326,10 +341,14 @@ function Structure({ state }: { state: StudioProductionState }) {
         <StatusPill status="MISSING" />
       </Panel>
       <Panel title="ARRANGEMENTS">
-        <p>Blocked until stems, layers, sections or events are persisted.</p>
+        <p>{state.timeCoordinateFeatures.timeRange ? `Observed marker: ${state.timeCoordinateFeatures.placeLabel ?? 'marker'} / ${state.timeCoordinateFeatures.timeRange}` : 'Blocked until stems, layers, sections or events are persisted.'}</p>
       </Panel>
       <Panel title="MIX">
         <p>No faders rendered: real channels are required for mute, solo, meter, masking, panorama, correlation and energy controls.</p>
+      </Panel>
+      <Panel title="WAVEFORM / ENERGY">
+        {state.audioFeatures.waveform.length ? <StudioPixiStage state={state} variant="waveform" label="Persisted waveform peaks" /> : <p>MISSING: waveform peaks require decoded audio evidence.</p>}
+        <p>{state.audioFeatures.energySegments.length ? `${state.audioFeatures.energySegments.length} energy segments persisted.` : 'MISSING: energy segments require decoded audio evidence.'}</p>
       </Panel>
       <Panel title="NEURAL GRAPH">
         <FieldGraphInspector state={state} />
@@ -550,6 +569,9 @@ const productionCss = `
 .sfi-production__metric-card dt { color: var(--cyan); font-size: 9px; }
 .sfi-production__metric-card dd { margin: 0; overflow-wrap: anywhere; }
 .sfi-production__warning { color: var(--orange) !important; }
+.sfi-production__audio-player { border: 1px solid var(--line2); padding: 10px; margin-bottom: 10px; display: grid; gap: 8px; }
+.sfi-production__audio-player span { color: var(--cyan); font-size: 9px; letter-spacing: .12em; }
+.sfi-production__audio-player audio { width: 100%; height: 34px; }
 .sfi-production__field-panel { min-height: 430px; display: grid; grid-template-rows: auto minmax(360px, 1fr); }
 .sfi-production__pixi-stage { position: relative; min-height: 360px; overflow: hidden; background: radial-gradient(circle at 50% 50%, rgba(157,92,255,.16), transparent 48%); }
 .sfi-production__pixi-host, .sfi-production__pixi-host canvas, .sfi-production__pixi-fallback { position: absolute; inset: 0; width: 100%; height: 100%; }

--- a/src/components/studio/production/StudioProductionShell.tsx
+++ b/src/components/studio/production/StudioProductionShell.tsx
@@ -1,29 +1,38 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import type { StudioProductionState } from '@/lib/studio/production/studioProductionTypes';
+import type { MetricStatus, MetricValue, PhaseState, StudioFieldNode, StudioProductionState } from '@/lib/studio/production/studioProductionTypes';
 import { StudioEvaluationStrip } from './StudioEvaluationStrip';
 import { StudioFooterTransport } from './StudioFooterTransport';
 import { StudioHeader } from './StudioHeader';
 import { StudioObjectIntake } from './StudioObjectIntake';
-import { StudioRightRail } from './StudioRightRail';
-import { StudioPixiStage, type StudioPixiStageVariant } from './pixi/StudioPixiStage';
+import { StudioPixiStage } from './pixi/StudioPixiStage';
 import { StudioSidebar, type StudioProductionScreen } from './StudioSidebar';
 
-function metric(value: number | null | undefined) {
-  return value === null || value === undefined ? 'SIN DATO' : value.toFixed(2);
+const STATUS_LABEL: Record<MetricStatus, string> = {
+  PENDING: 'PENDING',
+  RUNNING: 'RUNNING',
+  OBSERVED: 'OBSERVED',
+  DERIVED: 'DERIVED',
+  DEGRADED: 'DEGRADED',
+  MISSING: 'MISSING',
+  FAILED: 'FAILED',
+  COMPLETE: 'COMPLETE',
+  EXPERIMENTAL: 'EXPERIMENTAL',
+};
+
+function statusClass(status: MetricStatus) {
+  return `is-${status.toLowerCase()}`;
 }
 
-function pct(value: number | null | undefined) {
-  return value === null || value === undefined ? 'SIN DATO' : `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`;
+function formatMetricValue(metric: MetricValue) {
+  if (metric.value === null) return 'SIN DATO';
+  if (typeof metric.value === 'number') return `${Number(metric.value.toFixed(3))}${metric.unit ? ` ${metric.unit}` : ''}`;
+  return metric.unit ? `${metric.value} ${metric.unit}` : metric.value;
 }
 
-function readinessValue(value: string | null | undefined) {
-  const text = String(value ?? '').toLowerCase();
-  if (text.includes('ready') || text.includes('complete')) return 1;
-  if (text.includes('partial') || text.includes('degraded') || text.includes('uploaded')) return 0.46;
-  if (text.includes('blocked') || text.includes('missing') || text.includes('failed')) return 0.08;
-  return 0.18;
+function metricByKey(state: StudioProductionState, key: string) {
+  return state.metricValues.find((metric) => metric.key === key) ?? null;
 }
 
 function Panel({ title, children, action }: { title: string; children: React.ReactNode; action?: React.ReactNode }) {
@@ -38,319 +47,403 @@ function Panel({ title, children, action }: { title: string; children: React.Rea
   );
 }
 
-function PixiPanel({ state, variant, title, subtitle }: { state: StudioProductionState; variant: StudioPixiStageVariant; title: string; subtitle: string }) {
+function StatusPill({ status }: { status: MetricStatus }) {
+  return <b className={`sfi-production__status ${statusClass(status)}`}>{STATUS_LABEL[status]}</b>;
+}
+
+function MetricCard({ metric }: { metric: MetricValue }) {
   return (
-    <section className="sfi-production__live-panel">
-      <header>
-        <div>
-          <span>{title}</span>
-          <strong>{subtitle}</strong>
-        </div>
-        <em>{state.activeObject.readiness.toUpperCase()}</em>
-      </header>
-      <StudioPixiStage state={state} variant={variant} label={title} />
-    </section>
+    <article className={`sfi-production__metric-card ${statusClass(metric.status)}`}>
+      <div>
+        <span>{metric.label}</span>
+        <StatusPill status={metric.status} />
+      </div>
+      <strong>{formatMetricValue(metric)}</strong>
+      <p>{metric.explanation}</p>
+      <dl>
+        <dt>Source</dt>
+        <dd>{metric.source ?? 'NO_SOURCE'}</dd>
+        <dt>Confidence</dt>
+        <dd>{Number(metric.confidence.toFixed(3))}</dd>
+        <dt>Formula</dt>
+        <dd>{metric.formulaVersion ?? 'NO_FORMULA'}</dd>
+        <dt>Evidence</dt>
+        <dd>{metric.evidenceIds.length ? metric.evidenceIds.join(', ') : 'NO_EVIDENCE'}</dd>
+      </dl>
+      {metric.warnings.length ? <p className="sfi-production__warning">{metric.warnings.join(' / ')}</p> : null}
+    </article>
   );
 }
 
-function ObjectSummary({ state, onOpenIntake }: { state: StudioProductionState; onOpenIntake: () => void }) {
+function PhaseList({ phases }: { phases: PhaseState[] }) {
   return (
-    <Panel title="OBJETO A EVALUAR" action={<button type="button" onClick={onOpenIntake}>CARGAR</button>}>
-      <div className="sfi-production__object-card">
-        <strong>{state.activeObject.title}</strong>
-        <span>{state.activeObject.type.toUpperCase()} / {state.activeObject.status.toUpperCase()}</span>
-        <p>{state.activeObject.sourceUri ?? 'NO_SOURCE_URI'}</p>
+    <ol className="sfi-production__phase-list">
+      {phases.map((item) => (
+        <li key={item.key} className={statusClass(item.status)}>
+          <div>
+            <span>{item.label}</span>
+            <StatusPill status={item.status} />
+          </div>
+          <p>{item.details ?? item.error ?? item.nextAction ?? item.requirements.join(', ')}</p>
+          {item.progress !== null ? <i><b style={{ width: `${Math.round(item.progress * 100)}%` }} /></i> : null}
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function EvidenceMatrix({ state }: { state: StudioProductionState }) {
+  const counts = state.metricValues.reduce<Record<MetricStatus, number>>((acc, metric) => {
+    acc[metric.status] += 1;
+    return acc;
+  }, {
+    PENDING: 0,
+    RUNNING: 0,
+    OBSERVED: 0,
+    DERIVED: 0,
+    DEGRADED: 0,
+    MISSING: 0,
+    FAILED: 0,
+    COMPLETE: 0,
+    EXPERIMENTAL: 0,
+  });
+
+  return (
+    <div className="sfi-production__evidence-matrix">
+      {(['OBSERVED', 'DERIVED', 'DEGRADED', 'MISSING', 'FAILED'] as MetricStatus[]).map((status) => (
+        <details key={status} open={status === 'MISSING' || status === 'OBSERVED'}>
+          <summary><span>{status}</span><strong>{counts[status]}</strong></summary>
+          {state.metricValues.filter((metric) => metric.status === status).map((metric) => (
+            <p key={metric.key}>{metric.label}: {metric.source ?? metric.explanation}</p>
+          ))}
+          {!state.metricValues.some((metric) => metric.status === status) ? <p>NO_ITEMS</p> : null}
+        </details>
+      ))}
+    </div>
+  );
+}
+
+function NextAction({ state, onOpenIntake }: { state: StudioProductionState; onOpenIntake: () => void }) {
+  const [actionState, setActionState] = useState<'idle' | 'running' | 'complete' | 'failed'>('idle');
+  const [message, setMessage] = useState<string | null>(null);
+  const action = state.nextAction;
+
+  async function execute() {
+    if (!action.endpoint || action.method !== 'POST') return;
+    setActionState('running');
+    setMessage('Ejecutando accion contra endpoint POST real.');
+    const response = await fetch(action.endpoint, { method: 'POST' });
+    const body = await response.json().catch(() => null);
+    if (!response.ok || body?.ok === false) {
+      setActionState('failed');
+      setMessage(body?.details || body?.reason || body?.error || `HTTP_${response.status}`);
+      return;
+    }
+    setActionState('complete');
+    setMessage(body?.status || 'Accion completada.');
+  }
+
+  const canOpenIntake = action.code === 'UPLOAD_OBJECT';
+  const canExecute = Boolean(action.endpoint && action.method === 'POST' && !action.disabledReason);
+
+  return (
+    <Panel title="NEXT ACTION">
+      <div className="sfi-production__next-action">
+        <strong>{action.action}</strong>
+        <p>{action.reason}</p>
+        <span>{action.requirement ?? 'NO_REQUIREMENT'}</span>
+        {canOpenIntake ? <button type="button" onClick={onOpenIntake}>CARGAR OBJETO</button> : null}
+        {canExecute ? <button type="button" onClick={execute} disabled={actionState === 'running'}>EJECUTAR ACCION</button> : null}
+        {!canOpenIntake && !canExecute ? <em>{action.disabledReason ?? action.code}</em> : null}
+        {message ? <p className={`sfi-production__action-result is-${actionState}`}>{message}</p> : null}
       </div>
     </Panel>
   );
 }
 
-function OverviewStatusBar({ label, value, tone }: { label: string; value: number; tone: 'pink' | 'cyan' | 'orange' | 'green' }) {
+function ActiveObject({ state, onOpenIntake }: { state: StudioProductionState; onOpenIntake: () => void }) {
   return (
-    <div className={`sfi-overview__bar is-${tone}`}>
-      <span>{label}</span>
-      <i><b style={{ width: `${Math.max(4, Math.round(value * 100))}%` }} /></i>
-      <em>{Math.round(value * 100)}%</em>
+    <Panel title="ACTIVE OBJECT" action={<button type="button" onClick={onOpenIntake}>CARGAR</button>}>
+      <dl className="sfi-production__object-grid">
+        <dt>Title</dt><dd>{state.activeObject.title}</dd>
+        <dt>Type</dt><dd>{state.activeObject.type}</dd>
+        <dt>Source URI</dt><dd>{state.activeObject.sourceUri ?? 'MISSING'}</dd>
+        <dt>MIME</dt><dd>{state.activeObject.mimeType ?? 'MISSING'}</dd>
+        <dt>Size</dt><dd>{state.activeObject.sizeBytes === null ? 'MISSING' : `${state.activeObject.sizeBytes} bytes`}</dd>
+        <dt>Created</dt><dd>{state.activeObject.uploadedAt ?? 'MISSING'}</dd>
+        <dt>Session</dt><dd>{state.activeObject.sessionId ?? state.session.id ?? 'MISSING'}</dd>
+        <dt>Storage</dt><dd><StatusPill status={state.activeObject.storageStatus} /></dd>
+        <dt>Analysis</dt><dd><StatusPill status={state.activeObject.analysisStatus} /></dd>
+        <dt>Version</dt><dd>{state.activeObject.version ?? 'MISSING'}</dd>
+      </dl>
+    </Panel>
+  );
+}
+
+function ExecutiveReading({ state }: { state: StudioProductionState }) {
+  const hasEvidence = state.evidence.length > 0 && state.metricValues.some((metric) => metric.status === 'OBSERVED' || metric.status === 'DERIVED');
+  const dominantHypothesis = state.fieldGraph.nodes.find((node) => node.type === 'hypothesis');
+  const cultural = metricByKey(state, 'cultural_resonance');
+  const mihm = metricByKey(state, 'mihm_activation');
+
+  if (!hasEvidence || !dominantHypothesis) {
+    return (
+      <Panel title="EXECUTIVE READING">
+        <p>No existe evidencia suficiente para generar lectura ejecutiva.</p>
+        <p>Limitaciones: {state.provenance.limits.join(' / ') || 'NO_LIMITS_DECLARED'}</p>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel title="EXECUTIVE READING">
+      <div className="sfi-production__reading">
+        <span>Tension principal</span><strong>{dominantHypothesis.label}</strong>
+        <span>Direccion observada</span><p>{cultural?.explanation ?? 'MISSING'}</p>
+        <span>Atractor declarado</span><p>{state.culturalLens?.dominantSignal ?? 'MISSING'}</p>
+        <span>Hipotesis dominante</span><p>{dominantHypothesis.explanation}</p>
+        <span>Confidence</span><p>{Number(Math.min(cultural?.confidence ?? 0, mihm?.confidence ?? 0).toFixed(3))}</p>
+        <span>Limitaciones</span><p>{state.provenance.limits.join(' / ') || 'NO_LIMITS_DECLARED'}</p>
+      </div>
+    </Panel>
+  );
+}
+
+function FieldGraphInspector({ state }: { state: StudioProductionState }) {
+  const [selectedId, setSelectedId] = useState<string | null>(state.fieldGraph.nodes[0]?.id ?? null);
+  const selected = state.fieldGraph.nodes.find((node) => node.id === selectedId) ?? null;
+
+  return (
+    <Panel title="FIELD NODE INSPECTOR">
+      <div className="sfi-production__node-layout">
+        <div className="sfi-production__node-list">
+          {state.fieldGraph.nodes.map((node) => (
+            <button key={node.id} type="button" className={node.id === selectedId ? 'is-active' : ''} onClick={() => setSelectedId(node.id)}>
+              {node.label}
+            </button>
+          ))}
+          {!state.fieldGraph.nodes.length ? <p>No renderable nodes: every node requires source, status, confidence and explanation.</p> : null}
+        </div>
+        {selected ? (
+          <dl className="sfi-production__object-grid">
+            <dt>Label</dt><dd>{selected.label}</dd>
+            <dt>Type</dt><dd>{selected.type}</dd>
+            <dt>Value</dt><dd>{selected.value ?? 'MISSING'}</dd>
+            <dt>Status</dt><dd><StatusPill status={selected.status} /></dd>
+            <dt>Source</dt><dd>{selected.source ?? 'NO_SOURCE'}</dd>
+            <dt>Formula</dt><dd>{selected.formulaVersion ?? 'NO_FORMULA'}</dd>
+            <dt>Confidence</dt><dd>{Number(selected.confidence.toFixed(3))}</dd>
+            <dt>Explanation</dt><dd>{selected.explanation}</dd>
+            <dt>Evidence IDs</dt><dd>{selected.evidenceIds.join(', ') || 'NO_EVIDENCE'}</dd>
+          </dl>
+        ) : null}
+      </div>
+    </Panel>
+  );
+}
+
+function Overview({ state, onOpenIntake }: { state: StudioProductionState; onOpenIntake: () => void }) {
+  return (
+    <div className="sfi-production__module">
+      <div className="sfi-production__overview-grid">
+        <ActiveObject state={state} onOpenIntake={onOpenIntake} />
+        <Panel title="PIPELINE REAL"><PhaseList phases={state.phaseStates} /></Panel>
+        <Panel title="EVIDENCE MATRIX"><EvidenceMatrix state={state} /></Panel>
+        <ExecutiveReading state={state} />
+        <NextAction state={state} onOpenIntake={onOpenIntake} />
+      </div>
+      <section className="sfi-production__field-panel">
+        <header><span>VISUAL FIELD</span><strong>OBSERVED / DERIVED NODES ONLY</strong></header>
+        <StudioPixiStage state={state} variant="overview" label="Studio overview field" />
+      </section>
+      <FieldGraphInspector state={state} />
     </div>
   );
 }
 
-function OverviewDashboard({ state, onOpenIntake }: { state: StudioProductionState; onOpenIntake: () => void }) {
-  const objectReady = readinessValue(state.activeObject.readiness);
-  const featureReady = readinessValue(state.objectFeatures.readiness);
-  const cultural = Math.max(0, Math.min(1, state.culturalLens?.confidence ?? 0));
-  const mihm = Math.max(0, Math.min(1, state.mihmReport.score ?? 0));
-  const archive = readinessValue(state.archive.integrity);
-  const hasObject = Boolean(state.activeObject.id);
-  const hypothesisCount = (state.hypotheses?.hypotheses.length ?? 0) + (state.hypotheses?.correlations.length ?? 0);
-  const diagnostic = state.degradedSources[0] ?? 'studio object source unavailable';
+function Measure({ state }: { state: StudioProductionState }) {
+  const technicalKeys = ['rms', 'peak', 'clippingRisk', 'spectralCentroid', 'dynamicRange', 'lufs'];
+  const technicalMetrics = technicalKeys.map((key) => metricByKey(state, key)).filter((metric): metric is MetricValue => Boolean(metric));
+  const hasAudioData = state.audioFeatures.waveform.length > 0 || technicalMetrics.some((metric) => metric.status !== 'MISSING');
 
   return (
-    <section className="sfi-overview">
-      <div className="sfi-overview__topline">
-        <div>
-          <span>01 / OVERVIEW HUB</span>
-          <strong>STUDIO OBJECT COMMAND FIELD</strong>
-        </div>
-        <button type="button" onClick={onOpenIntake}>INTAKE OBJECT</button>
-      </div>
-
-      <div className="sfi-overview__field">
-        <div className="sfi-overview__micro sfi-overview__micro--left">
-          <span>ACTIVE OBJECT</span>
-          <strong>{state.activeObject.title}</strong>
-          <p>{state.activeObject.type.toUpperCase()} · {state.activeObject.readiness.toUpperCase()}</p>
-        </div>
-        <div className="sfi-overview__micro sfi-overview__micro--right">
-          <span>SYSTEM STATE</span>
-          <strong>{state.systemState.toUpperCase()}</strong>
-          <p>{state.generatedAt}</p>
-        </div>
-        <div className="sfi-overview__micro sfi-overview__micro--bottom-left">
-          <span>FEATURE GRAPH</span>
-          <strong>{state.objectFeatures.graph.nodes.length} NODES / {state.objectFeatures.graph.edges.length} EDGES</strong>
-          <p>{state.objectFeatures.readiness.toUpperCase()}</p>
-        </div>
-        <div className="sfi-overview__micro sfi-overview__micro--bottom-right">
-          <span>HYPOTHESIS ENGINE</span>
-          <strong>{hypothesisCount} SIGNALS</strong>
-          <p>{state.hypotheses?.summary ?? 'BLOCKED_BY_MISSING_LAYERS'}</p>
-        </div>
-        <div className="sfi-overview__frame sfi-overview__frame--a" />
-        <div className="sfi-overview__frame sfi-overview__frame--b" />
-        <StudioPixiStage state={state} variant="overview" label="Overview object field" />
-        {!hasObject && (
-          <div className="sfi-overview__blocked">
-            <span>BLOCKED SOURCE</span>
-            <strong>SIN OBJETO PERSISTIDO</strong>
-            <p>{diagnostic}</p>
-          </div>
-        )}
-      </div>
-
-      <div className="sfi-overview__lower">
-        <section className="sfi-overview__dock sfi-overview__dock--wide">
-          <header><span>READINESS MATRIX</span><b>LIVE DIAGNOSTIC</b></header>
-          <OverviewStatusBar label="OBJECT" value={objectReady} tone="pink" />
-          <OverviewStatusBar label="FEATURES" value={featureReady} tone="cyan" />
-          <OverviewStatusBar label="CULTURAL" value={cultural} tone="orange" />
-          <OverviewStatusBar label="MIHM" value={mihm} tone="green" />
-          <OverviewStatusBar label="ARCHIVE" value={archive} tone="cyan" />
-        </section>
-
-        <section className="sfi-overview__dock">
-          <header><span>PIPELINE</span><b>NO MOCK DATA</b></header>
-          <ol className="sfi-production__pipeline">
-            {['OBJECT', 'ANALYSIS', 'LAYERS', 'HYPOTHESIS', 'PMV', 'VALIDATION', 'ARCHIVE'].map((item, index) => (
-              <li key={item} className={index <= (hasObject ? 2 : 0) ? 'is-live' : ''}>{item}</li>
-            ))}
-          </ol>
-        </section>
-
-        <section className="sfi-overview__dock">
-          <header><span>PROVENANCE</span><b>{state.provenance.basedOn.length} SOURCES</b></header>
-          {(state.provenance.basedOn.length ? state.provenance.basedOn : ['NO_PROVENANCE_DECLARED']).slice(0, 5).map((item) => <p key={item}>{item}</p>)}
-        </section>
-      </div>
-    </section>
-  );
-}
-
-function OverviewScreen({ state, onOpenIntake }: { state: StudioProductionState; onOpenIntake: () => void }) {
-  return <OverviewDashboard state={state} onOpenIntake={onOpenIntake} />;
-}
-
-function SessionsScreen({ state, onOpenIntake }: { state: StudioProductionState; onOpenIntake: () => void }) {
-  return (
-    <div className="sfi-production__screen-grid">
-      <Panel title="SESSION HUB" action={<a href="/api/studio/sessions">API</a>}>
-        <div className="sfi-production__object-card">
-          <strong>{state.session.title}</strong>
-          <span>{state.session.id ?? 'NO_SESSION_ID'}</span>
-          <p>{state.session.status.toUpperCase()}</p>
+    <div className="sfi-production__module">
+      <Panel title="LIVE SIGNAL">
+        {hasAudioData ? <StudioPixiStage state={state} variant="waveform" label="Live signal waveform" /> : <p>No animar waveform: no hay audio analizable persistido ni buffer Web Audio activo.</p>}
+        <div className="sfi-production__metric-grid">
+          {technicalMetrics.length ? technicalMetrics.map((metric) => <MetricCard key={metric.key} metric={metric} />) : <MetricCard metric={{ key: 'live_signal_missing', label: 'Live Signal', value: null, unit: null, status: 'MISSING', source: null, evidenceIds: [], confidence: 0, observedAt: null, formulaVersion: null, warnings: ['AUDIO_EVIDENCE_REQUIRED'], explanation: 'No persisted audio features or active browser audio analysis are available.' }} />}
         </div>
       </Panel>
-      <ObjectSummary state={state} onOpenIntake={onOpenIntake} />
-      <Panel title="SESSION OBJECTS">
-        <p>{state.activeObject.id ? state.activeObject.title : 'No hay objetos persistidos en studio_objects.'}</p>
+      <Panel title="COMPOSITION">
+        <p>{state.textFeatures.sections === null ? 'Segmentation unavailable. Manual markers require a persistence endpoint before controls are shown.' : `${state.textFeatures.sections} sections observed.`}</p>
+        {state.textFeatures.motifs.map((item) => <p key={item}>{item}</p>)}
       </Panel>
-      <Panel title="SEARCH / FILTERS">
-        <div className="sfi-production__filter-row">
-          <button type="button">ACTIVE</button>
-          <button type="button">ARCHIVE</button>
-          <button type="button">FAVORITES</button>
+      <Panel title="SOUND DESIGN">
+        <div className="sfi-production__metric-grid">
+          {['spectralCentroid', 'spectral_rolloff', 'spectral_flux', 'noise_floor', 'dynamicRange', 'harmonic_stability', 'percussive_load', 'transient_density', 'stereo_width'].map((key) => metricByKey(state, key) ?? {
+            key,
+            label: key.replace(/_/g, ' ').toUpperCase(),
+            value: null,
+            unit: null,
+            status: 'MISSING' as MetricStatus,
+            source: null,
+            evidenceIds: [],
+            confidence: 0,
+            observedAt: null,
+            formulaVersion: null,
+            warnings: ['ACOUSTIC_FEATURE_REQUIRED'],
+            explanation: 'No persisted acoustic feature row exists for this value.',
+          }).map((metric) => <MetricCard key={metric.key} metric={metric} />)}
         </div>
       </Panel>
-    </div>
-  );
-}
-
-function LiveDeskScreen({ state }: { state: StudioProductionState }) {
-  return (
-    <>
-      <PixiPanel state={state} variant="waveform" title="LIVE DESK" subtitle="WAVEFORM / VECTOR SCOPE / ANOMALIAS" />
-      <div className="sfi-production__grid">
-        <Panel title="SIGNAL HEALTH">
-          <div className="sfi-production__metric-list">
-            <span>RMS <b>{metric(state.audioFeatures.rms)}</b></span>
-            <span>PEAK <b>{metric(state.audioFeatures.peak)}</b></span>
-            <span>CLIP RISK <b>{metric(state.audioFeatures.clippingRisk)}</b></span>
-          </div>
-        </Panel>
-        <Panel title="INTERVENTION QUEUE" action={<a href="/api/studio/interventions/simulate">SIMULATE</a>}>
-          {state.interventions.length ? state.interventions.map((item) => <p key={item.id}>{item.title}</p>) : <p>NO_VERIFIED_INTERVENTIONS</p>}
-        </Panel>
-      </div>
-    </>
-  );
-}
-
-function CompositionScreen({ state }: { state: StudioProductionState }) {
-  return (
-    <>
-      <PixiPanel state={state} variant="timeline" title="COMPOSITION" subtitle="STRUCTURE / MOTIFS / EMOTIONAL ARC" />
-      <div className="sfi-production__grid">
-        <Panel title="MOTIFS">{state.textFeatures.motifs.length ? state.textFeatures.motifs.slice(0, 8).map((item) => <p key={item}>{item}</p>) : <p>MOTIF_EXTRACTION_UNAVAILABLE</p>}</Panel>
-        <Panel title="HYPOTHESES">{state.hypotheses?.summary ?? 'HYPOTHESIS_ENGINE_BLOCKED_BY_MISSING_LAYERS'}</Panel>
-      </div>
-    </>
-  );
-}
-
-function SoundDesignScreen({ state }: { state: StudioProductionState }) {
-  return (
-    <>
-      <PixiPanel state={state} variant="spectral" title="SOUND DESIGN" subtitle="SPECTRAL CLOUD / TEXTURE CLUSTERS" />
-      <div className="sfi-production__grid">
-        <Panel title="TIMBRE DNA">
-          <div className="sfi-production__metric-list">
-            <span>SPECTRAL CENTROID <b>{metric(state.audioFeatures.spectralCentroid)}</b></span>
-            <span>TEXTURE DENSITY <b>{metric(state.imageFeatures.textureDensity)}</b></span>
-            <span>SEMANTIC DENSITY <b>{metric(state.textFeatures.semanticDensity)}</b></span>
-          </div>
-        </Panel>
-        <Panel title="CULTURAL FIT">{state.culturalLens?.dominantSignal ?? 'NO_DOMINANT_SIGNAL'}</Panel>
-      </div>
-    </>
-  );
-}
-
-function ArrangementsScreen({ state }: { state: StudioProductionState }) {
-  return (
-    <>
-      <PixiPanel state={state} variant="timeline" title="ARRANGEMENTS" subtitle="DENSITY / SILENCE / TRANSITIONS" />
-      <div className="sfi-production__grid">
-        <Panel title="LAYERS">{state.objectFeatures.layers.map((layer) => <p key={layer.id}>{layer.label} / {pct(layer.weight)}</p>)}</Panel>
-        <Panel title="TRANSITIONS"><p>TRANSITION_SCORING_NOT_CONNECTED</p></Panel>
-      </div>
-    </>
-  );
-}
-
-function MixConsoleScreen({ state }: { state: StudioProductionState }) {
-  return (
-    <>
-      <PixiPanel state={state} variant="vector" title="MIX CONSOLE" subtitle="METERS / ROUTING / PHASE" />
-      <div className="sfi-production__faders">
-        {state.objectFeatures.layers.length ? state.objectFeatures.layers.map((layer) => (
-          <div key={layer.id}>
-            <span>{layer.label}</span>
-            <i style={{ height: `${Math.max(12, Math.round((layer.weight ?? 0.05) * 100))}%` }} />
-            <b>{pct(layer.weight)}</b>
-          </div>
-        )) : <p>NO_STEMS_CONNECTED</p>}
-      </div>
-    </>
-  );
-}
-
-function MasteringScreen({ state }: { state: StudioProductionState }) {
-  return (
-    <div className="sfi-production__screen-grid">
-      <PixiPanel state={state} variant="vector" title="MASTERING" subtitle="LOUDNESS / STEREO / EXPORT READINESS" />
-      <Panel title="MASTER READINESS">
-        <div className="sfi-production__metric-list">
-          <span>LUFS <b>{metric(state.audioFeatures.lufs)}</b></span>
-          <span>DYNAMIC RANGE <b>{metric(state.audioFeatures.dynamicRange)}</b></span>
-          <span>SIGNOFF <b>{state.exports.signoffReadiness.toUpperCase()}</b></span>
+      <Panel title="MASTERING TECHNICAL">
+        <div className="sfi-production__metric-grid">
+          {['lufs', 'true_peak', 'loudness_range', 'crest_factor', 'clippingRisk', 'headroom', 'stereo_width', 'tonal_balance'].map((key) => metricByKey(state, key) ?? {
+            key,
+            label: key.replace(/_/g, ' ').toUpperCase(),
+            value: null,
+            unit: null,
+            status: 'MISSING' as MetricStatus,
+            source: null,
+            evidenceIds: [],
+            confidence: 0,
+            observedAt: null,
+            formulaVersion: null,
+            warnings: ['MASTERING_FEATURE_REQUIRED'],
+            explanation: 'No persisted mastering technical feature row exists for this value.',
+          }).map((metric) => <MetricCard key={metric.key} metric={metric} />)}
         </div>
       </Panel>
     </div>
   );
 }
 
-function NeuralAudioGraphScreen({ state, onOpenIntake }: { state: StudioProductionState; onOpenIntake: () => void }) {
+function Structure({ state }: { state: StudioProductionState }) {
   return (
-    <>
-      <PixiPanel state={state} variant="graph" title="NEURAL AUDIO GRAPH" subtitle="CAUSAL GRAPH / FEATURE LAYERS / MIHM LINKS" />
-      <div className="sfi-production__grid">
-        <Panel title="NODE INSPECTOR" action={<button type="button" onClick={onOpenIntake}>INTAKE</button>}>
-          {state.objectFeatures.graph.nodes.map((node) => <p key={node.id}>{node.label} / {node.layer} / {metric(node.value)}</p>)}
-          {!state.objectFeatures.graph.nodes.length && <p>GRAPH_REQUIRES_OBJECT_FEATURES</p>}
-        </Panel>
-        <Panel title="CAUSAL EXPLANATION">
-          {state.objectFeatures.graph.edges.map((edge) => <p key={`${edge.from}-${edge.to}`}>{edge.from} - {edge.to} / {metric(edge.weight)}</p>)}
-          {!state.objectFeatures.graph.edges.length && <p>NO_WEIGHTED_EDGES</p>}
-        </Panel>
-      </div>
-    </>
-  );
-}
-
-function MemoryArchivesScreen({ state }: { state: StudioProductionState }) {
-  return (
-    <>
-      <PixiPanel state={state} variant="archive" title="MEMORY / ARCHIVES" subtitle="LONGITUDINAL TRACE / EVIDENCE DOTS" />
-      <div className="sfi-production__grid">
-        <Panel title="ARCHIVE EVENTS" action={<a href="/api/studio/archive">API</a>}>
-          {state.archive.events.length ? state.archive.events.map((event) => <p key={event.id}>{event.label}</p>) : <p>NO_ARCHIVE_EVENTS</p>}
-        </Panel>
-        <Panel title="EVIDENCE INTEGRITY">{state.archive.integrity.toUpperCase()}</Panel>
-      </div>
-    </>
-  );
-}
-
-function DeliverablesScreen({ state }: { state: StudioProductionState }) {
-  return (
-    <div className="sfi-production__screen-grid">
-      <Panel title="EXPORT PACKAGES" action={<a href="/api/studio/deliverables">API</a>}>
-        {state.exports.packages.length ? state.exports.packages.map((item) => <p key={item.id}>{item.label}</p>) : <p>NO_EXPORT_PACKAGES</p>}
+    <div className="sfi-production__module">
+      <Panel title="LAYERS">
+        <p>{state.objectFeatures.layers.length ? 'Persisted generic feature rows exist, but no stem/layer evidence is connected.' : 'MULTILAYER_EVIDENCE_REQUIRED'}</p>
+        <StatusPill status="MISSING" />
       </Panel>
-      <Panel title="SIGNOFF READINESS">{state.exports.signoffReadiness.toUpperCase()}</Panel>
-      <Panel title="BUILD EXPORT" action={<a href="/api/studio/exports/build">POST</a>}>
-        <p>Export builder returns blocked until evidence bundle and destination are connected.</p>
+      <Panel title="ARRANGEMENTS">
+        <p>Blocked until stems, layers, sections or events are persisted.</p>
+      </Panel>
+      <Panel title="MIX">
+        <p>No faders rendered: real channels are required for mute, solo, meter, masking, panorama, correlation and energy controls.</p>
+      </Panel>
+      <Panel title="NEURAL GRAPH">
+        <FieldGraphInspector state={state} />
       </Panel>
     </div>
   );
 }
 
-function SettingsScreen({ state }: { state: StudioProductionState }) {
+function Field({ state }: { state: StudioProductionState }) {
+  const internal = ['mihm_activation', 'feature_coverage'].map((key) => metricByKey(state, key)).filter((metric): metric is MetricValue => Boolean(metric));
+  const cultural = metricByKey(state, 'cultural_resonance');
+
   return (
-    <div className="sfi-production__screen-grid">
-      <Panel title="PROVENANCE">{state.provenance.basedOn.map((item) => <p key={item}>{item}</p>)}</Panel>
-      <Panel title="DEGRADED SOURCES">{state.degradedSources.length ? state.degradedSources.map((item) => <p key={item}>{item}</p>) : <p>NONE_DECLARED</p>}</Panel>
-      <Panel title="LIMITS">{state.provenance.limits.map((item) => <p key={item}>{item}</p>)}</Panel>
+    <div className="sfi-production__module">
+      <Panel title="INTERNAL SIGNAL">
+        <p>INTERNAL_SIGNAL_RANKING / NOT_EXTERNAL_PREDICTION / PROVISIONAL_NO_TRACEABILITY_NO_HISTORICAL_CALIBRATION</p>
+        <div className="sfi-production__metric-grid">{internal.map((metric) => <MetricCard key={metric.key} metric={metric} />)}</div>
+      </Panel>
+      <Panel title="CULTURAL FIELD">
+        <MetricCard metric={cultural ?? { key: 'cultural_resonance', label: 'Cultural Resonance', value: null, unit: null, status: 'MISSING', source: null, evidenceIds: [], confidence: 0, observedAt: null, formulaVersion: null, warnings: ['CULTURAL_VECTOR_REQUIRED'], explanation: 'Cultural Vector evidence is unavailable.' }} />
+      </Panel>
+      <Panel title="WORLD TIMING">
+        <dl className="sfi-production__object-grid">
+          <dt>Snapshot ID</dt><dd>MISSING</dd>
+          <dt>Observed At</dt><dd>{state.culturalLens?.observedAt ?? 'MISSING'}</dd>
+          <dt>Confidence</dt><dd>{state.culturalLens ? Number(state.culturalLens.confidence.toFixed(3)) : 'MISSING'}</dd>
+          <dt>Degraded Sources</dt><dd>{state.culturalLens?.warnings.join(', ') || 'MISSING'}</dd>
+          <dt>Regime</dt><dd>MISSING</dd>
+          <dt>Timing Fit</dt><dd>{state.culturalLens ? state.culturalLens.status.toUpperCase() : 'MISSING'}</dd>
+        </dl>
+      </Panel>
+      <Panel title="FIELD TENSIONS">
+        {state.fieldGraph.nodes.filter((node) => node.type === 'hypothesis').map((node) => <MetricCard key={node.id} metric={{ key: node.id, label: node.label, value: node.value, unit: null, status: node.status, source: node.source, evidenceIds: node.evidenceIds, confidence: node.confidence, observedAt: null, formulaVersion: node.formulaVersion, warnings: [], explanation: node.explanation }} />)}
+        {!state.fieldGraph.nodes.some((node) => node.type === 'hypothesis') ? <p>No tensions generated: relationships require MIHM, Cultural Vector, WSV, external evidence or declared attractor evidence.</p> : null}
+      </Panel>
+    </div>
+  );
+}
+
+function Intervention({ state }: { state: StudioProductionState }) {
+  const hypotheses = state.fieldGraph.nodes.filter((node) => node.type === 'hypothesis');
+  return (
+    <div className="sfi-production__module">
+      <Panel title="MINIMUM PERTURBATION">
+        {!hypotheses.length ? <p>No mostrar intervencion: no existe hipotesis activa.</p> : hypotheses.map((node) => <p key={node.id}>{node.explanation}</p>)}
+      </Panel>
+      <Panel title="CANDIDATE ACTIONS">
+        {state.interventions.length ? state.interventions.map((item) => <p key={item.id}>{item.title} / {item.state} / {item.source}</p>) : <p>NO_VERIFIED_INTERVENTION_QUEUE</p>}
+      </Panel>
+      <Panel title="SIMULATION">
+        <p>SIMULATION_NOT_AVAILABLE</p>
+        <p>El endpoint POST existe, pero declara `simulation_engine_not_connected`; no se muestra boton.</p>
+      </Panel>
+      <Panel title="VERIFICATION WINDOW">
+        <p>72 h, 7 d y 30 d se habilitan solo cuando una hipotesis persistida declara tipo y expectedSignal.</p>
+      </Panel>
+      <Panel title="OUTCOME REGISTRATION">
+        <p>Registrar outcome requiere endpoint de persistencia explicito. No se muestra control hasta que exista.</p>
+      </Panel>
+    </div>
+  );
+}
+
+function Memory({ state }: { state: StudioProductionState }) {
+  return (
+    <div className="sfi-production__module">
+      <Panel title="SESSIONS">
+        <table className="sfi-production__table">
+          <thead><tr><th>Session</th><th>Object</th><th>Date</th><th>Phase</th><th>Status</th><th>Evidence</th><th>Hypothesis</th><th>Intervention</th><th>Outcome</th><th>Confidence</th></tr></thead>
+          <tbody>
+            <tr>
+              <td>{state.session.id ?? 'MISSING'}</td>
+              <td>{state.activeObject.id ?? 'MISSING'}</td>
+              <td>{state.session.updatedAt ?? state.generatedAt}</td>
+              <td>{state.phaseStates.find((item) => item.status !== 'COMPLETE' && item.status !== 'OBSERVED')?.label ?? 'COMPLETE'}</td>
+              <td>{state.systemState}</td>
+              <td>{state.evidence.length}</td>
+              <td>{state.fieldGraph.nodes.filter((node) => node.type === 'hypothesis').length}</td>
+              <td>{state.interventions.length}</td>
+              <td>{state.archive.events.filter((event) => event.label.toLowerCase().includes('outcome')).length}</td>
+              <td>{Number(Math.max(...state.metricValues.map((metric) => metric.confidence), 0).toFixed(3))}</td>
+            </tr>
+          </tbody>
+        </table>
+      </Panel>
+      <Panel title="TIMELINE"><PhaseList phases={state.phaseStates} /></Panel>
+      <Panel title="ARCHIVES">
+        {state.archive.events.length ? state.archive.events.map((event) => <p key={event.id}>{event.time} / {event.label} / {event.source}</p>) : <p>NO_ARCHIVE_EVENTS</p>}
+      </Panel>
+      <Panel title="VERSIONS">
+        <p>{state.activeObject.version ? `Active version: ${state.activeObject.version}` : 'No comparable versions persisted for this object.'}</p>
+      </Panel>
+      <Panel title="DELIVERABLES">
+        {state.exports.packages.length ? state.exports.packages.map((item) => (
+          <p key={item.id}>{item.label} / {item.state} {item.url ? <a href={item.url}>DESCARGAR</a> : null}</p>
+        )) : <p>BLOCKED: no studio_exports rows. Generation buttons are hidden until real generation endpoints exist.</p>}
+      </Panel>
+      <Panel title="LEARNING">
+        <p>No ajustar pesos automaticamente: falta muestra minima definida y learning archive event.</p>
+      </Panel>
     </div>
   );
 }
 
 function Screen({ active, state, onOpenIntake }: { active: StudioProductionScreen; state: StudioProductionState; onOpenIntake: () => void }) {
   switch (active) {
-    case 'sessions': return <SessionsScreen state={state} onOpenIntake={onOpenIntake} />;
-    case 'live-desk': return <LiveDeskScreen state={state} />;
-    case 'composition': return <CompositionScreen state={state} />;
-    case 'sound-design': return <SoundDesignScreen state={state} />;
-    case 'arrangements': return <ArrangementsScreen state={state} />;
-    case 'mix-console': return <MixConsoleScreen state={state} />;
-    case 'mastering': return <MasteringScreen state={state} />;
-    case 'neural-audio-graph': return <NeuralAudioGraphScreen state={state} onOpenIntake={onOpenIntake} />;
-    case 'memory-archives': return <MemoryArchivesScreen state={state} />;
-    case 'deliverables': return <DeliverablesScreen state={state} />;
-    case 'settings': return <SettingsScreen state={state} />;
+    case 'measure': return <Measure state={state} />;
+    case 'structure': return <Structure state={state} />;
+    case 'field': return <Field state={state} />;
+    case 'intervention': return <Intervention state={state} />;
+    case 'memory': return <Memory state={state} />;
     case 'overview':
     default:
-      return <OverviewScreen state={state} onOpenIntake={onOpenIntake} />;
+      return <Overview state={state} onOpenIntake={onOpenIntake} />;
   }
 }
 
@@ -368,7 +461,6 @@ export function StudioProductionShell({ state }: { state: StudioProductionState 
         <StudioFooterTransport state={state} />
         <StudioEvaluationStrip state={state} />
       </section>
-      <StudioRightRail state={state} />
       <StudioObjectIntake open={intakeOpen} onClose={() => setIntakeOpen(false)} />
       <style jsx global>{css}</style>
     </main>
@@ -377,158 +469,118 @@ export function StudioProductionShell({ state }: { state: StudioProductionState 
 
 const productionCss = `
 .sfi-production {
-  --bg: #050309;
-  --panel: rgba(8, 5, 14, .92);
-  --panel2: rgba(15, 7, 22, .95);
-  --line: rgba(186, 92, 255, .28);
-  --line2: rgba(69, 240, 255, .18);
-  --pink: #ff79d9;
-  --purple: #ba5cff;
-  --cyan: #45f0ff;
-  --orange: #ff9f43;
-  --green: #7cffb2;
-  --red: #ff5f7a;
-  --text: #f2e9ff;
-  --muted: #9584a7;
+  --bg: #05020a;
+  --panel: rgba(12, 7, 18, .94);
+  --panel2: rgba(18, 9, 27, .96);
+  --line: rgba(154, 92, 255, .28);
+  --line2: rgba(69, 220, 235, .2);
+  --purple: #9d5cff;
+  --cyan: #45dceb;
+  --orange: #f59e42;
+  --green: #78e6a3;
+  --red: #ee5d70;
+  --missing: #787184;
+  --text: #efe8fb;
+  --muted: #9b8daa;
   min-height: 100vh;
   display: grid;
-  grid-template-columns: 230px minmax(0, 1fr) 280px;
+  grid-template-columns: 220px minmax(0, 1fr);
   gap: 10px;
   padding: 10px;
-  background:
-    radial-gradient(circle at 50% 30%, rgba(186, 92, 255, .18), transparent 42%),
-    radial-gradient(circle at 78% 58%, rgba(69, 240, 255, .09), transparent 34%),
-    linear-gradient(135deg, rgba(255, 121, 217, .06), transparent 28%, rgba(69, 240, 255, .05)),
-    var(--bg);
+  background: radial-gradient(circle at 52% 32%, rgba(157,92,255,.14), transparent 38%), linear-gradient(135deg, #05020a, #0c0613 48%, #040208);
   color: var(--text);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 .sfi-production * { box-sizing: border-box; }
-.sfi-production button, .sfi-production a {
-  border: 1px solid var(--line);
-  background: rgba(255, 121, 217, .06);
-  color: var(--text);
-  text-decoration: none;
-  font: 700 10px ui-monospace, monospace;
-  letter-spacing: .12em;
-  text-transform: uppercase;
-  cursor: pointer;
-}
-.sfi-production__sidebar,
-.sfi-production__right-rail,
-.sfi-production__header,
-.sfi-production__panel,
-.sfi-production__live-panel,
-.sfi-production__transport,
-.sfi-production__evaluation-strip {
-  border: 1px solid var(--line);
-  background: linear-gradient(180deg, rgba(15, 7, 22, .95), rgba(5, 3, 9, .94));
-  box-shadow: inset 0 0 40px rgba(186, 92, 255, .045), 0 0 28px rgba(69, 240, 255, .035);
-}
-.sfi-production__sidebar { display: grid; grid-template-rows: auto 1fr auto; min-height: calc(100vh - 20px); overflow: hidden; }
+.sfi-production button, .sfi-production a { border: 1px solid var(--line); background: rgba(157,92,255,.08); color: var(--text); text-decoration: none; font: 800 10px ui-monospace, monospace; letter-spacing: .08em; text-transform: uppercase; cursor: pointer; }
+.sfi-production button:disabled { cursor: not-allowed; opacity: .45; }
+.sfi-production__sidebar, .sfi-production__header, .sfi-production__panel, .sfi-production__field-panel, .sfi-production__transport, .sfi-production__evaluation-strip { border: 1px solid var(--line); background: linear-gradient(180deg, var(--panel2), var(--panel)); box-shadow: inset 0 0 36px rgba(157,92,255,.04); }
+.sfi-production__sidebar { display: grid; grid-template-rows: auto 1fr auto; min-height: calc(100vh - 20px); }
 .sfi-production__brand { display: flex; align-items: center; gap: 12px; padding: 18px; border-bottom: 1px solid var(--line); }
-.sfi-production__mark { width: 32px; height: 32px; border: 1px solid var(--pink); border-radius: 50%; box-shadow: 0 0 24px rgba(255, 121, 217, .38); }
-.sfi-production__brand strong { display: block; font-size: 20px; letter-spacing: .18em; }
-.sfi-production__brand em { display: block; color: var(--pink); font-style: normal; font-size: 10px; letter-spacing: .32em; }
-.sfi-production__sidebar nav { display: grid; align-content: start; gap: 4px; padding: 12px; }
-.sfi-production__sidebar nav button { width: 100%; padding: 10px 12px; text-align: left; color: var(--muted); display: grid; grid-template-columns: 28px 1fr; gap: 10px; align-items: center; }
-.sfi-production__sidebar nav button span { color: var(--pink); opacity: .82; }
-.sfi-production__sidebar nav button b { font-size: 9px; font-weight: 800; }
-.sfi-production__sidebar nav button.is-active { color: var(--cyan); border-color: var(--cyan); background: linear-gradient(90deg, rgba(69, 240, 255, .12), rgba(255, 121, 217, .06)); box-shadow: inset 0 0 28px rgba(69, 240, 255, .08); }
+.sfi-production__mark { width: 30px; height: 30px; border: 1px solid var(--purple); border-radius: 50%; box-shadow: 0 0 18px rgba(157,92,255,.3); }
+.sfi-production__brand strong { display: block; font-size: 20px; letter-spacing: .16em; }
+.sfi-production__brand em { display: block; color: var(--cyan); font-style: normal; font-size: 10px; letter-spacing: .26em; }
+.sfi-production__sidebar nav { display: grid; align-content: start; gap: 5px; padding: 12px; }
+.sfi-production__sidebar nav button { width: 100%; display: grid; grid-template-columns: 28px 1fr; gap: 10px; padding: 11px; text-align: left; color: var(--muted); }
+.sfi-production__sidebar nav button.is-active { border-color: var(--cyan); color: var(--cyan); background: rgba(69,220,235,.09); }
 .sfi-production__side-status { padding: 14px; border-top: 1px solid var(--line); }
-.sfi-production__side-status span, .sfi-production__panel header span, .sfi-production__right-rail span, .sfi-production__transport span { color: var(--muted); font-size: 9px; letter-spacing: .18em; text-transform: uppercase; }
+.sfi-production__side-status span, .sfi-production__panel header span, .sfi-production__field-panel header span, .sfi-production__transport span { color: var(--muted); font-size: 9px; letter-spacing: .15em; text-transform: uppercase; }
 .sfi-production__side-status strong { display: block; margin-top: 8px; color: var(--green); }
-.sfi-production__side-status p, .sfi-production__panel p, .sfi-production__right-rail p, .sfi-overview__dock p { color: var(--muted); font-size: 10px; line-height: 1.55; }
-.sfi-production__main { display: grid; grid-template-rows: auto minmax(540px, 1fr) auto auto; gap: 10px; min-width: 0; }
-.sfi-production__header { display: grid; grid-template-columns: 1fr 1.3fr auto; gap: 16px; padding: 14px 18px; align-items: center; }
-.sfi-production__header span { display: block; color: var(--muted); font-size: 9px; letter-spacing: .2em; }
-.sfi-production__header strong { display: block; margin-top: 5px; color: var(--pink); font-size: 12px; letter-spacing: .16em; }
-.sfi-production__header-state { text-align: right; }
-.sfi-production__header-state em { display: block; color: var(--cyan); font-style: normal; font-size: 10px; margin-top: 5px; }
-.sfi-production__live-panel { min-height: 430px; display: grid; grid-template-rows: auto 1fr; }
-.sfi-production__live-panel > header { display: flex; justify-content: space-between; gap: 12px; padding: 12px 14px; border-bottom: 1px solid var(--line); }
-.sfi-production__live-panel > header span { display: block; color: var(--pink); font-size: 10px; letter-spacing: .22em; }
-.sfi-production__live-panel > header strong { display: block; color: var(--muted); font-size: 9px; letter-spacing: .18em; margin-top: 4px; }
-.sfi-production__live-panel > header em { color: var(--green); font-style: normal; font-size: 10px; letter-spacing: .16em; }
-.sfi-production__pixi-stage { position: relative; min-height: 390px; overflow: hidden; background: radial-gradient(circle at 50% 50%, rgba(186, 92, 255, .18), transparent 48%); }
+.sfi-production__side-status p, .sfi-production__panel p, .sfi-production__panel dd, .sfi-production__panel td { color: var(--muted); font-size: 11px; line-height: 1.5; }
+.sfi-production__main { display: grid; grid-template-rows: auto minmax(0, 1fr) auto auto; gap: 10px; min-width: 0; }
+.sfi-production__header { display: grid; grid-template-columns: 1fr 1.2fr auto; gap: 16px; padding: 14px 18px; align-items: center; }
+.sfi-production__header span { display: block; color: var(--muted); font-size: 9px; letter-spacing: .16em; }
+.sfi-production__header strong { display: block; margin-top: 5px; color: var(--purple); font-size: 12px; letter-spacing: .12em; }
+.sfi-production__module { display: grid; gap: 10px; align-content: start; }
+.sfi-production__overview-grid { display: grid; grid-template-columns: minmax(260px, .9fr) minmax(360px, 1.4fr) minmax(260px, .9fr); gap: 10px; }
+.sfi-production__panel { min-height: 128px; padding: 14px; overflow: hidden; }
+.sfi-production__panel header, .sfi-production__field-panel header { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 12px; }
+.sfi-production__panel header button, .sfi-production__panel header a { padding: 7px 9px; }
+.sfi-production__object-grid { display: grid; grid-template-columns: 130px minmax(0, 1fr); gap: 8px 12px; margin: 0; }
+.sfi-production__object-grid dt { color: var(--cyan); font-size: 10px; text-transform: uppercase; }
+.sfi-production__object-grid dd { margin: 0; overflow-wrap: anywhere; }
+.sfi-production__status { display: inline-block; border: 1px solid currentColor; padding: 3px 6px; font-size: 9px; color: var(--muted); }
+.sfi-production__status.is-observed, .sfi-production__status.is-complete { color: var(--green); }
+.sfi-production__status.is-derived { color: var(--cyan); }
+.sfi-production__status.is-degraded, .sfi-production__status.is-pending { color: var(--orange); }
+.sfi-production__status.is-missing { color: var(--missing); }
+.sfi-production__status.is-failed { color: var(--red); }
+.sfi-production__phase-list { display: grid; gap: 7px; margin: 0; padding: 0; list-style: none; }
+.sfi-production__phase-list li { border: 1px solid var(--line2); padding: 8px; }
+.sfi-production__phase-list li div { display: flex; justify-content: space-between; gap: 8px; }
+.sfi-production__phase-list li span { color: var(--text); font-size: 10px; }
+.sfi-production__phase-list li i { display: block; height: 6px; border: 1px solid var(--line2); margin-top: 8px; }
+.sfi-production__phase-list li i b { display: block; height: 100%; background: var(--green); }
+.sfi-production__evidence-matrix { display: grid; gap: 8px; }
+.sfi-production__evidence-matrix details { border: 1px solid var(--line2); padding: 8px; }
+.sfi-production__evidence-matrix summary { cursor: pointer; display: flex; justify-content: space-between; color: var(--cyan); }
+.sfi-production__reading { display: grid; gap: 7px; }
+.sfi-production__reading span { color: var(--cyan); font-size: 10px; text-transform: uppercase; }
+.sfi-production__reading strong { color: var(--orange); }
+.sfi-production__next-action strong { display: block; color: var(--cyan); font-size: 16px; }
+.sfi-production__next-action span, .sfi-production__next-action em { display: block; color: var(--orange); font-style: normal; margin: 8px 0; }
+.sfi-production__next-action button { padding: 10px 12px; }
+.sfi-production__action-result { border: 1px solid var(--line2); padding: 8px; }
+.sfi-production__metric-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 10px; }
+.sfi-production__metric-card { border: 1px solid var(--line2); padding: 10px; background: rgba(5,2,10,.38); }
+.sfi-production__metric-card div { display: flex; justify-content: space-between; gap: 8px; }
+.sfi-production__metric-card span { color: var(--muted); font-size: 10px; text-transform: uppercase; }
+.sfi-production__metric-card strong { display: block; margin: 10px 0; color: var(--cyan); font-size: 18px; overflow-wrap: anywhere; }
+.sfi-production__metric-card dl { display: grid; grid-template-columns: 78px minmax(0,1fr); gap: 5px; margin: 10px 0 0; }
+.sfi-production__metric-card dt { color: var(--cyan); font-size: 9px; }
+.sfi-production__metric-card dd { margin: 0; overflow-wrap: anywhere; }
+.sfi-production__warning { color: var(--orange) !important; }
+.sfi-production__field-panel { min-height: 430px; display: grid; grid-template-rows: auto minmax(360px, 1fr); }
+.sfi-production__pixi-stage { position: relative; min-height: 360px; overflow: hidden; background: radial-gradient(circle at 50% 50%, rgba(157,92,255,.16), transparent 48%); }
 .sfi-production__pixi-host, .sfi-production__pixi-host canvas, .sfi-production__pixi-fallback { position: absolute; inset: 0; width: 100%; height: 100%; }
 .sfi-production__pixi-host { z-index: 2; }
-.sfi-production__pixi-fallback { z-index: 1; opacity: .42; }
-.sfi-production__pixi-fallback circle { fill: var(--pink); opacity: .55; }
-.sfi-production__pixi-fallback text { fill: var(--muted); font-size: 5px; letter-spacing: .25em; }
-.sfi-overview { min-height: 100%; display: grid; grid-template-rows: auto minmax(430px, 1fr) auto; gap: 10px; }
-.sfi-overview__topline { border: 1px solid var(--line); background: linear-gradient(90deg, rgba(255, 121, 217, .08), rgba(69, 240, 255, .04)); padding: 12px 14px; display: flex; align-items: center; justify-content: space-between; box-shadow: inset 0 0 40px rgba(255, 121, 217, .035); }
-.sfi-overview__topline span, .sfi-overview__micro span, .sfi-overview__dock header span, .sfi-overview__bar span, .sfi-overview__blocked span { display: block; color: var(--muted); font-size: 9px; letter-spacing: .2em; text-transform: uppercase; }
-.sfi-overview__topline strong { display: block; margin-top: 4px; color: var(--pink); font-size: 14px; letter-spacing: .22em; }
-.sfi-overview__topline button { padding: 10px 14px; }
-.sfi-overview__field { position: relative; min-height: 500px; border: 1px solid var(--line); overflow: hidden; background: radial-gradient(circle at 50% 45%, rgba(186, 92, 255, .24), transparent 34%), linear-gradient(180deg, rgba(8, 5, 14, .96), rgba(5, 3, 9, .98)); box-shadow: inset 0 0 90px rgba(69, 240, 255, .035), inset 0 0 120px rgba(255, 121, 217, .055); }
-.sfi-overview__field:before { content: ''; position: absolute; inset: 0; background-image: linear-gradient(rgba(186, 92, 255, .13) 1px, transparent 1px), linear-gradient(90deg, rgba(69, 240, 255, .08) 1px, transparent 1px); background-size: 36px 36px; opacity: .28; z-index: 0; }
-.sfi-overview__field .sfi-production__pixi-stage { position: absolute; inset: 0; min-height: 100%; z-index: 1; background: transparent; }
-.sfi-overview__micro { position: absolute; z-index: 4; width: min(285px, 30%); padding: 12px; border: 1px solid var(--line2); background: rgba(5, 3, 9, .72); backdrop-filter: blur(8px); box-shadow: inset 0 0 28px rgba(69, 240, 255, .04); }
-.sfi-overview__micro strong { display: block; margin-top: 8px; color: var(--cyan); font-size: 13px; letter-spacing: .08em; text-transform: uppercase; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.sfi-overview__micro p { margin: 8px 0 0; color: var(--muted); font-size: 9px; line-height: 1.45; max-height: 42px; overflow: hidden; }
-.sfi-overview__micro--left { top: 18px; left: 18px; }
-.sfi-overview__micro--right { top: 18px; right: 18px; text-align: right; }
-.sfi-overview__micro--bottom-left { bottom: 18px; left: 18px; }
-.sfi-overview__micro--bottom-right { bottom: 18px; right: 18px; text-align: right; }
-.sfi-overview__frame { position: absolute; z-index: 3; pointer-events: none; border: 1px solid rgba(255, 121, 217, .16); }
-.sfi-overview__frame--a { inset: 54px 72px; box-shadow: 0 0 70px rgba(255, 121, 217, .05); }
-.sfi-overview__frame--b { inset: 96px 146px; border-color: rgba(69, 240, 255, .16); transform: skewX(-4deg); }
-.sfi-overview__blocked { position: absolute; z-index: 5; left: 50%; top: 50%; transform: translate(-50%, -50%); width: min(430px, 70%); padding: 18px; text-align: center; border: 1px solid rgba(255, 95, 122, .5); background: rgba(10, 4, 12, .78); backdrop-filter: blur(10px); box-shadow: 0 0 48px rgba(255, 95, 122, .12); }
-.sfi-overview__blocked strong { display: block; color: var(--red); margin: 10px 0; letter-spacing: .18em; }
-.sfi-overview__blocked p { color: var(--muted); font-size: 10px; }
-.sfi-overview__lower { display: grid; grid-template-columns: 1.35fr .9fr .95fr; gap: 10px; }
-.sfi-overview__dock { min-height: 150px; padding: 12px; border: 1px solid var(--line); background: linear-gradient(180deg, rgba(15, 7, 22, .92), rgba(5, 3, 9, .96)); box-shadow: inset 0 0 32px rgba(186, 92, 255, .04); }
-.sfi-overview__dock header { display: flex; justify-content: space-between; gap: 10px; margin-bottom: 10px; }
-.sfi-overview__dock header b { color: var(--pink); font-size: 9px; letter-spacing: .14em; }
-.sfi-overview__bar { display: grid; grid-template-columns: 92px 1fr 42px; gap: 10px; align-items: center; margin: 8px 0; }
-.sfi-overview__bar i { display: block; height: 8px; background: rgba(255,255,255,.04); border: 1px solid var(--line2); overflow: hidden; }
-.sfi-overview__bar b { display: block; height: 100%; background: var(--cyan); box-shadow: 0 0 18px rgba(69, 240, 255, .32); }
-.sfi-overview__bar em { color: var(--muted); font-style: normal; font-size: 9px; text-align: right; }
-.sfi-overview__bar.is-pink b { background: var(--pink); box-shadow: 0 0 18px rgba(255, 121, 217, .32); }
-.sfi-overview__bar.is-orange b { background: var(--orange); box-shadow: 0 0 18px rgba(255, 159, 67, .24); }
-.sfi-overview__bar.is-green b { background: var(--green); box-shadow: 0 0 18px rgba(124, 255, 178, .24); }
-.sfi-production__grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; margin-top: 10px; }
-.sfi-production__screen-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; align-content: start; }
-.sfi-production__panel { min-height: 140px; padding: 14px; }
-.sfi-production__panel header { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 14px; }
-.sfi-production__panel header a, .sfi-production__panel header button { padding: 7px 9px; }
-.sfi-production__object-card strong { display: block; color: var(--text); font-size: 18px; letter-spacing: .08em; text-transform: uppercase; }
-.sfi-production__object-card span { display: block; color: var(--cyan); margin-top: 10px; font-size: 10px; letter-spacing: .16em; }
-.sfi-production__metric-list { display: grid; gap: 8px; }
-.sfi-production__metric-list span { display: flex; justify-content: space-between; gap: 10px; border-bottom: 1px solid var(--line2); padding-bottom: 6px; color: var(--muted); font-size: 10px; }
-.sfi-production__metric-list b { color: var(--cyan); }
-.sfi-production__pipeline { display: grid; gap: 6px; margin: 0; padding: 0; list-style: none; }
-.sfi-production__pipeline li { padding: 7px 9px; border: 1px solid var(--line2); color: var(--muted); font-size: 10px; letter-spacing: .12em; }
-.sfi-production__pipeline li.is-live { color: var(--green); border-color: rgba(124, 255, 178, .32); background: rgba(124, 255, 178, .035); }
-.sfi-production__filter-row { display: flex; gap: 8px; flex-wrap: wrap; }
-.sfi-production__filter-row button { padding: 9px 10px; }
-.sfi-production__faders { display: grid; grid-template-columns: repeat(8, minmax(64px, 1fr)); gap: 8px; min-height: 260px; padding: 14px; border: 1px solid var(--line); background: var(--panel); align-items: end; }
-.sfi-production__faders div { height: 230px; display: grid; grid-template-rows: auto 1fr auto; justify-items: center; gap: 8px; color: var(--muted); font-size: 9px; }
-.sfi-production__faders i { width: 18px; align-self: end; background: linear-gradient(180deg, var(--pink), var(--cyan)); box-shadow: 0 0 24px rgba(255, 121, 217, .35); }
-.sfi-production__right-rail { display: grid; gap: 8px; align-content: start; padding: 8px; min-height: calc(100vh - 20px); }
-.sfi-production__right-rail section { border: 1px solid var(--line2); padding: 12px; background: rgba(5, 3, 9, .58); }
-.sfi-production__right-rail strong { display: block; margin: 10px 0; color: var(--cyan); font-size: 22px; letter-spacing: .08em; }
-.sfi-production__right-rail a { display: block; margin-top: 8px; padding: 8px; }
-.sfi-production__right-rail b { color: var(--orange); font-size: 9px; }
-.sfi-production__transport { display: grid; grid-template-columns: 1fr auto auto; gap: 12px; padding: 12px; align-items: center; }
-.sfi-production__transport strong, .sfi-production__transport a { display: block; margin-top: 5px; color: var(--cyan); }
+.sfi-production__pixi-fallback { z-index: 1; opacity: .5; }
+.sfi-production__pixi-fallback circle { fill: var(--cyan); opacity: .5; }
+.sfi-production__pixi-fallback text { fill: var(--muted); font-size: 5px; letter-spacing: .12em; }
+.sfi-production__node-layout { display: grid; grid-template-columns: 220px minmax(0,1fr); gap: 12px; }
+.sfi-production__node-list { display: grid; align-content: start; gap: 7px; }
+.sfi-production__node-list button { padding: 8px; text-align: left; }
+.sfi-production__node-list button.is-active { border-color: var(--cyan); color: var(--cyan); }
+.sfi-production__transport { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 12px; padding: 12px; }
+.sfi-production__transport strong { display: block; margin-top: 5px; color: var(--cyan); }
 .sfi-production__evaluation-strip { display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); gap: 1px; padding: 8px; }
 .sfi-production__evaluation-strip div { border: 1px solid var(--line2); padding: 9px; min-width: 0; }
-.sfi-production__evaluation-strip span, .sfi-production__evaluation-strip em { display: block; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; color: var(--muted); font-size: 8px; letter-spacing: .12em; font-style: normal; }
-.sfi-production__evaluation-strip strong { display: block; margin: 6px 0; color: var(--pink); font-size: 12px; }
-.sfi-production__intake { position: fixed; inset: 0; z-index: 30; display: grid; place-items: center; background: rgba(0, 0, 0, .72); backdrop-filter: blur(8px); }
-.sfi-production__intake-panel { position: relative; width: min(520px, calc(100vw - 32px)); border: 1px solid var(--line); background: rgba(8, 5, 14, .98); padding: 26px; box-shadow: 0 0 90px rgba(186, 92, 255, .24); }
+.sfi-production__evaluation-strip span, .sfi-production__evaluation-strip em { display: block; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; color: var(--muted); font-size: 8px; letter-spacing: .1em; font-style: normal; }
+.sfi-production__evaluation-strip strong { display: block; margin: 6px 0; color: var(--purple); font-size: 12px; }
+.sfi-production__intake { position: fixed; inset: 0; z-index: 30; display: grid; place-items: center; background: rgba(0,0,0,.72); backdrop-filter: blur(8px); }
+.sfi-production__intake-panel { position: relative; width: min(520px, calc(100vw - 32px)); border: 1px solid var(--line); background: rgba(8,5,14,.98); padding: 26px; box-shadow: 0 0 70px rgba(157,92,255,.22); }
 .sfi-production__intake-panel input { display: none; }
-.sfi-production__intake-panel h2 { color: var(--pink); letter-spacing: .12em; }
+.sfi-production__intake-panel h2 { color: var(--purple); letter-spacing: .1em; }
 .sfi-production__intake-panel p { color: var(--muted); line-height: 1.6; }
 .sfi-production__intake-panel button:not(.sfi-production__icon-button) { width: 100%; padding: 16px; margin-top: 14px; }
 .sfi-production__icon-button { position: absolute; top: 10px; right: 10px; width: 30px; height: 30px; }
+.sfi-production__table { width: 100%; border-collapse: collapse; min-width: 920px; }
+.sfi-production__table th, .sfi-production__table td { border: 1px solid var(--line2); padding: 8px; text-align: left; }
+.sfi-production__table th { color: var(--cyan); font-size: 9px; text-transform: uppercase; }
 @media (max-width: 1180px) {
-  .sfi-production { display: block; padding: 8px; }
-  .sfi-production__sidebar, .sfi-production__right-rail { min-height: auto; margin-bottom: 10px; }
-  .sfi-production__main { display: block; }
-  .sfi-overview__lower, .sfi-production__grid, .sfi-production__screen-grid { grid-template-columns: 1fr; }
-  .sfi-overview__field { min-height: 420px; }
+  .sfi-production { display: block; }
+  .sfi-production__sidebar { min-height: auto; margin-bottom: 10px; }
+  .sfi-production__overview-grid, .sfi-production__node-layout { grid-template-columns: 1fr; }
+  .sfi-production__header, .sfi-production__transport, .sfi-production__evaluation-strip { grid-template-columns: 1fr; }
 }
 `;

--- a/src/components/studio/production/StudioRightRail.tsx
+++ b/src/components/studio/production/StudioRightRail.tsx
@@ -1,11 +1,11 @@
 import type { StudioProductionState } from '@/lib/studio/production/studioProductionTypes';
 
 function value(value: number | null, suffix = '') {
-  return value === null ? 'SIN DATO' : `${value.toFixed(2)}${suffix}`;
+  return value === null ? 'SIN DATO' : `${Number(value.toFixed(3))}${suffix}`;
 }
 
 export function StudioRightRail({ state }: { state: StudioProductionState }) {
-  const hypotheses = state.hypotheses?.hypotheses.slice(0, 4) ?? [];
+  const hypotheses = state.fieldGraph.nodes.filter((item) => item.type === 'hypothesis').slice(0, 4);
 
   return (
     <aside className="sfi-production__right-rail">
@@ -22,19 +22,13 @@ export function StudioRightRail({ state }: { state: StudioProductionState }) {
       <section>
         <span>HYPOTHESES</span>
         {hypotheses.length ? hypotheses.map((item) => (
-          <a key={item.id} href="/api/studio/hypotheses/build">
-            <b>{item.severity.toUpperCase()}</b>
-            <p>{item.statement}</p>
-          </a>
+          <p key={item.id}>{item.status}: {item.explanation}</p>
         )) : <p>BLOCKED_UNTIL_OBJECT_FEATURES_EXIST</p>}
       </section>
       <section>
         <span>INTERVENTIONS</span>
         {state.interventions.length ? state.interventions.map((item) => (
-          <a key={item.id} href="/api/studio/interventions/simulate">
-            <b>{item.state.toUpperCase()}</b>
-            <p>{item.title}</p>
-          </a>
+          <p key={item.id}>{item.state.toUpperCase()}: {item.title}</p>
         )) : <p>NO_VERIFIED_INTERVENTION_QUEUE</p>}
       </section>
     </aside>

--- a/src/components/studio/production/StudioSidebar.tsx
+++ b/src/components/studio/production/StudioSidebar.tsx
@@ -2,29 +2,19 @@
 
 export type StudioProductionScreen =
   | 'overview'
-  | 'sessions'
-  | 'live-desk'
-  | 'composition'
-  | 'sound-design'
-  | 'arrangements'
-  | 'mix-console'
-  | 'mastering'
-  | 'neural-audio-graph'
-  | 'memory-archives'
-  | 'deliverables'
-  | 'settings';
+  | 'measure'
+  | 'structure'
+  | 'field'
+  | 'intervention'
+  | 'memory';
 
 export const studioProductionScreens: Array<{ id: StudioProductionScreen; label: string; code: string }> = [
-  { id: 'overview', label: 'Overview', code: '01' },
-  { id: 'sessions', label: 'Sessions', code: '02' },
-  { id: 'live-desk', label: 'Live Desk', code: '03' },
-  { id: 'composition', label: 'Composition', code: '04' },
-  { id: 'sound-design', label: 'Sound Design', code: '05' },
-  { id: 'arrangements', label: 'Arrangements', code: '06' },
-  { id: 'mix-console', label: 'Mix Console', code: '07' },
-  { id: 'mastering', label: 'Mastering', code: '08' },
-  { id: 'neural-audio-graph', label: 'Neural Audio Graph', code: '09' },
-  { id: 'memory-archives', label: 'Memory / Archives', code: '10' },
+  { id: 'overview', label: 'OVERVIEW', code: '01' },
+  { id: 'measure', label: 'MEASURE', code: '02' },
+  { id: 'structure', label: 'STRUCTURE', code: '03' },
+  { id: 'field', label: 'FIELD', code: '04' },
+  { id: 'intervention', label: 'INTERVENTION', code: '05' },
+  { id: 'memory', label: 'MEMORY', code: '06' },
 ];
 
 export function StudioSidebar({
@@ -45,7 +35,7 @@ export function StudioSidebar({
           <em>STUDIO</em>
         </div>
       </div>
-      <nav aria-label="Studio production screens">
+      <nav aria-label="Studio modules">
         {studioProductionScreens.map((screen) => (
           <button
             key={screen.id}
@@ -61,7 +51,7 @@ export function StudioSidebar({
       <div className="sfi-production__side-status">
         <span>SESSION STATUS</span>
         <strong>{sessionStatus.toUpperCase()}</strong>
-        <p>Core Studio surface only. No collaborator module mounted.</p>
+        <p>Canonical Studio object laboratory.</p>
       </div>
     </aside>
   );

--- a/src/components/studio/production/pixi/StudioPixiStage.tsx
+++ b/src/components/studio/production/pixi/StudioPixiStage.tsx
@@ -24,19 +24,14 @@ const renderers: Record<StudioPixiStageVariant, StudioPixiRenderer> = {
 };
 
 function fallbackPoints(state: StudioProductionState) {
-  const nodes = state.objectFeatures.graph.nodes;
+  const nodes = state.fieldGraph.nodes.filter((node) => node.status !== 'MISSING' && node.explanation);
   if (nodes.length) return nodes.map((node, index) => ({
     id: node.id,
     x: 50 + Math.cos(index * 1.7) * (22 + index * 2),
     y: 50 + Math.sin(index * 1.7) * (18 + index * 1.4),
-    value: node.value ?? 0.08,
+    value: typeof node.value === 'number' ? Math.max(0, Math.min(1, node.value > 1 ? node.value / 100 : node.value)) : node.confidence,
   }));
-  return Array.from({ length: 10 }, (_, index) => ({
-    id: `missing-vector-${index + 1}`,
-    x: 50 + Math.cos((index / 10) * Math.PI * 2) * 24,
-    y: 50 + Math.sin((index / 10) * Math.PI * 2) * 16,
-    value: 0.03,
-  }));
+  return [];
 }
 
 export function StudioPixiStage({ state, variant, label }: { state: StudioProductionState; variant: StudioPixiStageVariant; label: string }) {
@@ -111,7 +106,7 @@ export function StudioPixiStage({ state, variant, label }: { state: StudioProduc
         {fallback.map((point) => (
           <circle key={point.id} cx={point.x} cy={point.y} r={1.4 + point.value * 5} />
         ))}
-        {state.activeObject.id ? null : <text x="50" y="52" textAnchor="middle">MISSING_OBJECT</text>}
+        {!fallback.length ? <text x="50" y="52" textAnchor="middle">NO_RENDERABLE_NODES</text> : null}
       </svg>
       <div ref={hostRef} className="sfi-production__pixi-host" />
     </div>

--- a/src/components/studio/production/pixi/renderers/ArchiveTimelineRenderer.ts
+++ b/src/components/studio/production/pixi/renderers/ArchiveTimelineRenderer.ts
@@ -3,7 +3,17 @@ import { type StudioPixiRenderer } from './rendererTypes';
 export const ArchiveTimelineRenderer: StudioPixiRenderer = ({ PIXI, app, state, width, height, time }) => {
   const g = new PIXI.Graphics();
   const events = state.archive.events;
-  const count = Math.max(1, events.length);
+  if (!events.length) {
+    const label = new PIXI.Text({
+      text: 'NO_ARCHIVE_EVENTS',
+      style: { fill: 0x787184, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace', fontSize: 11, letterSpacing: 1.4 },
+    });
+    label.x = width / 2 - 78;
+    label.y = height / 2 - 8;
+    app.stage.addChild(label);
+    return;
+  }
+  const count = events.length;
   const y = height * 0.56;
   g.moveTo(24, y);
   g.lineTo(width - 24, y);
@@ -12,8 +22,8 @@ export const ArchiveTimelineRenderer: StudioPixiRenderer = ({ PIXI, app, state, 
   for (let i = 0; i < count; i += 1) {
     const x = 36 + (i / Math.max(1, count - 1)) * (width - 72);
     const pulse = 1 + Math.sin(time * 0.002 + i) * 0.2;
-    g.circle(x, y, (events.length ? 7 : 4) * pulse);
-    g.fill({ color: events.length ? 0xff79d9 : 0x392044, alpha: events.length ? 0.68 : 0.42 });
+    g.circle(x, y, 7 * pulse);
+    g.fill({ color: 0xff79d9, alpha: 0.68 });
     g.moveTo(x, y);
     g.lineTo(x, y - 45 - (i % 3) * 12);
     g.stroke({ width: 1, color: 0x45f0ff, alpha: 0.18 });

--- a/src/components/studio/production/pixi/renderers/NeuralGraphRenderer.ts
+++ b/src/components/studio/production/pixi/renderers/NeuralGraphRenderer.ts
@@ -1,17 +1,4 @@
-import { featureValues, safeValue, type StudioPixiRenderer } from './rendererTypes';
-
-const vectorLabels = [
-  'HARMONIC / MELODY',
-  'DRUMS / ONSET',
-  'BASS / LOW-END',
-  'VOCAL PRESENCE',
-  'ATMOSPHERE',
-  'FX / TEXTURE',
-  'MASTER CHAIN',
-  'MIHM VECTOR',
-  'COHERENCE',
-  'SYSTEM STRAIN',
-];
+import { safeValue, type StudioPixiRenderer } from './rendererTypes';
 
 function drawLabel(input: Parameters<StudioPixiRenderer>[0], text: string, x: number, y: number, fill: number) {
   const label = new input.PIXI.Text({
@@ -30,40 +17,41 @@ function drawLabel(input: Parameters<StudioPixiRenderer>[0], text: string, x: nu
 
 export const NeuralGraphRenderer: StudioPixiRenderer = ({ PIXI, app, state, width, height, time }) => {
   const g = new PIXI.Graphics();
-  const nodes = state.objectFeatures.graph.nodes;
-  const values = featureValues(state);
-  const count = Math.max(10, nodes.length || values.length || 10);
+  const nodes = state.fieldGraph.nodes.filter((node) => node.status !== 'MISSING' && node.explanation);
+  if (!nodes.length) {
+    drawLabel({ PIXI, app, state, width, height, time }, 'NO_RENDERABLE_GRAPH_NODES', width / 2 - 104, height / 2 - 8, 0x787184);
+    return;
+  }
+  const count = nodes.length;
   const cx = width / 2;
   const cy = height / 2;
   const radius = Math.min(width, height) * 0.28;
-  const density = state.activeObject.id ? 1 : 0.34;
 
   for (let i = 0; i < count; i += 1) {
     const angle = (i / count) * Math.PI * 2 + time * 0.00015;
-    const value = safeValue(nodes[i]?.value ?? values[i % Math.max(1, values.length)], state.activeObject.id ? 0.35 : 0.08);
+    const rawValue = nodes[i]?.value;
+    const value = typeof rawValue === 'number' ? safeValue(rawValue, 0) : nodes[i]?.confidence ?? 0;
     const x = cx + Math.cos(angle) * radius * (0.75 + value * 0.45);
     const y = cy + Math.sin(angle) * radius * (0.7 + value * 0.3);
     g.moveTo(cx, cy);
     g.lineTo(x, y);
-    g.stroke({ width: (1 + value * 2) * density, color: 0xba5cff, alpha: (0.18 + value * 0.45) * density });
+    g.stroke({ width: 1 + value * 2, color: 0xba5cff, alpha: 0.18 + value * 0.45 });
     g.circle(x, y, 4 + value * 10);
-    g.fill({ color: i % 3 === 0 ? 0x45f0ff : 0xff79d9, alpha: (0.32 + value * 0.55) * density });
+    g.fill({ color: i % 3 === 0 ? 0x45f0ff : 0xff79d9, alpha: 0.32 + value * 0.55 });
   }
 
   for (let ring = 0; ring < 5; ring += 1) {
     g.circle(cx, cy, 34 + ring * 28 + Math.sin(time * 0.001 + ring) * 3);
-    g.stroke({ width: 1, color: ring % 2 ? 0xff79d9 : 0x45f0ff, alpha: (0.1 + ring * 0.035) * density });
+    g.stroke({ width: 1, color: ring % 2 ? 0xff79d9 : 0x45f0ff, alpha: 0.1 + ring * 0.035 });
   }
 
-  g.circle(cx, cy, state.activeObject.id ? 28 : 18);
-  g.fill({ color: state.activeObject.id ? 0xff79d9 : 0x392044, alpha: state.activeObject.id ? 0.72 : 0.34 });
+  g.circle(cx, cy, 28);
+  g.fill({ color: 0xff79d9, alpha: 0.72 });
   app.stage.addChild(g);
 
-  vectorLabels.forEach((item, index) => {
-    const left = index % 2 === 0;
-    const x = left ? 18 : width - 160;
+  nodes.slice(0, 10).forEach((item, index) => {
+    const x = index % 2 === 0 ? 18 : width - 180;
     const y = 18 + Math.floor(index / 2) * 32;
-    const status = state.activeObject.id ? 'NO_TIME_SERIES_AVAILABLE' : 'MISSING';
-    drawLabel({ PIXI, app, state, width, height, time }, `${item}\n${status}`, x, y, left ? 0x45f0ff : 0xff79d9);
+    drawLabel({ PIXI, app, state, width, height, time }, `${item.label}\n${item.status}`, x, y, index % 2 === 0 ? 0x45f0ff : 0xff79d9);
   });
 };

--- a/src/components/studio/production/pixi/renderers/SpectralCloudRenderer.ts
+++ b/src/components/studio/production/pixi/renderers/SpectralCloudRenderer.ts
@@ -3,10 +3,19 @@ import { featureValues, safeValue, type StudioPixiRenderer } from './rendererTyp
 export const SpectralCloudRenderer: StudioPixiRenderer = ({ PIXI, app, state, width, height, time }) => {
   const g = new PIXI.Graphics();
   const values = state.audioFeatures.frequencyBands.length ? state.audioFeatures.frequencyBands : featureValues(state);
-  const usable = values.length ? values : [0.05, 0.08, 0.04, 0.02];
+  if (!values.length) {
+    const label = new PIXI.Text({
+      text: 'MISSING_SPECTRAL_FEATURES',
+      style: { fill: 0x787184, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace', fontSize: 11, letterSpacing: 1.4 },
+    });
+    label.x = width / 2 - 112;
+    label.y = height / 2 - 8;
+    app.stage.addChild(label);
+    return;
+  }
 
   for (let i = 0; i < 160; i += 1) {
-    const source = safeValue(usable[i % usable.length], 0.04);
+    const source = safeValue(values[i % values.length], 0);
     const angle = i * 2.399 + time * 0.00008;
     const spread = Math.sqrt(i / 160) * Math.min(width, height) * (0.18 + source * 0.55);
     const x = width / 2 + Math.cos(angle) * spread * 1.45;

--- a/src/components/studio/production/pixi/renderers/StudioOverviewFieldRenderer.ts
+++ b/src/components/studio/production/pixi/renderers/StudioOverviewFieldRenderer.ts
@@ -45,6 +45,7 @@ export const StudioOverviewFieldRenderer: StudioPixiRenderer = (input) => {
   const { PIXI, app, state, width, height, time } = input;
   const g = new PIXI.Graphics();
   const hasObject = Boolean(state.activeObject.id);
+  const nodes = state.fieldGraph.nodes.filter((node) => node.status !== 'MISSING' && node.explanation);
   const density = hasObject ? 1 : 0.26;
   const cx = width * 0.5;
   const cy = height * 0.52;
@@ -68,15 +69,21 @@ export const StudioOverviewFieldRenderer: StudioPixiRenderer = (input) => {
     g.lineTo(width, y);
   }
   g.stroke({ width: 1, color: 0x2c1738, alpha: 0.18 });
+  if (!nodes.length) {
+    app.stage.addChild(g);
+    drawMissingOverlay(input, state.degradedSources[0] ?? 'No explainable Studio nodes are available');
+    return;
+  }
 
   [0.16, 0.26, 0.36].forEach((factor, index) => {
     g.circle(cx, cy, min * factor + Math.sin(time * 0.001 + index) * 2);
     g.stroke({ width: 1, color: index % 2 ? 0x45f0ff : 0xba5cff, alpha: (0.07 - index * 0.01) * density });
   });
 
-  const particleCount = hasObject ? Math.min(140, 54 + state.objectFeatures.metrics.length * 8 + state.objectFeatures.layers.length * 6) : 84;
+  const particleCount = Math.min(140, 32 + nodes.length * 8);
   for (let i = 0; i < particleCount; i += 1) {
-    const value = hasObject ? values[i % values.length] : 0.05;
+    const sourceNode = nodes[i % nodes.length];
+    const value = typeof sourceNode.value === 'number' ? safeValue(sourceNode.value, sourceNode.confidence) : sourceNode.confidence;
     const angle = i * 2.39996 + time * 0.00012 * (0.4 + value);
     const radius = min * (0.12 + ((i % 34) / 34) * 0.34) * (0.72 + value * 0.32);
     const x = cx + Math.cos(angle) * radius * 1.28;

--- a/src/components/studio/production/pixi/renderers/TimelineDensityRenderer.ts
+++ b/src/components/studio/production/pixi/renderers/TimelineDensityRenderer.ts
@@ -3,8 +3,18 @@ import { safeValue, type StudioPixiRenderer } from './rendererTypes';
 export const TimelineDensityRenderer: StudioPixiRenderer = ({ PIXI, app, state, width, height, time }) => {
   const g = new PIXI.Graphics();
   const values = state.audioFeatures.energySegments.length ? state.audioFeatures.energySegments : state.textFeatures.narrativeArc;
-  const lanes = Math.max(4, Math.min(8, state.objectFeatures.layers.length || 5));
-  const segmentCount = Math.max(12, values.length || 12);
+  if (!values.length) {
+    const label = new PIXI.Text({
+      text: 'MISSING_TIMELINE_SEGMENTS',
+      style: { fill: 0x787184, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace', fontSize: 11, letterSpacing: 1.4 },
+    });
+    label.x = width / 2 - 106;
+    label.y = height / 2 - 8;
+    app.stage.addChild(label);
+    return;
+  }
+  const lanes = Math.max(1, Math.min(8, state.objectFeatures.layers.length || 1));
+  const segmentCount = values.length;
 
   for (let lane = 0; lane < lanes; lane += 1) {
     const y = 30 + lane * ((height - 60) / lanes);
@@ -12,7 +22,7 @@ export const TimelineDensityRenderer: StudioPixiRenderer = ({ PIXI, app, state, 
     g.lineTo(width - 20, y);
     g.stroke({ width: 1, color: 0x45f0ff, alpha: 0.12 });
     for (let i = 0; i < segmentCount; i += 1) {
-      const value = safeValue(values[i % Math.max(1, values.length)] ?? 0, state.activeObject.id ? 0.24 : 0.04);
+      const value = safeValue(values[i], 0);
       const x = 20 + (i / segmentCount) * (width - 40);
       const w = (width - 40) / segmentCount - 2;
       const h = 8 + value * 28;

--- a/src/components/studio/production/pixi/renderers/VectorScopeRenderer.ts
+++ b/src/components/studio/production/pixi/renderers/VectorScopeRenderer.ts
@@ -5,7 +5,17 @@ export const VectorScopeRenderer: StudioPixiRenderer = ({ PIXI, app, state, widt
   const cx = width / 2;
   const cy = height / 2;
   const radius = Math.min(width, height) * 0.34;
-  const stereo = safeValue(state.audioFeatures.stereoImage, state.activeObject.id ? 0.35 : 0.08);
+  if (state.audioFeatures.stereoImage === null) {
+    const label = new PIXI.Text({
+      text: 'MISSING_STEREO_WIDTH',
+      style: { fill: 0x787184, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace', fontSize: 11, letterSpacing: 1.4 },
+    });
+    label.x = cx - 88;
+    label.y = cy - 8;
+    app.stage.addChild(label);
+    return;
+  }
+  const stereo = safeValue(state.audioFeatures.stereoImage, 0);
 
   for (let i = 0; i < 64; i += 1) {
     const angle = (i / 64) * Math.PI * 2;

--- a/src/components/studio/production/pixi/renderers/WaveformRenderer.ts
+++ b/src/components/studio/production/pixi/renderers/WaveformRenderer.ts
@@ -3,8 +3,18 @@ import { safeValue, type StudioPixiRenderer } from './rendererTypes';
 export const WaveformRenderer: StudioPixiRenderer = ({ PIXI, app, state, width, height, time }) => {
   const g = new PIXI.Graphics();
   const waveform = state.audioFeatures.waveform.length ? state.audioFeatures.waveform : state.audioFeatures.energySegments;
-  const values = waveform.length ? waveform : [0, 0, 0, 0, 0, 0];
+  const values = waveform;
   const mid = height * 0.5;
+  if (!values.length) {
+    const label = new PIXI.Text({
+      text: 'MISSING_AUDIO_BUFFER',
+      style: { fill: 0x787184, fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace', fontSize: 11, letterSpacing: 1.4 },
+    });
+    label.x = width / 2 - 86;
+    label.y = mid - 8;
+    app.stage.addChild(label);
+    return;
+  }
 
   for (let pass = 0; pass < 3; pass += 1) {
     values.forEach((raw, index) => {

--- a/src/lib/studio/audio/analyzeStudioAudioObject.ts
+++ b/src/lib/studio/audio/analyzeStudioAudioObject.ts
@@ -1,0 +1,190 @@
+import 'server-only';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { buildAudioIdempotencyKey } from './audioChecksum';
+import { decodeStudioAudio } from './audioDecode';
+import { isStudioAudioError, StudioAudioError } from './audioErrors';
+import {
+  createStudioAudioJob,
+  findExistingStudioAudioAnalysis,
+  markStudioObjectAnalyzing,
+  markStudioObjectAnalysisFinished,
+  payloadWithError,
+  persistStudioAudioAnalysis,
+  updateStudioAudioJob,
+} from './audioPersistence';
+import { loadStudioAudioBytes } from './audioStorage';
+import {
+  STUDIO_AUDIO_ENGINE_NAME,
+  STUDIO_AUDIO_ENGINE_VERSION,
+  type StudioAudioAnalysisOptions,
+  type StudioAudioAnalysisResult,
+  type StudioAudioProbe,
+  type TimeRegion,
+} from './audioTypes';
+import { extractStudioAudioFeatures } from './features/featureRegistry';
+import { detectOnsets } from './segmentation/onsetDetection';
+import { detectSections } from './segmentation/sectionDetection';
+import { detectSilenceRegions } from './segmentation/silenceDetection';
+import { buildWaveformPeaks } from './segmentation/waveformPeaks';
+
+function maxDurationSeconds(options: StudioAudioAnalysisOptions) {
+  const fromEnv = Number(process.env.STUDIO_AUDIO_MAX_DURATION_SECONDS);
+  if (Number.isFinite(fromEnv) && fromEnv > 0) return fromEnv;
+  return options.maxDurationSeconds ?? 20 * 60;
+}
+
+function buildRegionsFromMarkers(markers: ReturnType<typeof detectSilenceRegions>): TimeRegion[] {
+  return markers.map((marker) => ({
+    id: marker.id,
+    type: marker.type,
+    label: marker.label,
+    startSeconds: marker.startSeconds,
+    endSeconds: marker.endSeconds,
+    confidence: marker.confidence,
+    payload: marker.payload,
+  }));
+}
+
+function probeOnly(decoded: StudioAudioProbe): StudioAudioProbe {
+  return {
+    container: decoded.container,
+    codec: decoded.codec,
+    sampleRate: decoded.sampleRate,
+    channels: decoded.channels,
+    bitsPerSample: decoded.bitsPerSample,
+    byteRate: decoded.byteRate,
+    blockAlign: decoded.blockAlign,
+    durationSeconds: decoded.durationSeconds,
+    dataOffset: decoded.dataOffset,
+    dataLength: decoded.dataLength,
+  };
+}
+
+export async function analyzeStudioAudioObject(objectId: string, options: StudioAudioAnalysisOptions = {}) {
+  const supabase = createServiceSupabaseClient();
+  const stored = await loadStudioAudioBytes(objectId, options, supabase);
+  const idempotencyKey = buildAudioIdempotencyKey(objectId, stored.checksumSha256, STUDIO_AUDIO_ENGINE_VERSION);
+
+  if (!options.force) {
+    const existing = await findExistingStudioAudioAnalysis(supabase, objectId, idempotencyKey);
+    if (existing) {
+      return {
+        ok: true,
+        reused: true,
+        status: 'COMPLETE',
+        objectId,
+        jobId: String(existing.id),
+        idempotencyKey,
+        checksumSha256: stored.checksumSha256,
+      };
+    }
+  }
+
+  const job = await createStudioAudioJob(supabase, objectId, idempotencyKey, {
+    engine: STUDIO_AUDIO_ENGINE_NAME,
+    engineVersion: STUDIO_AUDIO_ENGINE_VERSION,
+    checksumSha256: stored.checksumSha256,
+    byteLength: stored.byteLength,
+    requestedByUserId: options.requestedByUserId ?? null,
+  });
+  const jobId = String(job.id);
+  const basePayload = {
+    idempotencyKey,
+    engine: STUDIO_AUDIO_ENGINE_NAME,
+    engineVersion: STUDIO_AUDIO_ENGINE_VERSION,
+    checksumSha256: stored.checksumSha256,
+    byteLength: stored.byteLength,
+    requestedByUserId: options.requestedByUserId ?? null,
+  };
+
+  try {
+    await markStudioObjectAnalyzing(supabase, objectId);
+    await updateStudioAudioJob(supabase, jobId, 'running', null, { ...basePayload, startedAt: new Date().toISOString() });
+
+    const decoded = decodeStudioAudio(stored.bytes, maxDurationSeconds(options));
+    const extraction = extractStudioAudioFeatures(decoded);
+    const waveform = buildWaveformPeaks(decoded);
+    const silence = buildRegionsFromMarkers(detectSilenceRegions(extraction.energySegments));
+    const onsets = buildRegionsFromMarkers(detectOnsets(extraction.energySegments));
+    const sections = buildRegionsFromMarkers(detectSections(extraction.energySegments));
+    const timeRegions = [...silence, ...onsets, ...sections];
+    const warnings = extraction.features.flatMap((feature) => feature.warnings).filter((warning, index, all) => all.indexOf(warning) === index);
+    const hasMissingRequired = extraction.features.some((feature) => feature.status === 'MISSING');
+    const probe = probeOnly(decoded);
+    const result: StudioAudioAnalysisResult = {
+      objectId,
+      jobId,
+      idempotencyKey,
+      engine: STUDIO_AUDIO_ENGINE_NAME,
+      engineVersion: STUDIO_AUDIO_ENGINE_VERSION,
+      checksumSha256: stored.checksumSha256,
+      probe,
+      features: extraction.features,
+      waveform,
+      energySegments: extraction.energySegments,
+      timeRegions,
+      warnings,
+      status: hasMissingRequired ? 'DEGRADED' : 'COMPLETE',
+    };
+
+    await persistStudioAudioAnalysis(result, stored.object, probe, extraction.frequencyBands, supabase);
+    await updateStudioAudioJob(supabase, jobId, 'complete', null, {
+      ...basePayload,
+      completedAt: new Date().toISOString(),
+      semanticStatus: result.status,
+      featureCount: result.features.length,
+      waveformPeaks: result.waveform.length,
+      timeRegions: result.timeRegions.length,
+      warnings,
+    });
+    await markStudioObjectAnalysisFinished(supabase, objectId, 'ready', {
+      ...(stored.object.metadata ?? {}),
+      studioAudioEngine: {
+        idempotencyKey,
+        jobId,
+        engine: STUDIO_AUDIO_ENGINE_NAME,
+        engineVersion: STUDIO_AUDIO_ENGINE_VERSION,
+        status: result.status,
+        checksumSha256: stored.checksumSha256,
+        completedAt: new Date().toISOString(),
+      },
+    });
+
+    return {
+      ok: true,
+      reused: false,
+      status: result.status,
+      objectId,
+      jobId,
+      idempotencyKey,
+      checksumSha256: stored.checksumSha256,
+      probe: result.probe,
+      featureCount: result.features.length,
+      waveformPeaks: result.waveform.length,
+      timeRegions: result.timeRegions.length,
+      warnings,
+    };
+  } catch (error) {
+    const reason = isStudioAudioError(error) ? error.code : 'ANALYSIS_FAILED';
+    const dbStatus = reason === 'UNSUPPORTED_CODEC' || reason === 'INVALID_AUDIO_CONTAINER' || reason === 'DURATION_TOO_LONG' ? 'blocked' : 'failed';
+    await updateStudioAudioJob(supabase, jobId, dbStatus, reason, payloadWithError(basePayload, error));
+    await markStudioObjectAnalysisFinished(supabase, objectId, dbStatus === 'blocked' ? 'blocked' : 'failed', {
+      ...(stored.object.metadata ?? {}),
+      studioAudioEngine: {
+        idempotencyKey,
+        jobId,
+        engine: STUDIO_AUDIO_ENGINE_NAME,
+        engineVersion: STUDIO_AUDIO_ENGINE_VERSION,
+        status: dbStatus.toUpperCase(),
+        reason,
+        failedAt: new Date().toISOString(),
+      },
+    });
+
+    if (error instanceof StudioAudioError) throw error;
+    throw new StudioAudioError('ANALYSIS_FAILED', error instanceof Error ? error.message : 'Studio audio analysis failed.', 500, {
+      objectId,
+      jobId,
+    });
+  }
+}

--- a/src/lib/studio/audio/audioChecksum.ts
+++ b/src/lib/studio/audio/audioChecksum.ts
@@ -1,0 +1,9 @@
+import { createHash } from 'node:crypto';
+
+export function sha256Buffer(bytes: Buffer) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+export function buildAudioIdempotencyKey(objectId: string, checksumSha256: string, engineVersion: string) {
+  return `studio-audio:${objectId}:${checksumSha256}:${engineVersion}`;
+}

--- a/src/lib/studio/audio/audioDecode.ts
+++ b/src/lib/studio/audio/audioDecode.ts
@@ -1,0 +1,75 @@
+import { StudioAudioError } from './audioErrors';
+import { probeStudioAudio } from './audioProbe';
+import type { StudioDecodedAudio } from './audioTypes';
+
+function clampSample(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(-1, Math.min(1, value));
+}
+
+function readPcm(bytes: Buffer, offset: number, bitsPerSample: number) {
+  if (bitsPerSample === 8) return (bytes.readUInt8(offset) - 128) / 128;
+  if (bitsPerSample === 16) return bytes.readInt16LE(offset) / 32768;
+  if (bitsPerSample === 24) return bytes.readIntLE(offset, 3) / 8388608;
+  if (bitsPerSample === 32) return bytes.readInt32LE(offset) / 2147483648;
+  throw new StudioAudioError('UNSUPPORTED_CODEC', 'Unsupported PCM bit depth.', 415, { bitsPerSample });
+}
+
+function readFloat(bytes: Buffer, offset: number, bitsPerSample: number) {
+  if (bitsPerSample === 32) return bytes.readFloatLE(offset);
+  if (bitsPerSample === 64) return bytes.readDoubleLE(offset);
+  throw new StudioAudioError('UNSUPPORTED_CODEC', 'Unsupported float WAV bit depth.', 415, { bitsPerSample });
+}
+
+export function decodeStudioAudio(bytes: Buffer, maxDurationSeconds?: number): StudioDecodedAudio {
+  const probe = probeStudioAudio(bytes);
+  if (maxDurationSeconds && probe.durationSeconds > maxDurationSeconds) {
+    throw new StudioAudioError('DURATION_TOO_LONG', 'Audio duration exceeds synchronous Studio audio engine limit.', 413, {
+      durationSeconds: probe.durationSeconds,
+      maxDurationSeconds,
+    });
+  }
+
+  const formatIsFloat = probe.codec.startsWith('float');
+  const bytesPerSample = probe.bitsPerSample / 8;
+  const frameCount = Math.floor(probe.dataLength / probe.blockAlign);
+  const channelData = Array.from({ length: probe.channels }, () => new Float32Array(frameCount));
+
+  try {
+    for (let frame = 0; frame < frameCount; frame += 1) {
+      const frameOffset = probe.dataOffset + frame * probe.blockAlign;
+      for (let channel = 0; channel < probe.channels; channel += 1) {
+        const sampleOffset = frameOffset + channel * bytesPerSample;
+        const sample = formatIsFloat
+          ? readFloat(bytes, sampleOffset, probe.bitsPerSample)
+          : readPcm(bytes, sampleOffset, probe.bitsPerSample);
+        channelData[channel][frame] = clampSample(sample);
+      }
+    }
+  } catch (error) {
+    if (error instanceof StudioAudioError) throw error;
+    throw new StudioAudioError('DECODE_FAILED', error instanceof Error ? error.message : 'WAV decode failed.', 422, {
+      codec: probe.codec,
+      bitsPerSample: probe.bitsPerSample,
+    });
+  }
+
+  return {
+    ...probe,
+    channelData,
+    frameCount,
+    durationSeconds: frameCount / probe.sampleRate,
+  };
+}
+
+export function mixdownToMono(decoded: StudioDecodedAudio) {
+  const mono = new Float32Array(decoded.frameCount);
+  for (let frame = 0; frame < decoded.frameCount; frame += 1) {
+    let sum = 0;
+    for (let channel = 0; channel < decoded.channels; channel += 1) {
+      sum += decoded.channelData[channel][frame] ?? 0;
+    }
+    mono[frame] = sum / decoded.channels;
+  }
+  return mono;
+}

--- a/src/lib/studio/audio/audioErrors.ts
+++ b/src/lib/studio/audio/audioErrors.ts
@@ -1,0 +1,37 @@
+import type { StudioAudioErrorCode } from './audioTypes';
+
+export class StudioAudioError extends Error {
+  readonly code: StudioAudioErrorCode;
+  readonly status: number;
+  readonly details: Record<string, unknown>;
+
+  constructor(code: StudioAudioErrorCode, message: string, status = 400, details: Record<string, unknown> = {}) {
+    super(message);
+    this.name = 'StudioAudioError';
+    this.code = code;
+    this.status = status;
+    this.details = details;
+  }
+}
+
+export function isStudioAudioError(error: unknown): error is StudioAudioError {
+  return error instanceof StudioAudioError;
+}
+
+export function toStudioAudioApiError(error: unknown) {
+  if (isStudioAudioError(error)) {
+    return {
+      ok: false,
+      error: error.code,
+      details: error.message,
+      context: error.details,
+    };
+  }
+
+  return {
+    ok: false,
+    error: 'ANALYSIS_FAILED',
+    details: error instanceof Error ? error.message : 'Unknown Studio audio analysis failure.',
+    context: {},
+  };
+}

--- a/src/lib/studio/audio/audioPersistence.ts
+++ b/src/lib/studio/audio/audioPersistence.ts
@@ -1,0 +1,246 @@
+import 'server-only';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { StudioAudioError } from './audioErrors';
+import type {
+  EnergySegment,
+  StudioAudioAnalysisResult,
+  StudioAudioFeature,
+  StudioAudioObjectRow,
+  StudioAudioProbe,
+  TimeRegion,
+  WaveformPeak,
+} from './audioTypes';
+
+type Row = Record<string, unknown>;
+
+function featureValueColumns(feature: StudioAudioFeature) {
+  if (typeof feature.value === 'number') return { numeric_value: feature.value, text_value: null };
+  if (typeof feature.value === 'string') return { numeric_value: null, text_value: feature.value };
+  return { numeric_value: null, text_value: null };
+}
+
+function featureByKey(features: StudioAudioFeature[], key: string) {
+  return features.find((feature) => feature.key === key)?.value ?? null;
+}
+
+function numericFeature(features: StudioAudioFeature[], key: string) {
+  const value = featureByKey(features, key);
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function jsonNumberArray(values: number[], limit = 4096) {
+  return values.slice(0, limit).map((value) => (Number.isFinite(value) ? Number(value.toFixed(6)) : null));
+}
+
+function waveformForColumn(waveform: WaveformPeak[]) {
+  return waveform.map((item) => ({
+    i: item.index,
+    t0: Number(item.startSeconds.toFixed(4)),
+    t1: Number(item.endSeconds.toFixed(4)),
+    min: Number(item.min.toFixed(6)),
+    max: Number(item.max.toFixed(6)),
+    rms: Number(item.rms.toFixed(6)),
+  }));
+}
+
+function energyForColumn(segments: EnergySegment[]) {
+  return segments.map((item) => ({
+    i: item.index,
+    t0: Number(item.startSeconds.toFixed(4)),
+    t1: Number(item.endSeconds.toFixed(4)),
+    rms: Number(item.rms.toFixed(6)),
+    peak: Number(item.peak.toFixed(6)),
+    centroidHz: item.centroidHz === null ? null : Number(item.centroidHz.toFixed(3)),
+  }));
+}
+
+export async function findExistingStudioAudioAnalysis(
+  supabase: SupabaseClient,
+  objectId: string,
+  idempotencyKey: string
+) {
+  const { data, error } = await supabase
+    .from('studio_analysis_jobs')
+    .select('*')
+    .eq('object_id', objectId)
+    .eq('status', 'complete')
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  if (error) throw new StudioAudioError('PERSISTENCE_FAILED', error.message, 500, { objectId, table: 'studio_analysis_jobs' });
+  return (data as Row[] | null ?? []).find((row) => {
+    const payload = row.payload as Row | null;
+    return payload?.idempotencyKey === idempotencyKey;
+  }) ?? null;
+}
+
+export async function createStudioAudioJob(
+  supabase: SupabaseClient,
+  objectId: string,
+  idempotencyKey: string,
+  payload: Record<string, unknown>
+) {
+  const { data, error } = await supabase
+    .from('studio_analysis_jobs')
+    .insert({
+      object_id: objectId,
+      status: 'queued',
+      reason: null,
+      payload: { ...payload, idempotencyKey },
+    })
+    .select('*')
+    .single();
+
+  if (error || !data) throw new StudioAudioError('PERSISTENCE_FAILED', error?.message ?? 'Unable to create Studio analysis job.', 500, { objectId });
+  return data as Row;
+}
+
+export async function updateStudioAudioJob(
+  supabase: SupabaseClient,
+  jobId: string,
+  status: 'queued' | 'running' | 'complete' | 'blocked' | 'failed',
+  reason: string | null,
+  payload: Record<string, unknown>
+) {
+  const { error } = await supabase
+    .from('studio_analysis_jobs')
+    .update({
+      status,
+      reason,
+      payload,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', jobId);
+
+  if (error) throw new StudioAudioError('PERSISTENCE_FAILED', error.message, 500, { jobId, table: 'studio_analysis_jobs' });
+}
+
+export async function markStudioObjectAnalyzing(supabase: SupabaseClient, objectId: string) {
+  const { error } = await supabase
+    .from('studio_objects')
+    .update({ status: 'analyzing', updated_at: new Date().toISOString() })
+    .eq('id', objectId);
+  if (error) throw new StudioAudioError('PERSISTENCE_FAILED', error.message, 500, { objectId, table: 'studio_objects' });
+}
+
+export async function markStudioObjectAnalysisFinished(
+  supabase: SupabaseClient,
+  objectId: string,
+  status: 'ready' | 'blocked' | 'failed',
+  metadata: Record<string, unknown>
+) {
+  const { error } = await supabase
+    .from('studio_objects')
+    .update({ status, metadata, updated_at: new Date().toISOString() })
+    .eq('id', objectId);
+  if (error) throw new StudioAudioError('PERSISTENCE_FAILED', error.message, 500, { objectId, table: 'studio_objects' });
+}
+
+export async function persistStudioAudioAnalysis(
+  result: StudioAudioAnalysisResult,
+  object: StudioAudioObjectRow,
+  probe: StudioAudioProbe,
+  frequencyBands: number[],
+  supabase: SupabaseClient = createServiceSupabaseClient()
+) {
+  const observedAt = new Date().toISOString();
+  const commonPayload = {
+    idempotencyKey: result.idempotencyKey,
+    jobId: result.jobId,
+    engine: result.engine,
+    engineVersion: result.engineVersion,
+    checksumSha256: result.checksumSha256,
+    observedAt,
+    probe,
+  };
+
+  const objectFeatureRows = result.features.map((item) => ({
+    object_id: result.objectId,
+    feature_key: item.key,
+    label: item.label,
+    ...featureValueColumns(item),
+    unit: item.unit,
+    source: item.source,
+    confidence: item.confidence,
+    payload: {
+      ...commonPayload,
+      status: item.status,
+      formulaVersion: item.formulaVersion,
+      warnings: item.warnings,
+      explanation: item.explanation,
+      featurePayload: item.payload ?? {},
+    },
+  }));
+
+  const { error: featureError } = await supabase.from('studio_object_features').insert(objectFeatureRows);
+  if (featureError) throw new StudioAudioError('PERSISTENCE_FAILED', featureError.message, 500, { table: 'studio_object_features' });
+
+  const { error: audioError } = await supabase.from('studio_audio_features').insert({
+    object_id: result.objectId,
+    rms: numericFeature(result.features, 'rms_dbfs'),
+    peak: numericFeature(result.features, 'peak_dbfs'),
+    clipping_risk: numericFeature(result.features, 'clipping_risk'),
+    dynamic_range: numericFeature(result.features, 'dynamic_range_db'),
+    lufs: numericFeature(result.features, 'lufs_integrated'),
+    spectral_centroid: numericFeature(result.features, 'spectral_centroid_hz'),
+    frequency_bands: jsonNumberArray(frequencyBands, 12),
+    waveform: waveformForColumn(result.waveform),
+    energy_segments: energyForColumn(result.energySegments),
+    payload: {
+      ...commonPayload,
+      featureKeys: result.features.map((item) => item.key),
+      warnings: result.warnings,
+    },
+  });
+  if (audioError) throw new StudioAudioError('PERSISTENCE_FAILED', audioError.message, 500, { table: 'studio_audio_features' });
+
+  const timeRows = result.timeRegions.slice(0, 512).map((region) => ({
+    object_id: result.objectId,
+    time_range: `${region.startSeconds.toFixed(3)}-${region.endSeconds.toFixed(3)}`,
+    place_label: region.type,
+    semantic_anchors: [region.label],
+    historical_vector_tags: [],
+    dominant_tensions: [],
+    gap_description: null,
+    payload: {
+      ...commonPayload,
+      markerId: region.id,
+      markerType: region.type,
+      startSeconds: region.startSeconds,
+      endSeconds: region.endSeconds,
+      confidence: region.confidence,
+      markerPayload: region.payload ?? {},
+    },
+  }));
+  if (timeRows.length) {
+    const { error: timeError } = await supabase.from('studio_time_coordinates').insert(timeRows);
+    if (timeError) throw new StudioAudioError('PERSISTENCE_FAILED', timeError.message, 500, { table: 'studio_time_coordinates' });
+  }
+
+  const { error: evidenceError } = await supabase.from('studio_evidence_traces').insert({
+    object_id: result.objectId,
+    source: result.engine,
+    label: 'Studio audio extraction',
+    reliability: result.status === 'COMPLETE' ? 0.86 : 0.62,
+    uri: object.source_uri,
+    payload: {
+      ...commonPayload,
+      status: result.status,
+      warnings: result.warnings,
+      featureCount: result.features.length,
+      waveformPeaks: result.waveform.length,
+      energySegments: result.energySegments.length,
+      timeRegions: result.timeRegions.length,
+    },
+  });
+  if (evidenceError) throw new StudioAudioError('PERSISTENCE_FAILED', evidenceError.message, 500, { table: 'studio_evidence_traces' });
+}
+
+export function payloadWithError(payload: Record<string, unknown>, error: unknown) {
+  return {
+    ...payload,
+    error: error instanceof Error ? error.message : 'Unknown audio analysis error.',
+    failedAt: new Date().toISOString(),
+  };
+}

--- a/src/lib/studio/audio/audioProbe.ts
+++ b/src/lib/studio/audio/audioProbe.ts
@@ -1,0 +1,88 @@
+import { StudioAudioError } from './audioErrors';
+import type { StudioAudioProbe } from './audioTypes';
+
+type Chunk = {
+  id: string;
+  offset: number;
+  size: number;
+  dataOffset: number;
+};
+
+function readAscii(bytes: Buffer, offset: number, length: number) {
+  return bytes.toString('ascii', offset, offset + length);
+}
+
+function collectChunks(bytes: Buffer) {
+  const chunks: Chunk[] = [];
+  let offset = 12;
+  while (offset + 8 <= bytes.byteLength) {
+    const id = readAscii(bytes, offset, 4);
+    const size = bytes.readUInt32LE(offset + 4);
+    const dataOffset = offset + 8;
+    if (dataOffset + size > bytes.byteLength) break;
+    chunks.push({ id, offset, size, dataOffset });
+    offset = dataOffset + size + (size % 2);
+  }
+  return chunks;
+}
+
+function codecName(formatCode: number, bitsPerSample: number) {
+  if (formatCode === 1) return `pcm_s${bitsPerSample}le`;
+  if (formatCode === 3) return `float${bitsPerSample}`;
+  return `wav_format_${formatCode}`;
+}
+
+export function probeStudioAudio(bytes: Buffer): StudioAudioProbe {
+  if (bytes.byteLength < 44 || readAscii(bytes, 0, 4) !== 'RIFF' || readAscii(bytes, 8, 4) !== 'WAVE') {
+    throw new StudioAudioError('INVALID_AUDIO_CONTAINER', 'Studio audio engine currently accepts RIFF/WAVE containers only.', 415, {
+      detectedHeader: bytes.subarray(0, Math.min(bytes.byteLength, 16)).toString('hex'),
+    });
+  }
+
+  const chunks = collectChunks(bytes);
+  const fmt = chunks.find((chunk) => chunk.id === 'fmt ');
+  const data = chunks.find((chunk) => chunk.id === 'data');
+  if (!fmt || fmt.size < 16 || !data) {
+    throw new StudioAudioError('INVALID_AUDIO_CONTAINER', 'WAV file is missing required fmt or data chunk.', 415, {
+      chunks: chunks.map((chunk) => chunk.id),
+    });
+  }
+
+  const formatCode = bytes.readUInt16LE(fmt.dataOffset);
+  const channels = bytes.readUInt16LE(fmt.dataOffset + 2);
+  const sampleRate = bytes.readUInt32LE(fmt.dataOffset + 4);
+  const byteRate = bytes.readUInt32LE(fmt.dataOffset + 8);
+  const blockAlign = bytes.readUInt16LE(fmt.dataOffset + 12);
+  const bitsPerSample = bytes.readUInt16LE(fmt.dataOffset + 14);
+  const codec = codecName(formatCode, bitsPerSample);
+
+  if (![1, 3].includes(formatCode) || ![8, 16, 24, 32, 64].includes(bitsPerSample)) {
+    throw new StudioAudioError('UNSUPPORTED_CODEC', 'WAV codec is not supported by the Node Studio audio decoder.', 415, {
+      formatCode,
+      bitsPerSample,
+      codec,
+    });
+  }
+  if (!channels || !sampleRate || !blockAlign || data.size < blockAlign) {
+    throw new StudioAudioError('INVALID_AUDIO_CONTAINER', 'WAV metadata is incomplete or inconsistent.', 415, {
+      channels,
+      sampleRate,
+      blockAlign,
+      dataLength: data.size,
+    });
+  }
+
+  const frameCount = Math.floor(data.size / blockAlign);
+  return {
+    container: 'wav',
+    codec,
+    sampleRate,
+    channels,
+    bitsPerSample,
+    byteRate,
+    blockAlign,
+    durationSeconds: frameCount / sampleRate,
+    dataOffset: data.dataOffset,
+    dataLength: data.size,
+  };
+}

--- a/src/lib/studio/audio/audioStorage.ts
+++ b/src/lib/studio/audio/audioStorage.ts
@@ -1,0 +1,118 @@
+import 'server-only';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { sha256Buffer } from './audioChecksum';
+import { StudioAudioError } from './audioErrors';
+import {
+  STUDIO_AUDIO_BUCKET,
+  type StudioAudioAnalysisOptions,
+  type StudioAudioObjectRow,
+  type StudioAudioUploadRow,
+  type StudioStoredAudio,
+} from './audioTypes';
+
+const DEFAULT_MAX_FILE_BYTES = 75 * 1024 * 1024;
+
+function maxFileBytes(options: StudioAudioAnalysisOptions) {
+  const fromEnv = Number(process.env.STUDIO_AUDIO_MAX_FILE_MB);
+  if (Number.isFinite(fromEnv) && fromEnv > 0) return Math.floor(fromEnv * 1024 * 1024);
+  return options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES;
+}
+
+function isAudioObject(object: StudioAudioObjectRow) {
+  const objectType = String(object.object_type ?? '').toLowerCase();
+  const mime = String(object.mime_type ?? '').toLowerCase();
+  const source = String(object.source_uri ?? '').toLowerCase();
+  return objectType === 'music' || objectType === 'audio' || mime.startsWith('audio/') || /\.(wav|wave)$/i.test(source);
+}
+
+async function blobToBuffer(blob: Blob) {
+  return Buffer.from(await blob.arrayBuffer());
+}
+
+export async function loadStudioAudioBytes(
+  objectId: string,
+  options: StudioAudioAnalysisOptions = {},
+  supabase: SupabaseClient = createServiceSupabaseClient()
+): Promise<StudioStoredAudio> {
+  const { data: object, error: objectError } = await supabase
+    .from('studio_objects')
+    .select('*')
+    .eq('id', objectId)
+    .maybeSingle();
+
+  if (objectError) {
+    throw new StudioAudioError('OBJECT_NOT_FOUND', objectError.message, 404, { objectId });
+  }
+  if (!object) {
+    throw new StudioAudioError('OBJECT_NOT_FOUND', 'Studio object was not found.', 404, { objectId });
+  }
+
+  const typedObject = object as StudioAudioObjectRow;
+  if (!isAudioObject(typedObject)) {
+    throw new StudioAudioError('OBJECT_NOT_AUDIO', 'Studio object is not typed as audio/music and has no audio MIME evidence.', 409, {
+      objectId,
+      objectType: typedObject.object_type,
+      mimeType: typedObject.mime_type,
+    });
+  }
+
+  const { data: upload, error: uploadError } = await supabase
+    .from('studio_uploads')
+    .select('*')
+    .eq('object_id', objectId)
+    .eq('status', 'stored')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (uploadError) {
+    throw new StudioAudioError('UPLOAD_NOT_FOUND', uploadError.message, 404, { objectId });
+  }
+  if (!upload?.storage_path) {
+    throw new StudioAudioError('UPLOAD_NOT_FOUND', 'No stored Studio upload exists for this audio object.', 404, { objectId });
+  }
+
+  const typedUpload = upload as StudioAudioUploadRow;
+  const storagePath = typedUpload.storage_path;
+  if (!storagePath) {
+    throw new StudioAudioError('UPLOAD_NOT_FOUND', 'Stored Studio upload row has no storage path.', 404, { objectId });
+  }
+  const declaredSize = Number(typedUpload.size_bytes ?? typedObject.size_bytes ?? 0);
+  const limit = maxFileBytes(options);
+  if (Number.isFinite(declaredSize) && declaredSize > limit) {
+    throw new StudioAudioError('FILE_TOO_LARGE', 'Stored audio object exceeds synchronous Studio audio engine limit.', 413, {
+      objectId,
+      declaredSize,
+      limit,
+    });
+  }
+
+  const { data: blob, error: downloadError } = await supabase.storage
+    .from(STUDIO_AUDIO_BUCKET)
+    .download(storagePath);
+
+  if (downloadError || !blob) {
+    throw new StudioAudioError('STORAGE_DOWNLOAD_FAILED', downloadError?.message ?? 'Supabase storage returned no audio bytes.', 502, {
+      objectId,
+      storagePath,
+    });
+  }
+
+  const bytes = await blobToBuffer(blob);
+  if (bytes.byteLength > limit) {
+    throw new StudioAudioError('FILE_TOO_LARGE', 'Downloaded audio object exceeds synchronous Studio audio engine limit.', 413, {
+      objectId,
+      byteLength: bytes.byteLength,
+      limit,
+    });
+  }
+
+  return {
+    object: typedObject,
+    upload: typedUpload,
+    bytes,
+    byteLength: bytes.byteLength,
+    checksumSha256: sha256Buffer(bytes),
+  };
+}

--- a/src/lib/studio/audio/audioTypes.ts
+++ b/src/lib/studio/audio/audioTypes.ts
@@ -1,0 +1,136 @@
+import type { MetricStatus } from '@/lib/studio/production/studioProductionTypes';
+
+export const STUDIO_AUDIO_ENGINE_NAME = 'studio_audio_node_wav_engine';
+export const STUDIO_AUDIO_ENGINE_VERSION = '2026-07-11.1';
+export const STUDIO_AUDIO_BUCKET = 'studio-objects';
+export const STUDIO_AUDIO_DBFS_FLOOR = -120;
+
+export type StudioAudioErrorCode =
+  | 'AUTH_REQUIRED'
+  | 'OBJECT_NOT_FOUND'
+  | 'OBJECT_NOT_AUDIO'
+  | 'UPLOAD_NOT_FOUND'
+  | 'STORAGE_DOWNLOAD_FAILED'
+  | 'FILE_TOO_LARGE'
+  | 'DURATION_TOO_LONG'
+  | 'INVALID_AUDIO_CONTAINER'
+  | 'UNSUPPORTED_CODEC'
+  | 'DECODE_FAILED'
+  | 'PERSISTENCE_FAILED'
+  | 'ANALYSIS_FAILED';
+
+export type StudioAudioAnalysisOptions = {
+  force?: boolean;
+  maxFileBytes?: number;
+  maxDurationSeconds?: number;
+  requestedByUserId?: string | null;
+};
+
+export type StudioAudioObjectRow = {
+  id: string;
+  session_id: string | null;
+  title: string | null;
+  object_type: string | null;
+  source_uri: string | null;
+  mime_type: string | null;
+  size_bytes: number | null;
+  status: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type StudioAudioUploadRow = {
+  id: string;
+  object_id: string;
+  storage_path: string | null;
+  mime_type: string | null;
+  size_bytes: number | null;
+  status: string | null;
+  created_at: string | null;
+};
+
+export type StudioStoredAudio = {
+  object: StudioAudioObjectRow;
+  upload: StudioAudioUploadRow;
+  bytes: Buffer;
+  byteLength: number;
+  checksumSha256: string;
+};
+
+export type StudioAudioProbe = {
+  container: 'wav';
+  codec: string;
+  sampleRate: number;
+  channels: number;
+  bitsPerSample: number;
+  byteRate: number;
+  blockAlign: number;
+  durationSeconds: number;
+  dataOffset: number;
+  dataLength: number;
+};
+
+export type StudioDecodedAudio = StudioAudioProbe & {
+  channelData: Float32Array[];
+  frameCount: number;
+  durationSeconds: number;
+};
+
+export type StudioAudioFeature = {
+  key: string;
+  label: string;
+  value: number | string | null;
+  unit: string | null;
+  status: MetricStatus;
+  source: string;
+  confidence: number;
+  formulaVersion: string;
+  explanation: string;
+  warnings: string[];
+  payload?: Record<string, unknown>;
+};
+
+export type WaveformPeak = {
+  index: number;
+  startSeconds: number;
+  endSeconds: number;
+  min: number;
+  max: number;
+  rms: number;
+};
+
+export type EnergySegment = {
+  index: number;
+  startSeconds: number;
+  endSeconds: number;
+  rms: number;
+  peak: number;
+  centroidHz: number | null;
+};
+
+export type TimeRegion = {
+  id: string;
+  type: 'silence' | 'active' | 'onset' | 'section';
+  startSeconds: number;
+  endSeconds: number;
+  confidence: number;
+  label: string;
+  payload?: Record<string, unknown>;
+};
+
+export type StudioAudioAnalysisResult = {
+  objectId: string;
+  jobId: string;
+  idempotencyKey: string;
+  engine: string;
+  engineVersion: string;
+  checksumSha256: string;
+  probe: StudioAudioProbe;
+  features: StudioAudioFeature[];
+  waveform: WaveformPeak[];
+  energySegments: EnergySegment[];
+  timeRegions: TimeRegion[];
+  warnings: string[];
+  status: 'COMPLETE' | 'DEGRADED';
+};

--- a/src/lib/studio/audio/features/basicFeatures.ts
+++ b/src/lib/studio/audio/features/basicFeatures.ts
@@ -1,0 +1,74 @@
+import { mixdownToMono } from '../audioDecode';
+import {
+  STUDIO_AUDIO_DBFS_FLOOR,
+  STUDIO_AUDIO_ENGINE_NAME,
+  STUDIO_AUDIO_ENGINE_VERSION,
+  type StudioAudioFeature,
+  type StudioDecodedAudio,
+} from '../audioTypes';
+
+export function amplitudeToDbfs(value: number) {
+  const magnitude = Math.max(0, Math.abs(value));
+  if (magnitude <= 0) return STUDIO_AUDIO_DBFS_FLOOR;
+  return Math.max(STUDIO_AUDIO_DBFS_FLOOR, 20 * Math.log10(Math.min(1, magnitude)));
+}
+
+export function rms(samples: Float32Array) {
+  if (!samples.length) return 0;
+  let sum = 0;
+  for (const sample of samples) sum += sample * sample;
+  return Math.sqrt(sum / samples.length);
+}
+
+export function peak(samples: Float32Array) {
+  let value = 0;
+  for (const sample of samples) value = Math.max(value, Math.abs(sample));
+  return value;
+}
+
+export function zeroCrossingRate(samples: Float32Array) {
+  if (samples.length < 2) return 0;
+  let crossings = 0;
+  for (let index = 1; index < samples.length; index += 1) {
+    if ((samples[index - 1] < 0 && samples[index] >= 0) || (samples[index - 1] >= 0 && samples[index] < 0)) crossings += 1;
+  }
+  return crossings / (samples.length - 1);
+}
+
+export function feature(
+  key: string,
+  label: string,
+  value: number | string | null,
+  unit: string | null,
+  explanation: string,
+  confidence = 0.88,
+  warnings: string[] = []
+): StudioAudioFeature {
+  return {
+    key,
+    label,
+    value,
+    unit,
+    status: value === null ? 'MISSING' : 'OBSERVED',
+    source: STUDIO_AUDIO_ENGINE_NAME,
+    confidence: value === null ? 0 : confidence,
+    formulaVersion: STUDIO_AUDIO_ENGINE_VERSION,
+    explanation,
+    warnings,
+  };
+}
+
+export function missingFeature(key: string, label: string, explanation: string, warnings: string[]) {
+  return feature(key, label, null, null, explanation, 0, warnings);
+}
+
+export function extractBasicFeatures(decoded: StudioDecodedAudio): StudioAudioFeature[] {
+  const mono = mixdownToMono(decoded);
+  return [
+    feature('duration_seconds', 'Duration', decoded.durationSeconds, 's', 'Duration derived from decoded frame count and WAV sample rate.'),
+    feature('sample_rate_hz', 'Sample Rate', decoded.sampleRate, 'Hz', 'Sample rate observed from WAV fmt chunk.'),
+    feature('channel_count', 'Channels', decoded.channels, null, 'Channel count observed from WAV fmt chunk.'),
+    feature('bit_depth', 'Bit Depth', decoded.bitsPerSample, 'bit', 'Bit depth observed from WAV fmt chunk.'),
+    feature('zero_crossing_rate', 'Zero Crossing Rate', zeroCrossingRate(mono), null, 'Zero crossings measured over decoded mono mixdown.'),
+  ];
+}

--- a/src/lib/studio/audio/features/dynamicFeatures.ts
+++ b/src/lib/studio/audio/features/dynamicFeatures.ts
@@ -1,0 +1,44 @@
+import { mixdownToMono } from '../audioDecode';
+import type { StudioAudioFeature, StudioDecodedAudio } from '../audioTypes';
+import { amplitudeToDbfs, feature, peak, rms } from './basicFeatures';
+
+function percentile(values: number[], p: number) {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.floor((sorted.length - 1) * p)));
+  return sorted[index];
+}
+
+function windowRmsValues(samples: Float32Array, sampleRate: number) {
+  const size = Math.max(256, Math.floor(sampleRate * 0.05));
+  const values: number[] = [];
+  for (let offset = 0; offset < samples.length; offset += size) {
+    values.push(rms(samples.subarray(offset, Math.min(samples.length, offset + size))));
+  }
+  return values;
+}
+
+export function extractDynamicFeatures(decoded: StudioDecodedAudio): StudioAudioFeature[] {
+  const mono = mixdownToMono(decoded);
+  const rmsValue = rms(mono);
+  const peakValue = peak(mono);
+  const windows = windowRmsValues(mono, decoded.sampleRate);
+  const quiet = percentile(windows, 0.1);
+  const loud = percentile(windows, 0.95);
+  const dynamicRangeDb = amplitudeToDbfs(loud) - amplitudeToDbfs(quiet);
+  const clippingSamples = Array.from(mono).filter((sample) => Math.abs(sample) >= 0.999).length;
+  const clippingRisk = mono.length ? clippingSamples / mono.length : 0;
+  const crestFactorDb = amplitudeToDbfs(peakValue) - amplitudeToDbfs(rmsValue);
+  const headroomDb = Math.abs(amplitudeToDbfs(peakValue));
+
+  return [
+    feature('rms_dbfs', 'RMS', amplitudeToDbfs(rmsValue), 'dBFS', 'RMS level measured from decoded mono mixdown and expressed as dBFS.'),
+    feature('peak_dbfs', 'Sample Peak', amplitudeToDbfs(peakValue), 'dBFS', 'Sample peak measured from decoded mono mixdown. This is not true peak.', 0.9, ['NOT_TRUE_PEAK']),
+    feature('clipping_risk', 'Clipping Risk', clippingRisk, null, 'Ratio of decoded samples at or above 0.999 absolute amplitude.', 0.86),
+    feature('clipping_sample_count', 'Clipping Samples', clippingSamples, 'samples', 'Count of decoded mono samples at or above 0.999 absolute amplitude.', 0.86),
+    feature('dynamic_range_db', 'Dynamic Range', dynamicRangeDb, 'dB', 'Difference between 95th and 10th percentile short-window RMS levels.', 0.74),
+    feature('crest_factor_db', 'Crest Factor', crestFactorDb, 'dB', 'Difference between sample peak dBFS and RMS dBFS.', 0.82),
+    feature('headroom_db', 'Headroom', headroomDb, 'dB', 'Distance between decoded sample peak and 0 dBFS. This is sample-peak headroom.', 0.82, ['SAMPLE_PEAK_HEADROOM']),
+    feature('peak_amplitude', 'Peak Amplitude', peakValue, null, 'Absolute sample peak amplitude measured from decoded mono mixdown.', 0.9),
+  ];
+}

--- a/src/lib/studio/audio/features/featureRegistry.ts
+++ b/src/lib/studio/audio/features/featureRegistry.ts
@@ -1,0 +1,40 @@
+import type { EnergySegment, StudioAudioFeature, StudioDecodedAudio } from '../audioTypes';
+import { extractBasicFeatures } from './basicFeatures';
+import { extractDynamicFeatures } from './dynamicFeatures';
+import { extractMasteringFeatures } from './masteringFeatures';
+import { extractSpectralFeatures } from './spectralFeatures';
+import { extractStereoFeatures } from './stereoFeatures';
+import { extractTonalFeatures } from './tonalFeatures';
+import { extractTransientFeatures } from './transientFeatures';
+
+export type StudioAudioFeatureExtraction = {
+  features: StudioAudioFeature[];
+  energySegments: EnergySegment[];
+  frequencyBands: number[];
+};
+
+function frequencyBandsFromSummary(summary: { low: number; mid: number; high: number } | null) {
+  if (!summary) return [];
+  const total = Math.max(1e-12, summary.low + summary.mid + summary.high);
+  return [summary.low / total, summary.mid / total, summary.high / total];
+}
+
+export function extractStudioAudioFeatures(decoded: StudioDecodedAudio): StudioAudioFeatureExtraction {
+  const spectral = extractSpectralFeatures(decoded);
+  const frequencyBands = frequencyBandsFromSummary(spectral.summary);
+  const features = [
+    ...extractBasicFeatures(decoded),
+    ...extractDynamicFeatures(decoded),
+    ...spectral.features,
+    ...extractStereoFeatures(decoded),
+    ...extractTonalFeatures(spectral.summary),
+    ...extractTransientFeatures(decoded, spectral.energySegments),
+    ...extractMasteringFeatures(),
+  ];
+
+  return {
+    features,
+    energySegments: spectral.energySegments,
+    frequencyBands,
+  };
+}

--- a/src/lib/studio/audio/features/masteringFeatures.ts
+++ b/src/lib/studio/audio/features/masteringFeatures.ts
@@ -1,0 +1,31 @@
+import type { StudioAudioFeature } from '../audioTypes';
+import { missingFeature } from './basicFeatures';
+
+export function extractMasteringFeatures(): StudioAudioFeature[] {
+  return [
+    missingFeature(
+      'lufs_integrated',
+      'Integrated LUFS',
+      'Integrated LUFS requires a standards-aligned BS.1770 loudness engine. RMS is not relabeled as LUFS.',
+      ['LOUDNESS_ENGINE_REQUIRED']
+    ),
+    missingFeature(
+      'true_peak_dbtp',
+      'True Peak',
+      'True peak requires oversampled peak detection. Sample peak is reported separately and is not relabeled as true peak.',
+      ['TRUE_PEAK_ENGINE_REQUIRED']
+    ),
+    missingFeature(
+      'loudness_range_lu',
+      'Loudness Range',
+      'Loudness range requires standards-aligned gated loudness windows.',
+      ['LOUDNESS_ENGINE_REQUIRED']
+    ),
+    missingFeature(
+      'short_term_lufs_summary',
+      'Short Term LUFS',
+      'Short-term LUFS requires a standards-aligned loudness engine.',
+      ['LOUDNESS_ENGINE_REQUIRED']
+    ),
+  ];
+}

--- a/src/lib/studio/audio/features/spectralFeatures.ts
+++ b/src/lib/studio/audio/features/spectralFeatures.ts
@@ -1,0 +1,178 @@
+import { mixdownToMono } from '../audioDecode';
+import type { EnergySegment, StudioAudioFeature, StudioDecodedAudio } from '../audioTypes';
+import { feature, missingFeature, rms, zeroCrossingRate } from './basicFeatures';
+
+type SpectrumSummary = {
+  centroidHz: number;
+  rolloffHz: number;
+  bandwidthHz: number;
+  flux: number;
+  low: number;
+  mid: number;
+  high: number;
+  noiseFloorDb: number;
+  energySegments: EnergySegment[];
+};
+
+const FRAME_SIZE = 2048;
+const MAX_FRAMES = 140;
+
+function hanning(index: number, size: number) {
+  return 0.5 - 0.5 * Math.cos((2 * Math.PI * index) / Math.max(1, size - 1));
+}
+
+function frameOffsets(length: number) {
+  if (length <= FRAME_SIZE) return [0];
+  const available = Math.floor((length - FRAME_SIZE) / FRAME_SIZE) + 1;
+  const count = Math.min(MAX_FRAMES, available);
+  return Array.from({ length: count }, (_, index) => Math.floor((index * (length - FRAME_SIZE)) / Math.max(1, count - 1)));
+}
+
+function magnitudeSpectrum(samples: Float32Array, start: number, sampleRate: number) {
+  const bins = FRAME_SIZE / 2;
+  const magnitudes = new Float64Array(bins);
+  for (let bin = 0; bin < bins; bin += 1) {
+    let real = 0;
+    let imag = 0;
+    for (let n = 0; n < FRAME_SIZE; n += 1) {
+      const sample = (samples[start + n] ?? 0) * hanning(n, FRAME_SIZE);
+      const angle = (-2 * Math.PI * bin * n) / FRAME_SIZE;
+      real += sample * Math.cos(angle);
+      imag += sample * Math.sin(angle);
+    }
+    magnitudes[bin] = Math.sqrt(real * real + imag * imag);
+  }
+
+  let total = 0;
+  let weighted = 0;
+  let low = 0;
+  let mid = 0;
+  let high = 0;
+  for (let bin = 1; bin < magnitudes.length; bin += 1) {
+    const frequency = (bin * sampleRate) / FRAME_SIZE;
+    const magnitude = magnitudes[bin];
+    total += magnitude;
+    weighted += magnitude * frequency;
+    if (frequency < 250) low += magnitude;
+    else if (frequency < 4000) mid += magnitude;
+    else high += magnitude;
+  }
+
+  const centroid = total > 0 ? weighted / total : 0;
+  let cumulative = 0;
+  let rolloff = 0;
+  for (let bin = 1; bin < magnitudes.length; bin += 1) {
+    cumulative += magnitudes[bin];
+    if (total > 0 && cumulative >= total * 0.85) {
+      rolloff = (bin * sampleRate) / FRAME_SIZE;
+      break;
+    }
+  }
+
+  let variance = 0;
+  for (let bin = 1; bin < magnitudes.length; bin += 1) {
+    const frequency = (bin * sampleRate) / FRAME_SIZE;
+    variance += magnitudes[bin] * Math.pow(frequency - centroid, 2);
+  }
+
+  return {
+    magnitudes,
+    centroid,
+    rolloff,
+    bandwidth: total > 0 ? Math.sqrt(variance / total) : 0,
+    low,
+    mid,
+    high,
+    total,
+  };
+}
+
+export function summarizeSpectrum(decoded: StudioDecodedAudio): SpectrumSummary | null {
+  const mono = mixdownToMono(decoded);
+  if (!mono.length) return null;
+
+  const offsets = frameOffsets(mono.length);
+  let centroid = 0;
+  let rolloff = 0;
+  let bandwidth = 0;
+  let low = 0;
+  let mid = 0;
+  let high = 0;
+  let flux = 0;
+  let noiseFloor = 0;
+  let previous: Float64Array | null = null;
+
+  const energySegments: EnergySegment[] = [];
+  for (const [index, offset] of offsets.entries()) {
+    const summary = magnitudeSpectrum(mono, offset, decoded.sampleRate);
+    centroid += summary.centroid;
+    rolloff += summary.rolloff;
+    bandwidth += summary.bandwidth;
+    low += summary.low;
+    mid += summary.mid;
+    high += summary.high;
+    noiseFloor += 20 * Math.log10(Math.max(1e-8, summary.total / summary.magnitudes.length));
+
+    if (previous) {
+      let frameFlux = 0;
+      for (let bin = 0; bin < summary.magnitudes.length; bin += 1) {
+        const delta = summary.magnitudes[bin] - previous[bin];
+        if (delta > 0) frameFlux += delta;
+      }
+      flux += frameFlux / summary.magnitudes.length;
+    }
+    previous = summary.magnitudes;
+
+    const end = Math.min(offset + FRAME_SIZE, mono.length);
+    const frame = mono.subarray(offset, end);
+    energySegments.push({
+      index,
+      startSeconds: offset / decoded.sampleRate,
+      endSeconds: end / decoded.sampleRate,
+      rms: rms(frame),
+      peak: Math.max(...Array.from(frame, (sample) => Math.abs(sample))),
+      centroidHz: summary.centroid || null,
+    });
+  }
+
+  const divisor = Math.max(1, offsets.length);
+  return {
+    centroidHz: centroid / divisor,
+    rolloffHz: rolloff / divisor,
+    bandwidthHz: bandwidth / divisor,
+    flux: flux / Math.max(1, offsets.length - 1),
+    low,
+    mid,
+    high,
+    noiseFloorDb: noiseFloor / divisor,
+    energySegments,
+  };
+}
+
+export function extractSpectralFeatures(decoded: StudioDecodedAudio): { features: StudioAudioFeature[]; energySegments: EnergySegment[]; summary: SpectrumSummary | null } {
+  const summary = summarizeSpectrum(decoded);
+  if (!summary) {
+    return {
+      features: [
+        missingFeature('spectral_centroid_hz', 'Spectral Centroid', 'No decoded samples were available for spectral analysis.', ['AUDIO_SAMPLES_REQUIRED']),
+        missingFeature('spectral_rolloff_hz', 'Spectral Rolloff', 'No decoded samples were available for spectral analysis.', ['AUDIO_SAMPLES_REQUIRED']),
+        missingFeature('spectral_flux', 'Spectral Flux', 'No decoded samples were available for spectral analysis.', ['AUDIO_SAMPLES_REQUIRED']),
+      ],
+      energySegments: [],
+      summary,
+    };
+  }
+
+  return {
+    features: [
+      feature('spectral_centroid_hz', 'Spectral Centroid', summary.centroidHz, 'Hz', 'Mean spectral centroid from bounded DFT frames over decoded mono mixdown.', 0.76),
+      feature('spectral_rolloff_hz', 'Spectral Rolloff', summary.rolloffHz, 'Hz', 'Mean 85 percent spectral rolloff from bounded DFT frames.', 0.74),
+      feature('spectral_bandwidth_hz', 'Spectral Bandwidth', summary.bandwidthHz, 'Hz', 'Mean spectral bandwidth from bounded DFT frames.', 0.72),
+      feature('spectral_flux', 'Spectral Flux', summary.flux, null, 'Positive frame-to-frame spectral magnitude change over bounded DFT frames.', 0.7),
+      feature('noise_floor_dbfs', 'Noise Floor', summary.noiseFloorDb, 'dBFS', 'Low-level spectral energy floor estimated from bounded DFT frame magnitudes.', 0.62),
+      feature('zero_crossing_rate_spectral', 'Zero Crossing Rate', zeroCrossingRate(mixdownToMono(decoded)), null, 'Zero crossing rate measured over decoded mono samples.', 0.82),
+    ],
+    energySegments: summary.energySegments,
+    summary,
+  };
+}

--- a/src/lib/studio/audio/features/stereoFeatures.ts
+++ b/src/lib/studio/audio/features/stereoFeatures.ts
@@ -1,0 +1,41 @@
+import type { StudioAudioFeature, StudioDecodedAudio } from '../audioTypes';
+import { feature, missingFeature, rms } from './basicFeatures';
+
+export function extractStereoFeatures(decoded: StudioDecodedAudio): StudioAudioFeature[] {
+  if (decoded.channels < 2) {
+    return [
+      missingFeature('stereo_width', 'Stereo Width', 'Stereo width requires at least two decoded channels.', ['STEREO_SOURCE_REQUIRED']),
+      missingFeature('phase_correlation', 'Phase Correlation', 'Phase correlation requires at least two decoded channels.', ['STEREO_SOURCE_REQUIRED']),
+    ];
+  }
+
+  const left = decoded.channelData[0];
+  const right = decoded.channelData[1];
+  let dot = 0;
+  let leftEnergy = 0;
+  let rightEnergy = 0;
+  const mid = new Float32Array(decoded.frameCount);
+  const side = new Float32Array(decoded.frameCount);
+
+  for (let index = 0; index < decoded.frameCount; index += 1) {
+    const l = left[index] ?? 0;
+    const r = right[index] ?? 0;
+    dot += l * r;
+    leftEnergy += l * l;
+    rightEnergy += r * r;
+    mid[index] = (l + r) / 2;
+    side[index] = (l - r) / 2;
+  }
+
+  const correlation = dot / Math.sqrt(Math.max(1e-12, leftEnergy * rightEnergy));
+  const midRms = rms(mid);
+  const sideRms = rms(side);
+  const width = sideRms / Math.max(1e-9, midRms + sideRms);
+
+  return [
+    feature('stereo_width', 'Stereo Width', width, null, 'Mid-side ratio measured from the first two decoded channels.', 0.76),
+    feature('phase_correlation', 'Phase Correlation', correlation, null, 'Pearson-style sample correlation between first two decoded channels.', 0.76),
+    feature('mid_energy', 'Mid Energy', midRms, null, 'RMS of mid channel derived from first two decoded channels.', 0.72),
+    feature('side_energy', 'Side Energy', sideRms, null, 'RMS of side channel derived from first two decoded channels.', 0.72),
+  ];
+}

--- a/src/lib/studio/audio/features/tonalFeatures.ts
+++ b/src/lib/studio/audio/features/tonalFeatures.ts
@@ -1,0 +1,31 @@
+import type { StudioAudioFeature } from '../audioTypes';
+import { feature, missingFeature } from './basicFeatures';
+
+export type TonalBandSummary = {
+  low: number;
+  mid: number;
+  high: number;
+};
+
+export function extractTonalFeatures(summary: TonalBandSummary | null): StudioAudioFeature[] {
+  if (!summary) {
+    return [
+      missingFeature('tonal_balance_low', 'Tonal Balance Low', 'Tonal balance requires spectral summary evidence.', ['SPECTRAL_FEATURE_REQUIRED']),
+      missingFeature('tonal_balance_mid', 'Tonal Balance Mid', 'Tonal balance requires spectral summary evidence.', ['SPECTRAL_FEATURE_REQUIRED']),
+      missingFeature('tonal_balance_high', 'Tonal Balance High', 'Tonal balance requires spectral summary evidence.', ['SPECTRAL_FEATURE_REQUIRED']),
+    ];
+  }
+
+  const total = Math.max(1e-12, summary.low + summary.mid + summary.high);
+  const low = summary.low / total;
+  const mid = summary.mid / total;
+  const high = summary.high / total;
+  const descriptor = `low:${low.toFixed(3)} mid:${mid.toFixed(3)} high:${high.toFixed(3)}`;
+
+  return [
+    feature('tonal_balance_low', 'Tonal Balance Low', low, null, 'Low-band spectral energy share below 250 Hz.', 0.66),
+    feature('tonal_balance_mid', 'Tonal Balance Mid', mid, null, 'Mid-band spectral energy share from 250 Hz to 4 kHz.', 0.66),
+    feature('tonal_balance_high', 'Tonal Balance High', high, null, 'High-band spectral energy share above 4 kHz.', 0.66),
+    feature('tonal_balance', 'Tonal Balance', descriptor, null, 'Text summary of observed low, mid, and high spectral energy shares.', 0.66),
+  ];
+}

--- a/src/lib/studio/audio/features/transientFeatures.ts
+++ b/src/lib/studio/audio/features/transientFeatures.ts
@@ -1,0 +1,34 @@
+import type { EnergySegment, StudioAudioFeature, StudioDecodedAudio } from '../audioTypes';
+import { feature, missingFeature } from './basicFeatures';
+
+export function detectTransientIndexes(segments: EnergySegment[]) {
+  if (segments.length < 3) return [];
+  const deltas = segments.slice(1).map((segment, index) => segment.rms - segments[index].rms);
+  const positive = deltas.filter((delta) => delta > 0);
+  const mean = positive.reduce((sum, value) => sum + value, 0) / Math.max(1, positive.length);
+  const variance = positive.reduce((sum, value) => sum + Math.pow(value - mean, 2), 0) / Math.max(1, positive.length);
+  const threshold = mean + Math.sqrt(variance);
+  return deltas
+    .map((delta, index) => ({ delta, index: index + 1 }))
+    .filter((item) => item.delta > threshold && segments[item.index].peak > 0.04)
+    .map((item) => item.index);
+}
+
+export function extractTransientFeatures(decoded: StudioDecodedAudio, segments: EnergySegment[]): StudioAudioFeature[] {
+  if (!segments.length) {
+    return [
+      missingFeature('transient_density', 'Transient Density', 'Transient density requires energy segment evidence.', ['ENERGY_SEGMENTS_REQUIRED']),
+      missingFeature('percussive_load', 'Percussive Load', 'Percussive load requires energy segment evidence.', ['ENERGY_SEGMENTS_REQUIRED']),
+    ];
+  }
+
+  const indexes = detectTransientIndexes(segments);
+  const density = indexes.length / Math.max(1, decoded.durationSeconds);
+  const percussiveLoad = indexes.reduce((sum, index) => sum + segments[index].peak, 0) / Math.max(1, indexes.length);
+
+  return [
+    feature('transient_density', 'Transient Density', density, 'events/s', 'Transient count per second from positive short-window energy deltas.', 0.62),
+    feature('percussive_load', 'Percussive Load', indexes.length ? percussiveLoad : 0, null, 'Mean peak amplitude of detected transient windows.', 0.58),
+    missingFeature('harmonic_stability', 'Harmonic Stability', 'Harmonic stability requires a pitch or harmonic tracker that is not present in this engine.', ['HARMONIC_TRACKER_REQUIRED']),
+  ];
+}

--- a/src/lib/studio/audio/segmentation/onsetDetection.ts
+++ b/src/lib/studio/audio/segmentation/onsetDetection.ts
@@ -1,0 +1,22 @@
+import type { EnergySegment } from '../audioTypes';
+import { detectTransientIndexes } from '../features/transientFeatures';
+import type { StudioAudioMarker } from './segmentationTypes';
+
+export function detectOnsets(segments: EnergySegment[]): StudioAudioMarker[] {
+  return detectTransientIndexes(segments).slice(0, 256).map((index, markerIndex) => {
+    const segment = segments[index];
+    return {
+      id: `onset-${markerIndex + 1}`,
+      type: 'onset',
+      label: 'Onset',
+      startSeconds: segment.startSeconds,
+      endSeconds: segment.endSeconds,
+      confidence: 0.62,
+      payload: {
+        rms: segment.rms,
+        peak: segment.peak,
+        centroidHz: segment.centroidHz,
+      },
+    };
+  });
+}

--- a/src/lib/studio/audio/segmentation/sectionDetection.ts
+++ b/src/lib/studio/audio/segmentation/sectionDetection.ts
@@ -1,0 +1,49 @@
+import type { EnergySegment } from '../audioTypes';
+import type { StudioAudioMarker } from './segmentationTypes';
+
+function mean(values: number[]) {
+  return values.reduce((sum, value) => sum + value, 0) / Math.max(1, values.length);
+}
+
+export function detectSections(segments: EnergySegment[]): StudioAudioMarker[] {
+  if (segments.length < 4) return [];
+  const averageRms = mean(segments.map((segment) => segment.rms));
+  const sections: StudioAudioMarker[] = [];
+  let currentStart = segments[0].startSeconds;
+  let currentEnergyClass = segments[0].rms >= averageRms ? 'high' : 'low';
+
+  for (let index = 1; index < segments.length; index += 1) {
+    const segment = segments[index];
+    const energyClass = segment.rms >= averageRms ? 'high' : 'low';
+    const changed = energyClass !== currentEnergyClass;
+    const longEnough = segment.startSeconds - currentStart >= 6;
+    if (changed && longEnough) {
+      sections.push({
+        id: `section-${sections.length + 1}`,
+        type: 'section',
+        label: `Section ${sections.length + 1}`,
+        startSeconds: currentStart,
+        endSeconds: segment.startSeconds,
+        confidence: 0.48,
+        payload: { basis: 'energy_class_change', energyClass: currentEnergyClass, averageRms },
+      });
+      currentStart = segment.startSeconds;
+      currentEnergyClass = energyClass;
+    }
+  }
+
+  const last = segments[segments.length - 1];
+  if (last.endSeconds - currentStart >= 1) {
+    sections.push({
+      id: `section-${sections.length + 1}`,
+      type: 'section',
+      label: `Section ${sections.length + 1}`,
+      startSeconds: currentStart,
+      endSeconds: last.endSeconds,
+      confidence: 0.48,
+      payload: { basis: 'energy_class_change', energyClass: currentEnergyClass, averageRms },
+    });
+  }
+
+  return sections;
+}

--- a/src/lib/studio/audio/segmentation/segmentationTypes.ts
+++ b/src/lib/studio/audio/segmentation/segmentationTypes.ts
@@ -1,0 +1,15 @@
+export type StudioAudioSegmentationOptions = {
+  silenceThresholdDbfs?: number;
+  minimumSilenceSeconds?: number;
+  waveformPointCount?: number;
+};
+
+export type StudioAudioMarker = {
+  id: string;
+  type: 'silence' | 'active' | 'onset' | 'section';
+  label: string;
+  startSeconds: number;
+  endSeconds: number;
+  confidence: number;
+  payload?: Record<string, unknown>;
+};

--- a/src/lib/studio/audio/segmentation/silenceDetection.ts
+++ b/src/lib/studio/audio/segmentation/silenceDetection.ts
@@ -1,0 +1,44 @@
+import type { EnergySegment } from '../audioTypes';
+import { amplitudeToDbfs } from '../features/basicFeatures';
+import type { StudioAudioMarker, StudioAudioSegmentationOptions } from './segmentationTypes';
+
+export function detectSilenceRegions(segments: EnergySegment[], options: StudioAudioSegmentationOptions = {}): StudioAudioMarker[] {
+  const threshold = options.silenceThresholdDbfs ?? -60;
+  const minimumSeconds = options.minimumSilenceSeconds ?? 0.25;
+  const regions: StudioAudioMarker[] = [];
+  let current: { start: number; end: number } | null = null;
+
+  for (const segment of segments) {
+    const isSilent = amplitudeToDbfs(segment.rms) <= threshold;
+    if (isSilent && !current) current = { start: segment.startSeconds, end: segment.endSeconds };
+    else if (isSilent && current) current.end = segment.endSeconds;
+    else if (!isSilent && current) {
+      if (current.end - current.start >= minimumSeconds) {
+        regions.push({
+          id: `silence-${regions.length + 1}`,
+          type: 'silence',
+          label: 'Silence',
+          startSeconds: current.start,
+          endSeconds: current.end,
+          confidence: 0.7,
+          payload: { thresholdDbfs: threshold },
+        });
+      }
+      current = null;
+    }
+  }
+
+  if (current && current.end - current.start >= minimumSeconds) {
+    regions.push({
+      id: `silence-${regions.length + 1}`,
+      type: 'silence',
+      label: 'Silence',
+      startSeconds: current.start,
+      endSeconds: current.end,
+      confidence: 0.7,
+      payload: { thresholdDbfs: threshold },
+    });
+  }
+
+  return regions;
+}

--- a/src/lib/studio/audio/segmentation/waveformPeaks.ts
+++ b/src/lib/studio/audio/segmentation/waveformPeaks.ts
@@ -1,0 +1,37 @@
+import { mixdownToMono } from '../audioDecode';
+import type { StudioDecodedAudio, WaveformPeak } from '../audioTypes';
+import { peak, rms } from '../features/basicFeatures';
+
+export function buildWaveformPeaks(decoded: StudioDecodedAudio, pointCount = 4096): WaveformPeak[] {
+  const mono = mixdownToMono(decoded);
+  if (!mono.length) return [];
+  const count = Math.min(pointCount, mono.length);
+  const samplesPerPoint = Math.max(1, Math.floor(mono.length / count));
+  const peaks: WaveformPeak[] = [];
+
+  for (let index = 0; index < count; index += 1) {
+    const start = index * samplesPerPoint;
+    const end = index === count - 1 ? mono.length : Math.min(mono.length, start + samplesPerPoint);
+    const frame = mono.subarray(start, end);
+    let min = 1;
+    let max = -1;
+    for (const sample of frame) {
+      if (sample < min) min = sample;
+      if (sample > max) max = sample;
+    }
+    peaks.push({
+      index,
+      startSeconds: start / decoded.sampleRate,
+      endSeconds: end / decoded.sampleRate,
+      min,
+      max,
+      rms: rms(frame),
+    });
+  }
+
+  return peaks;
+}
+
+export function waveformPeakAmplitudes(peaks: WaveformPeak[]) {
+  return peaks.map((item) => peak(new Float32Array([item.min, item.max])));
+}

--- a/src/lib/studio/production/studioContracts.ts
+++ b/src/lib/studio/production/studioContracts.ts
@@ -1,0 +1,164 @@
+export type MetricStatus =
+  | 'PENDING'
+  | 'RUNNING'
+  | 'OBSERVED'
+  | 'DERIVED'
+  | 'DEGRADED'
+  | 'MISSING'
+  | 'FAILED'
+  | 'COMPLETE'
+  | 'EXPERIMENTAL';
+
+export type MetricValue = {
+  key: string;
+  label: string;
+  value: number | string | null;
+  unit: string | null;
+  status: MetricStatus;
+  source: string | null;
+  evidenceIds: string[];
+  confidence: number;
+  observedAt: string | null;
+  formulaVersion: string | null;
+  warnings: string[];
+  explanation: string;
+};
+
+export type PhaseState = {
+  key: string;
+  label: string;
+  status: MetricStatus;
+  progress: number | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  error: string | null;
+  details: string | null;
+  nextAction: string | null;
+  requirements: string[];
+};
+
+export type EvidenceRef = {
+  id: string;
+  type: string;
+  source: string;
+  label: string;
+  observedAt: string | null;
+  reliability: number;
+  uri: string | null;
+};
+
+export type ViewContract = {
+  key: string;
+  title: string;
+  purpose: string;
+  inputs: string[];
+  outputs: string[];
+  requiredEvidence: string[];
+  status: MetricStatus;
+  blockedReason: string | null;
+};
+
+export type StudioFieldNode = {
+  id: string;
+  label: string;
+  type: 'object' | 'metric' | 'phase' | 'evidence' | 'hypothesis' | 'tension' | 'domain';
+  value: number | string | null;
+  status: MetricStatus;
+  source: string | null;
+  formulaVersion: string | null;
+  confidence: number;
+  explanation: string;
+  evidenceIds: string[];
+};
+
+export type StudioFieldEdge = {
+  from: string;
+  to: string;
+  relationType: string;
+  weight: number | null;
+  source: string | null;
+  confidence: number;
+  explanation: string;
+};
+
+export type StudioNextAction = {
+  code: string;
+  action: string;
+  reason: string;
+  requirement: string | null;
+  endpoint: string | null;
+  method: 'GET' | 'POST' | null;
+  disabledReason: string | null;
+};
+
+export function clampConfidence(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(0, Math.min(1, parsed > 1 ? parsed / 100 : parsed));
+}
+
+export function missingMetric(key: string, label: string, explanation: string, requirements: string[] = []): MetricValue {
+  return {
+    key,
+    label,
+    value: null,
+    unit: null,
+    status: 'MISSING',
+    source: null,
+    evidenceIds: [],
+    confidence: 0,
+    observedAt: null,
+    formulaVersion: null,
+    warnings: requirements,
+    explanation,
+  };
+}
+
+export function observedMetric(input: {
+  key: string;
+  label: string;
+  value: number | string | null;
+  unit?: string | null;
+  source: string;
+  evidenceIds?: string[];
+  confidence?: number | null;
+  observedAt?: string | null;
+  formulaVersion?: string | null;
+  warnings?: string[];
+  explanation: string;
+}): MetricValue {
+  return {
+    key: input.key,
+    label: input.label,
+    value: input.value,
+    unit: input.unit ?? null,
+    status: input.value === null ? 'MISSING' : 'OBSERVED',
+    source: input.value === null ? null : input.source,
+    evidenceIds: input.evidenceIds ?? [],
+    confidence: clampConfidence(input.confidence ?? (input.value === null ? 0 : 1)),
+    observedAt: input.observedAt ?? null,
+    formulaVersion: input.formulaVersion ?? null,
+    warnings: input.warnings ?? [],
+    explanation: input.explanation,
+  };
+}
+
+export function derivedMetric(input: Omit<Parameters<typeof observedMetric>[0], 'source'> & { source: string; status?: MetricStatus }): MetricValue {
+  const metric = observedMetric(input);
+  return { ...metric, status: input.value === null ? 'MISSING' : input.status ?? 'DERIVED' };
+}
+
+export function phase(input: Partial<PhaseState> & { key: string; label: string; status: MetricStatus }): PhaseState {
+  return {
+    key: input.key,
+    label: input.label,
+    status: input.status,
+    progress: input.progress ?? null,
+    startedAt: input.startedAt ?? null,
+    completedAt: input.completedAt ?? null,
+    error: input.error ?? null,
+    details: input.details ?? null,
+    nextAction: input.nextAction ?? null,
+    requirements: input.requirements ?? [],
+  };
+}

--- a/src/lib/studio/production/studioProductionAdapter.ts
+++ b/src/lib/studio/production/studioProductionAdapter.ts
@@ -5,15 +5,42 @@ import { buildStudioCulturalLens } from './studioCulturalLens';
 import { buildStudioHypotheses, type StudioLayerInput } from './hypothesisEngine';
 import { buildStudioProductionDegradedState } from './studioProductionDegradedState';
 import type {
+  EvidenceRef,
+  MetricStatus,
+  MetricValue,
   StudioFeatureMetric,
+  StudioFieldEdge,
+  StudioFieldNode,
   StudioObjectType,
   StudioProductionObject,
   StudioProductionSession,
   StudioProductionState,
   StudioReadinessState,
+  ViewContract,
 } from './studioProductionTypes';
+import { clampConfidence, derivedMetric, missingMetric, observedMetric, phase } from './studioContracts';
 
 type Row = Record<string, unknown>;
+
+type StudioStoredState = {
+  session: Row | null;
+  object: Row | null;
+  features: Row[];
+  uploads: Row[];
+  audio: Row[];
+  video: Row[];
+  image: Row[];
+  text: Row[];
+  community: Row[];
+  timeCoordinates: Row[];
+  hypotheses: Row[];
+  interventions: Row[];
+  evidenceTraces: Row[];
+  archiveEvents: Row[];
+  exports: Row[];
+  jobs: Row[];
+  degraded: string[];
+};
 
 function asRecord(value: unknown): Row {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
@@ -30,6 +57,14 @@ function asString(value: unknown, fallback = '') {
 function asNumber(value: unknown): number | null {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function latest(rows: Row[]): Row | null {
+  return rows[0] ?? null;
 }
 
 function clamp01(value: number | null): number | null {
@@ -55,7 +90,7 @@ function inferObjectType(value: unknown): StudioObjectType {
   return 'unknown';
 }
 
-async function queryLatestSessionAndObject() {
+async function queryLatestSessionAndObject(): Promise<StudioStoredState> {
   const degraded: string[] = [];
   try {
     const supabase = createServiceSupabaseClient();
@@ -67,7 +102,25 @@ async function queryLatestSessionAndObject() {
       .maybeSingle();
 
     if (sessionError) throw sessionError;
-    if (!session) return { session: null, object: null, features: [], degraded };
+    if (!session) return {
+      session: null,
+      object: null,
+      features: [],
+      uploads: [],
+      audio: [],
+      video: [],
+      image: [],
+      text: [],
+      community: [],
+      timeCoordinates: [],
+      hypotheses: [],
+      interventions: [],
+      evidenceTraces: [],
+      archiveEvents: [],
+      exports: [],
+      jobs: [],
+      degraded,
+    };
 
     const { data: object, error: objectError } = await supabase
       .from('studio_objects')
@@ -80,15 +133,117 @@ async function queryLatestSessionAndObject() {
     if (objectError) throw objectError;
 
     const objectId = asString((object as Row | null)?.id);
-    const { data: features, error: featureError } = objectId
-      ? await supabase.from('studio_object_features').select('*').eq('object_id', objectId)
-      : { data: [], error: null };
+    if (!objectId) return {
+      session: asRecord(session),
+      object: object ? asRecord(object) : null,
+      features: [],
+      uploads: [],
+      audio: [],
+      video: [],
+      image: [],
+      text: [],
+      community: [],
+      timeCoordinates: [],
+      hypotheses: [],
+      interventions: [],
+      evidenceTraces: [],
+      archiveEvents: [],
+      exports: [],
+      jobs: [],
+      degraded,
+    };
 
-    if (featureError) throw featureError;
-    return { session: asRecord(session), object: object ? asRecord(object) : null, features: asRows(features), degraded };
+    const [
+      featuresResult,
+      uploadsResult,
+      audioResult,
+      videoResult,
+      imageResult,
+      textResult,
+      communityResult,
+      timeCoordinatesResult,
+      hypothesesResult,
+      interventionsResult,
+      evidenceResult,
+      archiveResult,
+      exportsResult,
+      jobsResult,
+    ] = await Promise.all([
+      supabase.from('studio_object_features').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_uploads').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_audio_features').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_video_features').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_image_features').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_text_features').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_community_features').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_time_coordinates').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_hypotheses').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_interventions').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_evidence_traces').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_archive_events').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_exports').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+      supabase.from('studio_analysis_jobs').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+    ]);
+
+    const results = [
+      featuresResult,
+      uploadsResult,
+      audioResult,
+      videoResult,
+      imageResult,
+      textResult,
+      communityResult,
+      timeCoordinatesResult,
+      hypothesesResult,
+      interventionsResult,
+      evidenceResult,
+      archiveResult,
+      exportsResult,
+      jobsResult,
+    ];
+    const failed = results.find((result) => result.error);
+    if (failed?.error) throw failed.error;
+
+    return {
+      session: asRecord(session),
+      object: object ? asRecord(object) : null,
+      features: asRows(featuresResult.data),
+      uploads: asRows(uploadsResult.data),
+      audio: asRows(audioResult.data),
+      video: asRows(videoResult.data),
+      image: asRows(imageResult.data),
+      text: asRows(textResult.data),
+      community: asRows(communityResult.data),
+      timeCoordinates: asRows(timeCoordinatesResult.data),
+      hypotheses: asRows(hypothesesResult.data),
+      interventions: asRows(interventionsResult.data),
+      evidenceTraces: asRows(evidenceResult.data),
+      archiveEvents: asRows(archiveResult.data),
+      exports: asRows(exportsResult.data),
+      jobs: asRows(jobsResult.data),
+      degraded,
+    };
   } catch (error) {
     degraded.push(error instanceof Error ? error.message : 'studio_tables_unavailable');
-    return { session: null, object: null, features: [], degraded };
+    return {
+      session: null,
+      object: null,
+      features: [],
+      uploads: [],
+      audio: [],
+      video: [],
+      image: [],
+      text: [],
+      community: [],
+      timeCoordinates: [],
+      hypotheses: [],
+      interventions: [],
+      evidenceTraces: [],
+      archiveEvents: [],
+      exports: [],
+      jobs: [],
+      degraded,
+    };
   }
 }
 
@@ -121,11 +276,18 @@ function objectFrom(row: Row | null, session: StudioProductionSession): StudioPr
       type: 'unknown',
       sourceUri: null,
       mimeType: null,
+      sizeBytes: null,
       status: 'blocked',
       readiness: 'missing',
       uploadedAt: null,
+      version: null,
+      storageStatus: 'MISSING',
+      analysisStatus: 'MISSING',
     };
   }
+
+  const rawStatus = asString(row.status);
+  const status = rawStatus === 'ready' ? 'complete' : rawStatus === 'analyzing' ? 'running' : rawStatus === 'failed' ? 'failed' : rawStatus === 'blocked' ? 'blocked' : 'queued';
 
   return {
     id: asString(row.id) || null,
@@ -134,54 +296,32 @@ function objectFrom(row: Row | null, session: StudioProductionSession): StudioPr
     type: inferObjectType(row.object_type),
     sourceUri: asString(row.source_uri) || null,
     mimeType: asString(row.mime_type) || null,
-    status: asString(row.status) === 'ready' ? 'complete' : asString(row.status) === 'analyzing' ? 'running' : 'queued',
-    readiness: asString(row.status) === 'ready' ? 'ready' : 'partial',
+    sizeBytes: asNumber(row.size_bytes),
+    status,
+    readiness: rawStatus === 'ready' ? 'ready' : rawStatus === 'failed' || rawStatus === 'blocked' ? 'blocked' : 'partial',
     uploadedAt: asString(row.created_at) || null,
+    version: asString(asRecord(row.metadata).version) || asString(row.updated_at) || null,
+    storageStatus: rawStatus ? 'PENDING' : 'MISSING',
+    analysisStatus: status === 'complete' ? 'COMPLETE' : status === 'running' ? 'RUNNING' : status === 'failed' ? 'FAILED' : 'PENDING',
   };
 }
 
-function metricsFromFeatureRows(rows: Row[], gold: Awaited<ReturnType<typeof readStudioGoldState>>): StudioFeatureMetric[] {
-  const persisted = rows.map((row) => ({
-    id: asString(row.feature_key, asString(row.id, 'feature')),
-    label: asString(row.label, asString(row.feature_key, 'FEATURE')).toUpperCase(),
-    value: clamp01(asNumber(row.numeric_value)),
-    unit: asString(row.unit) || undefined,
-    source: 'studio_object_features',
-    status: asNumber(row.numeric_value) === null ? 'blocked' as const : 'ready' as const,
-  }));
-
-  if (persisted.length) return persisted;
-
-  return [
-    {
-      id: 'coherence',
-      label: 'COHERENCIA DEL OBJETO',
-      value: clamp01(gold.culturalWave.coherenceGlobal),
-      source: 'studioGold.culturalWave.coherenceGlobal',
-      status: gold.activeCase.id ? 'partial' : 'missing',
-    },
-    {
-      id: 'entropy',
-      label: 'TENSION / ENTROPIA',
-      value: clamp01(gold.culturalWave.culturalEntropy),
-      source: 'studioGold.culturalWave.culturalEntropy',
-      status: gold.activeCase.id ? 'partial' : 'missing',
-    },
-    {
-      id: 'symbolic_density',
-      label: 'DENSIDAD SIMBOLICA',
-      value: clamp01(gold.culturalWave.symbolicDensity),
-      source: 'studioGold.culturalWave.symbolicDensity',
-      status: gold.activeCase.id ? 'partial' : 'missing',
-    },
-    {
-      id: 'plasticity',
-      label: 'PLASTICIDAD',
-      value: clamp01(gold.culturalWave.plasticity),
-      source: 'studioGold.culturalWave.plasticity',
-      status: gold.activeCase.id ? 'partial' : 'missing',
-    },
-  ];
+function metricsFromFeatureRows(rows: Row[]): StudioFeatureMetric[] {
+  return rows.map((row) => {
+    const numeric = asNumber(row.numeric_value);
+    const key = asString(row.feature_key, asString(row.id, 'feature')) ?? 'feature';
+    return {
+      id: key,
+      label: asString(row.label, key).toUpperCase(),
+      value: numeric,
+      unit: asString(row.unit),
+      source: asString(row.source, 'studio_object_features'),
+      status: numeric === null ? 'MISSING' as const : 'OBSERVED' as const,
+      confidence: clampConfidence(row.confidence ?? (numeric === null ? 0 : 1)),
+      explanation: asString(asRecord(row.payload).explanation, 'Persisted Studio object feature row.'),
+      evidenceIds: [asString(row.id, key) ?? key],
+    };
+  });
 }
 
 function layerInputsFromMetrics(metrics: StudioFeatureMetric[]): StudioLayerInput[] {
@@ -203,6 +343,324 @@ function layerInputsFromMetrics(metrics: StudioFeatureMetric[]): StudioLayerInpu
   });
 }
 
+function numberArray(value: unknown): number[] {
+  return asArray(value).map((item) => asNumber(item)).filter((item): item is number => item !== null);
+}
+
+function statusFromUpload(row: Row | null): MetricStatus {
+  const status = asString(row?.status);
+  if (status === 'stored') return 'OBSERVED';
+  if (status === 'degraded') return 'DEGRADED';
+  if (status === 'failed') return 'FAILED';
+  return 'MISSING';
+}
+
+function evidenceFromRows(stored: Awaited<ReturnType<typeof queryLatestSessionAndObject>>, activeObject: StudioProductionObject): EvidenceRef[] {
+  const evidence: EvidenceRef[] = [];
+  if (activeObject.id) {
+    evidence.push({
+      id: activeObject.id,
+      type: 'studio_object',
+      source: 'studio_objects',
+      label: activeObject.title,
+      observedAt: activeObject.uploadedAt,
+      reliability: 1,
+      uri: activeObject.sourceUri,
+    });
+  }
+  stored.uploads.forEach((row) => evidence.push({
+    id: asString(row.id, `upload-${evidence.length + 1}`) ?? `upload-${evidence.length + 1}`,
+    type: 'upload',
+    source: 'studio_uploads',
+    label: asString(row.storage_path, 'Studio upload') ?? 'Studio upload',
+    observedAt: asString(row.created_at),
+    reliability: asString(row.status) === 'stored' ? 1 : 0.35,
+    uri: asString(row.storage_path),
+  }));
+  stored.features.forEach((row) => evidence.push({
+    id: asString(row.id, `feature-${evidence.length + 1}`) ?? `feature-${evidence.length + 1}`,
+    type: 'feature',
+    source: asString(row.source, 'studio_object_features') ?? 'studio_object_features',
+    label: asString(row.label, asString(row.feature_key, 'Feature')) ?? 'Feature',
+    observedAt: asString(row.created_at),
+    reliability: clampConfidence(row.confidence ?? 1),
+    uri: null,
+  }));
+  stored.evidenceTraces.forEach((row) => evidence.push({
+    id: asString(row.id, `trace-${evidence.length + 1}`) ?? `trace-${evidence.length + 1}`,
+    type: 'trace',
+    source: asString(row.source, 'studio_evidence_traces') ?? 'studio_evidence_traces',
+    label: asString(row.label, 'Evidence trace') ?? 'Evidence trace',
+    observedAt: asString(row.created_at),
+    reliability: 1,
+    uri: null,
+  }));
+  return evidence;
+}
+
+function metricValuesFromState(input: {
+  activeObject: StudioProductionObject;
+  metrics: StudioFeatureMetric[];
+  evidence: EvidenceRef[];
+  lens: Awaited<ReturnType<typeof buildStudioCulturalLens>> | null;
+  mihmScore: number | null;
+  gold: Awaited<ReturnType<typeof readStudioGoldState>>;
+  stored: Awaited<ReturnType<typeof queryLatestSessionAndObject>>;
+}): MetricValue[] {
+  const { activeObject, metrics, evidence, lens, mihmScore, gold, stored } = input;
+  const latestUpload = latest(stored.uploads);
+  const uploadEvidence = latestUpload ? [asString(latestUpload.id, 'upload') ?? 'upload'] : [];
+  const values: MetricValue[] = [
+    activeObject.id
+      ? observedMetric({
+        key: 'active_object',
+        label: 'Active Object',
+        value: activeObject.title,
+        source: 'studio_objects',
+        evidenceIds: [activeObject.id],
+        confidence: 1,
+        observedAt: activeObject.uploadedAt,
+        explanation: 'Object row persisted in studio_objects.',
+      })
+      : missingMetric('active_object', 'Active Object', 'No persisted Studio object is active.', ['studio_object']),
+    latestUpload
+      ? observedMetric({
+        key: 'storage_verified',
+        label: 'Storage Verified',
+        value: asString(latestUpload.status),
+        source: 'studio_uploads',
+        evidenceIds: uploadEvidence,
+        confidence: asString(latestUpload.status) === 'stored' ? 1 : 0.35,
+        observedAt: asString(latestUpload.created_at),
+        explanation: 'Latest upload row for the active object.',
+      })
+      : missingMetric('storage_verified', 'Storage Verified', 'No upload row exists for the active object.', ['studio_uploads']),
+    metrics.length
+      ? derivedMetric({
+        key: 'feature_coverage',
+        label: 'Feature Coverage',
+        value: `${metrics.filter((metric) => metric.value !== null).length}/${metrics.length}`,
+        unit: null,
+        source: 'studio_object_features',
+        evidenceIds: metrics.flatMap((metric) => metric.evidenceIds),
+        confidence: metrics.reduce((sum, metric) => sum + metric.confidence, 0) / metrics.length,
+        observedAt: asString(stored.features[0]?.created_at),
+        formulaVersion: 'studio.feature_coverage.v1',
+        explanation: 'Count of persisted feature rows with numeric values over total persisted feature rows.',
+      })
+      : missingMetric('feature_coverage', 'Feature Coverage', 'No persisted object feature rows exist.', ['studio_object_features']),
+    mihmScore !== null && activeObject.id
+      ? derivedMetric({
+        key: 'mihm_activation',
+        label: 'MIHM Activation',
+        value: Number(mihmScore.toFixed(3)),
+        unit: null,
+        source: 'studioGold.mihmModel',
+        evidenceIds: evidence.map((item) => item.id).slice(0, 8),
+        confidence: gold.provenance.basedOn.length ? 0.68 : 0.32,
+        observedAt: asString((gold as unknown as Row).generatedAt),
+        formulaVersion: 'EXISTING_PHASE_1_FORMULAS_UNMODIFIED',
+        warnings: ['INTERNAL_SIGNAL_RANKING', 'NOT_EXTERNAL_PREDICTION', 'PROVISIONAL_NO_TRACEABILITY_NO_HISTORICAL_CALIBRATION'],
+        explanation: 'Internal MIHM score read from existing Studio Gold adapter without changing formulas.',
+      })
+      : missingMetric('mihm_activation', 'MIHM Activation', 'MIHM cannot be interpreted for Studio without an active object.', ['active_object']),
+    lens
+      ? derivedMetric({
+        key: 'cultural_resonance',
+        label: 'Cultural Resonance',
+        value: Number(lens.confidence.toFixed(3)),
+        unit: null,
+        source: 'buildStudioCulturalLens',
+        evidenceIds: lens.domainValues.map((item) => `domain:${item.domain}`),
+        confidence: lens.confidence,
+        observedAt: lens.observedAt,
+        formulaVersion: 'studio.cultural_lens.current',
+        warnings: lens.warnings,
+        explanation: lens.interpretation,
+        status: lens.status === 'degraded' || lens.status === 'thin' ? 'DEGRADED' : 'DERIVED',
+      })
+      : missingMetric('cultural_resonance', 'Cultural Resonance', 'Cultural Vector evidence is unavailable.', ['world_vector', 'worldspect_snapshots']),
+  ];
+
+  metrics.forEach((metric) => values.push(observedMetric({
+    key: metric.id,
+    label: metric.label,
+    value: metric.value,
+    unit: metric.unit,
+    source: metric.source ?? 'studio_object_features',
+    evidenceIds: metric.evidenceIds,
+    confidence: metric.confidence,
+    observedAt: asString(stored.features.find((row) => asString(row.feature_key) === metric.id)?.created_at),
+    explanation: metric.explanation,
+  })));
+
+  return values;
+}
+
+function phaseStatesFromState(input: {
+  activeObject: StudioProductionObject;
+  metrics: StudioFeatureMetric[];
+  lens: Awaited<ReturnType<typeof buildStudioCulturalLens>> | null;
+  hypotheses: ReturnType<typeof buildStudioHypotheses> | null;
+  interventions: Row[];
+  stored: Awaited<ReturnType<typeof queryLatestSessionAndObject>>;
+  exportsRows: Row[];
+  archiveRows: Row[];
+}): StudioProductionState['phaseStates'] {
+  const { activeObject, metrics, lens, hypotheses, interventions, stored, exportsRows, archiveRows } = input;
+  const uploadStatus = statusFromUpload(latest(stored.uploads));
+  const latestJob = latest(stored.jobs);
+  const jobStatus = asString(latestJob?.status);
+  const hasMetadata = Boolean(activeObject.mimeType || activeObject.sizeBytes !== null || activeObject.sourceUri);
+  const hasFeatures = metrics.some((metric) => metric.value !== null);
+  const hasHypotheses = Boolean(hypotheses?.hypotheses.length || stored.hypotheses.length);
+  const hasIntervention = interventions.length > 0;
+  const hasExports = exportsRows.length > 0;
+  const hasReturn = archiveRows.some((row) => asString(row.event_type)?.includes('return'));
+  const hasOutcome = archiveRows.some((row) => asString(row.event_type)?.includes('outcome'));
+  const hasLearning = archiveRows.some((row) => asString(row.event_type)?.includes('learning'));
+
+  return [
+    phase({ key: 'object_received', label: 'OBJECT RECEIVED', status: activeObject.id ? 'OBSERVED' : 'MISSING', progress: activeObject.id ? 1 : null, completedAt: activeObject.uploadedAt, requirements: ['studio_object'] }),
+    phase({ key: 'storage_verified', label: 'STORAGE VERIFIED', status: uploadStatus, progress: uploadStatus === 'OBSERVED' ? 1 : null, completedAt: asString(latest(stored.uploads)?.created_at), error: uploadStatus === 'FAILED' ? asString(latest(stored.uploads)?.status) : null, requirements: ['studio_uploads'] }),
+    phase({ key: 'metadata_extracted', label: 'METADATA EXTRACTED', status: hasMetadata ? 'OBSERVED' : 'MISSING', progress: hasMetadata ? 1 : null, completedAt: activeObject.uploadedAt, requirements: ['mime_type', 'size_bytes', 'source_uri'] }),
+    phase({ key: 'feature_extraction', label: 'FEATURE EXTRACTION', status: hasFeatures ? 'COMPLETE' : jobStatus === 'failed' ? 'FAILED' : jobStatus === 'blocked' ? 'FAILED' : activeObject.id ? 'MISSING' : 'MISSING', progress: hasFeatures ? 1 : null, error: jobStatus === 'failed' || jobStatus === 'blocked' ? asString(latestJob?.reason, 'feature_extractors_not_connected') : null, nextAction: hasFeatures ? null : 'Run analysis job to record blocked or complete status.', requirements: ['studio_object_features'] }),
+    phase({ key: 'mihm_evaluation', label: 'MIHM EVALUATION', status: activeObject.id ? 'DERIVED' : 'MISSING', progress: activeObject.id ? 1 : null, details: 'Existing Phase 1 MIHM formulas are read, not modified.', requirements: ['active_object'] }),
+    phase({ key: 'cultural_vector', label: 'CULTURAL VECTOR', status: lens ? (lens.status === 'degraded' || lens.status === 'thin' ? 'DEGRADED' : 'DERIVED') : 'MISSING', progress: lens ? 1 : null, error: lens?.status === 'failed' ? lens.interpretation : null, requirements: ['world_vector', 'cultural_lens'] }),
+    phase({ key: 'wsv_timing', label: 'WSV TIMING', status: lens ? (lens.status === 'degraded' || lens.status === 'thin' ? 'DEGRADED' : 'DERIVED') : 'MISSING', progress: lens ? 1 : null, details: lens ? 'Uses existing Studio cultural lens/WorldSpect snapshot adapter; not recalculated by render.' : null, requirements: ['worldspect_snapshots'] }),
+    phase({ key: 'hypothesis_generation', label: 'HYPOTHESIS GENERATION', status: hasHypotheses ? 'DERIVED' : 'MISSING', progress: hasHypotheses ? 1 : null, nextAction: hasFeatures ? null : 'Persist feature evidence before generating hypotheses.', requirements: ['feature_evidence'] }),
+    phase({ key: 'intervention_design', label: 'INTERVENTION DESIGN', status: hasIntervention ? 'OBSERVED' : hasHypotheses ? 'PENDING' : 'MISSING', progress: hasIntervention ? 1 : null, requirements: ['hypothesis'] }),
+    phase({ key: 'report_ready', label: 'REPORT READY', status: hasExports ? 'COMPLETE' : 'MISSING', progress: hasExports ? 1 : null, requirements: ['studio_exports'] }),
+    phase({ key: 'return_pending', label: 'RETURN PENDING', status: hasReturn ? 'COMPLETE' : 'MISSING', progress: hasReturn ? 1 : null, requirements: ['return archive event'] }),
+    phase({ key: 'outcome_recorded', label: 'OUTCOME RECORDED', status: hasOutcome ? 'COMPLETE' : 'MISSING', progress: hasOutcome ? 1 : null, requirements: ['outcome archive event'] }),
+    phase({ key: 'learning_registered', label: 'LEARNING REGISTERED', status: hasLearning ? 'COMPLETE' : 'MISSING', progress: hasLearning ? 1 : null, requirements: ['learning archive event'] }),
+  ];
+}
+
+function buildViewContracts(input: {
+  activeObject: StudioProductionObject;
+  metrics: StudioFeatureMetric[];
+  lens: Awaited<ReturnType<typeof buildStudioCulturalLens>> | null;
+  hypotheses: ReturnType<typeof buildStudioHypotheses> | null;
+  stored: Awaited<ReturnType<typeof queryLatestSessionAndObject>>;
+}): ViewContract[] {
+  const { activeObject, metrics, lens, hypotheses, stored } = input;
+  const hasObject = Boolean(activeObject.id);
+  const hasAudio = activeObject.mimeType?.startsWith('audio/') || stored.audio.length > 0;
+  const hasFeatures = metrics.some((metric) => metric.value !== null);
+  const hasLayers = false;
+  const hasHypothesis = Boolean(hypotheses?.hypotheses.length || stored.hypotheses.length);
+  const hasMemory = stored.archiveEvents.length > 0 || stored.exports.length > 0 || stored.jobs.length > 0;
+
+  return [
+    {
+      key: 'overview',
+      title: 'OVERVIEW',
+      purpose: 'Show active object, pipeline, evidence matrix, executive reading, current tension, and next action.',
+      inputs: ['studio_object', 'studio_uploads', 'studio_object_features', 'studio_analysis_jobs'],
+      outputs: ['phaseStates', 'evidence', 'nextAction'],
+      requiredEvidence: ['studio_object'],
+      status: hasObject ? 'OBSERVED' : 'MISSING',
+      blockedReason: hasObject ? null : 'ACTIVE_OBJECT_REQUIRED',
+    },
+    {
+      key: 'measure',
+      title: 'MEASURE',
+      purpose: 'Display technical measurements only from persisted features or browser audio analysis.',
+      inputs: ['audio file', 'studio_audio_features', 'studio_object_features'],
+      outputs: ['audio metrics', 'composition markers', 'mastering technical metrics'],
+      requiredEvidence: ['audio evidence or text evidence'],
+      status: hasFeatures || hasAudio ? 'OBSERVED' : 'MISSING',
+      blockedReason: hasFeatures || hasAudio ? null : 'MEASUREMENT_EVIDENCE_REQUIRED',
+    },
+    {
+      key: 'structure',
+      title: 'STRUCTURE',
+      purpose: 'Inspect layers, arrangements, mix and graph only when structural evidence exists.',
+      inputs: ['stems', 'layers', 'sections', 'channels', 'feature graph'],
+      outputs: ['layer table', 'arrangement dependencies', 'mix controls', 'neural graph'],
+      requiredEvidence: ['multilayer evidence'],
+      status: hasLayers ? 'OBSERVED' : 'MISSING',
+      blockedReason: hasLayers ? null : 'MULTILAYER_EVIDENCE_REQUIRED',
+    },
+    {
+      key: 'field',
+      title: 'FIELD',
+      purpose: 'Separate internal signal, cultural field and world timing without merging metrics.',
+      inputs: ['MIHM', 'Cultural Vector', 'WorldSpect snapshot'],
+      outputs: ['field tensions', 'hypotheses'],
+      requiredEvidence: ['active object', 'field evidence'],
+      status: lens || hasObject ? (lens?.status === 'degraded' || lens?.status === 'thin' ? 'DEGRADED' : 'DERIVED') : 'MISSING',
+      blockedReason: hasObject ? null : 'ACTIVE_OBJECT_REQUIRED',
+    },
+    {
+      key: 'intervention',
+      title: 'INTERVENTION',
+      purpose: 'Expose minimum perturbation, simulation availability, verification and outcome registration.',
+      inputs: ['hypothesis', 'intervention row', 'simulation endpoint'],
+      outputs: ['candidate actions', 'verification window', 'outcome registration'],
+      requiredEvidence: ['hypothesis'],
+      status: hasHypothesis ? 'PENDING' : 'MISSING',
+      blockedReason: hasHypothesis ? null : 'HYPOTHESIS_REQUIRED',
+    },
+    {
+      key: 'memory',
+      title: 'MEMORY',
+      purpose: 'Show persisted sessions, timeline, archives, versions, deliverables and learning.',
+      inputs: ['studio_sessions', 'studio_archive_events', 'studio_exports', 'studio_analysis_jobs'],
+      outputs: ['longitudinal table', 'timeline', 'deliverable state'],
+      requiredEvidence: ['session or archive rows'],
+      status: hasMemory ? 'OBSERVED' : hasObject ? 'PENDING' : 'MISSING',
+      blockedReason: hasObject ? null : 'ACTIVE_OBJECT_REQUIRED',
+    },
+  ];
+}
+
+function buildNextAction(activeObject: StudioProductionObject, metrics: StudioFeatureMetric[], stored: Awaited<ReturnType<typeof queryLatestSessionAndObject>>): StudioProductionState['nextAction'] {
+  if (!activeObject.id) {
+    return {
+      code: 'UPLOAD_OBJECT',
+      action: 'Cargar objeto',
+      reason: 'Studio no tiene objeto activo persistido.',
+      requirement: 'audio, imagen, texto, documento, URL o evidencia manual',
+      endpoint: null,
+      method: null,
+      disabledReason: null,
+    };
+  }
+  if (!stored.uploads.length) {
+    return {
+      code: 'STORAGE_EVIDENCE_MISSING',
+      action: 'Verificar storage',
+      reason: 'El objeto existe, pero no hay fila en studio_uploads.',
+      requirement: 'studio_uploads row',
+      endpoint: null,
+      method: null,
+      disabledReason: 'No existe endpoint de reparacion de storage en Studio.',
+    };
+  }
+  if (!metrics.some((metric) => metric.value !== null)) {
+    return {
+      code: 'RUN_ANALYSIS',
+      action: 'Ejecutar analisis',
+      reason: 'No hay features persistidas para el objeto activo.',
+      requirement: 'studio_object_features',
+      endpoint: `/api/studio/objects/${encodeURIComponent(activeObject.id)}/analyze`,
+      method: 'POST',
+      disabledReason: null,
+    };
+  }
+  return {
+    code: 'NO_ACTION_AVAILABLE',
+    action: 'NO_ACTION_AVAILABLE',
+    reason: 'No hay accion automatica segura con la evidencia actual.',
+    requirement: null,
+    endpoint: null,
+    method: null,
+    disabledReason: 'All available follow-up actions require additional persisted hypotheses or intervention engines.',
+  };
+}
+
 export async function readStudioProductionState(): Promise<StudioProductionState> {
   const generatedAt = new Date().toISOString();
   try {
@@ -214,8 +672,15 @@ export async function readStudioProductionState(): Promise<StudioProductionState
 
     const session = sessionFrom(stored.session, generatedAt);
     const activeObject = objectFrom(stored.object, session);
-    const metrics = metricsFromFeatureRows(stored.features, gold);
+    const uploadStatus = statusFromUpload(latest(stored.uploads));
+    const metrics = metricsFromFeatureRows(stored.features);
     const readiness = activeObject.id ? readinessFromMetrics(metrics) : 'missing';
+    const activeObjectWithStatus = {
+      ...activeObject,
+      readiness,
+      storageStatus: uploadStatus,
+      analysisStatus: metrics.some((metric) => metric.value !== null) ? 'COMPLETE' as const : activeObject.analysisStatus,
+    };
     const layers = metrics.map((metric) => ({
       id: metric.id,
       label: metric.label,
@@ -223,81 +688,164 @@ export async function readStudioProductionState(): Promise<StudioProductionState
       weight: metric.value,
       status: metric.status,
     }));
-    const graphNodes = [
-      activeObject.id ? { id: activeObject.id, label: activeObject.title, layer: 'object', value: readiness === 'ready' ? 1 : readiness === 'partial' ? 0.5 : null } : null,
-      ...metrics.map((metric) => ({ id: metric.id, label: metric.label, layer: 'feature', value: metric.value })),
-      { id: 'cultural-lens', label: 'CULTURAL LENS', layer: 'context', value: lens?.confidence ?? null },
-      { id: 'mihm', label: 'MIHM', layer: 'model', value: gold.objectEvaluation.measurements.find((item) => item.id === 'mihm-systemic')?.value ?? gold.mihmModel.systemic },
-      { id: 'archive', label: 'ARCHIVE', layer: 'memory', value: gold.provenance.basedOn.length ? Math.min(1, gold.provenance.basedOn.length / 8) : null },
-    ].filter((item): item is { id: string; label: string; layer: string; value: number | null } => Boolean(item));
-
-    const graphEdges = graphNodes.slice(1).map((node) => ({
-      from: graphNodes[0]?.id ?? 'object',
-      to: node.id,
-      weight: node.value,
-      source: node.layer === 'feature' ? 'studio_object_features' : 'derived_state_link',
-    }));
 
     const layerInputs = layerInputsFromMetrics(metrics);
     const hypotheses = layerInputs.length ? buildStudioHypotheses({ layers: layerInputs, culturalLens: lens }) : null;
     const scoreValues = [gold.mihmModel.individual, gold.mihmModel.group, gold.mihmModel.institutional, gold.mihmModel.systemic, gold.mihmModel.civilizational].filter((value) => Number.isFinite(value));
     const mihmScore = scoreValues.length ? scoreValues.reduce((sum, value) => sum + value, 0) / scoreValues.length : null;
+    const evidence = evidenceFromRows(stored, activeObjectWithStatus);
+    const metricValues = metricValuesFromState({ activeObject: activeObjectWithStatus, metrics, evidence, lens, mihmScore, gold, stored });
+    const graphNodes: StudioProductionState['objectFeatures']['graph']['nodes'] = [
+      activeObjectWithStatus.id ? { id: activeObjectWithStatus.id, label: activeObjectWithStatus.title, layer: 'object', value: null } : null,
+      ...metrics.filter((metric) => metric.value !== null).map((metric) => ({ id: metric.id, label: metric.label, layer: 'feature', value: metric.value })),
+      lens ? { id: 'cultural-lens', label: 'CULTURAL LENS', layer: 'context', value: lens.confidence } : null,
+      activeObjectWithStatus.id && mihmScore !== null ? { id: 'mihm', label: 'MIHM', layer: 'model', value: Number(mihmScore.toFixed(3)) } : null,
+    ].filter((item): item is { id: string; label: string; layer: string; value: number | null } => Boolean(item));
+    const graphEdges = activeObjectWithStatus.id
+      ? graphNodes
+        .filter((node) => node.id !== activeObjectWithStatus.id && node.value !== null)
+        .map((node) => ({
+          from: activeObjectWithStatus.id as string,
+          to: node.id,
+          weight: typeof node.value === 'number' ? clamp01(node.value) : null,
+          source: node.layer === 'feature' ? 'studio_object_features' : node.layer === 'context' ? 'buildStudioCulturalLens' : 'studioGold.mihmModel',
+        }))
+      : [];
+    const phaseStates = phaseStatesFromState({
+      activeObject: activeObjectWithStatus,
+      metrics,
+      lens,
+      hypotheses,
+      interventions: stored.interventions,
+      stored,
+      exportsRows: stored.exports,
+      archiveRows: stored.archiveEvents,
+    });
+    const fieldNodes: StudioFieldNode[] = [
+      ...metricValues
+        .filter((metric) => metric.status !== 'MISSING' && metric.explanation)
+        .map((metric) => ({
+          id: metric.key,
+          label: metric.label,
+          type: metric.key === 'active_object' ? 'object' as const : 'metric' as const,
+          value: metric.value,
+          status: metric.status,
+          source: metric.source,
+          formulaVersion: metric.formulaVersion,
+          confidence: metric.confidence,
+          explanation: metric.explanation,
+          evidenceIds: metric.evidenceIds,
+        })),
+      ...evidence.map((item) => ({
+        id: `evidence:${item.id}`,
+        label: item.label,
+        type: 'evidence' as const,
+        value: item.type,
+        status: 'OBSERVED' as const,
+        source: item.source,
+        formulaVersion: null,
+        confidence: item.reliability,
+        explanation: `Evidence reference from ${item.source}.`,
+        evidenceIds: [item.id],
+      })),
+      ...(hypotheses?.hypotheses ?? []).map((item) => ({
+        id: `hypothesis:${item.id}`,
+        label: item.metric,
+        type: 'hypothesis' as const,
+        value: item.severity,
+        status: 'DERIVED' as const,
+        source: item.sources.join(', '),
+        formulaVersion: 'mihmThresholds.current',
+        confidence: item.dataClass === 'real' ? 0.85 : 0.55,
+        explanation: item.statement,
+        evidenceIds: item.sources,
+      })),
+    ];
+    const fieldEdges: StudioFieldEdge[] = graphEdges.map((edge) => ({
+      from: edge.from,
+      to: edge.to,
+      relationType: 'explains',
+      weight: edge.weight,
+      source: edge.source,
+      confidence: edge.weight ?? 0,
+      explanation: `Relation from active object to ${edge.to} based on ${edge.source}.`,
+    }));
+    const viewContracts = buildViewContracts({ activeObject: activeObjectWithStatus, metrics, lens, hypotheses, stored });
+    const nextAction = buildNextAction(activeObjectWithStatus, metrics, stored);
 
     return {
       generatedAt,
-      systemState: stored.degraded.length || gold.systemState !== 'nominal' || !activeObject.id ? 'degraded' : 'nominal',
+      systemState: stored.degraded.length || gold.systemState !== 'nominal' || !activeObjectWithStatus.id ? 'degraded' : 'nominal',
       session,
-      activeObject: { ...activeObject, readiness },
+      activeObject: activeObjectWithStatus,
       objectFeatures: {
-        modality: activeObject.type,
+        modality: activeObjectWithStatus.type,
         readiness,
         metrics,
         layers,
         graph: { nodes: graphNodes, edges: graphEdges },
       },
+      metricValues,
+      phaseStates,
+      evidence,
+      viewContracts,
+      fieldGraph: { nodes: fieldNodes, edges: fieldEdges },
+      nextAction,
       audioFeatures: {
-        waveform: gold.longitudinalTracking[0]?.series ?? [],
+        waveform: numberArray(asRecord(latest(stored.audio)?.payload).waveform).length ? numberArray(asRecord(latest(stored.audio)?.payload).waveform) : numberArray(latest(stored.audio)?.waveform),
         rms: metrics.find((item) => item.id === 'rms')?.value ?? null,
         peak: metrics.find((item) => item.id === 'peak')?.value ?? null,
         clippingRisk: metrics.find((item) => item.id === 'clippingRisk')?.value ?? null,
         dynamicRange: metrics.find((item) => item.id === 'dynamicRange')?.value ?? null,
         lufs: metrics.find((item) => item.id === 'lufs')?.value ?? null,
         spectralCentroid: metrics.find((item) => item.id === 'spectralCentroid')?.value ?? null,
-        frequencyBands: gold.keyObservables.map((item) => item.value).filter((value) => Number.isFinite(value)),
+        frequencyBands: numberArray(latest(stored.audio)?.frequency_bands),
         stereoImage: null,
         silenceStartSeconds: null,
         silenceEndSeconds: null,
-        energySegments: gold.culturalWave.points.map((point) => point.amplitude).slice(0, 48),
+        energySegments: numberArray(latest(stored.audio)?.energy_segments),
         stemCorrelation: hypotheses?.correlations.map((item) => ({ a: item.layerA, b: item.layerB, value: item.correlation })) ?? [],
       },
-      videoFeatures: { shots: null, scenes: null, motionIntensity: null, transitionRhythm: null, visualMotifs: [] },
-      imageFeatures: { dominantColors: [], textureDensity: null, visualEntropy: null, spatialBalance: null, symbolicTags: [] },
+      videoFeatures: {
+        shots: asNumber(latest(stored.video)?.shots),
+        scenes: asNumber(latest(stored.video)?.scenes),
+        motionIntensity: asNumber(latest(stored.video)?.motion_intensity),
+        transitionRhythm: asNumber(latest(stored.video)?.transition_rhythm),
+        visualMotifs: asArray(latest(stored.video)?.visual_motifs).map(String),
+      },
+      imageFeatures: {
+        dominantColors: asArray(latest(stored.image)?.dominant_colors).map(String),
+        textureDensity: asNumber(latest(stored.image)?.texture_density),
+        visualEntropy: asNumber(latest(stored.image)?.visual_entropy),
+        spatialBalance: asNumber(latest(stored.image)?.spatial_balance),
+        symbolicTags: asArray(latest(stored.image)?.symbolic_tags).map(String),
+      },
       textFeatures: {
-        tokens: null,
-        sections: null,
-        themes: lens?.domainValues.map((item) => item.domain) ?? [],
-        motifs: gold.persistentSignals.map((item) => item.label),
+        tokens: asNumber(latest(stored.text)?.tokens),
+        sections: asNumber(latest(stored.text)?.sections),
+        themes: asArray(latest(stored.text)?.themes).map(String),
+        motifs: asArray(latest(stored.text)?.motifs).map(String),
         sentimentArousal: null,
-        narrativeArc: gold.longitudinalTracking[0]?.series ?? [],
-        semanticDensity: gold.culturalWave.symbolicDensity || null,
-        symbolicRecurrence: gold.culturalWave.coherenceGlobal || null,
+        narrativeArc: numberArray(latest(stored.text)?.narrative_arc),
+        semanticDensity: asNumber(latest(stored.text)?.semantic_density),
+        symbolicRecurrence: asNumber(latest(stored.text)?.symbolic_recurrence),
       },
       communityFeatures: {
-        participantCount: null,
-        messageDensity: null,
-        topicClusters: lens?.trends.map((item) => item.domain) ?? [],
-        affectiveTone: gold.wsvLens.cultural || null,
-        recurrence: gold.culturalWave.coherenceGlobal || null,
-        coherence: gold.culturalWave.coherenceGlobal || null,
-        friction: gold.culturalWave.culturalEntropy || null,
+        participantCount: asNumber(latest(stored.community)?.participant_count),
+        messageDensity: asNumber(latest(stored.community)?.message_density),
+        topicClusters: asArray(latest(stored.community)?.topic_clusters).map(String),
+        affectiveTone: asNumber(latest(stored.community)?.affective_tone),
+        recurrence: asNumber(latest(stored.community)?.recurrence),
+        coherence: asNumber(latest(stored.community)?.coherence),
+        friction: asNumber(latest(stored.community)?.friction),
       },
       timeCoordinateFeatures: {
-        timeRange: null,
-        placeLabel: null,
-        semanticAnchors: lens?.domainValues.map((item) => item.domain) ?? [],
-        historicalVectorTags: lens?.trends.map((item) => `${item.domain}:${item.direction}`) ?? [],
-        dominantTensions: gold.persistentSignals.map((item) => item.label),
-        gapDescription: activeObject.type === 'time_coordinate' ? gold.synthesis.implication : null,
+        timeRange: asString(latest(stored.timeCoordinates)?.time_range),
+        placeLabel: asString(latest(stored.timeCoordinates)?.place_label),
+        semanticAnchors: asArray(latest(stored.timeCoordinates)?.semantic_anchors).map(String),
+        historicalVectorTags: asArray(latest(stored.timeCoordinates)?.historical_vector_tags).map(String),
+        dominantTensions: asArray(latest(stored.timeCoordinates)?.dominant_tensions).map(String),
+        gapDescription: asString(latest(stored.timeCoordinates)?.gap_description),
       },
       culturalLens: lens,
       mihmReport: {
@@ -310,31 +858,41 @@ export async function readStudioProductionState(): Promise<StudioProductionState
         source: 'studioGold.mihmModel',
       },
       hypotheses,
-      interventions: gold.pmv.state === 'blocked' ? [] : [{
-        id: gold.pmv.id,
-        title: gold.pmv.hypothesis,
-        state: gold.pmv.state === 'complete' ? 'complete' : gold.pmv.state === 'running' ? 'running' : 'queued',
+      interventions: stored.interventions.map((row) => ({
+        id: asString(row.id, 'intervention') ?? 'intervention',
+        title: asString(row.title, 'Intervention') ?? 'Intervention',
+        state: asString(row.state) === 'complete' ? 'complete' : asString(row.state) === 'running' ? 'running' : asString(row.state) === 'failed' ? 'failed' : asString(row.state) === 'blocked' ? 'blocked' : 'queued',
         scope: 'overview',
-        expectedImpact: gold.pmv.expectedImpact,
-        risk: gold.pmv.intensity === 'high' ? 0.72 : gold.pmv.intensity === 'medium' ? 0.44 : 0.22,
-        source: 'studioGold.pmv',
-      }],
+        expectedImpact: asNumber(row.expected_impact),
+        risk: asNumber(row.risk),
+        source: 'studio_interventions',
+      })),
       archive: {
-        events: gold.provenance.basedOn.map((source, index) => ({ id: `source-${index + 1}`, time: generatedAt, label: source, source })),
-        evidenceTraceCount: gold.activeCase.signals || null,
-        integrity: gold.provenance.basedOn.length ? 'partial' : 'missing',
+        events: stored.archiveEvents.map((row) => ({
+          id: asString(row.id, 'archive') ?? 'archive',
+          time: asString(row.created_at, generatedAt) ?? generatedAt,
+          label: asString(row.label, asString(row.event_type, 'Archive event')) ?? 'Archive event',
+          source: asString(row.source, 'studio_archive_events') ?? 'studio_archive_events',
+        })),
+        evidenceTraceCount: stored.evidenceTraces.length || null,
+        integrity: stored.archiveEvents.length || stored.evidenceTraces.length ? 'partial' : 'missing',
       },
       exports: {
-        packages: [],
-        signoffReadiness: activeObject.id && hypotheses ? 'partial' : 'missing',
+        packages: stored.exports.map((row) => ({
+          id: asString(row.id, 'export') ?? 'export',
+          label: asString(row.label, 'Studio export') ?? 'Studio export',
+          state: asString(row.state) === 'complete' ? 'complete' : asString(row.state) === 'running' ? 'running' : asString(row.state) === 'failed' ? 'failed' : asString(row.state) === 'blocked' ? 'blocked' : 'queued',
+          url: asString(row.url),
+        })),
+        signoffReadiness: stored.exports.some((row) => asString(row.state) === 'complete') ? 'ready' : 'missing',
       },
       provenance: {
-        basedOn: ['readStudioGoldState', ...(lens ? ['buildStudioCulturalLens'] : []), ...gold.provenance.basedOn],
-        derivedFrom: ['StudioProductionState adapter'],
+        basedOn: ['studio_sessions', 'studio_objects', 'studio_uploads', 'studio_object_features', ...(lens ? ['buildStudioCulturalLens'] : []), 'readStudioGoldState'],
+        derivedFrom: ['StudioProductionState adapter', 'canonical Studio contracts'],
         limits: [
           ...stored.degraded,
           ...gold.provenance.limits,
-          ...(activeObject.id ? [] : ['studio_objects has no active object; Studio remains object-gated']),
+          ...(activeObjectWithStatus.id ? [] : ['studio_objects has no active object; Studio remains object-gated']),
           ...(hypotheses ? [] : ['hypothesisEngine not invoked because no usable object feature layer is persisted']),
         ],
       },

--- a/src/lib/studio/production/studioProductionAdapter.ts
+++ b/src/lib/studio/production/studioProductionAdapter.ts
@@ -309,6 +309,7 @@ function objectFrom(row: Row | null, session: StudioProductionSession): StudioPr
 function metricsFromFeatureRows(rows: Row[]): StudioFeatureMetric[] {
   return rows.map((row) => {
     const numeric = asNumber(row.numeric_value);
+    const payload = asRecord(row.payload);
     const key = asString(row.feature_key, asString(row.id, 'feature')) ?? 'feature';
     return {
       id: key,
@@ -316,7 +317,7 @@ function metricsFromFeatureRows(rows: Row[]): StudioFeatureMetric[] {
       value: numeric,
       unit: asString(row.unit),
       source: asString(row.source, 'studio_object_features'),
-      status: numeric === null ? 'MISSING' as const : 'OBSERVED' as const,
+      status: (asString(payload.status) as MetricStatus) || (numeric === null ? 'MISSING' as const : 'OBSERVED' as const),
       confidence: clampConfidence(row.confidence ?? (numeric === null ? 0 : 1)),
       explanation: asString(asRecord(row.payload).explanation, 'Persisted Studio object feature row.'),
       evidenceIds: [asString(row.id, key) ?? key],
@@ -325,26 +326,46 @@ function metricsFromFeatureRows(rows: Row[]): StudioFeatureMetric[] {
 }
 
 function layerInputsFromMetrics(metrics: StudioFeatureMetric[]): StudioLayerInput[] {
-  if (!metrics.some((metric) => metric.value !== null)) return [];
-  return metrics.slice(0, 5).map((metric, index) => {
-    const value = metric.value ?? 0;
-    return {
-      id: metric.id,
-      name: metric.label,
-      peak: value,
-      rms: value * 0.72,
-      clippingRisk: metric.id.includes('entropy') ? value : null,
-      dynamicRange: metric.id.includes('plasticity') ? value : null,
-      silenceStartSeconds: null,
-      silenceEndSeconds: null,
-      energySegments: Array.from({ length: 12 }, (_, segment) => Number(Math.max(0, Math.min(1, value * (0.72 + ((segment + index) % 5) * 0.07))).toFixed(3))),
-      structureNote: metric.source,
-    };
-  });
+  const realLayerMetrics = metrics.filter((metric) => metric.id.startsWith('layer_') || metric.id.startsWith('stem_'));
+  if (!realLayerMetrics.length) return [];
+  return realLayerMetrics.map((metric) => ({
+    id: metric.id,
+    name: metric.label,
+    peak: null,
+    rms: null,
+    clippingRisk: null,
+    dynamicRange: null,
+    silenceStartSeconds: null,
+    silenceEndSeconds: null,
+    energySegments: [],
+    structureNote: metric.source,
+  }));
 }
 
 function numberArray(value: unknown): number[] {
   return asArray(value).map((item) => asNumber(item)).filter((item): item is number => item !== null);
+}
+
+function waveformValues(value: unknown): number[] {
+  return asArray(value).map((item) => {
+    if (typeof item === 'number') return item;
+    const row = asRecord(item);
+    const min = asNumber(row.min);
+    const max = asNumber(row.max);
+    if (min === null || max === null) return null;
+    return Math.max(Math.abs(min), Math.abs(max));
+  }).filter((item): item is number => item !== null);
+}
+
+function energyValues(value: unknown): number[] {
+  return asArray(value).map((item) => {
+    if (typeof item === 'number') return item;
+    return asNumber(asRecord(item).rms);
+  }).filter((item): item is number => item !== null);
+}
+
+function metricNumber(metrics: StudioFeatureMetric[], key: string) {
+  return metrics.find((item) => item.id === key)?.value ?? null;
 }
 
 function statusFromUpload(row: Row | null): MetricStatus {
@@ -513,6 +534,7 @@ function phaseStatesFromState(input: {
   const jobStatus = asString(latestJob?.status);
   const hasMetadata = Boolean(activeObject.mimeType || activeObject.sizeBytes !== null || activeObject.sourceUri);
   const hasFeatures = metrics.some((metric) => metric.value !== null);
+  const hasFeatureRows = metrics.length > 0;
   const hasHypotheses = Boolean(hypotheses?.hypotheses.length || stored.hypotheses.length);
   const hasIntervention = interventions.length > 0;
   const hasExports = exportsRows.length > 0;
@@ -524,7 +546,15 @@ function phaseStatesFromState(input: {
     phase({ key: 'object_received', label: 'OBJECT RECEIVED', status: activeObject.id ? 'OBSERVED' : 'MISSING', progress: activeObject.id ? 1 : null, completedAt: activeObject.uploadedAt, requirements: ['studio_object'] }),
     phase({ key: 'storage_verified', label: 'STORAGE VERIFIED', status: uploadStatus, progress: uploadStatus === 'OBSERVED' ? 1 : null, completedAt: asString(latest(stored.uploads)?.created_at), error: uploadStatus === 'FAILED' ? asString(latest(stored.uploads)?.status) : null, requirements: ['studio_uploads'] }),
     phase({ key: 'metadata_extracted', label: 'METADATA EXTRACTED', status: hasMetadata ? 'OBSERVED' : 'MISSING', progress: hasMetadata ? 1 : null, completedAt: activeObject.uploadedAt, requirements: ['mime_type', 'size_bytes', 'source_uri'] }),
-    phase({ key: 'feature_extraction', label: 'FEATURE EXTRACTION', status: hasFeatures ? 'COMPLETE' : jobStatus === 'failed' ? 'FAILED' : jobStatus === 'blocked' ? 'FAILED' : activeObject.id ? 'MISSING' : 'MISSING', progress: hasFeatures ? 1 : null, error: jobStatus === 'failed' || jobStatus === 'blocked' ? asString(latestJob?.reason, 'feature_extractors_not_connected') : null, nextAction: hasFeatures ? null : 'Run analysis job to record blocked or complete status.', requirements: ['studio_object_features'] }),
+    phase({
+      key: 'feature_extraction',
+      label: 'FEATURE EXTRACTION',
+      status: hasFeatures ? 'COMPLETE' : hasFeatureRows || jobStatus === 'complete' ? 'DEGRADED' : jobStatus === 'running' || jobStatus === 'queued' ? 'RUNNING' : jobStatus === 'failed' || jobStatus === 'blocked' ? 'FAILED' : 'MISSING',
+      progress: hasFeatures ? 1 : jobStatus === 'running' ? 0.5 : null,
+      error: jobStatus === 'failed' || jobStatus === 'blocked' ? asString(latestJob?.reason, 'feature_extractors_not_connected') : null,
+      nextAction: hasFeatures ? null : 'Run analysis job to record blocked or complete status.',
+      requirements: ['studio_object_features'],
+    }),
     phase({ key: 'mihm_evaluation', label: 'MIHM EVALUATION', status: activeObject.id ? 'DERIVED' : 'MISSING', progress: activeObject.id ? 1 : null, details: 'Existing Phase 1 MIHM formulas are read, not modified.', requirements: ['active_object'] }),
     phase({ key: 'cultural_vector', label: 'CULTURAL VECTOR', status: lens ? (lens.status === 'degraded' || lens.status === 'thin' ? 'DEGRADED' : 'DERIVED') : 'MISSING', progress: lens ? 1 : null, error: lens?.status === 'failed' ? lens.interpretation : null, requirements: ['world_vector', 'cultural_lens'] }),
     phase({ key: 'wsv_timing', label: 'WSV TIMING', status: lens ? (lens.status === 'degraded' || lens.status === 'thin' ? 'DEGRADED' : 'DERIVED') : 'MISSING', progress: lens ? 1 : null, details: lens ? 'Uses existing Studio cultural lens/WorldSpect snapshot adapter; not recalculated by render.' : null, requirements: ['worldspect_snapshots'] }),
@@ -674,12 +704,21 @@ export async function readStudioProductionState(): Promise<StudioProductionState
     const activeObject = objectFrom(stored.object, session);
     const uploadStatus = statusFromUpload(latest(stored.uploads));
     const metrics = metricsFromFeatureRows(stored.features);
+    const latestJob = latest(stored.jobs);
+    const latestJobStatus = asString(latestJob?.status);
     const readiness = activeObject.id ? readinessFromMetrics(metrics) : 'missing';
+    const observedFeatureCount = metrics.filter((metric) => metric.value !== null).length;
     const activeObjectWithStatus = {
       ...activeObject,
       readiness,
       storageStatus: uploadStatus,
-      analysisStatus: metrics.some((metric) => metric.value !== null) ? 'COMPLETE' as const : activeObject.analysisStatus,
+      analysisStatus: observedFeatureCount > 0
+        ? 'COMPLETE' as const
+        : latestJobStatus === 'running' || latestJobStatus === 'queued'
+          ? 'RUNNING' as const
+          : latestJobStatus === 'failed' || latestJobStatus === 'blocked'
+            ? 'FAILED' as const
+            : activeObject.analysisStatus,
     };
     const layers = metrics.map((metric) => ({
       id: metric.id,
@@ -772,10 +811,14 @@ export async function readStudioProductionState(): Promise<StudioProductionState
     }));
     const viewContracts = buildViewContracts({ activeObject: activeObjectWithStatus, metrics, lens, hypotheses, stored });
     const nextAction = buildNextAction(activeObjectWithStatus, metrics, stored);
+    const latestAudio = latest(stored.audio);
+    const waveform = waveformValues(latestAudio?.waveform);
+    const energySegments = energyValues(latestAudio?.energy_segments);
+    const hasOperationalGaps = !activeObjectWithStatus.id || !observedFeatureCount || stored.degraded.length > 0 || gold.systemState !== 'nominal';
 
     return {
       generatedAt,
-      systemState: stored.degraded.length || gold.systemState !== 'nominal' || !activeObjectWithStatus.id ? 'degraded' : 'nominal',
+      systemState: hasOperationalGaps ? 'degraded' : 'nominal',
       session,
       activeObject: activeObjectWithStatus,
       objectFeatures: {
@@ -792,18 +835,18 @@ export async function readStudioProductionState(): Promise<StudioProductionState
       fieldGraph: { nodes: fieldNodes, edges: fieldEdges },
       nextAction,
       audioFeatures: {
-        waveform: numberArray(asRecord(latest(stored.audio)?.payload).waveform).length ? numberArray(asRecord(latest(stored.audio)?.payload).waveform) : numberArray(latest(stored.audio)?.waveform),
-        rms: metrics.find((item) => item.id === 'rms')?.value ?? null,
-        peak: metrics.find((item) => item.id === 'peak')?.value ?? null,
-        clippingRisk: metrics.find((item) => item.id === 'clippingRisk')?.value ?? null,
-        dynamicRange: metrics.find((item) => item.id === 'dynamicRange')?.value ?? null,
-        lufs: metrics.find((item) => item.id === 'lufs')?.value ?? null,
-        spectralCentroid: metrics.find((item) => item.id === 'spectralCentroid')?.value ?? null,
-        frequencyBands: numberArray(latest(stored.audio)?.frequency_bands),
-        stereoImage: null,
+        waveform,
+        rms: metricNumber(metrics, 'rms_dbfs'),
+        peak: metricNumber(metrics, 'peak_dbfs'),
+        clippingRisk: metricNumber(metrics, 'clipping_risk'),
+        dynamicRange: metricNumber(metrics, 'dynamic_range_db'),
+        lufs: metricNumber(metrics, 'lufs_integrated'),
+        spectralCentroid: metricNumber(metrics, 'spectral_centroid_hz'),
+        frequencyBands: numberArray(latestAudio?.frequency_bands),
+        stereoImage: metricNumber(metrics, 'stereo_width'),
         silenceStartSeconds: null,
         silenceEndSeconds: null,
-        energySegments: numberArray(latest(stored.audio)?.energy_segments),
+        energySegments,
         stemCorrelation: hypotheses?.correlations.map((item) => ({ a: item.layerA, b: item.layerB, value: item.correlation })) ?? [],
       },
       videoFeatures: {

--- a/src/lib/studio/production/studioProductionDegradedState.ts
+++ b/src/lib/studio/production/studioProductionDegradedState.ts
@@ -1,4 +1,5 @@
 import type { StudioProductionState } from './studioProductionTypes';
+import { missingMetric, phase } from './studioContracts';
 
 export function buildStudioProductionDegradedState(reason: string): StudioProductionState {
   const generatedAt = new Date().toISOString();
@@ -20,9 +21,13 @@ export function buildStudioProductionDegradedState(reason: string): StudioProduc
       type: 'unknown',
       sourceUri: null,
       mimeType: null,
+      sizeBytes: null,
       status: 'blocked',
       readiness: 'missing',
       uploadedAt: null,
+      version: null,
+      storageStatus: 'MISSING',
+      analysisStatus: 'FAILED',
     },
     objectFeatures: {
       modality: 'unknown',
@@ -30,6 +35,45 @@ export function buildStudioProductionDegradedState(reason: string): StudioProduc
       metrics: [],
       layers: [],
       graph: { nodes: [], edges: [] },
+    },
+    metricValues: [
+      missingMetric('active_object', 'Active Object', 'Studio cannot identify an active persisted object.', ['studio_objects readable row']),
+      missingMetric('storage_verified', 'Storage Verified', 'Storage verification is unavailable in degraded state.', ['studio_uploads readable row']),
+      missingMetric('feature_coverage', 'Feature Coverage', 'No feature rows were available.', ['studio_object_features rows']),
+    ],
+    phaseStates: [
+      phase({
+        key: 'object_received',
+        label: 'OBJECT RECEIVED',
+        status: 'FAILED',
+        error: reason,
+        details: 'Studio production state could not be built.',
+        nextAction: 'Inspect Supabase/Studio runtime error.',
+        requirements: ['studio_sessions', 'studio_objects', 'studio_uploads'],
+      }),
+    ],
+    evidence: [],
+    viewContracts: [
+      {
+        key: 'overview',
+        title: 'OVERVIEW',
+        purpose: 'Show active object and pipeline state.',
+        inputs: ['Studio production state'],
+        outputs: ['Object status', 'pipeline', 'next action'],
+        requiredEvidence: ['studio_object'],
+        status: 'FAILED',
+        blockedReason: reason,
+      },
+    ],
+    fieldGraph: { nodes: [], edges: [] },
+    nextAction: {
+      code: 'NO_ACTION_AVAILABLE',
+      action: 'NO_ACTION_AVAILABLE',
+      reason,
+      requirement: 'Restore Studio production state.',
+      endpoint: null,
+      method: null,
+      disabledReason: reason,
     },
     audioFeatures: {
       waveform: [],

--- a/src/lib/studio/production/studioProductionTypes.ts
+++ b/src/lib/studio/production/studioProductionTypes.ts
@@ -1,4 +1,15 @@
 import type { StudioCulturalLens, StudioHypothesisReport } from './hypothesisEngine';
+import type {
+  EvidenceRef,
+  MetricStatus,
+  MetricValue,
+  PhaseState,
+  StudioFieldEdge,
+  StudioFieldNode,
+  StudioNextAction,
+  ViewContract,
+} from './studioContracts';
+export type { EvidenceRef, MetricStatus, MetricValue, PhaseState, StudioFieldEdge, StudioFieldNode, StudioNextAction, ViewContract } from './studioContracts';
 
 export type StudioProductionSystemState = 'nominal' | 'degraded' | 'critical' | 'offline';
 export type StudioObjectType = 'music' | 'video' | 'image' | 'text' | 'community' | 'time_coordinate' | 'unknown';
@@ -20,18 +31,25 @@ export type StudioProductionObject = {
   type: StudioObjectType;
   sourceUri: string | null;
   mimeType: string | null;
+  sizeBytes: number | null;
   status: StudioJobState;
   readiness: StudioReadinessState;
   uploadedAt: string | null;
+  version: string | null;
+  storageStatus: MetricStatus;
+  analysisStatus: MetricStatus;
 };
 
 export type StudioFeatureMetric = {
   id: string;
   label: string;
   value: number | null;
-  unit?: string;
-  source: string;
-  status: StudioReadinessState;
+  unit: string | null;
+  source: string | null;
+  status: MetricStatus;
+  confidence: number;
+  explanation: string;
+  evidenceIds: string[];
 };
 
 export type StudioFeaturePoint = {
@@ -50,7 +68,7 @@ export type StudioObjectFeatures = {
     label: string;
     kind: string;
     weight: number | null;
-    status: StudioReadinessState;
+    status: MetricStatus;
   }>;
   graph: {
     nodes: Array<{ id: string; label: string; layer: string; value: number | null }>;
@@ -147,6 +165,15 @@ export type StudioProductionState = {
   session: StudioProductionSession;
   activeObject: StudioProductionObject;
   objectFeatures: StudioObjectFeatures;
+  metricValues: MetricValue[];
+  phaseStates: PhaseState[];
+  evidence: EvidenceRef[];
+  viewContracts: ViewContract[];
+  fieldGraph: {
+    nodes: StudioFieldNode[];
+    edges: StudioFieldEdge[];
+  };
+  nextAction: StudioNextAction;
   audioFeatures: StudioAudioFeatures;
   videoFeatures: StudioVideoFeatures;
   imageFeatures: StudioImageFeatures;


### PR DESCRIPTION
## Summary

- Adds a deploy-safe Studio audio extraction engine for real WAV PCM/float decoding from Supabase Storage.
- Persists acoustic features, waveform peaks, energy segments, time coordinates, evidence traces, and analysis jobs.
- Connects `/api/studio/objects/[id]/analyze`, authenticated playback through `/api/studio/objects/[id]/audio`, and post-upload analysis for audio objects.
- Maps canonical extracted metrics into the Studio production state and updates Measure/Structure UI without fake controls.
- Documents architecture, feature coverage, environment, limitations, and QA.

## Important limits

- Codec support is currently WAV PCM/float only. MP3/AAC/FLAC/OGG/AIFF are explicitly blocked instead of mocked.
- LUFS, true peak, loudness range, and short-term LUFS remain `MISSING` until a standards-aligned loudness engine exists.
- Authenticated browser intake/playback e2e was not completed because no authenticated Supabase browser session or test credentials were available.
- `npm run lint` remains blocked by the existing `next lint` script under Next 16.

## Validation

- `npm install` passed.
- `npm run qa:studio-audio` passed.
- `npm run typecheck` passed.
- `npm run build` passed after stopping a repo-local dev server that held `.next/studio-dev.log`.
- `GET /studio` returned 200 locally.
- Unauthenticated `POST /api/studio/objects/test/analyze` returned `401 AUTH_REQUIRED`.
- Static Studio href check found no hrefs to API/POST actions.

## Branch note

This branch was created from `codex/studio-master-reconstruction`; if that PR is not merged first, this PR includes the reconstruction commits plus the Phase 2 audio engine commits.