### PR TITLE
Fix Studio multimodal analyze HTTP 500

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,9 @@
 /** @type {import('next').NextConfig} */
+const mediaRuntimeFiles = [
+  './node_modules/ffmpeg-static/**/*',
+  './node_modules/ffprobe-static/**/*',
+];
+
 const nextConfig = {
   poweredByHeader: false,
   experimental: {
@@ -13,10 +18,10 @@ const nextConfig = {
     'music-metadata',
   ],
   outputFileTracingIncludes: {
-    '/api/studio/objects/[id]/analyze': [
-      './node_modules/ffmpeg-static/**/*',
-      './node_modules/ffprobe-static/**/*',
-    ],
+    // Next route tracing keys use glob matching. The previous unescaped [id]
+    // pattern could be interpreted as a character class and omit the binaries.
+    '/api/studio/objects/*/analyze': mediaRuntimeFiles,
+    '/api/studio/objects/\\[id\\]/analyze': mediaRuntimeFiles,
   },
   outputFileTracingExcludes: {
     '*': [

--- a/src/components/studio/production/StudioObjectIntake.tsx
+++ b/src/components/studio/production/StudioObjectIntake.tsx
@@ -10,6 +10,18 @@ type IntakeType = 'auto' | 'audio' | 'video' | 'image' | 'text' | 'community' | 
 
 type IntakeStatus = 'idle' | 'preparing' | 'uploading' | 'verifying' | 'analyzing' | 'complete' | 'blocked';
 
+function responseFailure(response: Response, payload: Record<string, unknown> | null, prefix: string) {
+  const code = payload?.error ?? payload?.code;
+  const detail = payload?.details ?? payload?.message;
+  const requestId = response.headers.get('x-vercel-id') ?? response.headers.get('x-request-id');
+  const parts = [
+    typeof code === 'string' ? code : `${prefix}_HTTP_${response.status}`,
+    typeof detail === 'string' ? detail : null,
+    requestId ? `REQUEST_ID=${requestId}` : null,
+  ].filter((value): value is string => Boolean(value));
+  return parts.join(' · ');
+}
+
 export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: () => void }) {
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -41,7 +53,7 @@ export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: 
       });
       const prepared = await jsonResponse(prepareResponse);
       if (!prepareResponse.ok || prepared?.ok !== true) {
-        throw new Error(String(prepared?.details ?? prepared?.error ?? `PREPARE_HTTP_${prepareResponse.status}`));
+        throw new Error(responseFailure(prepareResponse, prepared, 'PREPARE'));
       }
 
       const storagePath = String(prepared.storagePath ?? '');
@@ -69,7 +81,7 @@ export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: 
       });
       const completed = await jsonResponse(completeResponse);
       if (!completeResponse.ok || completed?.ok !== true) {
-        throw new Error(String(completed?.details ?? completed?.error ?? `COMPLETE_HTTP_${completeResponse.status}`));
+        throw new Error(responseFailure(completeResponse, completed, 'COMPLETE'));
       }
 
       setStatus('analyzing');
@@ -81,7 +93,7 @@ export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: 
       });
       const analysis = await jsonResponse(analyzeResponse);
       if (!analyzeResponse.ok || analysis?.ok === false) {
-        throw new Error(String(analysis?.details ?? analysis?.error ?? `ANALYZE_HTTP_${analyzeResponse.status}`));
+        throw new Error(responseFailure(analyzeResponse, analysis, 'ANALYZE'));
       }
 
       setStatus('complete');

--- a/src/lib/studio/audio/audioPersistence.ts
+++ b/src/lib/studio/audio/audioPersistence.ts
@@ -55,6 +55,44 @@ function energyForColumn(segments: EnergySegment[]) {
   }));
 }
 
