### PR TITLE
System access, ownership and RLS foundation

### DIFF
--- a/docs/system/ACCESS_BOUNDARIES.md
+++ b/docs/system/ACCESS_BOUNDARIES.md
@@ -1,0 +1,61 @@
+# Canonical Access Boundaries
+
+## Roles
+
+- `PUBLIC`: unauthenticated public read access to approved Observatory data only.
+- `FIELD_USER`: authenticated user with access only to owned FIELD and owned Studio resources.
+- `FOUNDER`: explicitly allowed founder identity with private ROOT governance access.
+
+## Server enforcement
+
+Canonical helpers:
+
+- `requireAuthenticatedUser()`
+- `requireFieldUser()`
+- `requireFounder()`
+- `requireFounderPage()`
+- `requireCaseOwner(caseId)`
+- `requireObjectOwner(objectId)`
+- `requirePublicationAuthority()`
+
+Middleware is an early gate, not the sole authorization layer. ROOT pages and administrative route handlers must call founder authorization before reading private data.
+
+## Founder configuration
+
+Preferred variable:
+
+`SFI_FOUNDER_USER_IDS=<supabase-user-uuid>[,<uuid>]`
+
+Compatibility variables:
+
+- `SFI_FOUNDER_EMAILS`
+- `SYSTEM_ROOT_EMAIL`
+- profile roles `root` and `system`
+
+User ID allowlisting is preferred because email can change.
+
+## ROOT
+
+- Session required.
+- Founder authorization required before loading governance state.
+- No indexation.
+- FIELD users receive the unauthorized surface.
+- Founder-only writes must produce `sfi_audit_events`.
+
+## FIELD
+
+- Session required for `/field` and descendants.
+- All new private records include `owner_id`.
+- RLS validates `owner_id = auth.uid()` for SELECT, INSERT, UPDATE and DELETE.
+- The client must never be trusted to choose an owner.
+- Evidence storage uses private owner-prefixed paths.
+
+## OBSERVATORY
+
+- Public read-only surface.
+- Public state may contain only persisted WorldSpect snapshots or `PUBLISHED` rows from `sfi_publications`.
+- It must not query FIELD tables or expose internal publication source records.
+
+## Studio
+
+The migration adds nullable `owner_id` columns non-destructively. New Studio writes must set owner IDs. Legacy rows remain inaccessible to ordinary owner policies until an explicit backfill is designed and reviewed.

--- a/docs/system/ACCESS_OWNERSHIP_CURRENT_STATE_AUDIT.md
+++ b/docs/system/ACCESS_OWNERSHIP_CURRENT_STATE_AUDIT.md
@@ -1,0 +1,162 @@
+# Access, Ownership and RLS Current-State Audit
+
+Date: 2026-07-11
+Branch: `codex/system-access-ownership-foundation`
+Base: `main` after PR #96 and PR #97
+Scope: ROOT, OBSERVATORY, FIELD, shared authentication, ownership, RLS, storage, publications and audit.
+
+## Executive finding
+
+The repository already contains reusable identity and governance primitives, but it does not yet provide a canonical FIELD ownership model or a publication boundary between ROOT and OBSERVATORY.
+
+Existing reusable structures:
+
+- Supabase SSR authentication through `src/proxy.ts` and `src/runtime/supabase/server.ts`.
+- `profiles`, `accounts`, `account_members`, `root_audit_events` and `root_evidence_entries`.
+- ROOT route gating in `src/proxy.ts` by profile role or configured root email.
+- Public `/observatory` page using a cached server adapter.
+- Existing `/field` surface, currently public/static and not an authenticated case system.
+- Private Studio storage and authenticated Studio API routes.
+
+Critical gaps:
+
+1. `/root` is gated in middleware, but `src/app/root/page.tsx` reads the complete governance state without a second server-side founder assertion.
+2. ROOT founder identity is implemented through several role/email conventions instead of one canonical helper.
+3. `/field` is static and public; it does not establish authenticated ownership, cases, consent, evidence isolation or longitudinal records.
+4. Existing `accounts/account_members` model represents account membership, not user-owned FIELD cases.
+5. Existing RLS-enabled tables do not provide the required FIELD case policies.
+6. No canonical `Publication` state machine restricts OBSERVATORY to founder-approved public payloads.
+7. `root_audit_events` exists but does not expose a shared typed audit helper or canonical before/after contract.
+8. Studio objects lack a proven owner column in the current production schema.
+9. `/field` currently links to a ROOT prediction route, crossing the intended access boundary.
+10. Public Observatory adapters must be audited to ensure that only snapshots/publications are returned and that no service-role payload reaches the browser.
+
+## Route audit
+
+| Surface | Current state | Authentication | Ownership | Decision |
+| --- | --- | --- | --- | --- |
+| `/root` | Server page mounts `RootGovernanceConsole` and reads full governance state. | Middleware role/email gate. | Not applicable; founder-only. | Preserve UI; add canonical `requireFounder()` inside server page before data access. |
+| `/observatory` | Public cached server page. | Public. | Public data only. | Preserve public access; introduce canonical public-state boundary for future publication reads. |
+| `/field` | Static public landing/Mini MOP-H surface. | None. | None. | Preserve as temporary presentation only until FIELD workflow PR; remove cross-boundary ROOT link now and mark authenticated workflow as pending. |
+| `/campo` | Must be treated as possible legacy alias. | Unknown until full route inventory. | Unknown. | Choose `/field` as canonical; redirect `/campo` in a later route reconciliation if present. |
+| `/studio` | Auth-gated. | Middleware and route checks. | Schema does not prove owner. | Add shared owner-compatible schema only where non-destructive; do not redesign Studio in this PR. |
+
+## Authentication audit
+
+### `src/proxy.ts`
+
+- Creates a Supabase SSR client with request cookies.
+- Calls `auth.getUser()` only for ROOT and Studio paths.
+- ROOT authorization accepts profile roles `root` or `system`, or `SYSTEM_ROOT_EMAIL` equality.
+- Studio authorization accepts ROOT users or `STUDIO_AUTHORIZED_EMAILS`.
+- `/field` does not currently require a session.
+- Unauthorized ROOT users are redirected to `/field`, which obscures a 403 condition.
+
+Decision:
+
+- Retain middleware as early gate.
+- Add canonical server helpers as authoritative enforcement.
+- Use an explicit founder ID allowlist (`SFI_FOUNDER_USER_IDS`) with legacy role/email compatibility documented.
+- Do not rely on hidden navigation or redirect alone.
+
+### `src/runtime/supabase/server.ts`
+
+- `createServerSupabaseClient()` correctly uses the anon key and cookies.
+- `createServiceSupabaseClient()` is server-only and must remain server-only.
+- Service-role access must never be imported into client components.
+
+## Database audit
+
+### Existing identity and governance tables
+
+- `profiles`: keyed by `auth.users.id`; roles currently constrained to observer/operator/controller/root/system.
+- `accounts`: account identity and metadata.
+- `account_members`: account membership and role.
+- `root_audit_events`: actor/action/target/payload/ip/user-agent.
+- `root_evidence_entries`: founder evidence ledger.
+
+Reuse decisions:
+
+- Reuse `profiles` as the authenticated profile source.
+- Reuse `accounts/account_members`; do not create duplicate account systems.
+- Preserve `root_audit_events` for legacy ROOT consumers.
+- Introduce `sfi_audit_events` as the cross-surface canonical audit event because FIELD and publication auditing require target type/id and before/after values.
+
+### Missing FIELD entities
+
+No compatible user-owned longitudinal case contract was confirmed. Add non-destructive tables:
+
+- `field_profiles`
+- `field_cases`
+- `field_case_evidence`
+- `field_moph_runs`
+- `field_mihm_readings`
+- `field_hypotheses`
+- `field_interventions`
+- `field_returns`
+- `field_outcomes`
+- `field_lessons`
+
+All private FIELD rows must have `owner_id` directly or inherit through a mandatory `case_id`, with RLS using `auth.uid()`.
+
+### Missing publication entities
+
+Add:
+
+- `sfi_publications`
+
+Only sanitized `public_payload` may be read publicly, and only when status is `PUBLISHED`.
+
+## RLS audit
+
+RLS is enabled on several existing governance tables, but enablement alone does not prove complete policies. This PR must add explicit FIELD and publication policies.
+
+Required policy properties:
+
+- User-owned SELECT/INSERT/UPDATE/DELETE.
+- Client-provided `owner_id` cannot grant access because policies validate `auth.uid()`.
+- Public users cannot read FIELD tables.
+- Public users may read only `PUBLISHED` rows from `sfi_publications`.
+- Founder access occurs through authorized server routes using a service client after `requireFounder()`.
+
+## Storage audit
+
+Studio already uses a private storage pattern. FIELD requires an explicit private bucket and canonical path:
+
+`field/{owner_id}/{case_id}/{object_id}/{filename}`
+
+This PR may create the private bucket and storage policies, but no public bucket or unrestricted signed URL route.
+
+## Public/private boundary
+
+### ROOT
+
+Private, founder-only, noindex, complete governance visibility after server authorization.
+
+### OBSERVATORY
+
+Public, read-only, snapshot/publication data only. It must not query FIELD cases directly.
+
+### FIELD
+
+Authenticated and private by default. A user may only access their own profile, cases and dependent rows.
+
+## Immediate implementation decisions
+
+1. Create shared system contracts.
+2. Create server-only access helpers.
+3. Add non-destructive FIELD/publication/audit migration with RLS.
+4. Add server-side founder assertion to `/root` before reading governance state.
+5. Remove FIELD-to-ROOT navigation crossing the access boundary.
+6. Add public Observatory state reader contract without rebuilding Observatory UI.
+7. Document required environment and migration application.
+
+## Deferred work
+
+- Complete FIELD UI and account lifecycle.
+- MOPH/MIHM execution and hypothesis generation.
+- ROOT field oversight modules.
+- ROOT publication UI.
+- Observatory visual reconstruction.
+- Studio ownership backfill and account migration where existing rows have no owner.
+- Authenticated A/B browser QA requiring two real Supabase users and applied migrations.

