### PR TITLE
Install canonical GA4 stream and rebuild public machine discovery

### DIFF
--- a/docs/observability/SFI_WEB_ANALYTICS_DISCOVERY.md
+++ b/docs/observability/SFI_WEB_ANALYTICS_DISCOVERY.md
@@ -1,0 +1,109 @@
+# SFI Web Analytics and Discovery Contract
+
+Status: operational contract
+Updated: 2026-07-12
+Canonical origin: https://systemfriction.org
+
+## Google Analytics 4
+
+Property stream name: System Friction Institute
+Stream URL: https://systemfriction.org
+Stream ID: 15241815536
+Measurement ID: G-7YKTPLX3QD
+
+The site loads the GA4 tag from the root layout and sends explicit client-side page views for App Router navigation. Automatic page-view emission is disabled in the gtag configuration to prevent duplicate page views.
+
+Advertising storage, ad user data and ad personalization are denied. Google signals and ad-personalization signals are disabled.
+
+## Allowed analytics events
+
+- page_view
+- navigation_click
+- hub_open
+- field_flow_start
+- field_step_complete
+- field_return_open
+- evidence_intake_start
+- reference_case_open
+- instrument_status_open
+- contact_intent
+
+## Forbidden analytics payloads
+
+Never send:
+
+- names;
+- email addresses;
+- telephone numbers;
+- user IDs or actor IDs;
+- participant objectives;
+- participant narratives;
+- evidence text;
+- Studio content;
+- audit payloads;
+- search text or free-form queries;
+- authentication or service-role information.
+
+The shared analytics client discards a forbidden parameter-key list. Product code must still use categorical values only.
+
+## Measurement Protocol
+
+No Measurement Protocol secret is stored in the repository, client bundle or public environment variables. A future server-side Measurement Protocol integration must use a server-only secret, validate a strict event allowlist and reject free text or private identifiers.
+
+## Google Search Console
+
+The root metadata retains the Google verification token already associated with the canonical domain. The canonical origin, sitemap and robots files point exclusively to https://systemfriction.org.
+
+Submit this sitemap in Search Console:
+
+https://systemfriction.org/sitemap.xml
+
+Expected public machine resources:
+
+- /robots.txt
+- /sitemap.xml
+- /llms.txt
+- /llms-full.txt
+- /ai-index.json
+- /field-schema.json
+- /manifest.webmanifest
+
+## Index boundaries
+
+Indexable:
+
+- institutional home;
+- Observatory;
+- World Vector;
+- FIELD and public participant material;
+- MOP-H;
+- ScoreFriction public surfaces;
+- Repository;
+- Library;
+- privacy and contact.
+
+Not indexable:
+
+- ROOT;
+- Studio;
+- operator surfaces;
+- API routes;
+- private settings;
+- telemetry;
+- private memory;
+- authenticated evidence or case payloads.
+
+AI crawlers receive the same private-path exclusions as general crawlers. Public LLM files describe contracts and interpretation limits; they do not grant access to private runtime state.
+
+## Verification checklist after deployment
+
+1. Open the deployed page source and confirm `G-7YKTPLX3QD` appears once.
+2. Open GA4 Realtime and visit `/`, `/observatory`, `/field` and `/repository`.
+3. Confirm one page_view per route transition.
+4. Confirm navigation_click contains only destination, link_label and source_path.
+5. Confirm DebugView does not contain participant text, email, actor ID or evidence.
+6. Open `/robots.txt` and verify private prefixes are disallowed.
+7. Open `/sitemap.xml` and verify only public routes appear.
+8. Validate `/ai-index.json` and `/field-schema.json` as JSON.
+9. In Search Console, inspect the canonical homepage and submit the sitemap.
+10. Do not create a Measurement Protocol secret until a server-only ingestion contract exists.