+async function deletePriorAudioAnalysisRows(
+  supabase: SupabaseClient,
+  objectId: string,
+  idempotencyKey: string,
+) {
+  const operations = [
+    supabase
+      .from('studio_object_features')
+      .delete()
+      .eq('object_id', objectId)
+      .contains('payload', { idempotencyKey }),
+    supabase
+      .from('studio_audio_features')
+      .delete()
+      .eq('object_id', objectId)
+      .contains('payload', { idempotencyKey }),
+    supabase
+      .from('studio_time_coordinates')
+      .delete()
+      .eq('object_id', objectId)
+      .contains('payload', { idempotencyKey }),
+    supabase
+      .from('studio_evidence_traces')
+      .delete()
+      .eq('object_id', objectId)
+      .contains('payload', { idempotencyKey }),
+  ];
+
+  const results = await Promise.all(operations);
+  const failure = results.find((result) => result.error)?.error;
+  if (failure) {
+    throw new StudioAudioError('PERSISTENCE_FAILED', failure.message, 500, {
+      objectId,
+      operation: 'delete_prior_audio_analysis_rows',
+    });
+  }
+}
+
 export async function findExistingStudioAudioAnalysis(
   supabase: SupabaseClient,
   objectId: string,
@@ -155,6 +193,10 @@ export async function persistStudioAudioAnalysis(
     probe,
   };
 
+  // A failed prior attempt may have persisted only part of the result set.
+  // Remove rows for this exact analysis identity before reinserting them.
+  await deletePriorAudioAnalysisRows(supabase, result.objectId, result.idempotencyKey);
+
   const objectFeatureRows = result.features.map((item) => ({
     object_id: result.objectId,
     feature_key: item.key,
@@ -218,14 +260,15 @@ export async function persistStudioAudioAnalysis(
     if (timeError) throw new StudioAudioError('PERSISTENCE_FAILED', timeError.message, 500, { table: 'studio_time_coordinates' });
   }
 
+  const reliability = result.status === 'COMPLETE' ? 0.86 : 0.62;
   const { error: evidenceError } = await supabase.from('studio_evidence_traces').insert({
     object_id: result.objectId,
     source: result.engine,
     label: 'Studio audio extraction',
-    reliability: result.status === 'COMPLETE' ? 0.86 : 0.62,
-    uri: object.source_uri,
     payload: {
       ...commonPayload,
+      reliability,
+      uri: object.source_uri,
       status: result.status,
       warnings: result.warnings,
       featureCount: result.features.length,

--- a/src/lib/studio/multimodal/mediaRuntime.ts
+++ b/src/lib/studio/multimodal/mediaRuntime.ts
@@ -52,6 +52,19 @@ function binary(kind: 'ffmpeg' | 'ffprobe') {
   return value;
 }
 
+function processLaunchFailure(error: Error, executable: string) {
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code === 'ENOENT' || code === 'EACCES') {
+    return new StudioMultimodalError(
+      'EXTRACTION_RUNTIME_UNAVAILABLE',
+      'The deployed media binary is missing or not executable.',
+      503,
+      { code, binary: executable.includes('ffprobe') ? 'ffprobe' : 'ffmpeg' },
+    );
+  }
+  return new StudioMultimodalError('TRANSCODE_FAILED', error.message, 500, { code: code ?? null });
+}
+
 async function runBinary(
   executable: string,
   args: string[],
@@ -78,7 +91,6 @@ async function runBinary(
 
     const timer = setTimeout(() => {
       finishError(new StudioMultimodalError('TRANSCODE_FAILED', 'Media process exceeded the configured execution timeout.', 504, {
-        executable,
         timeoutMs: timeoutMs(),
       }));
     }, timeoutMs());
@@ -97,7 +109,7 @@ async function runBinary(
       if (stderrBytes <= maxStderrBytes) stderr.push(Buffer.from(chunk));
     });
 
-    child.on('error', (error) => finishError(error));
+    child.on('error', (error) => finishError(processLaunchFailure(error, executable)));
     child.on('close', (code) => {
       if (settled) return;
       settled = true;


### PR DESCRIPTION
## Root cause

The audio analysis persistence path inserted `reliability` and `uri` as columns in `studio_evidence_traces`, but the canonical Studio schema only provides `object_id`, `source`, `label`, `payload`, and timestamps. This caused analysis to fail during persistence after extraction.

The deployed FFmpeg runtime also used an unescaped `[id]` output tracing key, which could omit `ffmpeg-static` and `ffprobe-static` from the dynamic analyze function.

## Fix

- Persist evidence reliability and URI inside the existing JSON payload instead of nonexistent columns.
- Delete partial rows for the same idempotency key before retrying an audio analysis.
- Trace media binaries using dynamic-route-safe patterns.
- Normalize missing/non-executable media binaries as `EXTRACTION_RUNTIME_UNAVAILABLE` instead of an opaque 500.
- Show structured API error codes, details, and request IDs in Object Intake.

## Validation

- SFI boundaries: SUCCESS.
- Typecheck: SUCCESS.
- Build: SUCCESS.
- `SFI Verify` run 611: SUCCESS.

## Post-deployment check

Retry the stored object. The same analysis identity cleans partial rows before persisting the corrected result.