--- a/docs/system/ACCESS_OWNERSHIP_MIGRATION_NOTES.md
+++ b/docs/system/ACCESS_OWNERSHIP_MIGRATION_NOTES.md
@@ -1,0 +1,45 @@
+# Access and Ownership Migration Notes
+
+Migration:
+
+`supabase/migrations/20260711103000_system_access_ownership_foundation.sql`
+
+## Application status
+
+The migration is versioned in GitHub but is not applied automatically to production by this PR.
+
+## Non-destructive behavior
+
+- Creates FIELD, publication and canonical audit tables only when absent.
+- Adds nullable `owner_id` to existing Studio session/object/upload tables.
+- Does not delete existing Studio rows.
+- Does not backfill legacy Studio ownership.
+- Creates a private `field-evidence` bucket.
+- Adds explicit owner RLS policies.
+
+## Required environment
+
+Preferred founder identity:
+
+`SFI_FOUNDER_USER_IDS`
+
+Optional compatibility:
+
+- `SFI_FOUNDER_EMAILS`
+- `SYSTEM_ROOT_EMAIL`
+
+Existing Supabase variables remain required.
+
+## Before production application
+
+1. Review existing policies on `studio_sessions`, `studio_objects` and `studio_uploads`.
+2. Confirm whether any current client workflow depends on broader Studio RLS policies.
+3. Identify ownership for legacy Studio rows before backfill.
+4. Confirm `storage.foldername` is available in the Supabase Storage schema.
+5. Apply in staging first.
+6. Test with anonymous, user A, user B and founder identities.
+7. Verify rollback procedure before production.
+
+## Known limitation
+
+Existing Studio objects with null ownership are intentionally not granted to ordinary authenticated users. Founder server routes may inspect them only after founder authorization. A separate audited backfill is required.

