### PR TITLE
Force Observatory build against current WSV regime contract

### DIFF
--- a/src/app/observatory/page.tsx
+++ b/src/app/observatory/page.tsx
@@ -2,19 +2,21 @@ import type { Metadata } from 'next';
 import { PublicWorldVectorObservatory } from '@/components/observatory/public/PublicWorldVectorObservatory';
 import { readObservatoryGoldState } from '@/lib/observatory/gold/observatoryGoldAdapter';
 
+const PUBLIC_OBSERVATORY_DESCRIPTION =
+  'Public 90-day World Vector, longitudinal WorldSpect observation, current tensions and the Daily Reading by System Friction Institute.';
+
 export const revalidate = 300;
 
 export const metadata: Metadata = {
   title: 'Public Observatory · World Vector · System Friction Institute',
-  description:
-    'Public World Vector, longitudinal WorldSpect observation, current tensions and the Daily Reading by System Friction Institute.',
+  description: PUBLIC_OBSERVATORY_DESCRIPTION,
   robots: {
     index: true,
     follow: true,
   },
   openGraph: {
     title: 'Public Observatory · World Vector',
-    description: 'Longitudinal observation of the world and the Daily Reading by System Friction Institute.',
+    description: PUBLIC_OBSERVATORY_DESCRIPTION,
     type: 'website',
   },
 };


### PR DESCRIPTION
## Problem

A Vercel deployment compiled an intermediate Observatory revision where the public `wsv` type already required `regime`, but the adapter object in that stale revision did not yet include it.

## Current main state

`src/lib/observatory/gold/observatoryGoldAdapter.ts` already computes and assigns:

```ts
const regime = ...

wsv: {
  globalIndex,
  coherence,
  resilience,
  alignment,
  tension,
  regime,
}
```

## Purpose of this PR

Produce a fresh commit so CI and Vercel compile the current schema-consistent `main`, while consolidating the public Observatory metadata description.

No engine, data, API, type, or database change.