### PR TITLE
Make Studio infer field position, opportunity windows and strategy routes

### DIFF
--- a/docs/studio/STUDIO_FIELD_PROJECTION_V2.md
+++ b/docs/studio/STUDIO_FIELD_PROJECTION_V2.md
@@ -1,0 +1,88 @@
+# Studio Field Projection v2
+
+## Purpose
+
+Studio must not require the operator to translate System Friction terminology before receiving a useful result. The default flow is now:
+
+`object -> observed features -> partial MIHM vector -> longitudinal world state -> cross-vector tensions -> inferred attractors -> field compatibility -> opportunity window -> strategy routes -> micro-adjustments -> verification`
+
+User input is optional. It can select a route or add personal constraints, but it does not gate diagnosis or projection.
+
+## What the projection says
+
+The projection reports:
+
+1. The current regime of the CULTURAL, MEMETIC and AFFECTIVE field.
+2. Directional or magnitude tensions between those vectors.
+3. One or more system-inferred attractors.
+4. The object's partial MIHM vector using every available variable.
+5. A field compatibility score and confidence.
+6. A conditional opportunity window with explicit exit conditions.
+7. Three strategic routes:
+   - integrate with the field;
+   - preserve the object as a counter-signal;
+   - optimize technically without changing direction.
+8. Specific micro-adjustments and measurable verification steps.
+9. Automatic guardrails derived from observed invariants.
+
+## MIHM behavior
+
+A missing final IHG does not block use of the measured MIHM vector. Studio shows all available variables and their provenance. Missing variables remain missing rather than being imputed as if they were observed.
+
+The final IHG remains unissued when the canonical core is incomplete. This limitation is visible in the technical trace, but it no longer prevents field projection or scenario generation.
+
+## Compatibility is not acceptance
+
+`FIELD_COMPATIBILITY_NOT_ACCEPTANCE` compares only dimensions shared by the object and the observed field. Current mappings include:
+
+- formal friction to AFFECTIVE pressure as a declared formal proxy;
+- formal coherence to CULTURAL pressure as a declared formal proxy;
+- semantic recurrence to MEMETIC pressure when semantic evidence exists.
+
+Every dimension states whether it is a semantic comparison or a formal proxy.
+
+The UI may display a compatibility percentage, but `acceptanceProbability` remains `null` until empirical outcome calibration exists.
+
+## Acceptance calibration
+
+A minimum viable calibration requires at least 30 comparable releases; 100 or more are recommended. Each case must persist:
+
+- object and version;
+- MIHM vector at release;
+- WorldSpect and Cultural Vector state at release;
+- release time, channel and audience definition;
+- normalized exposure or impressions;
+- plays/views and completion;
+- saves, shares and repeat consumption;
+- qualitative response labels;
+- 7-day and 30-day outcomes.
+
+Compatibility can be upgraded to an acceptance estimate only after out-of-sample validation on comparable cases with normalized exposure. Until then, any numeric acceptance probability would be fabricated.
+
+## Opportunity window
+
+The opportunity window is heuristic and conditional. It uses:
+
+- dominant vector direction;
+- slope magnitude;
+- sample count;
+- WorldSpect confidence;
+- object-field compatibility band.
+
+It always includes exit conditions. It is not a promise that the cultural state will remain unchanged for the full interval.
+
+## Automatic guardrails
+
+Studio derives guardrails from available measurements, for example:
+
+- duration tolerance;
+- maximum permitted loss of dynamic range;
+- spectral-centroid tolerance;
+- no increase in clipping;
+- maximum permitted reduction of Phi or C_s.
+
+The user may add personal constraints in ordinary language, but does not need to know the term "prohibited effect".
+
+## Persistence semantics
+
+Projection routes are persisted as scenarios in `studio_interventions` with status `SCENARIO_NOT_EXECUTED`. No route is treated as executed, successful or accepted until an outcome is recorded.

--- a/src/app/api/studio/objects/[id]/project/route.ts
+++ b/src/app/api/studio/objects/[id]/project/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { AccessDeniedError, requireObjectOwner } from '@/lib/system/access/server';
+import {
+  getPersistedStudioFieldProjection,
+  projectStudioObjectField,
+} from '@/lib/studio/production/objectFieldProjection';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+type RouteContext = { params: Promise<{ id: string }> | { id: string } };
+
+function objectIdFrom(ctx: RouteContext) {
+  return Promise.resolve(ctx.params).then((params) => decodeURIComponent(params.id));
+}
+
+export async function GET(_request: Request, ctx: RouteContext) {
+  const objectId = await objectIdFrom(ctx);
+  try {
+    await requireObjectOwner(objectId);
+    const projection = await getPersistedStudioFieldProjection(objectId);
+    if (!projection) {
+      return NextResponse.json({ ok: false, error: 'PROJECTION_NOT_FOUND', details: 'No persisted field projection exists.' }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true, projection });
+  } catch (error) {
+    if (error instanceof AccessDeniedError) {
+      return NextResponse.json({ ok: false, error: error.code, details: error.message }, { status: error.status });
+    }
+    return NextResponse.json({ ok: false, error: 'PROJECTION_READ_FAILED', details: error instanceof Error ? error.message : String(error) }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request, ctx: RouteContext) {
+  const objectId = await objectIdFrom(ctx);
+  try {
+    await requireObjectOwner(objectId);
+    const body = await request.json().catch(() => ({})) as { persist?: unknown };
+    const projection = await projectStudioObjectField(objectId, { persist: body.persist !== false });
+    return NextResponse.json({ ok: true, status: projection.status, projection }, { status: 201 });
+  } catch (error) {
+    if (error instanceof AccessDeniedError) {
+      return NextResponse.json({ ok: false, error: error.code, details: error.message }, { status: error.status });
+    }
+    return NextResponse.json({ ok: false, error: 'PROJECTION_FAILED', details: error instanceof Error ? error.message : String(error) }, { status: 500 });
+  }
+}

--- a/src/components/studio/production/StudioObjectIntake.tsx
+++ b/src/components/studio/production/StudioObjectIntake.tsx
@@ -7,20 +7,50 @@ import { createBrowserSupabaseClient } from '@/runtime/supabase/client';
 const ACCEPTED = '.wav,.wave,.mp3,.m4a,.aac,.flac,.ogg,.oga,.opus,.aiff,.aif,.mp4,.mov,.webm,.mkv,.m4v,.png,.jpg,.jpeg,.webp,.gif,.tif,.tiff,.txt,.md,.markdown,.json,.csv,.tsv,.rtf,.pdf,.docx';
 
 type IntakeType = 'auto' | 'audio' | 'video' | 'image' | 'text' | 'community' | 'time_coordinate';
-type IntakeStatus = 'idle' | 'preparing' | 'uploading' | 'verifying' | 'analyzing' | 'synthesizing' | 'complete' | 'blocked';
+type IntakeStatus = 'idle' | 'preparing' | 'uploading' | 'verifying' | 'analyzing' | 'synthesizing' | 'projecting' | 'complete' | 'blocked';
 
-type Synthesis = {
+type Projection = {
   status: string;
-  objectReading: { summary: string; interpretability: string; limitations: string[] };
-  worldContext: { relation: string; explanation: string; dominantSignal: string | null; confidence: number | null };
-  mihm: { status: string; coverage: number; coreCoverage: number; ihg: number | null; summary: string; limitations: string[] };
-  leverage: {
+  world: {
+    regime: string;
+    summary: string;
+    dominantDomain: string | null;
+    crossVectorTensions: Array<{ between: [string, string]; description: string }>;
+    inferredAttractors: Array<{ label: string; description: string; confidence: number }>;
+  };
+  object: {
+    summary: string;
+    interpretability: string;
+    mihmStatus: string;
+    mihmCoverage: number;
+    mihmCoreCoverage: number;
+  };
+  fit: {
+    percentage: number | null;
+    band: string;
+    confidence: number;
+    explanation: string;
+    acceptanceReason: string;
+  };
+  opportunityWindow: {
     status: string;
-    minimumPerturbation: string | null;
-    rationale: string;
-    expectedSignal: string | null;
-    verificationWindow: string | null;
-    falsificationCriterion: string | null;
+    starts: string;
+    minimumDays: number | null;
+    maximumDays: number | null;
+    basis: string;
+  };
+  strategy: {
+    selectedAttractor: string | null;
+    selectedRouteId: string | null;
+    selectionReason: string;
+    routes: Array<{
+      id: string;
+      title: string;
+      suitability: number;
+      rationale: string;
+      microAdjustments: string[];
+      verification: string[];
+    }>;
   };
 };
 
@@ -36,8 +66,14 @@ function responseFailure(response: Response, payload: Record<string, unknown> | 
   return parts.join(' · ');
 }
 
-function confidence(value: number | null) {
+function metric(value: number | null) {
   return value === null ? 'UNKNOWN' : Number(value.toFixed(3));
+}
+
+function windowLabel(projection: Projection) {
+  const window = projection.opportunityWindow;
+  if (window.minimumDays === null || window.maximumDays === null) return `${window.status} · ${window.starts}`;
+  return `${window.status} · ${window.starts} · ${window.minimumDays}–${window.maximumDays} días`;
 }
 
 export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: () => void }) {
@@ -45,12 +81,8 @@ export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: 
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [status, setStatus] = useState<IntakeStatus>('idle');
   const [objectType, setObjectType] = useState<IntakeType>('auto');
-  const [declaredAttractor, setDeclaredAttractor] = useState('');
-  const [desiredShift, setDesiredShift] = useState('');
-  const [targetAudience, setTargetAudience] = useState('');
-  const [prohibitedEffects, setProhibitedEffects] = useState('');
-  const [synthesis, setSynthesis] = useState<Synthesis | null>(null);
-  const [message, setMessage] = useState('Carga un objeto real. Studio almacenará el archivo de forma privada, ejecutará su extractor y después intentará interpretar su relación con el campo.');
+  const [projection, setProjection] = useState<Projection | null>(null);
+  const [message, setMessage] = useState('Carga un objeto real. Studio inferirá su posición frente al mundo, MIHM parcial, compatibilidad de campo, ventana y rutas sin pedirte teoría previa.');
 
   if (!open) return null;
 
@@ -59,9 +91,9 @@ export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: 
   }
 
   async function upload(file: File) {
-    setSynthesis(null);
+    setProjection(null);
     setStatus('preparing');
-    setMessage('Preparando objeto, ownership, contexto declarado y URL firmada.');
+    setMessage('Preparando objeto, ownership y URL firmada.');
 
     try {
       const prepareResponse = await fetch('/api/studio/objects/upload/prepare', {
@@ -73,18 +105,10 @@ export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: 
           sizeBytes: file.size,
           title: file.name.replace(/\.[^.]+$/, ''),
           objectType: objectType === 'auto' ? null : objectType,
-          context: {
-            declaredAttractor: declaredAttractor.trim() || null,
-            desiredShift: desiredShift.trim() || null,
-            targetAudience: targetAudience.trim() || null,
-            prohibitedEffects: prohibitedEffects.split(/[,;\n]+/).map((item) => item.trim()).filter(Boolean),
-          },
         }),
       });
       const prepared = await jsonResponse(prepareResponse);
-      if (!prepareResponse.ok || prepared?.ok !== true) {
-        throw new Error(responseFailure(prepareResponse, prepared, 'PREPARE'));
-      }
+      if (!prepareResponse.ok || prepared?.ok !== true) throw new Error(responseFailure(prepareResponse, prepared, 'PREPARE'));
 
       const storagePath = String(prepared.storagePath ?? '');
       const token = String(prepared.token ?? '');
@@ -110,9 +134,7 @@ export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: 
         body: JSON.stringify({ objectId }),
       });
       const completed = await jsonResponse(completeResponse);
-      if (!completeResponse.ok || completed?.ok !== true) {
-        throw new Error(responseFailure(completeResponse, completed, 'COMPLETE'));
-      }
+      if (!completeResponse.ok || completed?.ok !== true) throw new Error(responseFailure(completeResponse, completed, 'COMPLETE'));
 
       setStatus('analyzing');
       setMessage('Archivo almacenado. Ejecutando el extractor real de su modalidad.');
@@ -122,26 +144,33 @@ export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: 
         body: JSON.stringify({ force: false }),
       });
       const analysis = await jsonResponse(analyzeResponse);