--- a/docs/system/ACCESS_OWNERSHIP_QA.md
+++ b/docs/system/ACCESS_OWNERSHIP_QA.md
@@ -1,0 +1,43 @@
+# Access and Ownership QA Matrix
+
+## Static verification included in this branch
+
+- ROOT page calls `requireFounderPage()` before reading governance state.
+- ROOT metadata sets noindex/nofollow/nocache.
+- Middleware requires a session for `/root`, `/field` and `/studio`.
+- Middleware redirects non-founder ROOT users to `/unauthorized`.
+- FIELD no longer links directly to a ROOT action.
+- Shared contracts use nullable confidence; missing confidence is not represented as zero.
+- Public Observatory helper queries only `PUBLISHED` publication rows.
+- FIELD tables use explicit owner RLS policies.
+- FIELD evidence bucket is private and owner-prefixed.
+
+## Required staging tests after migration application
+
+| Actor | Operation | Expected |
+| --- | --- | --- |
+| Anonymous | Open `/observatory` | 200, public read only |
+| Anonymous | Open `/field` | Login redirect |
+| Anonymous | Open `/root` | Login redirect |
+| FIELD user | Open `/root` | Unauthorized/403 surface |
+| Founder | Open `/root` | Governance state loads |
+| User A | Insert own FIELD case | Allowed |
+| User A | Insert case with User B owner ID | Rejected by RLS |
+| User A | Read/update/delete User B case | Rejected by RLS |
+| User A | Upload under User B storage prefix | Rejected |
+| User A | Read DRAFT publication | No rows |
+| Anonymous | Read PUBLISHED publication | Allowed sanitized row |
+| FIELD user | Update publication state | Rejected |
+| Founder server route | Publish | Allowed and audited |
+
+## Pending executable QA
+
+Executable authorization tests require:
+
+- migration applied to a staging Supabase project;
+- two authenticated test users;
+- one founder identity configured through `SFI_FOUNDER_USER_IDS`;
+- test publication and FIELD records;
+- deployment or local environment with the repository secrets.
+
+This branch must not be described as production-authorized until those tests pass.

--- a/docs/system/FIELD_RLS_AND_PRIVACY.md
+++ b/docs/system/FIELD_RLS_AND_PRIVACY.md
@@ -1,0 +1,61 @@
+# FIELD RLS and Privacy
+
+## Ownership
+
+Every private FIELD entity is bound to `auth.users.id` through `owner_id`. Dependent records also include `case_id` for traceability.
+
+The client may submit content, but it must not be treated as authority for ownership. Server handlers must derive owner identity from the authenticated Supabase user.
+
+## RLS policies
+
+The migration defines owner policies for:
+
+- `field_profiles`
+- `field_cases`
+- `field_case_evidence`
+- `field_moph_runs`
+- `field_mihm_readings`
+- `field_hypotheses`
+- `field_interventions`
+- `field_returns`
+- `field_outcomes`
+- `field_lessons`
+
+For private rows:
+
+- SELECT: `owner_id = auth.uid()`
+- INSERT: `owner_id = auth.uid()`
+- UPDATE: existing and resulting `owner_id = auth.uid()`
+- DELETE: `owner_id = auth.uid()`
+
+`field_profiles` uses `user_id = auth.uid()`.
+
+## Storage
+
+Bucket: `field-evidence`
+
+Visibility: private
+
+Canonical path:
+
+`{owner_id}/{case_id}/{object_id}/{sanitized_filename}`
+
+Storage policies verify the first folder segment equals `auth.uid()`.
+
+Route handlers must additionally validate:
+
+- case ownership;
+- object ownership;
+- MIME type;
+- extension;
+- file size;
+- sanitized filename;
+- path consistency.
+
+## Founder access
+
+Founder oversight must use server-only routes after `requireFounder()`. Service-role access must not be exposed to the browser and must not be used as a substitute for checking founder identity.
+
+## Deletion
+
+The schema supports cascade deletion from a FIELD case to dependent analytical records. A future account deletion workflow must define retention, exports, audit retention and irreversible storage deletion before exposing a deletion control.

--- a/docs/system/PUBLICATION_FLOW.md
+++ b/docs/system/PUBLICATION_FLOW.md
@@ -1,0 +1,30 @@
+# ROOT to OBSERVATORY Publication Flow
+
+Canonical states:
+
+`DRAFT → REVIEWED → APPROVED_FOR_PUBLICATION → PUBLISHED → SUPERSEDED | RETRACTED`
+
+## Rules
+
+- Only a founder-authorized server operation may review, approve, publish, supersede or retract.
+- OBSERVATORY may read only rows with `status = 'PUBLISHED'` and a non-null `published_at`.
+- Public consumers receive `public_payload` and declared `public_fields`, never the private source row.
+- Publication does not delete or mutate FIELD evidence.
+- Retraction removes a publication from the public read set but preserves internal audit history.
+- Every state transition must produce `sfi_audit_events` with before and after state.
+
+## Required publication fields
+
+- `source_type`
+- `source_id`
+- `public_fields`
+- `public_payload`
+- `snapshot_version`
+- `confidence`
+- `approved_by`
+- `status`
+- timestamps
+
+## Sanitization
+
+The publisher must explicitly construct `public_payload`. It must not serialize a full private row and then remove selected keys. No user ID, email, private URI, storage path, internal error, SQL message, service metadata or private evidence text may be included unless separately approved and intended for public release.

--- a/src/app/field/page.tsx
+++ b/src/app/field/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import MiniMophField from '@/components/field/MiniMophField';
 