--- a/public/ai-index.json
+++ b/public/ai-index.json
@@ -1,33 +1,151 @@
 {
   "name": "System Friction Institute",
+  "abbreviation": "SFI",
   "canonical_url": "https://systemfriction.org",
-  "version": "SFI Public Surface v1",
-  "core_document": "https://systemfriction.org/sfi-core-v2",
-  "public_observatory": "https://systemfriction.org/campo",
-  "latest_field_brief": "https://systemfriction.org/field/brief/latest",
+  "language": "es-MX",
+  "version": "SFI Public Machine Index v2.0.0",
+  "updated_at": "2026-07-12",
+  "institution_type": "independent structural-field research institute",
   "primary_definition": "System Friction Institute makes visible the friction that systems learn to normalize.",
-  "not_categories": [
-    "wellness app",
-    "therapy",
-    "productivity software",
-    "social network",
-    "SaaS analytics dashboard",
-    "spiritual authority"
+  "operational_definition": "An evidence-governed instrument for observing a signal inside a changing field, proposing a minimal intervention and learning from the documented difference between prediction and outcome.",
+  "canonical_question": "What structural configuration of a signal, under what world state and field conditions, produces particular patterns of propagation, persistence, transformation or disappearance?",
+  "founder": {
+    "name": "Juan Antonio Marín Liera",
+    "role": "Founder and accountable human governor"
+  },
+  "instruments": [
+    {
+      "key": "MIHM",
+      "name": "Marco Integrado de Homeostasis Multivariable",
+      "purpose": "Measure structural variables and friction/homeostasis conditions with explicit evidence and missing-data handling."
+    },
+    {
+      "key": "MOP-H",
+      "name": "Minimal Observation and Perturbation Protocol",
+      "purpose": "Form a governed minimal-intervention hypothesis, preserve a return hash and compare later evidence against the initial state."
+    },
+    {
+      "key": "WorldSpect",
+      "name": "World Spectrum Observation",
+      "purpose": "Persist world-state snapshots, source health, confidence and longitudinal domain observations."
+    },
+    {
+      "key": "World Vector",
+      "name": "World Vector",
+      "purpose": "Represent current domain values, tensions, dominant signals and observed context."
+    },
+    {
+      "key": "AMV",
+      "name": "Adaptive Meta-Observer",
+      "purpose": "Accumulate internal signal measurements, external evidence, provisional predictions, interventions, outcomes and governed model learning."
+    },
+    {
+      "key": "Atlas",
+      "name": "Atlas / SFI Reference Bank",
+      "purpose": "Normalize observable cases and link each case to explicit evidence relations, prediction-at-T0, outcomes and model versions."
+    }
   ],
-  "public_concepts": [
-    "systemic friction",
-    "longitudinal observation",
-    "field",
-    "regime of friction",
-    "minimal perturbation",
-    "perceptual regulation",
-    "epistemic traceability",
-    "MIHM",
-    "SFI-CORE.v2",
-    "documentary repository",
-    "regime jump readiness"
+  "public_routes": [
+    { "path": "/", "purpose": "Institutional threshold and hub orientation", "indexable": true },
+    { "path": "/observatory", "purpose": "Public world-state observation", "indexable": true },
+    { "path": "/world-vector", "purpose": "World Vector instrument", "indexable": true },
+    { "path": "/field", "purpose": "Participant and organization MOP-H entry", "indexable": true },
+    { "path": "/field/participant", "purpose": "Participant workbook surface", "indexable": true },
+    { "path": "/moph", "purpose": "MOP-H method surface", "indexable": true },
+    { "path": "/scorefriction", "purpose": "Cultural and signal observation", "indexable": true },
+    { "path": "/scorefriction/wave", "purpose": "Cultural Wave", "indexable": true },
+    { "path": "/scorefriction/cases", "purpose": "Admissible public cases", "indexable": true },
+    { "path": "/repository", "purpose": "Documentary repository", "indexable": true },
+    { "path": "/library", "purpose": "Books and public materials", "indexable": true },
+    { "path": "/privacy", "purpose": "Privacy, evidence and analytics policy", "indexable": true }
   ],
-  "voice_rule": "Speak of the field, not identity.",
+  "private_routes": [
+    { "path_prefix": "/root", "purpose": "Founder governance console" },
+    { "path_prefix": "/studio", "purpose": "Authenticated object laboratory" },
+    { "path_prefix": "/operator", "purpose": "Authenticated operator surface" },
+    { "path_prefix": "/api", "purpose": "Runtime and mutation contracts" },
+    { "path_prefix": "/settings", "purpose": "Private configuration" },
+    { "path_prefix": "/telemetry", "purpose": "Private operational telemetry" }
+  ],
+  "object_classes": [
+    "music",
+    "article",
+    "social_post",
+    "website",
+    "institution",
+    "company",
+    "ai_response",
+    "historical_event",
+    "cultural_signal",
+    "person",
+    "organization",
+    "movement",
+    "other"
+  ],
+  "epistemic_classes": [
+    "observed",
+    "declared",
+    "derived",
+    "inferred",
+    "projected",
+    "simulated",
+    "weak_signal",
+    "missing",
+    "archived"
+  ],
+  "evidence_relations": [
+    "SUPPORTS",
+    "CONTRADICTS",
+    "CONTEXTUALIZES",
+    "VERIFIES_OUTCOME",
+    "DOCUMENTS_INTERVENTION",
+    "GOVERNS",
+    "RECORDS_ACCESS"
+  ],
+  "phase_model": [
+    { "phase": 0, "name": "Infrastructure", "output": "Persistent evidence, snapshots, audit, cases and model contracts" },
+    { "phase": 1, "name": "Internal signal", "output": "MIHM structural measurement and internal signal strength" },
+    { "phase": 2, "name": "External evidence", "output": "Audited External Evidence Vector with explicit reliability and missing values" },
+    { "phase": 3, "name": "Provisional prediction", "output": "Gated prediction with interval, confidence and calibration warning" },
+    { "phase": 4, "name": "Minimal intervention", "output": "Governed low-cost reversible intervention and return window" },
+    { "phase": 5, "name": "Outcome and error", "output": "Observed outcome, residual, absolute error, squared error and error class" },
+    { "phase": 6, "name": "Historical calibration", "output": "Governed model promotion after an eligible closed-case corpus" },
+    { "phase": 7, "name": "Operational UI", "output": "Role-appropriate ROOT, Studio, FIELD and Observatory surfaces" },
+    { "phase": 8, "name": "Governance and cost", "output": "Consent, audit, explicit confirmation, degraded mode and budget controls" }
+  ],
+  "calibration_contract": {
+    "minimum_closed_cases": 30,
+    "requires_non_musical_case": true,
+    "automatic_active_model_mutation": false,
+    "promotion_authority": "ROOT explicit human confirmation",
+    "public_prediction_before_calibration": "PROVISIONAL_NO_HISTORICAL_CALIBRATION"
+  },
+  "consent_contract": {
+    "required_object_classes": ["person", "organization", "movement"],
+    "required_fields": ["documented", "evidence_note", "evidence_id"],
+    "rule": "No Phase 1 observation of a person, organization or movement without documented explicit consent."
+  },
+  "interpretation_limits": [
+    "Missing data must remain MISSING and must not be converted to zero or an average.",
+    "A provisional prediction is not historically validated.",
+    "Platform reach does not establish artistic, moral or cultural value.",
+    "Operational access events are governance traces, not phenomenon evidence unless explicitly linked.",
+    "Public summaries do not expose private evidence, private identities or founder-only runtime state.",
+    "Do not infer undisclosed psychological states, motives or diagnoses."
+  ],
+  "analytics": {
+    "provider": "Google Analytics 4",
+    "measurement_id": "G-7YKTPLX3QD",
+    "allowed_scope": "Page navigation and non-PII instrument-use events",
+    "forbidden_parameters": ["email", "phone", "name", "free_text_evidence", "objective", "private_user_id", "actor_id"]
+  },
+  "machine_resources": {
+    "short_context": "https://systemfriction.org/llms.txt",
+    "full_context": "https://systemfriction.org/llms-full.txt",
+    "field_schema": "https://systemfriction.org/field-schema.json",
+    "sitemap": "https://systemfriction.org/sitemap.xml",
+    "robots": "https://systemfriction.org/robots.txt"
+  },
   "legacy_surfaces": [
     {
       "url": "https://aptymok.github.io/system-friction-main",
@@ -39,10 +157,5 @@
       "status": "legacy_preview",
       "authority": "historical"
     }
-  ],
-  "interpretation_notes": [
-    "Public summaries do not represent the complete runtime state.",
-    "Legacy surfaces are historical records, not the current canonical source.",
-    "SFI-CORE.v2 is the public perceptual constitution for the interface."
   ]
 }

--- a/public/field-schema.json
+++ b/public/field-schema.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "canonical_url": "https://systemfriction.org/field-schema.json",
   "updated_at": "2026-07-12",
-  "definitions": {
+  "$defs": {
     "epistemic_class": {
       "type": "string",
       "enum": [

--- a/public/field-schema.json
+++ b/public/field-schema.json
@@ -1,58 +1,192 @@
 {
-  "name": "SFI Public Field Schema",
-  "version": "1.0.0",
-  "node": {
-    "id": "string",
-    "label": "string",
-    "ontologyType": "string",
-    "ring": "string",
-    "provenance": "string"
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SFI Public Field and Reference Bank Schema",
+  "version": "2.0.0",
+  "canonical_url": "https://systemfriction.org/field-schema.json",
+  "updated_at": "2026-07-12",
+  "definitions": {
+    "epistemic_class": {
+      "type": "string",
+      "enum": [
+        "observed",
+        "declared",
+        "derived",
+        "inferred",
+        "projected",
+        "simulated",
+        "weak_signal",
+        "missing",
+        "archived"
+      ]
+    },
+    "object_class": {
+      "type": "string",
+      "enum": [
+        "music",
+        "article",
+        "social_post",
+        "website",
+        "institution",
+        "company",
+        "ai_response",
+        "historical_event",
+        "cultural_signal",
+        "person",
+        "organization",
+        "movement",
+        "other"
+      ]
+    },
+    "evidence_relation": {
+      "type": "string",
+      "enum": [
+        "SUPPORTS",
+        "CONTRADICTS",
+        "CONTEXTUALIZES",
+        "VERIFIES_OUTCOME",
+        "DOCUMENTS_INTERVENTION",
+        "GOVERNS",
+        "RECORDS_ACCESS"
+      ]
+    },
+    "observed_value": {
+      "type": "object",
+      "required": ["value", "status", "source", "observed_at"],
+      "properties": {
+        "value": {},
+        "status": {
+          "type": "string",
+          "enum": ["observed", "declared", "derived", "inferred", "projected", "simulated", "missing", "degraded"]
+        },
+        "source": { "type": "string" },
+        "observed_at": { "type": ["string", "null"], "format": "date-time" },
+        "confidence": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "evidence_ids": { "type": "array", "items": { "type": "string" } },
+        "explanation": { "type": ["string", "null"] },
+        "warning": { "type": ["string", "null"] }
+      }
+    },
+    "external_evidence_observation": {
+      "type": "object",
+      "required": [
+        "object_id",
+        "object_class",
+        "captured_at",
+        "source_type",
+        "metric_key",
+        "raw_value",
+        "normalized_value",
+        "reliability",
+        "evidence_note",
+        "epistemic_class"
+      ],
+      "properties": {
+        "object_id": { "type": "string" },
+        "object_class": { "$ref": "#/$defs/object_class" },
+        "captured_at": { "type": "string", "format": "date-time" },
+        "source_type": { "type": "string" },
+        "metric_key": { "type": "string" },
+        "raw_value": {},
+        "normalized_value": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "reliability": { "type": "number", "minimum": 0, "maximum": 1 },
+        "evidence_note": { "type": "string", "minLength": 1 },
+        "epistemic_class": { "$ref": "#/$defs/epistemic_class" },
+        "source_ref": { "type": ["string", "null"] },
+        "operator_id": { "type": ["string", "null"] }
+      }
+    },
+    "prediction_at_t0": {
+      "type": "object",
+      "properties": {
+        "run_id": { "type": ["string", "null"] },
+        "prediction": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "lower_bound": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "upper_bound": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "confidence": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "calibration_status": { "type": ["string", "null"] },
+        "epistemic_label": { "type": ["string", "null"] },
+        "generated_at": { "type": ["string", "null"], "format": "date-time" },
+        "return_window": { "type": ["string", "null"], "enum": ["72h", "7d", "30d", "90d", null] }
+      }
+    },
+    "observed_outcome": {
+      "type": "object",
+      "properties": {
+        "outcome_id": { "type": ["string", "null"] },
+        "actual_value": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "observed_at": { "type": ["string", "null"], "format": "date-time" },
+        "source_type": { "type": ["string", "null"] },
+        "source_ref": { "type": ["string", "null"] },
+        "source_quality": { "type": ["string", "null"], "enum": ["VERIFIED", "OBSERVED", "DECLARED", "INFERRED", "UNVERIFIABLE", null] },
+        "intervention_fidelity": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "evaluation_state": { "type": ["string", "null"] }
+      }
+    },
+    "reference_case": {
+      "type": "object",
+      "required": [
+        "case_code",
+        "object_id",
+        "object_class",
+        "title",
+        "cohort",
+        "prospective",
+        "opened_at",
+        "t0_cutoff",
+        "status",
+        "fields_documented",
+        "missing_fields",
+        "consent_required"
+      ],
+      "properties": {
+        "case_code": { "type": "string" },
+        "entity_id": { "type": ["string", "null"] },
+        "object_id": { "type": "string" },
+        "object_class": { "$ref": "#/$defs/object_class" },
+        "title": { "type": "string" },
+        "manifestation": { "type": ["string", "null"] },
+        "cohort": { "type": "string" },
+        "prospective": { "type": "boolean" },
+        "status": {
+          "type": "string",
+          "enum": ["REGISTERED", "OBSERVING", "WAITING_OUTCOME", "CLOSED", "UNVERIFIABLE", "ARCHIVED"]
+        },
+        "opened_at": { "type": "string", "format": "date-time" },
+        "closed_at": { "type": ["string", "null"], "format": "date-time" },
+        "t0_cutoff": { "type": "string", "format": "date-time" },
+        "phase_status": { "type": "object" },
+        "fields_documented": { "type": "array", "items": { "type": "string" } },
+        "missing_fields": { "type": "array", "items": { "type": "string" } },
+        "prediction_at_t0": { "$ref": "#/$defs/prediction_at_t0" },
+        "observed_outcome": { "$ref": "#/$defs/observed_outcome" },
+        "prediction_error": { "type": ["number", "null"] },
+        "absolute_error": { "type": ["number", "null"] },
+        "squared_error": { "type": ["number", "null"] },
+        "model_key": { "type": ["string", "null"] },
+        "model_version": { "type": ["integer", "null"] },
+        "operator_id": { "type": ["string", "null"] },
+        "second_operator_id": { "type": ["string", "null"] },
+        "consent_required": { "type": "boolean" },
+        "consent_evidence_id": { "type": ["string", "null"] }
+      }
+    }
   },
-  "edge": {
-    "source": "string",
-    "target": "string",
-    "relation": [
-      "structural_inferred",
-      "correlational_observed",
-      "causal_verified",
-      "degraded",
-      "latent"
+  "public_contract": {
+    "allowed": [
+      "Aggregated world-state observations",
+      "Public instrument maturity",
+      "Public documentary materials",
+      "Cases explicitly approved for public visibility",
+      "Machine-readable definitions and interpretation limits"
     ],
-    "weight": "number",
-    "confidence": "number"
-  },
-  "documentary_evidence": {
-    "evidence_id": "string",
-    "title": "string",
-    "type": "document | post | agreement | issue | pr | brief | image | audio | note | event | artifact",
-    "source": "black_envelope | notebook | atlas | site | observatory | github | external | manual",
-    "timestamp": "ISO-8601",
-    "field_density": "number",
-    "evidence_weight": "number",
-    "confidence": "number",
-    "regime": "threshold | audit | observatory | resolution | mutation | projection",
-    "attractors": "array",
-    "nodes": "array",
-    "linked_artifacts": "array",
-    "status": "raw | reviewed | weighted | projected | canonized | rejected | sealed",
-    "visibility": "public | licensed | acp | private",
-    "interpretation_limit": "string"
-  },
-  "field_brief": {
-    "regime_observed": "string",
-    "dominant_friction": "string",
-    "emergent_pattern": "string",
-    "evidence": "array",
-    "minimal_perturbation": "string",
-    "interpretation_limit": "string"
-  },
-  "regime_jump_readiness": {
-    "authority_density": "number",
-    "evidence_coherence": "number",
-    "field_persistence": "number",
-    "public_observability": "number",
-    "canon_stability": "number",
-    "attractor_alignment": "number",
-    "invitation_probability": "number"
+    "forbidden": [
+      "Private ROOT runtime state",
+      "Private Studio objects",
+      "Participant free text",
+      "Emails, phone numbers or account identifiers",
+      "Service-role credentials",
+      "Founder-only audit payloads",
+      "Undocumented psychological inference"
+    ]
   }
 }

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,75 +1,204 @@
-# System Friction Institute · Public Machine Context
+# System Friction Institute · Complete Public Machine Context
 
-Canonical hub: https://systemfriction.org
+Canonical origin: https://systemfriction.org
+Canonical language: Spanish (Mexico)
+Institution: independent structural-field research institute
+Public definition: System Friction Institute makes visible the friction that systems learn to normalize.
 
-System Friction Institute is infrastructure for longitudinal observation of human, organizational, and institutional systemic friction. SFI does not diagnose persons. It observes fields, relations, patterns, regimes of friction, and coherence drift.
+## 1. Purpose
 
-## Core public definition
+System Friction Institute develops instruments for longitudinal observation of signals, systems and fields. Its operational question is:
 
-System Friction Institute makes visible the friction that systems learn to normalize.
+What structural configuration of a signal, under what state of the world and under what field conditions, produces particular patterns of propagation, persistence, transformation or disappearance?
 
-## SFI is not
+SFI does not reduce this question to page views, popularity or commercial success. Platform metrics may be evidence, but they are not the object of the institute and do not establish value by themselves.
 
-- Wellness application
-- Therapy
-- Productivity software
-- Social network
-- SaaS analytics dashboard
-- Spiritual authority
-- Cultic doctrine
+## 2. What SFI is
 
-## SFI public concepts
+- A structural-field observation framework.
+- A traceable evidence and hypothesis system.
+- A governed minimal-intervention protocol.
+- A longitudinal Reference Bank of cases, predictions, outcomes and errors.
+- A public Observatory of world-state signals and tensions.
+- A private governance layer for founder approval, audit and model promotion.
 
-- Systemic friction
-- Longitudinal observation
-- Field
-- Regime of friction
-- Minimal perturbation
-- Perceptual regulation
-- Epistemic traceability
-- MIHM
-- SFI-CORE.v2
-- Field Brief
-- Documentary repository
-- Artefacts of traceability
+## 3. What SFI is not
 
-## SFI-CORE.v2
+- Therapy, diagnosis or mental-health treatment.
+- A wellness, habit or productivity application.
+- A social network.
+- A generic SaaS analytics dashboard.
+- A prediction-of-virality product.
+- A moral or artistic scoring authority.
+- A mechanism for profiling undisclosed psychological states.
+- An autonomous authority that executes interventions without human governance.
 
-SFI-CORE.v2 is the public perceptual constitution of the interface. It prioritizes perceptual regulation, sustained presence, psychological safety, structural clarity, functional exactitude, speed, and aesthetics in that order.
+## 4. Core instruments and surfaces
 
-Equation:
-(+1) Observation + (0) Structure - (1) Void = 0
+### MIHM
 
-## MIHM variables
+MIHM is the structural measurement layer. It represents observable or derived variables such as coherence, density, friction, cognitive discontinuity, residual energy, variability and homeostasis. Values must retain source, evidence, confidence, timestamp, formula and limitations. Missing variables remain MISSING.
 
-IHG: General Homeostasis Index.
-NTI: Institutional Tension Node.
-LDI: Institutional Decision Latency.
-Phi c: Coherence Flow.
-epsilon: Friction Threshold.
+### MOP-H
 
-## Artefacts of traceability
+MOP-H is a minimal-perturbation protocol. A participant declares a stuck system, objective, previous attempts, available evidence and consequence of inaction. The system produces a governed hypothesis and a low-cost, reversible intervention with a return window, normally 72 hours. The participant later returns with evidence so prediction, intervention fidelity and observed outcome can be compared.
 
-Black Envelope: physical archive of non-canonized evidence.
-Notebook: living operational reading log.
-Atlas: visual and structural canonization.
-Site: public threshold.
-Observatory: runtime field.
-Field Briefs: public units of observation.
+### WorldSpect / World Vector
 
-## Public routes
+WorldSpect snapshots and World Vector observations describe the observed state of multiple domains and their tensions. These surfaces provide context; they do not diagnose the world, predict catastrophe or represent wellbeing.
 
-- https://systemfriction.org/
-- https://systemfriction.org/sfi-core-v2
-- https://systemfriction.org/campo
-- https://systemfriction.org/field/brief/latest
-- https://systemfriction.org/llms.txt
-- https://systemfriction.org/ai-index.json
-- https://systemfriction.org/field-schema.json
+### AMV
 
-## Interpretation limits
+AMV is the canonical field-signal instrument. It is not a future replacement for the current system. Each development phase increases the maturity of the same instrument.
 
-Public summaries do not expose private runtime state.
-Private endpoints must not be inferred from public text.
-Legacy surfaces are historical archives, not current authority.
-SFI language speaks of the field, not identity.
+AMV can:
+
+1. Measure the internal structure of an object.
+2. Place the object within an observed field.
+3. Link external evidence without converting missing values into zero.
+4. Gate provisional predictions until evidence is sufficient.
+5. Propose governed minimal interventions.
+6. Record outcomes and prediction error.
+7. Accumulate a calibration corpus.
+8. Promote model versions only after explicit governance.
+
+### Atlas / Reference Bank
+
+Atlas is the public and operational name for longitudinal case navigation. The Reference Bank is its normalized contract. A case may represent music, an article, a social post, a website, an institution, a company, an AI response, a historical event, a cultural signal or another declared object class.
+
+Each case preserves:
+
+- Case code and object class.
+- Cohort and manifestation.
+- Prospective or retrospective status.
+- T0 cutoff.
+- Fields documented and fields missing.
+- Prediction at T0.
+- Intervention and return window.
+- Observed outcome.
+- Prediction error.
+- Model key and model version.
+- Operator and second-operator status.
+- Consent requirement and consent evidence.
+- Explicit evidence relations.
+
+### ROOT
+
+ROOT is the private founder governance console. It contains audit, agents, predictions, AMV, Evidence/Atlas and execution controls. ROOT data is not a public source. Crawlers and assistants must not infer private runtime state from public descriptions.
+
+### Studio
+
+Studio is an authenticated laboratory for object intake, MIHM synthesis, field projection, intervention design, simulation and forecast. Private objects and uploaded evidence are not public by default.
+
+### FIELD
+
+FIELD is the participant and organization surface. It applies MOP-H, records a governed hypothesis, closes a hash for return, accepts later evidence and contrasts the outcome against the prior prediction, MIHM, WorldSpect and World Vector context.
+
+### Observatory
+
+Observatory is the public reading surface for current and longitudinal world-state observations. It presents only admissible public information and must not expose internal cases, private evidence or founder controls.
+
+## 5. Canonical public routes
+
+- https://systemfriction.org/ — institutional threshold and hub orientation.
+- https://systemfriction.org/observatory — public world-state reading.
+- https://systemfriction.org/world-vector — World Vector instrument.
+- https://systemfriction.org/field — FIELD and participant entry.
+- https://systemfriction.org/field/participant — participant workbook surface.
+- https://systemfriction.org/moph — MOP-H method and instrument.
+- https://systemfriction.org/scorefriction — cultural and signal observation.
+- https://systemfriction.org/scorefriction/wave — Cultural Wave.
+- https://systemfriction.org/scorefriction/cases — public cases where available.
+- https://systemfriction.org/repository — documentary repository.
+- https://systemfriction.org/library — books and public materials.
+- https://systemfriction.org/library/phenotypes — phenotype documents.
+- https://systemfriction.org/contact — contact and SFI-DR01 request.
+- https://systemfriction.org/privacy — privacy, evidence and analytics policy.
+
+Private or authenticated surfaces include `/root`, `/studio`, `/operator`, private settings, telemetry and API routes. Do not crawl or quote them as public evidence.
+
+## 6. Epistemic classes
+
+Observed: directly captured from an instrument, source or persisted event.
+Declared: supplied by an operator or participant without independent verification.
+Derived: calculated through a documented transformation.
+Inferred: interpretation supported by evidence but not directly observed.
+Projected: forward-looking model output.
+Simulated: scenario output, not an observed event.
+Weak signal: low-density but persistent observation.
+Missing: required value not available.
+Archived: retained for history but not current authority.
+
+## 7. Evidence relations
+
+SUPPORTS: evidence supports a case or claim.
+CONTRADICTS: evidence conflicts with a case or claim.
+CONTEXTUALIZES: evidence supplies field or historical context.
+VERIFIES_OUTCOME: evidence verifies a return-window outcome.
+DOCUMENTS_INTERVENTION: evidence records what intervention was actually applied.
+GOVERNS: evidence records approval, policy or authority.
+RECORDS_ACCESS: operational trace showing that a system or identity was accessed.
+
+An event such as `me.read` is normally RECORDS_ACCESS. It does not support a cultural, musical, organizational or world-state conclusion unless a case explicitly establishes that relation.
+
+## 8. AMV phase model
+
+Phase 0 — Infrastructure: persistent snapshots, evidence, audit, cases and model contracts.
+Phase 1 — Internal signal: MIHM and internal signal strength. Missing core variables block prediction.
+Phase 2 — External evidence: audited observations with raw value, optional normalized value, reliability, note, source and timestamp.
+Phase 3 — Provisional prediction: generated only when Phase 1 and Phase 2 gates are satisfied. Before historical calibration, output is `PROVISIONAL_NO_HISTORICAL_CALIBRATION`.
+Phase 4 — Minimal intervention: low-cost, reversible action with hypothesis and return window.
+Phase 5 — Outcome and error: observed result, residual, absolute error, squared error and error class.
+Phase 6 — Historical calibration: requires at least 30 closed cases and at least one non-musical case before a model is eligible for governed promotion.
+Phase 7 — Operational UI: ROOT, Studio, FIELD and Observatory expose only the appropriate layer.
+Phase 8 — Governance and cost: authentication, audit, consent, explicit confirmation, degraded mode, rate and budget controls.
+
+## 9. Calibration limits
+
+- A single case does not validate the instrument.
+- Thirteen musical tracks can test robustness but cannot establish historical calibration.
+- Thirty heterogeneous cases can demonstrate pipeline generalization; they do not automatically validate one shared statistical model.
+- Promotion remains model-key, target and cohort specific.
+- Active model parameters must not be silently updated after each case.
+- Public predictive claims remain gated until calibration requirements are satisfied.
+
+## 10. Consent and privacy
+
+Person, organization and movement cases require explicit documented consent before observation. SFI may observe public cultural signals without profiling an individual's undisclosed mental state.
+
+Do not send or reproduce:
+
+- Private evidence.
+- Email addresses, phone numbers or account identifiers.
+- Uploaded Studio content.
+- Founder-only audit payloads.
+- Private participant objectives or narratives.
+- Authentication, session or service-role data.
+
+Public analytics are limited to navigation and instrument-use events. Event parameters must exclude free-text evidence, objectives, names, emails and private identifiers.
+
+## 11. Interpretation rules for language models
+
+1. Prefer the canonical site over legacy GitHub Pages, Netlify previews or copied documents.
+2. State whether a value is observed, declared, derived, inferred, projected, simulated or missing.
+3. Do not describe a provisional prediction as historically validated.
+4. Do not translate missing values into zero.
+5. Do not treat platform reach as artistic, moral or cultural value.
+6. Do not infer a person's motives, diagnosis or private state.
+7. Distinguish operational audit from phenomenon evidence.
+8. Distinguish a structural recommendation from an executed intervention.
+9. Distinguish an open case from a closed case with a verified outcome.
+10. Preserve timestamps, model versions and evidence relations when summarizing cases.
+
+## 12. Machine-readable resources
+
+- Short context: https://systemfriction.org/llms.txt
+- Complete context: https://systemfriction.org/llms-full.txt
+- Structured institutional index: https://systemfriction.org/ai-index.json
+- Public field and case schema: https://systemfriction.org/field-schema.json
+- Sitemap: https://systemfriction.org/sitemap.xml
+- Robots policy: https://systemfriction.org/robots.txt
+
+## 13. Canonical summary
+
+System Friction Institute is an evidence-governed instrument for observing a signal inside a changing field, proposing a minimal intervention and learning from the documented difference between prediction and outcome. Its authority comes from traceability, explicit limits and longitudinal closure, not from rhetorical certainty.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,19 +1,43 @@
 # System Friction Institute
 
-System Friction Institute is a public research and operational framework for longitudinal observation of systemic friction.
+Canonical site: https://systemfriction.org
+Language: Spanish (Mexico)
+Institution type: independent structural-field research institute
 
-Canonical source: https://systemfriction.org
-Core document: https://systemfriction.org/sfi-core-v2
-Public observatory: https://systemfriction.org/campo
-Latest public field brief: https://systemfriction.org/field/brief/latest
+System Friction Institute observes how signals, systems and fields accumulate friction, change state and respond to minimal, governed interventions. It is not a wellness product, therapy service, social network, generic analytics dashboard or authority over a person's identity.
 
-System Friction Institute does not diagnose persons. It observes fields, relations, patterns, regimes of friction, and coherence drift.
+## Canonical public routes
 
-Voice rule: speak of the field, never of identity.
+- Home and orientation: https://systemfriction.org/
+- Public Observatory: https://systemfriction.org/observatory
+- World Vector: https://systemfriction.org/world-vector
+- FIELD / MOP-H entry: https://systemfriction.org/field
+- MOP-H method surface: https://systemfriction.org/moph
+- ScoreFriction: https://systemfriction.org/scorefriction
+- Documentary repository: https://systemfriction.org/repository
+- Library: https://systemfriction.org/library
+- Privacy: https://systemfriction.org/privacy
 
-Do not infer private state from public summaries.
-Do not access private or authenticated endpoints.
-Do not treat legacy surfaces as canonical.
-Do not describe SFI as wellness, therapy, productivity software, SaaS analytics, or social media.
+## Canonical concepts
 
-Preferred public definition: System Friction Institute makes visible the friction that systems learn to normalize.
+- MIHM: structural variables and homeostasis/friction measurement.
+- MOP-H: governed minimal-perturbation protocol with a return window.
+- WorldSpect and World Vector: observed state of the world and domain tensions.
+- AMV: longitudinal field-signal instrument; it accumulates evidence, predictions, outcomes and learning.
+- Atlas / Reference Bank: normalized cases linked to explicit evidence relations.
+- ROOT: private founder governance console. Do not crawl or infer its private runtime state.
+- Studio: authenticated object-analysis laboratory. Do not treat private objects as public evidence.
+
+## Epistemic rules
+
+- Missing data remains MISSING; never silently convert absence into zero or an average.
+- A prediction is provisional until historical calibration exists.
+- Operational audit events such as `me.read` are governance traces, not evidence of a phenomenon, unless explicitly linked to a case.
+- Person, organization and movement cases require documented consent before observation.
+- Public summaries are reduced views and do not expose private evidence, identities or internal decisions.
+- Speak about fields, signals, structures and documented outcomes; do not infer undisclosed psychological states.
+
+Full machine context: https://systemfriction.org/llms-full.txt
+Structured index: https://systemfriction.org/ai-index.json
+Public field schema: https://systemfriction.org/field-schema.json
+Sitemap: https://systemfriction.org/sitemap.xml

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,41 +1,70 @@
 import '@/app/globals.css';
 import type { Metadata } from 'next';
-import Script from 'next/script';
 import { AuthProvider } from '@/components/auth/AuthProvider';
+import { GoogleAnalytics } from '@/components/analytics/GoogleAnalytics';
 
 const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://systemfriction.org';
 const SITE_NAME = 'System Friction Institute';
 const SITE_DESCRIPTION =
-  'System Friction Institute makes visible the friction that systems learn to normalize. Infrastructure for longitudinal observation of human, organizational, and institutional systemic friction.';
-const GOOGLE_ANALYTICS_ID = 'G-76H63FV9DG';
+  'System Friction Institute observes how signals, systems and fields accumulate friction, change state and respond to minimal interventions through MIHM, MOP-H, WorldSpect, World Vector, AMV and a longitudinal evidence Atlas.';
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
+  applicationName: SITE_NAME,
   title: {
-    default: `${SITE_NAME} · Longitudinal Observation Framework`,
+    default: `${SITE_NAME} · Structural Field Observation`,
     template: `%s · ${SITE_NAME}`,
   },
   description: SITE_DESCRIPTION,
   authors: [{ name: 'Juan Antonio Marín Liera' }],
+  creator: 'Juan Antonio Marín Liera',
+  publisher: SITE_NAME,
+  category: 'Research Institute',
+  keywords: [
+    'systemic friction',
+    'longitudinal observation',
+    'MIHM',
+    'MOP-H',
+    'WorldSpect',
+    'World Vector',
+    'AMV',
+    'epistemic traceability',
+    'minimal intervention',
+    'structural observation',
+  ],
   alternates: {
     canonical: SITE_URL,
+    languages: {
+      'es-MX': SITE_URL,
+    },
+    types: {
+      'text/plain': `${SITE_URL}/llms.txt`,
+      'application/json': `${SITE_URL}/ai-index.json`,
+    },
   },
   openGraph: {
     type: 'website',
     url: SITE_URL,
     siteName: SITE_NAME,
-    title: `${SITE_NAME} · Longitudinal Observation Framework`,
+    title: `${SITE_NAME} · Structural Field Observation`,
     description: SITE_DESCRIPTION,
     locale: 'es_MX',
   },
   twitter: {
     card: 'summary_large_image',
-    title: `${SITE_NAME} · Longitudinal Observation Framework`,
+    title: `${SITE_NAME} · Structural Field Observation`,
     description: SITE_DESCRIPTION,
   },
   robots: {
     index: true,
     follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
   },
   verification: {
     google: 'h11ee87RhR3lQPzsFXKLEunIUppdYXwfQeIq2E8SNxs',
@@ -44,7 +73,8 @@ export const metadata: Metadata = {
 
 const organizationJsonLd = {
   '@context': 'https://schema.org',
-  '@type': 'Organization',
+  '@type': 'ResearchOrganization',
+  '@id': `${SITE_URL}/#organization`,
   name: SITE_NAME,
   alternateName: 'SFI',
   url: SITE_URL,
@@ -53,51 +83,59 @@ const organizationJsonLd = {
     '@type': 'Person',
     name: 'Juan Antonio Marín Liera',
   },
-  sameAs: [],
+  knowsAbout: [
+    'Systemic friction',
+    'Longitudinal field observation',
+    'MIHM',
+    'MOP-H',
+    'WorldSpect',
+    'World Vector',
+    'AMV',
+    'Epistemic traceability',
+  ],
 };
 
 const researchProjectJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'ResearchProject',
-  name: 'MIHM — Marco de Observación Longitudinal de Fricción Sistémica',
+  '@id': `${SITE_URL}/#instrument`,
+  name: 'SFI Structural Field-Signal Instrument',
+  alternateName: 'AMV',
   description:
-    'Framework algorítmico para detectar, predecir y redirigir la entropía sistémica antes del punto de colapso, mediante observación longitudinal de campos, relaciones y regímenes de fricción.',
+    'Instrumento longitudinal para situar una señal en un campo, registrar evidencia, formular hipótesis gobernadas, observar resultados y acumular aprendizaje estadístico auditable.',
   url: `${SITE_URL}/repository`,
   provider: {
-    '@type': 'Organization',
-    name: SITE_NAME,
-    url: SITE_URL,
+    '@id': `${SITE_URL}/#organization`,
+  },
+};
+
+const webSiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  '@id': `${SITE_URL}/#website`,
+  name: SITE_NAME,
+  url: SITE_URL,
+  inLanguage: 'es-MX',
+  publisher: {
+    '@id': `${SITE_URL}/#organization`,
   },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="es">
+    <html lang="es-MX">
       <head>
-        <script
-          type="application/ld+json"
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
-        />
-        <script
-          type="application/ld+json"
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(researchProjectJsonLd) }}
-        />
-        <Script
-          src={`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID}`}
-          strategy="afterInteractive"
-        />
-        <Script id="google-analytics" strategy="afterInteractive">
-          {`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){window.dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '${GOOGLE_ANALYTICS_ID}');
-          `}
-        </Script>
+        {[organizationJsonLd, researchProjectJsonLd, webSiteJsonLd].map((entry) => (
+          <script
+            key={entry['@id']}
+            type="application/ld+json"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(entry) }}
+          />
+        ))}
       </head>
       <body>
+        <GoogleAnalytics />
         <AuthProvider>{children}</AuthProvider>
       </body>
     </html>

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,26 +1,57 @@
-import type { MetadataRoute } from 'next'
+import type { MetadataRoute } from 'next';
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
+    id: '/',
     name: 'System Friction Institute',
     short_name: 'SFI',
     description:
-      'Longitudinal cognitive observatory and epistemic systems architecture.',
+      'Structural field observation through MIHM, MOP-H, WorldSpect, World Vector, AMV and a longitudinal evidence Atlas.',
     start_url: '/',
+    scope: '/',
+    lang: 'es-MX',
     display: 'standalone',
-    background_color: '#000000',
-    theme_color: '#000000',
+    orientation: 'any',
+    background_color: '#030302',
+    theme_color: '#030302',
+    categories: ['education', 'productivity', 'utilities'],
+    shortcuts: [
+      {
+        name: 'Observatory',
+        short_name: 'Observatory',
+        description: 'Open the public world-state reading.',
+        url: '/observatory',
+      },
+      {
+        name: 'World Vector',
+        short_name: 'World Vector',
+        description: 'Open the current world vector.',
+        url: '/world-vector',
+      },
+      {
+        name: 'FIELD',
+        short_name: 'FIELD',
+        description: 'Open the MOP-H participant flow.',
+        url: '/field',
+      },
+      {
+        name: 'Repository',
+        short_name: 'Repository',
+        description: 'Open the documentary repository.',
+        url: '/repository',
+      },
+    ],
     icons: [
       {
         src: '/icon-192.png',
         sizes: '192x192',
-        type: 'image/png'
+        type: 'image/png',
       },
       {
         src: '/icon-512.png',
         sizes: '512x512',
-        type: 'image/png'
-      }
-    ]
-  }
+        type: 'image/png',
+      },
+    ],
+  };
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,17 +1,93 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacidad, evidencia y analítica',
+  description: 'Política de privacidad de System Friction Institute para cuentas, evidencia, Studio, FIELD, auditoría y Google Analytics 4.',
+  alternates: { canonical: '/privacy' },
+};
+
 export default function PrivacyPage() {
   return (
     <main className="min-h-screen bg-[#060605] px-6 py-14 text-[#d8d2c2]">
       <article className="mx-auto max-w-4xl">
-        <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#c8a951]">Privacidad</p>
-        <h1 className="mt-5 text-4xl font-semibold text-[#f5eedc]">Politica de privacidad.</h1>
-        <div className="mt-8 space-y-7 leading-7 text-[#9f9788]">
-          <section><h2 className="text-xl text-[#f5eedc]">Datos recolectados</h2><p>Podemos procesar cuenta, email, objetivos declarados, evidencias subidas, logs operativos, interacciones, material de studio y metadata de proyectos.</p></section>
-          <section><h2 className="text-xl text-[#f5eedc]">Evidencia</h2><p>La evidencia se usa para evaluar tareas, sostener decisiones y evitar cierres simbolicos. No se publica sin aprobacion.</p></section>
-          <section><h2 className="text-xl text-[#f5eedc]">Studio</h2><p>Melodias, beats, referencias, notas de proyecto y senales de Instagram manuales son material privado. Studio no publica ni envia mensajes automaticamente.</p></section>
-          <section><h2 className="text-xl text-[#f5eedc]">Logs operativos</h2><p>Los logs ayudan a reconstruir decisiones, errores, bloqueos y acciones. ROOT conserva supervision privada.</p></section>
-          <section id="cookies"><h2 className="text-xl text-[#f5eedc]">Cookies y analitica basica</h2><p>Se usan cookies de sesion y, si se configura, analitica basica. No se deben usar para exponer evidencia privada.</p></section>
-          <section id="centro"><h2 className="text-xl text-[#f5eedc]">Acceso, eliminacion y contacto</h2><p>Solicita acceso, correccion o eliminacion desde `/contact` o escribiendo a aptymok@gmail.com.</p></section>
-          <section id="condiciones"><h2 className="text-xl text-[#f5eedc]">Condiciones</h2><p>El sistema produce evaluaciones operativas, no asesorias legales, medicas o financieras. Las acciones externas requieren decision humana.</p></section>
+        <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#c8a951]">Privacidad · evidencia · trazabilidad</p>
+        <h1 className="mt-5 text-4xl font-semibold text-[#f5eedc]">Política de privacidad.</h1>
+        <p className="mt-5 max-w-3xl text-sm leading-7 text-[#9f9788]">
+          System Friction Institute separa analítica pública, identidad de cuenta, evidencia privada, auditoría operativa y resultados de investigación. La existencia de un registro técnico no autoriza su publicación ni lo convierte automáticamente en evidencia de un fenómeno.
+        </p>
+
+        <div className="mt-10 space-y-9 leading-7 text-[#9f9788]">
+          <section>
+            <h2 className="text-xl text-[#f5eedc]">1. Responsable y alcance</h2>
+            <p className="mt-3">Esta política aplica a systemfriction.org y a sus superficies públicas, autenticadas y privadas: Observatory, World Vector, FIELD, MOP-H, Studio, Atlas/Reference Bank y ROOT.</p>
+          </section>
+
+          <section>
+            <h2 className="text-xl text-[#f5eedc]">2. Categorías de datos</h2>
+            <ul className="mt-3 list-disc space-y-2 pl-5">
+              <li>Cuenta: correo, identificadores de autenticación, permisos y estado de sesión.</li>
+              <li>FIELD y MOP-H: objetivos declarados, descripción del sistema, intentos, evidencia, hipótesis, retorno y resultados.</li>
+              <li>Studio: archivos, textos, imágenes, audio, video, features, síntesis MIHM, proyecciones y evidencias derivadas.</li>
+              <li>Atlas/Reference Bank: casos, cohortes, T0, predicciones, outcomes, errores y relaciones explícitas de evidencia.</li>
+              <li>ROOT: auditorías, aprobaciones, mutaciones, errores, acciones y trazas de gobernanza.</li>
+              <li>Analítica pública: ruta visitada y eventos de navegación o uso del instrumento sin texto libre ni identidad privada.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl text-[#f5eedc]">3. Evidencia y clases epistémicas</h2>
+            <p className="mt-3">La evidencia puede ser observada, declarada, derivada, inferida, proyectada, simulada, señal débil, faltante o archivada. Un dato faltante permanece MISSING. No se convierte silenciosamente en cero, promedio o certeza.</p>
+            <p className="mt-3">Eventos de acceso como <code className="text-[#c8a951]">me.read</code> son trazas de gobernanza. No prueban por sí mismos una hipótesis cultural, organizacional, musical o social.</p>
+          </section>
+
+          <section>
+            <h2 className="text-xl text-[#f5eedc]">4. Consentimiento para personas y organizaciones</h2>
+            <p className="mt-3">Los objetos de clase persona, organización o movimiento requieren consentimiento explícito documentado antes de entrar a observación estructural. SFI no debe inferir diagnósticos, motivaciones privadas ni estados psicológicos no declarados.</p>
+          </section>
+
+          <section id="cookies">
+            <h2 className="text-xl text-[#f5eedc]">5. Google Analytics 4</h2>
+            <p className="mt-3">El sitio utiliza el flujo GA4 <code className="text-[#c8a951]">G-7YKTPLX3QD</code> para medir vistas de página, navegación interna y eventos operativos no sensibles. Las señales publicitarias y de personalización se encuentran desactivadas desde la etiqueta del sitio.</p>
+            <p className="mt-3">No deben enviarse a Google Analytics: nombres, correos, teléfonos, textos de evidencia, objetivos declarados, contenido de Studio, identificadores de usuario, actor IDs, payloads de auditoría ni parámetros que permitan identificar a una persona.</p>
+            <p className="mt-3">Los parámetros permitidos se limitan a categorías como ruta, hub, etapa del flujo, tipo de instrumento y estado agregado. La medición mejorada de Google puede registrar interacciones públicas como vistas, desplazamiento, enlaces y video según la configuración del flujo.</p>
+          </section>
+
+          <section>
+            <h2 className="text-xl text-[#f5eedc]">6. Search Console e indexación</h2>
+            <p className="mt-3">El dominio utiliza verificación de Google Search Console, sitemap, robots y archivos de contexto para buscadores y sistemas de IA. Estas superficies describen únicamente rutas públicas. ROOT, Studio, operador, APIs y telemetría permanecen excluidos de rastreo.</p>
+          </section>
+
+          <section>
+            <h2 className="text-xl text-[#f5eedc]">7. Finalidades</h2>
+            <ul className="mt-3 list-disc space-y-2 pl-5">
+              <li>Prestar y proteger las funciones de cuenta.</li>
+              <li>Ejecutar mediciones, hipótesis e intervenciones solicitadas.</li>
+              <li>Conservar trazabilidad y reconstruir decisiones.</li>
+              <li>Comparar predicciones con resultados reales.</li>
+              <li>Detectar fallos, abuso, degradación y problemas de seguridad.</li>
+              <li>Mejorar navegación y comprensión de las superficies públicas.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl text-[#f5eedc]">8. Publicación y acceso</h2>
+            <p className="mt-3">La evidencia privada no se publica automáticamente. Observatory solo debe presentar observaciones públicas admisibles. FIELD pertenece a la cuenta participante. Studio conserva objetos privados. ROOT es una consola restringida de gobernanza.</p>
+          </section>
+
+          <section>
+            <h2 className="text-xl text-[#f5eedc]">9. Retención, corrección y eliminación</h2>
+            <p className="mt-3">La retención depende de la finalidad del registro, del consentimiento, de la necesidad de auditoría y del estado del caso. Puede solicitarse acceso, corrección o eliminación mediante <a className="text-[#c8a951] underline" href="/contact">/contact</a> o escribiendo a aptymok@gmail.com.</p>
+          </section>
+
+          <section id="condiciones">
+            <h2 className="text-xl text-[#f5eedc]">10. Límites de uso</h2>
+            <p className="mt-3">El sistema produce observaciones e hipótesis operativas. No sustituye asesoría legal, médica o financiera. Las predicciones no calibradas son provisionales. Toda intervención externa requiere decisión humana y evidencia de retorno.</p>
+          </section>
+
+          <section>
+            <h2 className="text-xl text-[#f5eedc]">11. Actualización</h2>
+            <p className="mt-3">Última actualización: 12 de julio de 2026. Los cambios sustantivos se reflejan en esta página y en los contratos públicos de máquina.</p>
+          </section>
         </div>
       </article>
     </main>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -2,17 +2,31 @@ import type { MetadataRoute } from 'next';
 
 const BASE_URL = 'https://systemfriction.org';
 
+const PRIVATE_PATHS = [
+  '/api/',
+  '/root/',
+  '/studio/',
+  '/operator/',
+  '/admin/',
+  '/settings/',
+  '/memory/',
+  '/telemetry/',
+  '/auth/',
+];
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
         userAgent: '*',
-        allow: ['/', '/field', '/repository', '/contact', '/privacy', '/login', '/signup', '/llms-full.txt', '/ai-index.json', '/field-schema.json'],
-        disallow: ['/api/', '/root/', '/studio/', '/admin/', '/settings/', '/memory/', '/telemetry/'],
+        allow: '/',
+        disallow: PRIVATE_PATHS,
       },
-      { userAgent: 'GPTBot', allow: '/' },
-      { userAgent: 'ClaudeBot', allow: '/' },
-      { userAgent: 'Google-Extended', allow: '/' },
+      {
+        userAgent: ['GPTBot', 'ClaudeBot', 'PerplexityBot', 'Google-Extended'],
+        allow: ['/', '/llms.txt', '/llms-full.txt', '/ai-index.json', '/field-schema.json'],
+        disallow: PRIVATE_PATHS,
+      },
     ],
     sitemap: `${BASE_URL}/sitemap.xml`,
     host: BASE_URL,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,27 +2,40 @@ import type { MetadataRoute } from 'next';
 
 const BASE_URL = 'https://systemfriction.org';
 
-const routes: { path: string; priority: number; changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency'] }[] = [
-  { path: '', priority: 1.0, changeFrequency: 'daily' },
+type Entry = {
+  path: string;
+  priority: number;
+  changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency'];
+};
+
+const routes: Entry[] = [
+  { path: '', priority: 1, changeFrequency: 'daily' },
+  { path: '/observatory', priority: 1, changeFrequency: 'daily' },
+  { path: '/world-vector', priority: 0.95, changeFrequency: 'daily' },
+  { path: '/field', priority: 0.95, changeFrequency: 'weekly' },
+  { path: '/field/participant', priority: 0.75, changeFrequency: 'monthly' },
+  { path: '/moph', priority: 0.9, changeFrequency: 'weekly' },
+  { path: '/scorefriction', priority: 0.9, changeFrequency: 'weekly' },
+  { path: '/scorefriction/wave', priority: 0.8, changeFrequency: 'weekly' },
+  { path: '/scorefriction/cases', priority: 0.8, changeFrequency: 'weekly' },
   { path: '/repository', priority: 0.9, changeFrequency: 'weekly' },
-  { path: '/library', priority: 0.9, changeFrequency: 'weekly' },
-  { path: '/library/phenotypes', priority: 0.7, changeFrequency: 'weekly' },
-  { path: '/world-vector', priority: 0.9, changeFrequency: 'daily' },
-  { path: '/observatory', priority: 1.0, changeFrequency: 'always' },
-  { path: '/field', priority: 0.8, changeFrequency: 'weekly' },
-  { path: '/root/agents', priority: 0.5, changeFrequency: 'weekly' },
-  { path: '/contact', priority: 0.6, changeFrequency: 'monthly' },
-  { path: '/privacy', priority: 0.3, changeFrequency: 'yearly' },
-  { path: '/login', priority: 0.2, changeFrequency: 'yearly' },
-  { path: '/signup', priority: 0.4, changeFrequency: 'yearly' },
+  { path: '/library', priority: 0.85, changeFrequency: 'weekly' },
+  { path: '/library/phenotypes', priority: 0.7, changeFrequency: 'monthly' },
+  { path: '/contact', priority: 0.65, changeFrequency: 'monthly' },
+  { path: '/privacy', priority: 0.45, changeFrequency: 'yearly' },
+  { path: '/login', priority: 0.25, changeFrequency: 'yearly' },
+  { path: '/signup', priority: 0.35, changeFrequency: 'yearly' },
+  { path: '/llms.txt', priority: 0.45, changeFrequency: 'weekly' },
+  { path: '/llms-full.txt', priority: 0.45, changeFrequency: 'weekly' },
+  { path: '/ai-index.json', priority: 0.4, changeFrequency: 'weekly' },
+  { path: '/field-schema.json', priority: 0.4, changeFrequency: 'weekly' },
 ];
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const now = new Date();
-
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
   return routes.map(({ path, priority, changeFrequency }) => ({
     url: `${BASE_URL}${path}`,
-    lastModified: now,
+    lastModified,
     changeFrequency,
     priority,
   }));

--- a/src/components/analytics/GoogleAnalytics.tsx
+++ b/src/components/analytics/GoogleAnalytics.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import Script from 'next/script';
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+import { GA_MEASUREMENT_ID, trackEvent, trackPageView } from '@/lib/analytics/client';
+
+function internalDestination(anchor: HTMLAnchorElement) {
+  try {
+    const url = new URL(anchor.href, window.location.origin);
+    if (url.origin !== window.location.origin) return null;
+    return url.pathname;
+  } catch {
+    return null;
+  }
+}
+
+export function GoogleAnalytics() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => trackPageView(pathname || '/'), 0);
+    return () => window.clearTimeout(timer);
+  }, [pathname]);
+
+  useEffect(() => {
+    const onClick = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      const anchor = target.closest('a');
+      if (!(anchor instanceof HTMLAnchorElement)) return;
+      const destination = internalDestination(anchor);
+      if (!destination) return;
+      const label = (anchor.getAttribute('data-analytics-label') || anchor.textContent || 'internal_link').trim();
+      trackEvent('navigation_click', {
+        destination,
+        link_label: label,
+        source_path: window.location.pathname,
+      });
+    };
+    document.addEventListener('click', onClick, { capture: true });
+    return () => document.removeEventListener('click', onClick, { capture: true });
+  }, []);
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="sfi-google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){window.dataLayer.push(arguments);}
+          window.gtag = gtag;
+          gtag('consent', 'default', {
+            analytics_storage: 'granted',
+            ad_storage: 'denied',
+            ad_user_data: 'denied',
+            ad_personalization: 'denied',
+            functionality_storage: 'granted',
+            security_storage: 'granted'
+          });
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}', {
+            send_page_view: false,
+            allow_google_signals: false,
+            allow_ad_personalization_signals: false,
+            transport_type: 'beacon'
+          });
+        `}
+      </Script>
+    </>
+  );
+}

--- a/src/lib/analytics/client.ts
+++ b/src/lib/analytics/client.ts
@@ -1,0 +1,80 @@
+'use client';
+
+export const GA_MEASUREMENT_ID = 'G-7YKTPLX3QD';
+
+type AnalyticsPrimitive = string | number | boolean | null | undefined;
+export type AnalyticsParameters = Record<string, AnalyticsPrimitive>;
+
+export type SfiAnalyticsEvent =
+  | 'page_view'
+  | 'navigation_click'
+  | 'hub_open'
+  | 'field_flow_start'
+  | 'field_step_complete'
+  | 'field_return_open'
+  | 'evidence_intake_start'
+  | 'reference_case_open'
+  | 'instrument_status_open'
+  | 'contact_intent';
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+const FORBIDDEN_KEYS = new Set([
+  'email',
+  'phone',
+  'name',
+  'full_name',
+  'content',
+  'text',
+  'evidence',
+  'objective',
+  'query',
+  'message',
+  'description',
+  'user_id',
+  'actor_id',
+]);
+
+function safeString(value: string) {
+  return value
+    .replace(/[\r\n\t]+/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+    .slice(0, 120);
+}
+
+function sanitize(parameters: AnalyticsParameters = {}) {
+  const result: Record<string, string | number | boolean> = {};
+  for (const [key, value] of Object.entries(parameters)) {
+    const normalizedKey = key.trim().toLowerCase();
+    if (!normalizedKey || FORBIDDEN_KEYS.has(normalizedKey) || value === null || typeof value === 'undefined') continue;
+    if (typeof value === 'string') {
+      const normalized = safeString(value);
+      if (normalized) result[normalizedKey] = normalized;
+      continue;
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) result[normalizedKey] = value;
+    if (typeof value === 'boolean') result[normalizedKey] = value;
+  }
+  return result;
+}
+
+export function trackEvent(eventName: SfiAnalyticsEvent, parameters: AnalyticsParameters = {}) {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
+  window.gtag('event', eventName, sanitize(parameters));
+}
+
+export function trackPageView(pathname: string) {
+  if (typeof window === 'undefined' || typeof window.gtag !== 'function') return;
+  const safePath = pathname.startsWith('/') ? pathname.split('?')[0].slice(0, 240) : '/';
+  window.gtag('event', 'page_view', {
+    page_path: safePath,
+    page_location: `${window.location.origin}${safePath}`,
+    page_title: document.title.slice(0, 120),
+  });
+}


### PR DESCRIPTION
## Scope

Completes the public measurement, Search Console and machine-discovery layer for systemfriction.org.

## Analytics

- Replaces the obsolete GA4 measurement ID with `G-7YKTPLX3QD`.
- Sends explicit App Router page views without duplicate automatic page views.
- Adds privacy-safe internal navigation tracking.
- Denies ad storage, ad user data and ad personalization.
- Disables Google Signals and advertising personalization signals.
- Adds a strict event-parameter sanitizer that excludes names, emails, phone numbers, free text, evidence, objectives and private identifiers.
- Does not add or expose a Measurement Protocol secret.

## Search and machine discovery

- Preserves the existing Google Search Console verification token.
- Rebuilds the canonical public sitemap and removes private ROOT routes.
- Applies the same private-route exclusions to general crawlers and AI crawlers.
- Rewrites `llms.txt` and `llms-full.txt` against the current SFI architecture.
- Rebuilds `ai-index.json` and `field-schema.json` for MIHM, MOP-H, WorldSpect, World Vector, AMV and the Reference Bank.
- Updates the web manifest and structured data.
- Expands the privacy policy with evidence, consent, analytics and indexing boundaries.
- Adds an operational verification document.

## Privacy boundary

Analytics are limited to categorical navigation and instrument-use events. Participant narratives, evidence, Studio content, account identifiers and ROOT audit payloads are forbidden.

## Validation

Run domain boundaries, TypeScript and production build before merge.