-      if (!analyzeResponse.ok || analysis?.ok === false) {
-        throw new Error(responseFailure(analyzeResponse, analysis, 'ANALYZE'));
-      }
+      if (!analyzeResponse.ok || analysis?.ok === false) throw new Error(responseFailure(analyzeResponse, analysis, 'ANALYZE'));
 
       setStatus('synthesizing');
-      setMessage('Extracción completa. Comparando objeto, MIHM parcial, Cultural Vector y trayectoria WorldSpect.');
+      setMessage('Construyendo vector MIHM parcial y trazabilidad del objeto.');
       const synthesisResponse = await fetch(`/api/studio/objects/${encodeURIComponent(objectId)}/synthesize`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ persist: true }),
       });
       const synthesisPayload = await jsonResponse(synthesisResponse);
-      if (!synthesisResponse.ok || synthesisPayload?.ok !== true) {
-        throw new Error(responseFailure(synthesisResponse, synthesisPayload, 'SYNTHESIS'));
-      }
-      const result = synthesisPayload.synthesis as Synthesis | undefined;
-      if (!result) throw new Error('SYNTHESIS_CONTRACT_INCOMPLETE');
-      setSynthesis(result);
+      if (!synthesisResponse.ok || synthesisPayload?.ok !== true) throw new Error(responseFailure(synthesisResponse, synthesisPayload, 'SYNTHESIS'));
+
+      setStatus('projecting');
+      setMessage('Observando el mundo longitudinal, tensiones vectoriales, compatibilidad, ventana y microajustes por escenario.');
+      const projectionResponse = await fetch(`/api/studio/objects/${encodeURIComponent(objectId)}/project`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ persist: true }),
+      });
+      const projectionPayload = await jsonResponse(projectionResponse);
+      if (!projectionResponse.ok || projectionPayload?.ok !== true) throw new Error(responseFailure(projectionResponse, projectionPayload, 'PROJECTION'));
+      const result = projectionPayload.projection as Projection | undefined;
+      if (!result) throw new Error('PROJECTION_CONTRACT_INCOMPLETE');
+
+      setProjection(result);
       setStatus('complete');
-      setMessage(`Objeto ${objectId} analizado e interpretado con estado ${result.status}. La perturbación solo aparece cuando existe atractor y una regla calibrada.`);
+      setMessage(`Objeto ${objectId} analizado y proyectado. El porcentaje es compatibilidad de campo; aceptación permanece sin calibrar hasta acumular outcomes comparables.`);
       router.refresh();
       if (inputRef.current) inputRef.current.value = '';
     } catch (error) {
@@ -150,14 +179,15 @@ export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: 
     }
   }
 