-export const dynamic = 'force-static';
+export const dynamic = 'force-dynamic';
 
 const stages = [
   ['Signal intake', 'Sistema atorado'],
@@ -22,14 +22,13 @@ export default function FieldPage() {
                 Mini MOP-H para convertir friccion declarada en una perturbacion minima.
               </h1>
               <p className="mt-3 max-w-3xl text-sm leading-6 text-[#9f9788]">
-                Field captura senal publica o declarada. Participant y Operator conservan sus workbooks; User Twin y persistencia siguen ligados a cuenta.
+                FIELD es una superficie autenticada. Los casos, evidencias y retornos pertenecen al usuario y permanecen privados por defecto.
               </p>
             </div>
             <nav className="flex flex-wrap gap-2 font-mono text-[10px] uppercase tracking-[0.14em]">
               <Link href="/" className="border border-[#2f2a1e] px-3 py-2 text-[#d8d2c2]">SFI</Link>
               <Link href="/world-vector" className="border border-[#2f2a1e] px-3 py-2 text-[#d8d2c2]">World Vector</Link>
               <Link href="/repository" className="border border-[#2f2a1e] px-3 py-2 text-[#d8d2c2]">Repository</Link>
-              <Link href="/login?next=%2Ffield" className="border border-[#c8a95166] px-3 py-2 text-[#c8a951]">Iniciar sesion</Link>
             </nav>
           </div>
         </header>
@@ -72,9 +71,6 @@ export default function FieldPage() {
               <Link href="/operator/field" className="border border-[#c8a95166] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951]">
                 Operator Field
               </Link>
-              <Link href="/root/predictions/new" className="border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
-                ROOT Prediction
-              </Link>
               <Link href="/library/SFI-WB-001_Operator_Workbook.html" className="border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
                 WB-001
               </Link>
@@ -89,11 +85,11 @@ export default function FieldPage() {
           </article>
           <article className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
             <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">User Twin</div>
-            <p className="mt-3 text-sm leading-6 text-[#9f9788]">Con cuenta, el historial puede conectar lecturas, perturbaciones y retornos. Sin cuenta, la lectura queda como preview local.</p>
+            <p className="mt-3 text-sm leading-6 text-[#9f9788]">El historial conecta lecturas, perturbaciones y retornos únicamente dentro de la cuenta propietaria.</p>
           </article>
           <article className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
             <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Operational position</div>
-            <p className="mt-3 text-sm leading-6 text-[#9f9788]">Library formalizes the method. World Vector contextualizes the world. Field captures signal. ROOT decides what becomes evidence, archive, Atlas candidate or public output.</p>
+            <p className="mt-3 text-sm leading-6 text-[#9f9788]">Library formalizes the method. World Vector contextualizes the world. FIELD captures evidence. ROOT governs without exposing administrative actions to FIELD users.</p>
           </article>
         </section>
       </div>

--- a/src/app/root/page.tsx
+++ b/src/app/root/page.tsx
@@ -1,9 +1,20 @@
+import type { Metadata } from 'next';
 import { RootGovernanceConsole } from '@/components/root/gold/RootGovernanceConsole';
 import { readRootGovernanceState } from '@/lib/root/gold/rootGovernanceAdapter';
+import { requireFounderPage } from '@/lib/system/access/server';
 
 export const dynamic = 'force-dynamic';
 
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+    nocache: true,
+  },
+};
+
 export default async function RootPage() {
+  await requireFounderPage('/root');
   const state = await readRootGovernanceState();
   return <RootGovernanceConsole state={state} />;
 }

--- a/src/lib/observatory/publicState.ts
+++ b/src/lib/observatory/publicState.ts
@@ -1,0 +1,38 @@
+import 'server-only';
+
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import type { Publication } from '@/lib/system/contracts';
+
+export type PublicObservatoryState = {
+  generatedAt: string;
+  publications: Publication[];
+};
+
+export async function getPublicObservatoryState(): Promise<PublicObservatoryState> {
+  const service = createServiceSupabaseClient();
+  const { data, error } = await service
+    .from('sfi_publications')
+    .select('id, source_type, source_id, approved_by, public_fields, public_payload, status, published_at')
+    .eq('status', 'PUBLISHED')
+    .not('published_at', 'is', null)
+    .order('published_at', { ascending: false })
+    .limit(50);
+
+  if (error) {
+    return { generatedAt: new Date().toISOString(), publications: [] };
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    publications: (data ?? []).map((row) => ({
+      id: row.id,
+      sourceType: row.source_type,
+      sourceId: row.source_id,
+      approvedBy: row.approved_by,
+      publicFields: row.public_fields ?? [],
+      publicPayload: row.public_payload,
+      status: row.status,
+      publishedAt: row.published_at,
+    })),
+  };
+}

--- a/src/lib/system/access/server.ts
+++ b/src/lib/system/access/server.ts
@@ -1,0 +1,132 @@
+import 'server-only';
+
+import { redirect } from 'next/navigation';
+import { createServerSupabaseClient, createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+export class AccessDeniedError extends Error {
+  constructor(
+    public readonly status: 401 | 403 | 404,
+    public readonly code: 'AUTH_REQUIRED' | 'FOUNDER_REQUIRED' | 'FIELD_USER_REQUIRED' | 'OWNER_REQUIRED' | 'NOT_FOUND',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AccessDeniedError';
+  }
+}
+
+function founderIds() {
+  return new Set(
+    (process.env.SFI_FOUNDER_USER_IDS || '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+}
+
+function founderEmails() {
+  return new Set(
+    [process.env.SYSTEM_ROOT_EMAIL, ...(process.env.SFI_FOUNDER_EMAILS || '').split(',')]
+      .map((value) => value?.trim().toLowerCase())
+      .filter((value): value is string => Boolean(value)),
+  );
+}
+
+export async function requireAuthenticatedUser() {
+  const supabase = await createServerSupabaseClient();
+  const { data, error } = await supabase.auth.getUser();
+  if (error || !data.user) {
+    throw new AccessDeniedError(401, 'AUTH_REQUIRED', 'Authentication is required.');
+  }
+  return { supabase, user: data.user };
+}
+
+export async function requireFieldUser() {
+  const context = await requireAuthenticatedUser();
+  const { data: profile } = await context.supabase
+    .from('profiles')
+    .select('role')
+    .eq('user_id', context.user.id)
+    .maybeSingle();
+
+  if (!profile) {
+    throw new AccessDeniedError(403, 'FIELD_USER_REQUIRED', 'A FIELD profile is required.');
+  }
+
+  return { ...context, profile };
+}
+
+export async function requireFounder() {
+  const context = await requireAuthenticatedUser();
+  const { data: profile } = await context.supabase
+    .from('profiles')
+    .select('role')
+    .eq('user_id', context.user.id)
+    .maybeSingle();
+
+  const email = context.user.email?.toLowerCase() || null;
+  const allowed =
+    founderIds().has(context.user.id) ||
+    Boolean(email && founderEmails().has(email)) ||
+    profile?.role === 'root' ||
+    profile?.role === 'system';
+
+  if (!allowed) {
+    throw new AccessDeniedError(403, 'FOUNDER_REQUIRED', 'Founder authorization is required.');
+  }
+
+  return { ...context, profile };
+}
+
+export async function requireFounderPage(nextPath = '/root') {
+  try {
+    return await requireFounder();
+  } catch (error) {
+    if (error instanceof AccessDeniedError && error.status === 401) {
+      redirect(`/login?next=${encodeURIComponent(nextPath)}`);
+    }
+    redirect('/unauthorized');
+  }
+}
+
+export async function requireCaseOwner(caseId: string) {
+  const context = await requireFieldUser();
+  const { data: fieldCase, error } = await context.supabase
+    .from('field_cases')
+    .select('id, owner_id')
+    .eq('id', caseId)
+    .maybeSingle();
+
+  if (error || !fieldCase) {
+    throw new AccessDeniedError(404, 'NOT_FOUND', 'FIELD case not found.');
+  }
+  if (fieldCase.owner_id !== context.user.id) {
+    throw new AccessDeniedError(403, 'OWNER_REQUIRED', 'Case ownership is required.');
+  }
+  return { ...context, fieldCase };
+}
+
+export async function requireObjectOwner(objectId: string) {
+  const context = await requireAuthenticatedUser();
+  const service = createServiceSupabaseClient();
+  const { data: object, error } = await service
+    .from('studio_objects')
+    .select('id, owner_id')
+    .eq('id', objectId)
+    .maybeSingle();
+
+  if (error || !object) {
+    throw new AccessDeniedError(404, 'NOT_FOUND', 'Studio object not found.');
+  }
+  if (!object.owner_id || object.owner_id !== context.user.id) {
+    try {
+      await requireFounder();
+    } catch {
+      throw new AccessDeniedError(403, 'OWNER_REQUIRED', 'Object ownership is required.');
+    }
+  }
+  return { ...context, object };
+}
+
+export async function requirePublicationAuthority() {
+  return requireFounder();
+}

--- a/src/lib/system/audit/server.ts
+++ b/src/lib/system/audit/server.ts
@@ -1,0 +1,45 @@
+import 'server-only';
+
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+type AuditInput = {
+  actorId: string | null;
+  action: string;
+  targetType: string;
+  targetId: string;
+  before?: unknown;
+  after?: unknown;
+  context?: Record<string, unknown>;
+};
+
+function jsonValue(value: unknown) {
+  if (value === undefined) return null;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function sanitizeContext(context: Record<string, unknown> = {}) {
+  const blocked = new Set(['authorization', 'cookie', 'token', 'access_token', 'refresh_token', 'signed_url', 'service_role']);
+  return Object.fromEntries(
+    Object.entries(context).filter(([key]) => !blocked.has(key.toLowerCase())),
+  );
+}
+
+export async function recordAuditEvent(input: AuditInput) {
+  const service = createServiceSupabaseClient();
+  const { data, error } = await service
+    .from('sfi_audit_events')
+    .insert({
+      actor_id: input.actorId,
+      action: input.action,
+      target_type: input.targetType,
+      target_id: input.targetId,
+      before_state: jsonValue(input.before),
+      after_state: jsonValue(input.after),
+      context: sanitizeContext(input.context),
+    })
+    .select('id, created_at')
+    .single();
+
+  if (error) throw new Error(`AUDIT_WRITE_FAILED:${error.message}`);
+  return data;
+}

--- a/src/lib/system/contracts/index.ts
+++ b/src/lib/system/contracts/index.ts
@@ -1,0 +1,169 @@
+export type MetricStatus =
+  | 'PENDING'
+  | 'RUNNING'
+  | 'OBSERVED'
+  | 'DERIVED'
+  | 'DEGRADED'
+  | 'MISSING'
+  | 'FAILED'
+  | 'COMPLETE'
+  | 'LEARNING'
+  | 'VERIFIED'
+  | 'RETRACTED';
+
+export type VerificationWindow = '72h' | '7d' | '30d';
+export type EvidenceVisibility = 'private' | 'founder' | 'public';
+
+export type MetricValue = {
+  key: string;
+  label: string;
+  value: number | string | null;
+  unit: string | null;
+  status: MetricStatus;
+  source: string | null;
+  evidenceIds: string[];
+  confidence: number | null;
+  observedAt: string | null;
+  formulaVersion: string | null;
+  warnings: string[];
+  explanation: string;
+};
+
+export type EvidenceRef = {
+  id: string;
+  ownerId: string | null;
+  caseId: string | null;
+  type: string;
+  source: string;
+  label: string;
+  observedAt: string | null;
+  reliability: number | null;
+  uri: string | null;
+  visibility: EvidenceVisibility;
+};
+
+export type FieldCase = {
+  id: string;
+  ownerId: string;
+  title: string;
+  domain: string;
+  declaredAttractor: string;
+  baseline: string;
+  status: MetricStatus;
+  verificationWindow: VerificationWindow;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MophRun = {
+  id: string;
+  caseId: string;
+  ownerId: string;
+  status: MetricStatus;
+  input: unknown;
+  output: unknown;
+  evidenceIds: string[];
+  createdAt: string;
+  completedAt: string | null;
+};
+
+export type MihmReading = {
+  id: string;
+  caseId: string;
+  ownerId: string;
+  metrics: MetricValue[];
+  tensions: unknown[];
+  status: MetricStatus;
+  formulaVersion: string | null;
+  createdAt: string;
+};
+
+export type Hypothesis = {
+  id: string;
+  caseId: string;
+  ownerId: string;
+  statement: string;
+  target: string;
+  evidenceIds: string[];
+  expectedSignal: string;
+  verificationWindow: VerificationWindow;
+  confidence: number | null;
+  status: MetricStatus;
+};
+
+export type Intervention = {
+  id: string;
+  caseId: string;
+  ownerId: string;
+  hypothesisId: string;
+  minimumChange: string;
+  prohibitedEffects: string[];
+  status: MetricStatus;
+  startedAt: string | null;
+  completedAt: string | null;
+};
+
+export type ReturnRecord = {
+  id: string;
+  caseId: string;
+  ownerId: string;
+  interventionId: string | null;
+  window: VerificationWindow;
+  expectedAt: string;
+  returnedAt: string | null;
+  evidenceIds: string[];
+  status: MetricStatus;
+};
+
+export type Outcome = {
+  id: string;
+  caseId: string;
+  ownerId: string;
+  interventionId: string;
+  expected: string;
+  actual: string;
+  delta: number | null;
+  verified: boolean | null;
+  learned: string | null;
+  recordedAt: string;
+};
+
+export type Lesson = {
+  id: string;
+  caseId: string;
+  ownerId: string;
+  outcomeId: string;
+  statement: string;
+  evidenceIds: string[];
+  createdAt: string;
+};
+
+export type PublicationStatus =
+  | 'DRAFT'
+  | 'REVIEWED'
+  | 'APPROVED_FOR_PUBLICATION'
+  | 'PUBLISHED'
+  | 'SUPERSEDED'
+  | 'RETRACTED';
+
+export type Publication = {
+  id: string;
+  sourceType: string;
+  sourceId: string;
+  approvedBy: string | null;
+  publicFields: string[];
+  publicPayload: unknown;
+  status: PublicationStatus;
+  publishedAt: string | null;
+};
+
+export type AuditEvent = {
+  id: string;
+  actorId: string | null;
+  action: string;
+  targetType: string;
+  targetId: string;
+  before: unknown;
+  after: unknown;
+  createdAt: string;
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,40 +12,45 @@ function isRefreshTokenMissing(error: unknown) {
 
 function clearSupabaseAuthCookies(response: NextResponse, request: NextRequest) {
   const names = new Set(AUTH_COOKIE_NAMES)
-
   request.cookies.getAll().forEach((cookie) => {
-    if (cookie.name.startsWith('sb-') || cookie.name.includes('supabase')) {
-      names.add(cookie.name)
-    }
+    if (cookie.name.startsWith('sb-') || cookie.name.includes('supabase')) names.add(cookie.name)
   })
-
   names.forEach((name) => response.cookies.delete(name))
 }
 
-function isRootRouteUser(role?: string | null, email?: string | null) {
-  const rootEmail = process.env.SYSTEM_ROOT_EMAIL
+function configuredFounderIds() {
+  return new Set((process.env.SFI_FOUNDER_USER_IDS || '').split(',').map((value) => value.trim()).filter(Boolean))
+}
 
-  return (
-    role === 'root' ||
-    role === 'system' ||
-    Boolean(rootEmail && email && email.toLowerCase() === rootEmail.toLowerCase())
+function configuredFounderEmails() {
+  return new Set(
+    [process.env.SYSTEM_ROOT_EMAIL, ...(process.env.SFI_FOUNDER_EMAILS || '').split(',')]
+      .map((value) => value?.trim().toLowerCase())
+      .filter((value): value is string => Boolean(value)),
   )
 }
 
-function isStudioRouteUser(role?: string | null, email?: string | null) {
-  if (isRootRouteUser(role, email)) return true
+function isRootRouteUser(userId?: string | null, role?: string | null, email?: string | null) {
+  return (
+    Boolean(userId && configuredFounderIds().has(userId)) ||
+    role === 'root' ||
+    role === 'system' ||
+    Boolean(email && configuredFounderEmails().has(email.toLowerCase()))
+  )
+}
+
+function isStudioRouteUser(userId?: string | null, role?: string | null, email?: string | null) {
+  if (isRootRouteUser(userId, role, email)) return true
   const allowed = (process.env.STUDIO_AUTHORIZED_EMAILS || '')
     .split(',')
     .map((item) => item.trim().toLowerCase())
     .filter(Boolean)
-
   return Boolean(email && allowed.includes(email.toLowerCase()))
 }
 
 function redirectToLoginWithNext(request: NextRequest) {
   const loginUrl = new URL('/login', request.url)
   loginUrl.searchParams.set('next', `${request.nextUrl.pathname}${request.nextUrl.search}`)
-
   return NextResponse.redirect(loginUrl)
 }
 
@@ -67,22 +72,13 @@ export async function proxy(request: NextRequest) {
     response.headers.set('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400')
   }
 
-  if (pathname.startsWith('/root') || pathname === '/field' || pathname.startsWith('/studio')) {
+  if (pathname.startsWith('/root') || pathname.startsWith('/field') || pathname.startsWith('/studio')) {
     response.headers.set('Cache-Control', 'no-store, must-revalidate')
   }
 
-  const requiresSession =
-    pathname.startsWith('/root') ||
-    pathname.startsWith('/studio')
+  const requiresSession = pathname.startsWith('/root') || pathname.startsWith('/field') || pathname.startsWith('/studio')
+  if (!requiresSession) return response
 
-  // Public routes must not pay the Supabase Auth cost. A degraded Supabase Auth
-  // edge should not make /, /library, /repository, /contact, etc. wait 40s.
-  if (!requiresSession) {
-    return response
-  }
-
-  // Local-only visual inspection escape hatch. This never applies in production
-  // unless the host is localhost and the explicit env flag is present.
   if (pathname.startsWith('/studio') && isLocalStudioBypass(request)) {
     response.headers.set('X-SFI-Auth-Bypass', 'local-studio')
     return response
@@ -90,7 +86,6 @@ export async function proxy(request: NextRequest) {
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-
   if (!supabaseUrl || !supabaseKey) {
     const loginUrl = new URL('/login', request.url)
     loginUrl.searchParams.set('error', 'supabase_no_configurado')
@@ -100,9 +95,7 @@ export async function proxy(request: NextRequest) {
 
   const supabase = createServerClient(normalizeSupabaseUrl(supabaseUrl), supabaseKey, {
     cookies: {
-      getAll() {
-        return request.cookies.getAll()
-      },
+      getAll() { return request.cookies.getAll() },
       setAll(cookiesToSet: Array<{ name: string; value: string; options: CookieOptions }>) {
         cookiesToSet.forEach(({ name, value, options }) => {
           request.cookies.set(name, value)
@@ -113,11 +106,9 @@ export async function proxy(request: NextRequest) {
   })
 
   let user = null
-
   try {
     const result = await supabase.auth.getUser()
     user = result.data.user
-
     if (result.error && isRefreshTokenMissing(result.error)) {
       clearSupabaseAuthCookies(response, request)
       user = null
@@ -131,9 +122,7 @@ export async function proxy(request: NextRequest) {
     }
   }
 
-  if (!user) {
-    return redirectToLoginWithNext(request)
-  }
+  if (!user) return redirectToLoginWithNext(request)
 
   const { data: profile } = await supabase
     .from('profiles')
@@ -141,11 +130,11 @@ export async function proxy(request: NextRequest) {
     .eq('user_id', user.id)
     .maybeSingle()
 
-  if (pathname.startsWith('/root') && !isRootRouteUser(profile?.role, user.email)) {
-    return NextResponse.redirect(new URL('/field', request.url))
+  if (pathname.startsWith('/root') && !isRootRouteUser(user.id, profile?.role, user.email)) {
+    return NextResponse.redirect(new URL('/unauthorized', request.url))
   }
 
-  if (pathname.startsWith('/studio') && !isStudioRouteUser(profile?.role, user.email)) {
+  if (pathname.startsWith('/studio') && !isStudioRouteUser(user.id, profile?.role, user.email)) {
     return NextResponse.redirect(new URL('/unauthorized', request.url))
   }
 

--- a/supabase/migrations/20260711103000_system_access_ownership_foundation.sql
+++ b/supabase/migrations/20260711103000_system_access_ownership_foundation.sql
@@ -1,0 +1,274 @@
+create extension if not exists pgcrypto;
+
+-- FIELD profile extends the existing profiles/account system without replacing it.
+create table if not exists public.field_profiles (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  display_name text,
+  consent_version text,
+  consented_at timestamptz,
+  privacy_settings jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.field_cases (
+  id uuid primary key default gen_random_uuid(),
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  account_id uuid references public.accounts(id) on delete set null,
+  title text not null,
+  domain text not null,
+  declared_attractor text not null,
+  baseline text not null,
+  consent boolean not null default false,
+  visibility text not null default 'private' check (visibility in ('private','founder','public_candidate')),
+  verification_window text not null check (verification_window in ('72h','7d','30d')),
+  status text not null default 'PENDING',
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+
+create table if not exists public.field_case_evidence (
+  id uuid primary key default gen_random_uuid(),
+  case_id uuid not null references public.field_cases(id) on delete cascade,
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  evidence_type text not null,
+  label text not null,
+  source text not null,
+  reliability numeric,
+  storage_path text,
+  uri text,
+  visibility text not null default 'private' check (visibility in ('private','founder','public_candidate')),
+  payload jsonb not null default '{}'::jsonb,
+  observed_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.field_moph_runs (
+  id uuid primary key default gen_random_uuid(),
+  case_id uuid not null references public.field_cases(id) on delete cascade,
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  status text not null default 'PENDING',
+  input jsonb not null default '{}'::jsonb,
+  output jsonb,
+  evidence_ids uuid[] not null default '{}',
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.field_mihm_readings (
+  id uuid primary key default gen_random_uuid(),
+  case_id uuid not null references public.field_cases(id) on delete cascade,
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  status text not null default 'PENDING',
+  metrics jsonb not null default '[]'::jsonb,
+  tensions jsonb not null default '[]'::jsonb,
+  formula_version text,
+  evidence_ids uuid[] not null default '{}',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.field_hypotheses (
+  id uuid primary key default gen_random_uuid(),
+  case_id uuid not null references public.field_cases(id) on delete cascade,
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  statement text not null,
+  target text not null,
+  expected_signal text not null,
+  verification_window text not null check (verification_window in ('72h','7d','30d')),
+  confidence numeric,
+  status text not null default 'PENDING',
+  evidence_ids uuid[] not null default '{}',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.field_interventions (
+  id uuid primary key default gen_random_uuid(),
+  case_id uuid not null references public.field_cases(id) on delete cascade,
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  hypothesis_id uuid not null references public.field_hypotheses(id) on delete cascade,
+  minimum_change text not null,
+  prohibited_effects text[] not null default '{}',
+  status text not null default 'PENDING',
+  started_at timestamptz,
+  completed_at timestamptz,
+  evidence_ids uuid[] not null default '{}',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.field_returns (
+  id uuid primary key default gen_random_uuid(),
+  case_id uuid not null references public.field_cases(id) on delete cascade,
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  intervention_id uuid references public.field_interventions(id) on delete set null,
+  verification_window text not null check (verification_window in ('72h','7d','30d')),
+  expected_at timestamptz not null,
+  returned_at timestamptz,
+  status text not null default 'PENDING',
+  evidence_ids uuid[] not null default '{}',
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.field_outcomes (
+  id uuid primary key default gen_random_uuid(),
+  case_id uuid not null references public.field_cases(id) on delete cascade,
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  intervention_id uuid not null references public.field_interventions(id) on delete cascade,
+  expected text not null,
+  actual text not null,
+  delta numeric,
+  verified boolean,
+  learned text,
+  evidence_ids uuid[] not null default '{}',
+  recorded_at timestamptz not null default now()
+);
+
+create table if not exists public.field_lessons (
+  id uuid primary key default gen_random_uuid(),
+  case_id uuid not null references public.field_cases(id) on delete cascade,
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  outcome_id uuid not null references public.field_outcomes(id) on delete cascade,
+  statement text not null,
+  evidence_ids uuid[] not null default '{}',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.sfi_publications (
+  id uuid primary key default gen_random_uuid(),
+  source_type text not null,
+  source_id text not null,
+  approved_by uuid references auth.users(id) on delete set null,
+  public_fields text[] not null default '{}',
+  public_payload jsonb not null default '{}'::jsonb,
+  snapshot_version text,
+  confidence numeric,
+  status text not null default 'DRAFT' check (status in ('DRAFT','REVIEWED','APPROVED_FOR_PUBLICATION','PUBLISHED','SUPERSEDED','RETRACTED')),
+  reviewed_at timestamptz,
+  approved_at timestamptz,
+  published_at timestamptz,
+  retracted_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.sfi_audit_events (
+  id uuid primary key default gen_random_uuid(),
+  actor_id uuid references auth.users(id) on delete set null,
+  action text not null,
+  target_type text not null,
+  target_id text not null,
+  before_state jsonb,
+  after_state jsonb,
+  context jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+-- Non-destructive Studio ownership foundation. Existing rows remain nullable until explicitly backfilled.
+alter table public.studio_sessions add column if not exists owner_id uuid references auth.users(id) on delete set null;
+alter table public.studio_objects add column if not exists owner_id uuid references auth.users(id) on delete set null;
+alter table public.studio_uploads add column if not exists owner_id uuid references auth.users(id) on delete set null;
+
+create index if not exists field_cases_owner_idx on public.field_cases(owner_id, updated_at desc);
+create index if not exists field_case_evidence_owner_case_idx on public.field_case_evidence(owner_id, case_id, created_at desc);
+create index if not exists field_moph_runs_owner_case_idx on public.field_moph_runs(owner_id, case_id, created_at desc);
+create index if not exists field_mihm_readings_owner_case_idx on public.field_mihm_readings(owner_id, case_id, created_at desc);
+create index if not exists field_hypotheses_owner_case_idx on public.field_hypotheses(owner_id, case_id, created_at desc);
+create index if not exists field_interventions_owner_case_idx on public.field_interventions(owner_id, case_id, created_at desc);
+create index if not exists field_returns_owner_case_idx on public.field_returns(owner_id, case_id, expected_at);
+create index if not exists field_outcomes_owner_case_idx on public.field_outcomes(owner_id, case_id, recorded_at desc);
+create index if not exists sfi_publications_public_idx on public.sfi_publications(status, published_at desc);
+create index if not exists sfi_audit_events_target_idx on public.sfi_audit_events(target_type, target_id, created_at desc);
+create index if not exists studio_objects_owner_idx on public.studio_objects(owner_id, created_at desc);
+
+alter table public.field_profiles enable row level security;
+alter table public.field_cases enable row level security;
+alter table public.field_case_evidence enable row level security;
+alter table public.field_moph_runs enable row level security;
+alter table public.field_mihm_readings enable row level security;
+alter table public.field_hypotheses enable row level security;
+alter table public.field_interventions enable row level security;
+alter table public.field_returns enable row level security;
+alter table public.field_outcomes enable row level security;
+alter table public.field_lessons enable row level security;
+alter table public.sfi_publications enable row level security;
+alter table public.sfi_audit_events enable row level security;
+alter table public.studio_sessions enable row level security;
+alter table public.studio_objects enable row level security;
+alter table public.studio_uploads enable row level security;
+
+-- Direct owner policies.
+do $$
+declare t text;
+begin
+  foreach t in array array[
+    'field_profiles','field_cases','field_case_evidence','field_moph_runs','field_mihm_readings',
+    'field_hypotheses','field_interventions','field_returns','field_outcomes','field_lessons'
+  ] loop
+    execute format('drop policy if exists %I_owner_select on public.%I', t, t);
+    execute format('drop policy if exists %I_owner_insert on public.%I', t, t);
+    execute format('drop policy if exists %I_owner_update on public.%I', t, t);
+    execute format('drop policy if exists %I_owner_delete on public.%I', t, t);
+    if t = 'field_profiles' then
+      execute format('create policy %I_owner_select on public.%I for select using (user_id = auth.uid())', t, t);
+      execute format('create policy %I_owner_insert on public.%I for insert with check (user_id = auth.uid())', t, t);
+      execute format('create policy %I_owner_update on public.%I for update using (user_id = auth.uid()) with check (user_id = auth.uid())', t, t);
+      execute format('create policy %I_owner_delete on public.%I for delete using (user_id = auth.uid())', t, t);
+    else
+      execute format('create policy %I_owner_select on public.%I for select using (owner_id = auth.uid())', t, t);
+      execute format('create policy %I_owner_insert on public.%I for insert with check (owner_id = auth.uid())', t, t);
+      execute format('create policy %I_owner_update on public.%I for update using (owner_id = auth.uid()) with check (owner_id = auth.uid())', t, t);
+      execute format('create policy %I_owner_delete on public.%I for delete using (owner_id = auth.uid())', t, t);
+    end if;
+  end loop;
+end $$;
+
+-- Public publication read boundary. No public writes.
+drop policy if exists sfi_publications_public_read on public.sfi_publications;
+create policy sfi_publications_public_read on public.sfi_publications
+for select using (status = 'PUBLISHED' and published_at is not null);
+
+-- Audit events are service/server written. Authenticated actors may read only their own events.
+drop policy if exists sfi_audit_events_actor_read on public.sfi_audit_events;
+create policy sfi_audit_events_actor_read on public.sfi_audit_events
+for select to authenticated using (actor_id = auth.uid());
+
+-- New Studio rows are owner-bound. Legacy null-owner rows remain inaccessible to normal users until backfilled.
+drop policy if exists studio_sessions_owner_all on public.studio_sessions;
+create policy studio_sessions_owner_all on public.studio_sessions
+for all to authenticated using (owner_id = auth.uid()) with check (owner_id = auth.uid());
+drop policy if exists studio_objects_owner_all on public.studio_objects;
+create policy studio_objects_owner_all on public.studio_objects
+for all to authenticated using (owner_id = auth.uid()) with check (owner_id = auth.uid());
+drop policy if exists studio_uploads_owner_all on public.studio_uploads;
+create policy studio_uploads_owner_all on public.studio_uploads
+for all to authenticated using (owner_id = auth.uid()) with check (owner_id = auth.uid());
+
+-- Private FIELD evidence bucket.
+insert into storage.buckets (id, name, public)
+values ('field-evidence', 'field-evidence', false)
+on conflict (id) do update set public = false;
+
+drop policy if exists field_evidence_owner_select on storage.objects;
+create policy field_evidence_owner_select on storage.objects
+for select to authenticated
+using (bucket_id = 'field-evidence' and (storage.foldername(name))[1] = auth.uid()::text);
+
+drop policy if exists field_evidence_owner_insert on storage.objects;
+create policy field_evidence_owner_insert on storage.objects
+for insert to authenticated
+with check (bucket_id = 'field-evidence' and (storage.foldername(name))[1] = auth.uid()::text);
+
+drop policy if exists field_evidence_owner_update on storage.objects;
+create policy field_evidence_owner_update on storage.objects
+for update to authenticated
+using (bucket_id = 'field-evidence' and (storage.foldername(name))[1] = auth.uid()::text)
+with check (bucket_id = 'field-evidence' and (storage.foldername(name))[1] = auth.uid()::text);
+
+drop policy if exists field_evidence_owner_delete on storage.objects;
+create policy field_evidence_owner_delete on storage.objects
+for delete to authenticated
+using (bucket_id = 'field-evidence' and (storage.foldername(name))[1] = auth.uid()::text);


### PR DESCRIPTION
## Summary

- Adds canonical shared contracts for ROOT, OBSERVATORY and FIELD.
- Adds server-only authorization helpers for authenticated users, FIELD users, founders, case owners, object owners and publication authority.
- Adds a non-destructive FIELD ownership, publication and audit migration with explicit RLS policies and private evidence storage.
- Adds a second founder authorization gate inside `/root` before governance data is read.
- Requires authentication for `/field` and removes FIELD navigation into ROOT actions.
- Adds a public Observatory publication boundary that reads only `PUBLISHED` sanitized payloads.
- Documents current-state audit, access boundaries, privacy, publication, migration and QA requirements.

## Migration

`supabase/migrations/20260711103000_system_access_ownership_foundation.sql`

The migration is not applied automatically. It must be reviewed and tested in staging before production.

## Required configuration

Preferred founder allowlist:

`SFI_FOUNDER_USER_IDS`

Compatibility remains for `SFI_FOUNDER_EMAILS`, `SYSTEM_ROOT_EMAIL` and existing `root/system` profile roles.

## Known limitations

- Authenticated A/B authorization QA requires staging Supabase, two users and a configured founder identity.
- Legacy Studio rows are not backfilled; new nullable ownership columns are intentionally non-destructive.
- FIELD workflow UI, MOPH/MIHM execution and ROOT publication controls remain separate PRs.
- Existing `next lint` tooling remains unresolved in this PR and must not be reported as passing.

## Review focus

- Existing Studio RLS policy interaction before migration application.
- Founder identity configuration.
- FIELD owner policies for all CRUD operations.
- Storage path enforcement.
- Public publication payload sanitization.