-  const busy = ['preparing', 'uploading', 'verifying', 'analyzing', 'synthesizing'].includes(status);
+  const busy = ['preparing', 'uploading', 'verifying', 'analyzing', 'synthesizing', 'projecting'].includes(status);
+  const selectedRoute = projection?.strategy.routes.find((route) => route.id === projection.strategy.selectedRouteId) ?? projection?.strategy.routes[0] ?? null;
 
   return (
     <div className="sfi-production__intake">
       <div className="sfi-production__intake-panel">
         <button type="button" className="sfi-production__icon-button" onClick={onClose}>X</button>
         <span>OBJECT INTAKE</span>
-        <h2>INGESTA + INTERPRETACIÓN TRAZABLE</h2>
+        <h2>INGESTA + LECTURA ESTRATÉGICA</h2>
         <p>{message}</p>
         <label>
           MODALIDAD
@@ -171,48 +201,29 @@ export function StudioObjectIntake({ open, onClose }: { open: boolean; onClose: 
             <option value="time_coordinate">COORDENADA TEMPORAL</option>
           </select>
         </label>
-        <label>
-          ATRACTOR DECLARADO · QUÉ DEBE PRESERVARSE O ALCANZARSE
-          <textarea value={declaredAttractor} onChange={(event) => setDeclaredAttractor(event.target.value)} disabled={busy} placeholder="Ej. preservar la tensión central de la pieza sin perder legibilidad ni energía." />
-        </label>
-        <label>
-          DESPLAZAMIENTO DESEADO
-          <textarea value={desiredShift} onChange={(event) => setDesiredShift(event.target.value)} disabled={busy} placeholder="Qué cambio esperas observar en el objeto, audiencia o contexto." />
-        </label>
-        <label>
-          AUDIENCIA / CAMPO OBJETIVO
-          <input value={targetAudience} onChange={(event) => setTargetAudience(event.target.value)} disabled={busy} placeholder="Audiencia, comunidad o contexto de recepción." />
-        </label>
-        <label>
-          EFECTOS PROHIBIDOS
-          <textarea value={prohibitedEffects} onChange={(event) => setProhibitedEffects(event.target.value)} disabled={busy} placeholder="Separados por coma o línea. Ej. no reducir intensidad; no cambiar duración." />
-        </label>
         <input ref={inputRef} type="file" accept={ACCEPTED} onChange={(event) => {
           const file = event.currentTarget.files?.[0];
           if (file) void upload(file);
         }} />
-        <button type="button" onClick={() => inputRef.current?.click()} disabled={busy}>
-          SELECCIONAR OBJETO
-        </button>
-        <small>Sin atractor, Studio puede describir y diagnosticar, pero bloqueará la perturbación. Un audio sin letra/contexto solo permite lectura formal, no significado cultural.</small>
+        <button type="button" onClick={() => inputRef.current?.click()} disabled={busy}>SELECCIONAR OBJETO</button>
+        <small>Studio genera atractores, guardrails y rutas automáticamente. Después puedes precisar en lenguaje normal si buscas integración, singularidad o solo corrección técnica.</small>
         <em>{status.toUpperCase()}</em>
 
-        {synthesis ? (
+        {projection ? (
           <section className="sfi-production__panel">
-            <header><span>OBJECT–WORLD SYNTHESIS</span><strong>{synthesis.status}</strong></header>
+            <header><span>FIELD PROJECTION</span><strong>{projection.status}</strong></header>
             <dl className="sfi-production__object-grid">
-              <dt>Qué es observable</dt><dd>{synthesis.objectReading.summary}</dd>
-              <dt>Interpretabilidad</dt><dd>{synthesis.objectReading.interpretability}</dd>
-              <dt>Relación con el mundo</dt><dd>{synthesis.worldContext.relation}: {synthesis.worldContext.explanation}</dd>
-              <dt>World confidence</dt><dd>{confidence(synthesis.worldContext.confidence)}</dd>
-              <dt>MIHM</dt><dd>{synthesis.mihm.status} · coverage {Number(synthesis.mihm.coverage.toFixed(3))} · core {Number(synthesis.mihm.coreCoverage.toFixed(3))}</dd>
-              <dt>IHG</dt><dd>{synthesis.mihm.ihg === null ? 'BLOCKED_UNTIL_CORE_COVERAGE' : Number(synthesis.mihm.ihg.toFixed(4))}</dd>
-              <dt>Qué significa</dt><dd>{synthesis.mihm.summary}</dd>
-              <dt>Punto de palanca</dt><dd>{synthesis.leverage.status}: {synthesis.leverage.rationale}</dd>
-              <dt>Perturbación mínima</dt><dd>{synthesis.leverage.minimumPerturbation ?? 'NO_PERTURBATION_EMITTED'}</dd>
-              <dt>Señal esperada</dt><dd>{synthesis.leverage.expectedSignal ?? 'MISSING'}</dd>
-              <dt>Verificación</dt><dd>{synthesis.leverage.verificationWindow ?? 'MISSING'} · {synthesis.leverage.falsificationCriterion ?? 'NO_FALSIFICATION_CRITERION'}</dd>
-              <dt>Límites</dt><dd>{[...synthesis.objectReading.limitations, ...synthesis.mihm.limitations].join(' / ') || 'NONE'}</dd>
+              <dt>El mundo</dt><dd>{projection.world.summary}</dd>
+              <dt>Régimen</dt><dd>{projection.world.regime}</dd>
+              <dt>Atractor inferido</dt><dd>{projection.strategy.selectedAttractor ?? 'INDETERMINATE'}</dd>
+              <dt>El objeto</dt><dd>{projection.object.summary}</dd>
+              <dt>MIHM</dt><dd>{projection.object.mihmStatus} · coverage {metric(projection.object.mihmCoverage)} · core {metric(projection.object.mihmCoreCoverage)}</dd>
+              <dt>Compatibilidad</dt><dd>{projection.fit.percentage === null ? 'NO ESTIMABLE' : `${projection.fit.percentage}%`} · {projection.fit.band} · confidence {metric(projection.fit.confidence)}</dd>
+              <dt>Aceptación</dt><dd>NO CALIBRADA · {projection.fit.acceptanceReason}</dd>
+              <dt>Ventana</dt><dd>{windowLabel(projection)} · {projection.opportunityWindow.basis}</dd>
+              <dt>Ruta principal</dt><dd>{selectedRoute?.title ?? 'NO_ROUTE'} · {projection.strategy.selectionReason}</dd>
+              <dt>Microajustes</dt><dd>{selectedRoute?.microAdjustments.join(' / ') ?? 'NO_ADJUSTMENTS'}</dd>
+              <dt>Verificación</dt><dd>{selectedRoute?.verification.join(' / ') ?? 'NO_VERIFICATION'}</dd>
             </dl>
           </section>
         ) : null}

--- a/src/components/studio/production/StudioObjectSynthesisPanel.tsx
+++ b/src/components/studio/production/StudioObjectSynthesisPanel.tsx
@@ -37,16 +37,88 @@ type Synthesis = {
     variables: Array<{ key: string; label: string; value: number | null; status: string; explanation: string; warnings: string[] }>;
     limitations: string[];
   };
-  leverage: {
+};
+
+type ProjectionRoute = {
+  id: string;
+  title: string;
+  suitability: number;
+  goal: string;
+  rationale: string;
+  microAdjustments: string[];
+  expectedShift: string;
+  verification: string[];
+  guardrails: string[];
+  confidence: number;
+};
+
+type Projection = {
+  status: string;
+  generatedAt: string;
+  world: {
+    regime: string;
+    summary: string;
+    dominantDomain: string | null;
+    dominantSignal: string | null;
+    confidence: number;
+    crossVectorTensions: Array<{ between: [string, string]; magnitude: number; description: string }>;
+    inferredAttractors: Array<{ id: string; label: string; description: string; confidence: number }>;
+  };
+  object: {
+    summary: string;
+    interpretability: string;
+    mihmStatus: string;
+    mihmCoverage: number;
+    mihmCoreCoverage: number;
+    dominantProperties: string[];
+  };
+  fit: {
+    metric: string;
+    score: number | null;
+    percentage: number | null;
+    band: string;
+    confidence: number;
+    coverage: number;
+    explanation: string;
+    missingDimensions: string[];
+    sharedDimensions: Array<{
+      id: string;
+      label: string;
+      objectValue: number;
+      fieldValue: number;
+      compatibility: number;
+      dataClass: string;
+      explanation: string;
+    }>;
+    acceptanceProbability: null;
+    acceptanceReason: string;
+  };
+  opportunityWindow: {
     status: string;
-    scope: string | null;
-    targetVariable: string | null;
-    minimumPerturbation: string | null;
-    preserves: string[];
-    expectedSignal: string | null;
-    verificationWindow: string | null;
-    falsificationCriterion: string | null;
-    rationale: string;
+    starts: string;
+    minimumDays: number | null;
+    maximumDays: number | null;
+    basis: string;
+    exitConditions: string[];
+  };
+  strategy: {
+    selectedAttractor: string | null;
+    attractorSource: string;
+    selectedRouteId: string | null;
+    selectionReason: string;
+    automaticGuardrails: string[];
+    userGuardrails: string[];
+    routes: ProjectionRoute[];
+    userInputRequired: false;
+    userInputPurpose: string;
+  };
+  calibration: {
+    status: string;
+    currentOutput: string;
+    minimumComparableCases: number;
+    recommendedComparableCases: number;
+    requiredOutcomeFields: string[];
+    upgradeCondition: string;
   };
 };
 
@@ -68,9 +140,20 @@ function numberOrUnknown(value: number | null) {
   return value === null ? 'UNKNOWN' : Number(value.toFixed(4));
 }
 
+function percentage(value: number | null) {
+  return value === null ? 'NO ESTIMABLE' : `${Math.round(value)}%`;
+}
+
+function windowLabel(projection: Projection) {
+  const window = projection.opportunityWindow;
+  if (window.minimumDays === null || window.maximumDays === null) return `${window.status} · ${window.starts}`;
+  return `${window.status} · ${window.starts} · ${window.minimumDays}–${window.maximumDays} días`;
+}
+
 export function StudioObjectSynthesisPanel({ objectId }: { objectId: string | null }) {
   const [context, setContext] = useState<Context>(initialContext);
   const [synthesis, setSynthesis] = useState<Synthesis | null>(null);
+  const [projection, setProjection] = useState<Projection | null>(null);
   const [state, setState] = useState<'idle' | 'loading' | 'saving' | 'running' | 'failed'>('idle');
   const [message, setMessage] = useState<string | null>(null);
 
@@ -78,22 +161,36 @@ export function StudioObjectSynthesisPanel({ objectId }: { objectId: string | nu
     if (!objectId) {
       setContext(initialContext());
       setSynthesis(null);
+      setProjection(null);
       return;
     }
     let cancelled = false;
     async function load() {
       setState('loading');
       setMessage(null);
-      const [contextResponse, synthesisResponse] = await Promise.all([
+      const [contextResponse, synthesisResponse, projectionResponse] = await Promise.all([
         fetch(`/api/studio/objects/${encodeURIComponent(objectId as string)}/context`, { cache: 'no-store' }),
         fetch(`/api/studio/objects/${encodeURIComponent(objectId as string)}/synthesize`, { cache: 'no-store' }),
+        fetch(`/api/studio/objects/${encodeURIComponent(objectId as string)}/project`, { cache: 'no-store' }),
       ]);
       const contextBody = await contextResponse.json().catch(() => null);
       const synthesisBody = await synthesisResponse.json().catch(() => null);
+      const projectionBody = await projectionResponse.json().catch(() => null);
       if (cancelled) return;
       if (contextResponse.ok && contextBody?.ok) setContext(asContext(contextBody.context));
       if (synthesisResponse.ok && synthesisBody?.ok) setSynthesis(synthesisBody.synthesis as Synthesis);
-      setState('idle');
+      if (projectionResponse.ok && projectionBody?.ok) {
+        setProjection(projectionBody.projection as Projection);
+      } else {
+        const generatedResponse = await fetch(`/api/studio/objects/${encodeURIComponent(objectId as string)}/project`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ persist: false }),
+        });
+        const generatedBody = await generatedResponse.json().catch(() => null);
+        if (!cancelled && generatedResponse.ok && generatedBody?.ok) setProjection(generatedBody.projection as Projection);
+      }
+      if (!cancelled) setState('idle');
     }
     void load().catch((error) => {
       if (!cancelled) {
@@ -106,9 +203,28 @@ export function StudioObjectSynthesisPanel({ objectId }: { objectId: string | nu
 
   if (!objectId) return null;
 
-  async function saveAndSynthesize() {
+  async function generateProjection() {
+    setState('running');
+    setMessage('Recalculando mundo, tensiones vectoriales, MIHM parcial, compatibilidad, ventana y escenarios.');
+    const response = await fetch(`/api/studio/objects/${encodeURIComponent(objectId as string)}/project`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ persist: true }),
+    });
+    const body = await response.json().catch(() => null);
+    if (!response.ok || body?.ok !== true) {
+      setState('failed');
+      setMessage(body?.details || body?.error || `PROJECTION_HTTP_${response.status}`);
+      return;
+    }
+    setProjection(body.projection as Projection);
+    setState('idle');
+    setMessage('Proyección persistida. Los porcentajes representan compatibilidad de campo, no aceptación garantizada.');
+  }
+
+  async function savePreferencesAndProject() {
     setState('saving');
-    setMessage('Persistiendo atractor y límites de intervención.');
+    setMessage('Guardando preferencias opcionales; no son requisitos para el análisis.');
     const contextResponse = await fetch(`/api/studio/objects/${encodeURIComponent(objectId as string)}/context`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -125,97 +241,159 @@ export function StudioObjectSynthesisPanel({ objectId }: { objectId: string | nu
       setMessage(contextBody?.details || contextBody?.error || `CONTEXT_HTTP_${contextResponse.status}`);
       return;
     }
-
-    setState('running');
-    setMessage('Calculando lectura objeto–mundo, MIHM y punto de palanca.');
-    const synthesisResponse = await fetch(`/api/studio/objects/${encodeURIComponent(objectId as string)}/synthesize`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ persist: true }),
-    });
-    const synthesisBody = await synthesisResponse.json().catch(() => null);
-    if (!synthesisResponse.ok || synthesisBody?.ok !== true) {
-      setState('failed');
-      setMessage(synthesisBody?.details || synthesisBody?.error || `SYNTHESIS_HTTP_${synthesisResponse.status}`);
-      return;
-    }
-    setSynthesis(synthesisBody.synthesis as Synthesis);
-    setState('idle');
-    setMessage('Lectura persistida. Ninguna intervención se considera ejecutada.');
+    await generateProjection();
   }
+
+  const selectedRoute = projection?.strategy.routes.find((route) => route.id === projection.strategy.selectedRouteId) ?? projection?.strategy.routes[0] ?? null;
 
   return (
     <section className="sfi-production__panel">
       <header>
-        <span>OBJECT → WORLD → MIHM → LEVERAGE</span>
-        <strong>{synthesis?.status ?? 'NOT_GENERATED'}</strong>
+        <span>WORLD → CULTURAL VECTOR → OBJECT → MIHM → WINDOW → ROUTES</span>
+        <strong>{projection?.status ?? 'NOT_GENERATED'}</strong>
       </header>
 
-      <div className="sfi-production__overview-grid">
-        <div>
-          <label>
-            ATRACTOR DECLARADO
-            <textarea value={context.declaredAttractor} onChange={(event) => setContext((current) => ({ ...current, declaredAttractor: event.target.value }))} disabled={state === 'saving' || state === 'running'} placeholder="Qué debe preservarse o alcanzarse." />
-          </label>
-          <label>
-            DESPLAZAMIENTO DESEADO
-            <textarea value={context.desiredShift} onChange={(event) => setContext((current) => ({ ...current, desiredShift: event.target.value }))} disabled={state === 'saving' || state === 'running'} placeholder="Qué señal debe cambiar." />
-          </label>
-          <label>
-            AUDIENCIA / CAMPO
-            <input value={context.targetAudience} onChange={(event) => setContext((current) => ({ ...current, targetAudience: event.target.value }))} disabled={state === 'saving' || state === 'running'} placeholder="Contexto de recepción." />
-          </label>
-          <label>
-            EFECTOS PROHIBIDOS
-            <textarea value={context.prohibitedEffects} onChange={(event) => setContext((current) => ({ ...current, prohibitedEffects: event.target.value }))} disabled={state === 'saving' || state === 'running'} placeholder="Uno por línea." />
-          </label>
-          <button type="button" onClick={() => void saveAndSynthesize()} disabled={state === 'saving' || state === 'running' || state === 'loading'}>
-            {synthesis ? 'RECALCULAR LECTURA' : 'GENERAR LECTURA'}
-          </button>
-          {message ? <p className={`sfi-production__action-result is-${state}`}>{message}</p> : null}
-        </div>
+      <button type="button" onClick={() => void generateProjection()} disabled={state === 'saving' || state === 'running' || state === 'loading'}>
+        {projection ? 'ACTUALIZAR PROYECCIÓN' : 'GENERAR PROYECCIÓN'}
+      </button>
+      {message ? <p className={`sfi-production__action-result is-${state}`}>{message}</p> : null}
 
-        {synthesis ? (
-          <div>
-            <dl className="sfi-production__object-grid">
-              <dt>Objeto</dt><dd>{synthesis.objectReading.summary}</dd>
-              <dt>Interpretabilidad</dt><dd>{synthesis.objectReading.interpretability}</dd>
-              <dt>Cobertura de evidencia</dt><dd>{Number(synthesis.objectReading.evidenceCoverage.toFixed(3))}</dd>
-              <dt>Relación longitudinal</dt><dd>{synthesis.worldContext.relation}</dd>
-              <dt>Lectura del campo</dt><dd>{synthesis.worldContext.explanation}</dd>
-              <dt>Confianza WorldSpect</dt><dd>{numberOrUnknown(synthesis.worldContext.confidence)}</dd>
-              <dt>MIHM</dt><dd>{synthesis.mihm.status} · coverage {Number(synthesis.mihm.coverage.toFixed(3))} · core {Number(synthesis.mihm.coreCoverage.toFixed(3))}</dd>
-              <dt>IHG</dt><dd>{synthesis.mihm.ihg === null ? 'BLOCKED_UNTIL_CORE_VARIABLES_EXIST' : numberOrUnknown(synthesis.mihm.ihg)}</dd>
-              <dt>Qué significa</dt><dd>{synthesis.mihm.summary}</dd>
-              <dt>Punto de palanca</dt><dd>{synthesis.leverage.status} · {synthesis.leverage.rationale}</dd>
-              <dt>Perturbación mínima</dt><dd>{synthesis.leverage.minimumPerturbation ?? 'NO_PERTURBATION_EMITTED'}</dd>
-              <dt>Preserva</dt><dd>{synthesis.leverage.preserves.join(' / ') || 'ATTRACTOR_REQUIRED'}</dd>
-              <dt>Señal esperada</dt><dd>{synthesis.leverage.expectedSignal ?? 'MISSING'}</dd>
-              <dt>Ventana</dt><dd>{synthesis.leverage.verificationWindow ?? 'MISSING'}</dd>
-              <dt>Falsificación</dt><dd>{synthesis.leverage.falsificationCriterion ?? 'MISSING'}</dd>
-              <dt>Límites</dt><dd>{[...synthesis.objectReading.limitations, ...synthesis.mihm.limitations, ...synthesis.worldContext.warnings].join(' / ') || 'NONE'}</dd>
-            </dl>
+      {projection ? (
+        <div className="sfi-production__module">
+          <div className="sfi-production__overview-grid">
+            <section>
+              <h3>1 · ESTADO DEL MUNDO</h3>
+              <p>{projection.world.summary}</p>
+              <dl className="sfi-production__object-grid">
+                <dt>Régimen</dt><dd>{projection.world.regime}</dd>
+                <dt>Vector dominante</dt><dd>{projection.world.dominantDomain ?? 'INDETERMINATE'}</dd>
+                <dt>Señal dominante</dt><dd>{projection.world.dominantSignal ?? 'NO_DOMINANT_SIGNAL'}</dd>
+                <dt>Confianza</dt><dd>{numberOrUnknown(projection.world.confidence)}</dd>
+              </dl>
+              <h4>TENSIONES CRUZADAS</h4>
+              {projection.world.crossVectorTensions.length ? projection.world.crossVectorTensions.map((tension) => (
+                <p key={tension.between.join(':')}><strong>{tension.between.join(' ↔ ')}</strong> · {tension.description}</p>
+              )) : <p>No se detectó divergencia fuerte entre CULTURAL, MEMETIC y AFFECTIVE con la cobertura actual.</p>}
+            </section>
 
-            <details>
-              <summary>VARIABLES MIHM</summary>
-              {synthesis.mihm.variables.map((variable) => (
-                <p key={variable.key}>
-                  <strong>{variable.key} · {variable.label}</strong>: {variable.value === null ? 'MISSING' : numberOrUnknown(variable.value)} — {variable.explanation} {variable.warnings.length ? `(${variable.warnings.join(' / ')})` : ''}
-                </p>
+            <section>
+              <h3>2 · ATRACTORES INFERIDOS</h3>
+              {projection.world.inferredAttractors.length ? projection.world.inferredAttractors.map((attractor) => (
+                <article key={attractor.id} className="sfi-production__metric-card">
+                  <strong>{attractor.label}</strong>
+                  <p>{attractor.description}</p>
+                  <small>CONFIDENCE {numberOrUnknown(attractor.confidence)}</small>
+                </article>
+              )) : <p>No hay evidencia suficiente para proponer un atractor del campo.</p>}
+              <p><strong>Usado por Studio:</strong> {projection.strategy.selectedAttractor ?? 'NONE'} · {projection.strategy.attractorSource}</p>
+            </section>
+
+            <section>
+              <h3>3 · POSICIÓN DEL OBJETO</h3>
+              <p>{projection.object.summary}</p>
+              <p><strong>MIHM:</strong> {projection.object.mihmStatus} · coverage {numberOrUnknown(projection.object.mihmCoverage)} · core {numberOrUnknown(projection.object.mihmCoreCoverage)}</p>
+              {projection.object.dominantProperties.map((property) => <p key={property}>{property}</p>)}
+            </section>
+
+            <section>
+              <h3>4 · COMPATIBILIDAD DE CAMPO</h3>
+              <strong style={{ fontSize: '2rem' }}>{percentage(projection.fit.percentage)}</strong>
+              <p>{projection.fit.band} · confidence {numberOrUnknown(projection.fit.confidence)} · coverage {numberOrUnknown(projection.fit.coverage)}</p>
+              <p>{projection.fit.explanation}</p>
+              <p><strong>ACEPTACIÓN:</strong> NO CALIBRADA. {projection.fit.acceptanceReason}</p>
+              {projection.fit.sharedDimensions.map((dimension) => (
+                <p key={dimension.id}><strong>{dimension.label}</strong>: objeto {numberOrUnknown(dimension.objectValue)} / campo {numberOrUnknown(dimension.fieldValue)} / compatibilidad {Math.round(dimension.compatibility * 100)}% · {dimension.dataClass}</p>
               ))}
-            </details>
+              {projection.fit.missingDimensions.length ? <p>Dimensiones faltantes: {projection.fit.missingDimensions.join(' / ')}</p> : null}
+            </section>
 
-            <details>
-              <summary>SEÑALES DEL OBJETO</summary>
-              {synthesis.objectReading.salientSignals.map((signal) => (
-                <p key={signal.label}><strong>{signal.label}</strong>: {String(signal.value)} — {signal.meaning}</p>
-              ))}
-            </details>
+            <section>
+              <h3>5 · VENTANA PROYECTADA</h3>
+              <strong>{windowLabel(projection)}</strong>
+              <p>{projection.opportunityWindow.basis}</p>
+              <h4>TERMINA O SE REVISA CUANDO</h4>
+              {projection.opportunityWindow.exitConditions.map((condition) => <p key={condition}>{condition}</p>)}
+            </section>
+
+            <section>
+              <h3>6 · RUTA PRINCIPAL</h3>
+              <strong>{selectedRoute?.title ?? 'NO_ROUTE'}</strong>
+              <p>{projection.strategy.selectionReason}</p>
+              <p>{selectedRoute?.goal}</p>
+              <h4>MICROAJUSTES</h4>
+              {selectedRoute?.microAdjustments.map((adjustment) => <p key={adjustment}>{adjustment}</p>)}
+              <h4>VERIFICACIÓN</h4>
+              {selectedRoute?.verification.map((item) => <p key={item}>{item}</p>)}
+            </section>
           </div>
-        ) : (
-          <p>No existe una síntesis persistida. Declara al menos el atractor para que Studio pueda evaluar una perturbación; sin él, la salida será diagnóstica y quedará bloqueada para intervención.</p>
-        )}
-      </div>
+
+          <details open>
+            <summary>COMPARAR LAS TRES RUTAS</summary>
+            <div className="sfi-production__metric-grid">
+              {projection.strategy.routes.map((route) => (
+                <article key={route.id} className="sfi-production__metric-card">
+                  <div><span>{route.id}</span><strong>{Math.round(route.suitability * 100)}%</strong></div>
+                  <h4>{route.title}</h4>
+                  <p>{route.rationale}</p>
+                  {route.microAdjustments.map((item) => <p key={item}>{item}</p>)}
+                  <small>CONFIDENCE {numberOrUnknown(route.confidence)}</small>
+                </article>
+              ))}
+            </div>
+          </details>
+
+          <details>
+            <summary>GUARDRAILS AUTOMÁTICOS · LO QUE STUDIO INTENTA NO ROMPER</summary>
+            {projection.strategy.automaticGuardrails.map((guardrail) => <p key={guardrail}>{guardrail}</p>)}
+            {!projection.strategy.automaticGuardrails.length ? <p>No hay invariantes medibles suficientes para construir guardrails automáticos.</p> : null}
+          </details>
+
+          <details>
+            <summary>PREFERENCIAS OPCIONALES · SOLO PARA ELEGIR UNA RUTA</summary>
+            <p>{projection.strategy.userInputPurpose}</p>
+            <label>
+              LO QUE QUIERES CONSEGUIR, EN LENGUAJE NORMAL
+              <textarea value={context.desiredShift} onChange={(event) => setContext((current) => ({ ...current, desiredShift: event.target.value }))} disabled={state === 'saving' || state === 'running'} placeholder="Ej. quiero que se integre mejor; quiero conservar su rareza; solo quiero corregirla técnicamente." />
+            </label>
+            <label>
+              QUÉ NO QUIERES PERDER, SOLO SI YA LO SABES
+              <textarea value={context.declaredAttractor} onChange={(event) => setContext((current) => ({ ...current, declaredAttractor: event.target.value }))} disabled={state === 'saving' || state === 'running'} placeholder="Ej. la tensión central, el golpe del clímax o la sensación de extrañeza." />
+            </label>
+            <label>
+              DÓNDE LA PIENSAS USAR
+              <input value={context.targetAudience} onChange={(event) => setContext((current) => ({ ...current, targetAudience: event.target.value }))} disabled={state === 'saving' || state === 'running'} placeholder="Audiencia, canal o contexto. Opcional." />
+            </label>
+            <label>
+              LÍMITES PERSONALES, SI EXISTEN
+              <textarea value={context.prohibitedEffects} onChange={(event) => setContext((current) => ({ ...current, prohibitedEffects: event.target.value }))} disabled={state === 'saving' || state === 'running'} placeholder="Ej. no acortar la pieza; no volverla convencional. Uno por línea." />
+            </label>
+            <button type="button" onClick={() => void savePreferencesAndProject()} disabled={state === 'saving' || state === 'running' || state === 'loading'}>
+              GUARDAR PREFERENCIAS Y RECALCULAR
+            </button>
+          </details>
+
+          <details>
+            <summary>QUÉ FALTA PARA HABLAR DE ACEPTACIÓN REAL</summary>
+            <p>{projection.calibration.currentOutput}</p>
+            <p>Casos comparables mínimos: {projection.calibration.minimumComparableCases}; recomendados: {projection.calibration.recommendedComparableCases}.</p>
+            {projection.calibration.requiredOutcomeFields.map((field) => <p key={field}>{field}</p>)}
+            <p>{projection.calibration.upgradeCondition}</p>
+          </details>
+
+          {synthesis ? (
+            <details>
+              <summary>MIHM PARCIAL Y TRAZABILIDAD TÉCNICA</summary>
+              <p>{synthesis.mihm.summary}</p>
+              <p>IHG final: {synthesis.mihm.ihg === null ? 'NO EMITIDO; NO IMPIDE USAR EL VECTOR PARCIAL' : numberOrUnknown(synthesis.mihm.ihg)}</p>
+              {synthesis.mihm.variables.map((variable) => (
+                <p key={variable.key}><strong>{variable.key} · {variable.label}</strong>: {variable.value === null ? 'MISSING' : numberOrUnknown(variable.value)} — {variable.explanation}</p>
+              ))}
+            </details>
+          ) : null}
+        </div>
+      ) : (
+        <p>Studio puede generar la lectura sin que declares atractor, desplazamiento o efectos prohibidos. Esas preferencias solo refinan la selección de ruta.</p>
+      )}
     </section>
   );
 }

--- a/src/lib/studio/production/objectFieldProjection.ts
+++ b/src/lib/studio/production/objectFieldProjection.ts
@@ -1,0 +1,759 @@
+import 'server-only';
+
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { buildStudioCulturalLens } from './studioCulturalLens';
+import { synthesizeStudioObject, type StudioObjectContextSynthesis } from './objectContextSynthesis';
+
+export const STUDIO_FIELD_PROJECTION_SOURCE = 'studio_field_projection_v2';
+export const STUDIO_FIELD_PROJECTION_VERSION = '2026-07-11.2';
+
+type Row = Record<string, unknown>;
+type DomainName = 'CULTURAL' | 'MEMETIC' | 'AFFECTIVE';
+type MihmKey = 'F_s' | 'D_i' | 'G_f' | 'C_s' | 'D_cog' | 'E_r' | 'V_i' | 'I_mc' | 'Phi' | 'R_sem' | 'C_sem';
+
+type SharedDimension = {
+  id: string;
+  label: string;
+  objectValue: number;
+  fieldValue: number;
+  compatibility: number;
+  weight: number;
+  dataClass: 'SEMANTIC_SHARED' | 'FORMAL_PROXY';
+  explanation: string;
+  evidenceIds: string[];
+};
+
+type StrategyRoute = {
+  id: 'INTEGRATE_FIELD' | 'PRESERVE_COUNTER_SIGNAL' | 'TECHNICAL_OPTIMIZE';
+  title: string;
+  suitability: number;
+  goal: string;
+  rationale: string;
+  microAdjustments: string[];
+  expectedShift: string;
+  verification: string[];
+  guardrails: string[];
+  evidenceIds: string[];
+  confidence: number;
+};
+
+export type StudioFieldProjection = {
+  version: string;
+  objectId: string;
+  generatedAt: string;
+  status: 'PROJECTED' | 'PARTIAL' | 'INSUFFICIENT';
+  world: {
+    observedAt: string | null;
+    regime: 'HIGH_PRESSURE' | 'VECTORIAL_TENSION' | 'TRANSITION' | 'LOW_SIGNAL' | 'INDETERMINATE';
+    summary: string;
+    dominantDomain: DomainName | null;
+    dominantSignal: string | null;
+    confidence: number;
+    domains: Array<{ domain: string; value: number; confidence: number | null; sourceCount: number }>;
+    trends: Array<{ domain: string; direction: 'rising' | 'falling' | 'stable'; slope: number; sampleCount: number }>;
+    crossVectorTensions: Array<{
+      between: [DomainName, DomainName];
+      magnitude: number;
+      description: string;
+      evidence: string[];
+    }>;
+    inferredAttractors: Array<{
+      id: string;
+      label: string;
+      description: string;
+      confidence: number;
+      basis: string[];
+    }>;
+  };
+  object: {
+    summary: string;
+    interpretability: StudioObjectContextSynthesis['objectReading']['interpretability'];
+    mihmStatus: StudioObjectContextSynthesis['mihm']['status'];
+    mihmCoverage: number;
+    mihmCoreCoverage: number;
+    partialVector: Array<{
+      key: string;
+      value: number | null;
+      status: string;
+      meaning: string;
+      evidenceIds: string[];
+    }>;
+    dominantProperties: string[];
+  };
+  fit: {
+    metric: 'FIELD_COMPATIBILITY_NOT_ACCEPTANCE';
+    score: number | null;
+    percentage: number | null;
+    band: 'HIGH_ALIGNMENT' | 'COMPATIBLE' | 'MIXED' | 'COUNTER_SIGNAL' | 'INDETERMINATE';
+    confidence: number;
+    coverage: number;
+    explanation: string;
+    sharedDimensions: SharedDimension[];
+    missingDimensions: string[];
+    acceptanceProbability: null;
+    acceptanceReason: 'OUTCOME_CALIBRATION_REQUIRED';
+  };
+  opportunityWindow: {
+    status: 'OPEN_NOW' | 'EMERGING' | 'TEST_WINDOW' | 'NARROW' | 'COUNTER_SIGNAL_WINDOW' | 'INDETERMINATE';
+    starts: 'NOW' | 'AFTER_VALIDATION' | 'UNKNOWN';
+    minimumDays: number | null;
+    maximumDays: number | null;
+    basis: string;
+    exitConditions: string[];
+    formulaVersion: string;
+  };
+  strategy: {
+    selectedAttractor: string | null;
+    attractorSource: 'USER' | 'SYSTEM' | 'NONE';
+    selectedRouteId: StrategyRoute['id'] | null;
+    selectionReason: string;
+    automaticGuardrails: string[];
+    userGuardrails: string[];
+    routes: StrategyRoute[];
+    userInputRequired: false;
+    userInputPurpose: string;
+  };
+  calibration: {
+    status: 'UNCALIBRATED_FOR_ACCEPTANCE';
+    currentOutput: string;
+    minimumComparableCases: number;
+    recommendedComparableCases: number;
+    requiredOutcomeFields: string[];
+    upgradeCondition: string;
+  };
+  evidenceIds: string[];
+  persistence: {
+    evidenceTraceId: string | null;
+    hypothesisId: string | null;
+    interventionIds: string[];
+  };
+};
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function rows(value: unknown): Row[] {
+  return Array.isArray(value) ? value.filter((item): item is Row => Boolean(item) && typeof item === 'object' && !Array.isArray(item)) : [];
+}
+
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function numeric(value: unknown): number | null {
+  if (value === null || typeof value === 'undefined' || value === '') return null;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function clamp01(value: number) {
+  return Math.max(0, Math.min(1, Number.isFinite(value) ? value : 0));
+}
+
+function rounded(value: number | null, digits = 4) {
+  return value === null ? null : Number(value.toFixed(digits));
+}
+
+function mean(values: number[]) {
+  return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : 0;
+}
+
+function featureMap(featureRows: Row[]) {
+  return new Map(featureRows.map((row) => [String(row.feature_key ?? row.id), row]));
+}
+
+function featureNumber(features: Map<string, Row>, key: string) {
+  return numeric(features.get(key)?.numeric_value);
+}
+
+function featureEvidence(features: Map<string, Row>, key: string) {
+  const row = features.get(key);
+  return row?.id ? [String(row.id)] : [];
+}
+
+function mihmValue(synthesis: StudioObjectContextSynthesis, key: MihmKey) {
+  return synthesis.mihm.variables.find((item) => item.key === key)?.value ?? null;
+}
+
+function mihmEvidence(synthesis: StudioObjectContextSynthesis, key: MihmKey) {
+  return synthesis.mihm.variables.find((item) => item.key === key)?.evidenceIds ?? [];
+}
+
+function unique(values: string[]) {
+  return values.filter((value, index, all) => Boolean(value) && all.indexOf(value) === index);
+}
+
+function domainName(value: string): DomainName | null {
+  return value === 'CULTURAL' || value === 'MEMETIC' || value === 'AFFECTIVE' ? value : null;
+}
+
+function buildWorldState(lens: Awaited<ReturnType<typeof buildStudioCulturalLens>>) {
+  const domains = lens.domainValues.filter((item) => domainName(item.domain));
+  const sorted = [...domains].sort((a, b) => b.value - a.value);
+  const dominant = sorted[0] ?? null;
+  const domainByName = new Map(domains.map((item) => [item.domain, item]));
+  const trendByName = new Map(lens.trends.map((item) => [item.domain, item]));
+  const values = domains.map((item) => item.value);
+  const spread = values.length ? Math.max(...values) - Math.min(...values) : 0;
+  const rising = lens.trends.filter((item) => item.sampleCount >= 3 && item.direction === 'rising').length;
+  const falling = lens.trends.filter((item) => item.sampleCount >= 3 && item.direction === 'falling').length;
+
+  const tensions: StudioFieldProjection['world']['crossVectorTensions'] = [];
+  const pairs: Array<[DomainName, DomainName]> = [
+    ['CULTURAL', 'MEMETIC'],
+    ['CULTURAL', 'AFFECTIVE'],
+    ['MEMETIC', 'AFFECTIVE'],
+  ];
+  for (const pair of pairs) {
+    const a = domainByName.get(pair[0]);
+    const b = domainByName.get(pair[1]);
+    if (!a || !b) continue;
+    const magnitude = Math.abs(a.value - b.value);
+    const trendA = trendByName.get(pair[0]);
+    const trendB = trendByName.get(pair[1]);
+    const directionalConflict = trendA && trendB && trendA.sampleCount >= 3 && trendB.sampleCount >= 3
+      && ((trendA.direction === 'rising' && trendB.direction === 'falling') || (trendA.direction === 'falling' && trendB.direction === 'rising'));
+    if (magnitude < 0.18 && !directionalConflict) continue;
+    const higher = a.value >= b.value ? pair[0] : pair[1];
+    const lower = higher === pair[0] ? pair[1] : pair[0];
+    tensions.push({
+      between: pair,
+      magnitude: rounded(magnitude) ?? 0,
+      description: directionalConflict
+        ? `${pair[0]} y ${pair[1]} se desplazan en direcciones opuestas; el campo no tiene una única dirección estable.`
+        : `${higher} concentra más presión que ${lower}; la diferencia actual es ${rounded(magnitude)}.`,
+      evidence: [`world.domain.${pair[0]}`, `world.domain.${pair[1]}`, `world.trend.${pair[0]}`, `world.trend.${pair[1]}`],
+    });
+  }
+
+  let regime: StudioFieldProjection['world']['regime'] = 'INDETERMINATE';
+  const average = mean(values);
+  if (values.length) {
+    if (spread >= 0.28 || (rising > 0 && falling > 0)) regime = 'VECTORIAL_TENSION';
+    else if (average >= 0.65) regime = 'HIGH_PRESSURE';
+    else if (average >= 0.38 || rising > 0) regime = 'TRANSITION';
+    else regime = 'LOW_SIGNAL';
+  }
+
+  const dominantName = dominant ? domainName(dominant.domain) : null;
+  const dominantTrend = dominantName ? trendByName.get(dominantName) : null;
+  const summary = dominantName
+    ? `El campo actual está en régimen ${regime}. ${dominantName} es el vector dominante (${rounded(dominant?.value ?? null)}), con trayectoria ${dominantTrend?.direction ?? 'sin tendencia suficiente'}. ${tensions.length ? `Se observan ${tensions.length} tensión(es) cruzadas entre vectores.` : 'Los tres vectores relevantes no presentan una divergencia fuerte con la evidencia disponible.'}`
+    : 'WorldSpect no aporta cobertura suficiente para identificar régimen, dirección dominante o tensión cruzada.';
+
+  const attractors: StudioFieldProjection['world']['inferredAttractors'] = [];
+  if (dominantName && dominant) {
+    const descriptor: Record<DomainName, { label: string; description: string }> = {
+      CULTURAL: {
+        label: 'COHERENCIA CULTURAL RECONOCIBLE',
+        description: 'Formas legibles y consistentes que pueden sostener identidad sin depender de novedad extrema.',
+      },
+      MEMETIC: {
+        label: 'PERSISTENCIA Y RECONOCIMIENTO',
+        description: 'Elementos capaces de reaparecer, recordarse o circular bajo atención fragmentada.',
+      },
+      AFFECTIVE: {
+        label: 'ACTIVACIÓN AFECTIVA ORGANIZADA',
+        description: 'Intensidad perceptible que mantiene estructura suficiente para no convertirse en ruido indiferenciado.',
+      },
+    };
+    const item = descriptor[dominantName];
+    attractors.push({
+      id: `ATTRACTOR_${dominantName}`,
+      label: item.label,
+      description: item.description,
+      confidence: rounded(clamp01((dominant.confidence ?? lens.confidence) * (dominantTrend?.sampleCount && dominantTrend.sampleCount >= 3 ? 1 : 0.72))) ?? 0,
+      basis: [`world.domain.${dominantName}`, `world.trend.${dominantName}`],
+    });
+  }
+  const cultural = domainByName.get('CULTURAL');
+  const memetic = domainByName.get('MEMETIC');
+  const culturalTrend = trendByName.get('CULTURAL');
+  const memeticTrend = trendByName.get('MEMETIC');
+  if (cultural && memetic && (memetic.value - cultural.value >= 0.18 || (memeticTrend?.direction === 'rising' && culturalTrend?.direction === 'falling'))) {
+    attractors.unshift({
+      id: 'ATTRACTOR_RECOGNITION_UNDER_FRAGMENTED_ATTENTION',
+      label: 'RECONOCIMIENTO BAJO ATENCIÓN FRAGMENTADA',
+      description: 'El campo favorece señales comprimidas o recurrentes, mientras la integración cultural es menor o pierde dirección.',
+      confidence: rounded(clamp01(lens.confidence * 0.84)) ?? 0,
+      basis: ['world.domain.CULTURAL', 'world.domain.MEMETIC', 'world.trend.CULTURAL', 'world.trend.MEMETIC'],
+    });
+  }
+
+  return {
+    observedAt: lens.observedAt,
+    regime,
+    summary,
+    dominantDomain: dominantName,
+    dominantSignal: lens.dominantSignal,
+    confidence: rounded(lens.confidence) ?? 0,
+    domains: lens.domainValues,
+    trends: lens.trends,
+    crossVectorTensions: tensions,
+    inferredAttractors: attractors,
+  };
+}
+
+function buildSharedDimensions(synthesis: StudioObjectContextSynthesis, lens: Awaited<ReturnType<typeof buildStudioCulturalLens>>) {
+  const domains = new Map(lens.domainValues.map((item) => [item.domain, item]));
+  const dimensions: SharedDimension[] = [];
+  const add = (input: {
+    id: string;
+    label: string;
+    objectValue: number | null;
+    domain: DomainName;
+    weight: number;
+    dataClass: SharedDimension['dataClass'];
+    explanation: string;
+    evidenceIds: string[];
+  }) => {
+    const field = domains.get(input.domain);
+    if (input.objectValue === null || !field) return;
+    dimensions.push({
+      id: input.id,
+      label: input.label,
+      objectValue: rounded(input.objectValue) ?? 0,
+      fieldValue: rounded(field.value) ?? 0,
+      compatibility: rounded(clamp01(1 - Math.abs(input.objectValue - field.value))) ?? 0,
+      weight: input.weight,
+      dataClass: input.dataClass,
+      explanation: input.explanation,
+      evidenceIds: unique([...input.evidenceIds, `world.domain.${input.domain}`]),
+    });
+  };
+
+  add({
+    id: 'affective_pressure',
+    label: 'Presión afectiva / fricción formal',
+    objectValue: mihmValue(synthesis, 'F_s'),
+    domain: 'AFFECTIVE',
+    weight: 0.65,
+    dataClass: 'FORMAL_PROXY',
+    explanation: 'Compara presión formal del objeto con presión afectiva del campo. Es un proxy estructural, no una equivalencia emocional.',
+    evidenceIds: mihmEvidence(synthesis, 'F_s'),
+  });
+  add({
+    id: 'cultural_coherence',
+    label: 'Continuidad formal / campo cultural',
+    objectValue: mihmValue(synthesis, 'C_s'),
+    domain: 'CULTURAL',
+    weight: 0.65,
+    dataClass: 'FORMAL_PROXY',
+    explanation: 'Compara coherencia formal del objeto con densidad del vector cultural. No demuestra gusto ni aprobación.',
+    evidenceIds: mihmEvidence(synthesis, 'C_s'),
+  });
+  add({
+    id: 'memetic_recurrence',
+    label: 'Recurrencia semántica / campo memético',
+    objectValue: mihmValue(synthesis, 'R_sem'),
+    domain: 'MEMETIC',
+    weight: 1,
+    dataClass: 'SEMANTIC_SHARED',
+    explanation: 'Dimensión compartida cuando el objeto contiene recurrencia textual o simbólica medible.',
+    evidenceIds: mihmEvidence(synthesis, 'R_sem'),
+  });
+
+  const totalWeight = dimensions.reduce((sum, item) => sum + item.weight, 0);
+  const score = totalWeight > 0
+    ? dimensions.reduce((sum, item) => sum + item.compatibility * item.weight, 0) / totalWeight
+    : null;
+  const coverage = dimensions.length / 3;
+  const confidencePenalty = synthesis.objectReading.interpretability === 'FORMAL_ONLY' ? 0.74 : 1;
+  const confidence = score === null
+    ? 0
+    : clamp01(lens.confidence * (0.35 + coverage * 0.65) * (0.4 + synthesis.mihm.coverage * 0.6) * confidencePenalty);
+
+  let band: StudioFieldProjection['fit']['band'] = 'INDETERMINATE';
+  if (score !== null) {
+    if (score >= 0.75) band = 'HIGH_ALIGNMENT';
+    else if (score >= 0.58) band = 'COMPATIBLE';
+    else if (score >= 0.42) band = 'MIXED';
+    else band = 'COUNTER_SIGNAL';
+  }
+  const missing = [
+    dimensions.some((item) => item.id === 'affective_pressure') ? null : 'AFFECTIVE_PRESSURE',
+    dimensions.some((item) => item.id === 'cultural_coherence') ? null : 'CULTURAL_COHERENCE',
+    dimensions.some((item) => item.id === 'memetic_recurrence') ? null : 'MEMETIC_RECURRENCE',
+  ].filter((item): item is string => Boolean(item));
+
+  return {
+    metric: 'FIELD_COMPATIBILITY_NOT_ACCEPTANCE' as const,
+    score: rounded(score),
+    percentage: score === null ? null : Math.round(score * 100),
+    band,
+    confidence: rounded(confidence) ?? 0,
+    coverage: rounded(coverage) ?? 0,
+    explanation: score === null
+      ? 'No existen dimensiones compartidas suficientes para comparar el objeto con el campo.'
+      : `La compatibilidad de campo estimada es ${Math.round(score * 100)}% con confianza ${Math.round(confidence * 100)}%. Mide semejanza en dimensiones disponibles; no es una probabilidad de aceptación ni de éxito.`,
+    sharedDimensions: dimensions,
+    missingDimensions: missing,
+    acceptanceProbability: null,
+    acceptanceReason: 'OUTCOME_CALIBRATION_REQUIRED' as const,
+  };
+}
+
+function buildOpportunityWindow(world: ReturnType<typeof buildWorldState>, fit: StudioFieldProjection['fit']): StudioFieldProjection['opportunityWindow'] {
+  if (!world.dominantDomain || world.confidence < 0.25) {
+    return {
+      status: 'INDETERMINATE',
+      starts: 'UNKNOWN',
+      minimumDays: null,
+      maximumDays: null,
+      basis: 'La cobertura o confianza del campo es insuficiente para proyectar una ventana temporal.',
+      exitConditions: ['Restaurar cobertura WorldSpect', 'Acumular al menos tres snapshots comparables'],
+      formulaVersion: 'studio.field_window.heuristic.v1',
+    };
+  }
+  const trend = world.trends.find((item) => item.domain === world.dominantDomain);
+  if (!trend || trend.sampleCount < 3) {
+    return {
+      status: 'TEST_WINDOW',
+      starts: 'AFTER_VALIDATION',
+      minimumDays: 3,
+      maximumDays: 7,
+      basis: 'Existe estado actual, pero no una trayectoria longitudinal suficiente; solo se justifica una prueba breve.',
+      exitConditions: ['La prueba A/B no produce señal observable', 'La confianza del campo cae por debajo de 0.25'],
+      formulaVersion: 'studio.field_window.heuristic.v1',
+    };
+  }
+  const strong = Math.abs(trend.slope) >= 0.03;
+  if (trend.direction === 'rising') {
+    return {
+      status: fit.band === 'COUNTER_SIGNAL' ? 'EMERGING' : 'OPEN_NOW',
+      starts: 'NOW',
+      minimumDays: strong ? 3 : 7,
+      maximumDays: strong ? 14 : 30,
+      basis: `${world.dominantDomain} asciende con pendiente ${trend.slope} durante ${trend.sampleCount} observaciones. La duración es una proyección heurística condicionada a que la dirección persista.`,
+      exitConditions: [`${world.dominantDomain} cambia a estable o descendente`, 'La compatibilidad cambia más de 0.15', 'La confianza WorldSpect cae por debajo de 0.25'],
+      formulaVersion: 'studio.field_window.heuristic.v1',
+    };
+  }
+  if (trend.direction === 'falling') {
+    return {
+      status: fit.band === 'COUNTER_SIGNAL' ? 'COUNTER_SIGNAL_WINDOW' : 'NARROW',
+      starts: 'NOW',
+      minimumDays: 1,
+      maximumDays: strong ? 7 : 14,
+      basis: `${world.dominantDomain} desciende; la ventana es corta y debe tratarse como uso táctico o contra-señal, no como tendencia estable.`,
+      exitConditions: [`${world.dominantDomain} continúa descendiendo`, 'La prueba inicial no registra retención o recurrencia'],
+      formulaVersion: 'studio.field_window.heuristic.v1',
+    };
+  }
+  return {
+    status: 'TEST_WINDOW',
+    starts: 'NOW',
+    minimumDays: 3,
+    maximumDays: 14,
+    basis: `${world.dominantDomain} permanece estable; no hay aceleración suficiente para afirmar una ventana expansiva.`,
+    exitConditions: ['El vector cambia de dirección', 'La respuesta observada contradice la hipótesis de compatibilidad'],
+    formulaVersion: 'studio.field_window.heuristic.v1',
+  };
+}
+
+function buildAutomaticGuardrails(features: Map<string, Row>, synthesis: StudioObjectContextSynthesis) {
+  const guardrails: string[] = [];
+  const duration = featureNumber(features, 'duration_seconds');
+  const dynamicRange = featureNumber(features, 'dynamic_range_db');
+  const centroid = featureNumber(features, 'spectral_centroid_hz');
+  const clipping = featureNumber(features, 'clipping_risk');
+  const phi = mihmValue(synthesis, 'Phi');
+  const coherence = mihmValue(synthesis, 'C_s');
+  if (duration !== null) guardrails.push(`Mantener la duración dentro de ±2% de ${rounded(duration, 2)} s salvo que se elija explícitamente una reestructuración.`);
+  if (dynamicRange !== null) guardrails.push(`No reducir el rango dinámico más de 1 dB respecto a ${rounded(dynamicRange, 2)} dB.`);
+  if (centroid !== null) guardrails.push(`No desplazar el centroide espectral más de 12% respecto a ${Math.round(centroid)} Hz sin una razón estratégica.`);
+  if (clipping !== null) guardrails.push(`No aumentar clipping_risk por encima de ${rounded(clipping, 6)}.`);
+  if (phi !== null) guardrails.push(`No reducir Phi más de 0.05 respecto a ${rounded(phi)}.`);
+  if (coherence !== null) guardrails.push(`No reducir C_s más de 0.08 respecto a ${rounded(coherence)}.`);
+  return guardrails;
+}
+
+function routeConfidence(base: number, fit: StudioFieldProjection['fit']) {
+  return rounded(clamp01(base * (0.45 + fit.confidence * 0.55))) ?? 0;
+}
+
+function buildRoutes(input: {
+  synthesis: StudioObjectContextSynthesis;
+  features: Map<string, Row>;
+  world: ReturnType<typeof buildWorldState>;
+  fit: StudioFieldProjection['fit'];
+  automaticGuardrails: string[];
+  userGuardrails: string[];
+}) {
+  const { synthesis, features, world, fit, automaticGuardrails, userGuardrails } = input;
+  const allGuardrails = unique([...automaticGuardrails, ...userGuardrails.map((item) => `Preferencia del usuario: ${item}`)]);
+  const f = mihmValue(synthesis, 'F_s');
+  const c = mihmValue(synthesis, 'C_s');
+  const gf = mihmValue(synthesis, 'G_f');
+  const phi = mihmValue(synthesis, 'Phi');
+  const recurrence = mihmValue(synthesis, 'R_sem');
+  const dynamicRange = featureNumber(features, 'dynamic_range_db');
+  const clipping = featureNumber(features, 'clipping_risk');
+  const evidenceIds = unique([
+    ...synthesis.mihm.variables.flatMap((item) => item.evidenceIds),
+    ...fit.sharedDimensions.flatMap((item) => item.evidenceIds),
+  ]).slice(0, 30);
+
+  const technical: string[] = [];
+  if (clipping !== null && clipping > 0.0015) technical.push('Reducir 1–2 dB la ganancia de entrada o limitador; volver a medir clipping y rango dinámico.');
+  if (dynamicRange !== null && dynamicRange < 5) technical.push('Crear una única ventana de contraste de 10–20 s reduciendo 2–4 dB la densidad local; conservar motivo y duración global.');
+  if (f !== null && c !== null && f > 0.6 && c < 0.4) technical.push('Simplificar solo la transición de mayor gradiente, retirando o espaciando 10–15% de eventos simultáneos.');
+  if (gf !== null && phi !== null && gf > 0.55 && phi > 0.55) technical.push('Acentuar una sola entrada, corte o automatización en el punto de mayor gradiente; no modificar las demás secciones.');
+  if (!technical.length) technical.push('No realizar cambios estructurales todavía; conservar versión y producir una comparación A/B únicamente si aparece una hipótesis concreta.');
+
+  const integration: string[] = [];
+  const affective = fit.sharedDimensions.find((item) => item.id === 'affective_pressure');
+  const cultural = fit.sharedDimensions.find((item) => item.id === 'cultural_coherence');
+  const memetic = fit.sharedDimensions.find((item) => item.id === 'memetic_recurrence');
+  if (affective) {
+    const gap = affective.fieldValue - affective.objectValue;
+    if (gap > 0.12) integration.push('Incrementar intensidad únicamente en un punto focal —hook, entrada o clímax— entre 1 y 2 dB o mediante 5–10% más densidad; evitar elevar toda la pieza.');
+    if (gap < -0.12) integration.push('Introducir una liberación local de 8–16 compases o 10–20 s para reducir presión continua sin perder la tensión central.');
+  }
+  if (cultural) {
+    const gap = cultural.fieldValue - cultural.objectValue;
+    if (gap > 0.12) integration.push('Aumentar legibilidad en la transición más inestable: reducir una capa, anticipar un retorno o limpiar un conflicto espectral puntual.');
+    if (gap < -0.12) integration.push('Conservar coherencia, pero permitir una anomalía controlada en una sola sección para evitar integración excesivamente neutra.');
+  }
+  const memeticTrend = world.trends.find((item) => item.domain === 'MEMETIC');
+  if (!memetic && memeticTrend?.direction === 'rising') integration.push('Añadir un único punto de retorno reconocible —motivo, frase, textura o gesto— sin repetirlo de forma continua; después medir recuerdo o recurrencia real.');
+  if (memetic && memetic.fieldValue - memetic.objectValue > 0.12) integration.push('Reintroducir una vez el ancla semántica o simbólica dominante en la segunda mitad de la pieza.');
+  if (!integration.length) integration.push('La forma ya se encuentra cerca de las dimensiones compartidas disponibles; priorizar distribución, timing y prueba de recepción antes que reescritura.');
+
+  const counter: string[] = [
+    'Preservar las desviaciones que producen contraste con el vector dominante; corregir solo fallas técnicas demostrables.',
+    'Probar un fragmento de 15–30 s frente a una versión más integrada y medir retención, repetición, guardados o comentarios específicos.',
+  ];
+  if (world.regime === 'VECTORIAL_TENSION') counter.push('Usar la tensión entre vectores como ventaja: no intentar satisfacer simultáneamente CULTURAL, MEMETIC y AFFECTIVE; elegir una contradicción legible.');
+  if (recurrence === null) counter.push('No añadir repetición por defecto: primero comprobar si la singularidad ya funciona como contra-señal reconocible.');
+
+  const integrationSuitability = fit.score === null ? 0.42 : clamp01(0.35 + fit.score * 0.65);
+  const counterSuitability = fit.score === null ? 0.45 : clamp01(0.35 + (1 - fit.score) * 0.65 + (world.regime === 'VECTORIAL_TENSION' ? 0.08 : 0));
+  const technicalSuitability = clamp01(technical.some((item) => !item.startsWith('No realizar')) ? 0.82 : 0.48);
+
+  const routes: StrategyRoute[] = [
+    {
+      id: 'INTEGRATE_FIELD',
+      title: 'INTEGRAR CON EL CAMPO',
+      suitability: rounded(integrationSuitability) ?? 0,
+      goal: 'Aumentar compatibilidad con la dirección cultural/memética/afectiva disponible sin rehacer la identidad completa del objeto.',
+      rationale: fit.score === null ? 'La integración se plantea como escenario exploratorio porque faltan dimensiones compartidas.' : `La compatibilidad actual es ${fit.percentage}%; esta ruta intenta cerrar las diferencias observadas, no garantizar aceptación.`,
+      microAdjustments: integration,
+      expectedShift: 'Aumentar compatibilidad en las dimensiones compartidas y mejorar legibilidad del punto focal sin deteriorar los guardrails.',
+      verification: ['Recalcular features y MIHM sobre la nueva versión', 'Comparar compatibilidad de campo antes/después', 'Realizar prueba A/B con exposición comparable'],
+      guardrails: allGuardrails,
+      evidenceIds,
+      confidence: routeConfidence(0.72, fit),
+    },
+    {
+      id: 'PRESERVE_COUNTER_SIGNAL',
+      title: 'PRESERVAR LA CONTRA-SEÑAL',
+      suitability: rounded(counterSuitability) ?? 0,
+      goal: 'Mantener la diferencia que puede volver al objeto reconocible cuando el campo está saturado o vectorialmente dividido.',
+      rationale: world.regime === 'VECTORIAL_TENSION' ? 'El campo presenta tensiones cruzadas; una integración total puede eliminar la diferencia útil.' : 'Esta ruta conserva singularidad y exige evidencia de recepción antes de adaptar la estructura.',
+      microAdjustments: counter,
+      expectedShift: 'Conservar distancia frente al vector dominante mientras se elimina únicamente fricción técnica no intencional.',
+      verification: ['Comparar recuerdo/recurrencia entre versión original e integrada', 'No aceptar la ruta si la diferencia no produce señal observable', 'Registrar audiencia, exposición y ventana'],
+      guardrails: allGuardrails,
+      evidenceIds,
+      confidence: routeConfidence(0.64, fit),
+    },
+    {
+      id: 'TECHNICAL_OPTIMIZE',
+      title: 'OPTIMIZAR SIN CAMBIAR DIRECCIÓN',
+      suitability: rounded(technicalSuitability) ?? 0,
+      goal: 'Corregir puntos técnicos o estructurales locales sin afirmar una estrategia cultural que la evidencia todavía no sostiene.',
+      rationale: technical.length ? 'Los ajustes se derivan de umbrales y combinaciones MIHM observadas.' : 'No hay un cambio técnico obligatorio; la ruta sirve como control.',
+      microAdjustments: technical,
+      expectedShift: 'Mejorar legibilidad o estabilidad técnica sin reducir la identidad formal observada.',
+      verification: ['Reanalizar métricas técnicas', 'Confirmar que C_s y Phi no se deterioran', 'Conservar una versión original para reversión'],
+      guardrails: allGuardrails,
+      evidenceIds,
+      confidence: routeConfidence(0.84, fit),
+    },
+  ];
+  return routes.sort((a, b) => b.suitability - a.suitability);
+}
+
+function selectRoute(context: StudioObjectContextSynthesis['context'], routes: StrategyRoute[]) {
+  const desired = (context.desiredShift ?? '').toLowerCase();
+  if (/integr|acept|alcance|legib|circul/.test(desired)) {
+    return { id: 'INTEGRATE_FIELD' as const, reason: 'La preferencia opcional del usuario apunta a integración, alcance o legibilidad.' };
+  }
+  if (/singular|difer|contraste|rareza|contra.?señal/.test(desired)) {
+    return { id: 'PRESERVE_COUNTER_SIGNAL' as const, reason: 'La preferencia opcional del usuario apunta a preservar diferencia o contra-señal.' };
+  }
+  const first = routes[0];
+  return first ? { id: first.id, reason: `Studio seleccionó la ruta con mayor pertinencia derivada (${rounded(first.suitability)}). El usuario puede elegir otra sin recalibrar el objeto.` } : { id: null, reason: 'No existe una ruta evaluable.' };
+}
+
+async function persistProjection(objectId: string, projection: StudioFieldProjection) {
+  const service = createServiceSupabaseClient();
+  await service.from('studio_interventions').delete().eq('object_id', objectId).contains('payload', { projectionSource: STUDIO_FIELD_PROJECTION_SOURCE });
+  await service.from('studio_hypotheses').delete().eq('object_id', objectId).eq('origin', STUDIO_FIELD_PROJECTION_SOURCE);
+  await service.from('studio_evidence_traces').delete().eq('object_id', objectId).eq('source', STUDIO_FIELD_PROJECTION_SOURCE);
+
+  const selected = projection.strategy.routes.find((item) => item.id === projection.strategy.selectedRouteId) ?? projection.strategy.routes[0] ?? null;
+  let hypothesisId: string | null = null;
+  const interventionIds: string[] = [];
+  if (selected) {
+    const hypothesis = await service.from('studio_hypotheses').insert({
+      object_id: objectId,
+      origin: STUDIO_FIELD_PROJECTION_SOURCE,
+      severity: projection.fit.band === 'COUNTER_SIGNAL' || projection.world.regime === 'VECTORIAL_TENSION' ? 'watch' : 'info',
+      statement: `${projection.world.summary} ${projection.fit.explanation} Ruta principal: ${selected.title}.`,
+      recommended_change: selected.microAdjustments.join(' '),
+      route: 'inspect',
+      sources: projection.evidenceIds,
+      payload: {
+        projectionSource: STUDIO_FIELD_PROJECTION_SOURCE,
+        projectionVersion: STUDIO_FIELD_PROJECTION_VERSION,
+        fit: projection.fit,
+        opportunityWindow: projection.opportunityWindow,
+        selectedAttractor: projection.strategy.selectedAttractor,
+        selectedRouteId: selected.id,
+        calibration: projection.calibration,
+      },
+    }).select('id').single();
+    if (hypothesis.error) throw new Error(`studio_projection_hypothesis_failed: ${hypothesis.error.message}`);
+    hypothesisId = String(hypothesis.data.id);
+
+    for (const route of projection.strategy.routes) {
+      const inserted = await service.from('studio_interventions').insert({
+        object_id: objectId,
+        hypothesis_id: hypothesisId,
+        title: `${route.title}: ${route.microAdjustments[0] ?? route.goal}`,
+        state: 'queued',
+        scope: route.id === 'TECHNICAL_OPTIMIZE' ? 'overview' : route.id === 'INTEGRATE_FIELD' ? 'arrangement' : 'distribution',
+        expected_impact: null,
+        risk: null,
+        payload: {
+          projectionSource: STUDIO_FIELD_PROJECTION_SOURCE,
+          projectionVersion: STUDIO_FIELD_PROJECTION_VERSION,
+          route,
+          status: 'SCENARIO_NOT_EXECUTED',
+          acceptanceProbability: null,
+        },
+      }).select('id').single();
+      if (inserted.error) throw new Error(`studio_projection_intervention_failed: ${inserted.error.message}`);
+      interventionIds.push(String(inserted.data.id));
+    }
+  }
+
+  const evidence = await service.from('studio_evidence_traces').insert({
+    object_id: objectId,
+    source: STUDIO_FIELD_PROJECTION_SOURCE,
+    label: 'Studio field compatibility and opportunity projection',
+    payload: projection,
+  }).select('id').single();
+  if (evidence.error) throw new Error(`studio_projection_evidence_failed: ${evidence.error.message}`);
+  return { evidenceTraceId: String(evidence.data.id), hypothesisId, interventionIds };
+}
+
+export async function getPersistedStudioFieldProjection(objectId: string): Promise<StudioFieldProjection | null> {
+  const service = createServiceSupabaseClient();
+  const result = await service
+    .from('studio_evidence_traces')
+    .select('payload')
+    .eq('object_id', objectId)
+    .eq('source', STUDIO_FIELD_PROJECTION_SOURCE)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (result.error) throw new Error(`studio_projection_read_failed: ${result.error.message}`);
+  return result.data?.payload ? result.data.payload as StudioFieldProjection : null;
+}
+
+export async function projectStudioObjectField(objectId: string, options: { persist?: boolean } = {}): Promise<StudioFieldProjection> {
+  const service = createServiceSupabaseClient();
+  const [objectResult, featureResult, lens, synthesis] = await Promise.all([
+    service.from('studio_objects').select('id, title, object_type, metadata').eq('id', objectId).maybeSingle(),
+    service.from('studio_object_features').select('*').eq('object_id', objectId).order('created_at', { ascending: false }),
+    buildStudioCulturalLens(),
+    synthesizeStudioObject(objectId, { persist: false }),
+  ]);
+  if (objectResult.error || !objectResult.data) throw new Error(objectResult.error?.message ?? 'STUDIO_OBJECT_NOT_FOUND');
+  if (featureResult.error) throw new Error(featureResult.error.message);
+
+  const object = record(objectResult.data);
+  const features = featureMap(rows(featureResult.data));
+  const world = buildWorldState(lens);
+  const fit = buildSharedDimensions(synthesis, lens);
+  const opportunityWindow = buildOpportunityWindow(world, fit);
+  const automaticGuardrails = buildAutomaticGuardrails(features, synthesis);
+  const userGuardrails = synthesis.context.prohibitedEffects;
+  const routes = buildRoutes({ synthesis, features, world, fit, automaticGuardrails, userGuardrails });
+  const selectedRoute = selectRoute(synthesis.context, routes);
+  const selectedAttractor = synthesis.context.declaredAttractor ?? world.inferredAttractors[0]?.label ?? null;
+  const attractorSource = synthesis.context.declaredAttractor ? 'USER' as const : selectedAttractor ? 'SYSTEM' as const : 'NONE' as const;
+  const dominantProperties = synthesis.mihm.variables
+    .filter((item) => item.value !== null)
+    .sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
+    .slice(0, 4)
+    .map((item) => `${item.key} ${item.label}: ${rounded(item.value)}`);
+  const evidenceIds = unique([
+    ...synthesis.mihm.variables.flatMap((item) => item.evidenceIds),
+    ...fit.sharedDimensions.flatMap((item) => item.evidenceIds),
+  ]).slice(0, 40);
+
+  const projection: StudioFieldProjection = {
+    version: STUDIO_FIELD_PROJECTION_VERSION,
+    objectId,
+    generatedAt: new Date().toISOString(),
+    status: fit.score === null && synthesis.mihm.coverage < 0.25 ? 'INSUFFICIENT' : fit.coverage < 0.67 ? 'PARTIAL' : 'PROJECTED',
+    world,
+    object: {
+      summary: synthesis.objectReading.summary,
+      interpretability: synthesis.objectReading.interpretability,
+      mihmStatus: synthesis.mihm.status,
+      mihmCoverage: synthesis.mihm.coverage,
+      mihmCoreCoverage: synthesis.mihm.coreCoverage,
+      partialVector: synthesis.mihm.variables.map((item) => ({
+        key: item.key,
+        value: item.value,
+        status: item.status,
+        meaning: item.explanation,
+        evidenceIds: item.evidenceIds,
+      })),
+      dominantProperties,
+    },
+    fit,
+    opportunityWindow,
+    strategy: {
+      selectedAttractor,
+      attractorSource,
+      selectedRouteId: selectedRoute.id,
+      selectionReason: selectedRoute.reason,
+      automaticGuardrails,
+      userGuardrails,
+      routes,
+      userInputRequired: false,
+      userInputPurpose: 'Los datos del usuario son opcionales. Sirven para escoger una ruta o añadir límites personales; no son necesarios para que Studio produzca diagnóstico y escenarios.',
+    },
+    calibration: {
+      status: 'UNCALIBRATED_FOR_ACCEPTANCE',
+      currentOutput: 'Studio emite compatibilidad de campo, confianza y ventana de oportunidad. No emite probabilidad de aceptación.',
+      minimumComparableCases: 30,
+      recommendedComparableCases: 100,
+      requiredOutcomeFields: [
+        'object/version and MIHM vector at release',
+        'WorldSpect snapshot and cultural vector at release',
+        'release time, channel and audience definition',
+        'normalized exposure or impressions',
+        'plays/views and completion rate',
+        'saves, shares and repeat consumption',
+        'qualitative response labels',
+        '7-day and 30-day outcomes',
+      ],
+      upgradeCondition: 'Solo convertir compatibilidad en probabilidad de aceptación después de calibrar y validar fuera de muestra con casos comparables y exposición normalizada.',
+    },
+    evidenceIds,
+    persistence: { evidenceTraceId: null, hypothesisId: null, interventionIds: [] },
+  };
+
+  if (options.persist !== false) {
+    projection.persistence = await persistProjection(String(object.id ?? objectId), projection);
+  }
+  return projection;
+}


### PR DESCRIPTION
## Problem

Studio required the user to declare an attractor, desired displacement and prohibited effects before it could emit a useful intervention. That forces the operator to translate SFI theory instead of receiving an analysis.

The output also overemphasized a blocked final IHG and did not provide the requested operational reading: current world regime, Cultural/Memetic/Affective tensions, inferred attractors, object-field position, opportunity window and route-specific micro-adjustments.

## Changes

- Add `objectFieldProjection.ts` as a second-order strategic projection engine.
- Infer the current relevant world regime from persisted CULTURAL, MEMETIC and AFFECTIVE observations and trends.
- Detect cross-vector tensions by magnitude and directional divergence.
- Generate system attractor candidates without requiring user input.
- Keep MIHM partial and usable: missing final IHG no longer blocks projection or scenario generation.
- Calculate a coverage- and confidence-aware `FIELD_COMPATIBILITY_NOT_ACCEPTANCE` score.
- Keep `acceptanceProbability = null` until empirical outcome calibration exists.
- Project conditional opportunity windows with explicit exit conditions.
- Generate three comparable routes:
  - integrate with the field;
  - preserve the object as a counter-signal;
  - optimize technically without changing direction.
- Generate route-specific micro-adjustments, verification steps and automatic guardrails.
- Make user preferences optional and phrased in ordinary language.
- Remove theoretical attractor/effect fields from initial object intake.
- Run field projection automatically after extraction and partial MIHM synthesis.
- Persist projection evidence, hypothesis and scenario rows with `SCENARIO_NOT_EXECUTED` semantics.
- Document the minimum data required to calibrate a future acceptance model.

## Non-claims

- Field compatibility is not acceptance probability.
- A projected window is conditional and heuristic.
- A partial MIHM vector is not a final IHG.
- Persisted strategy routes are scenarios, not executed interventions.

## Validation

- Domain boundaries
- Typecheck
- Production build
- Vercel preview
- Verify upload -> analyze -> synthesize -> project flow
- Verify projection works with no user-declared attractor
- Verify acceptance probability remains null
