### PR TITLE
Make the SFI home navigable and complete the FIELD 72-hour cycle

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -28,7 +28,23 @@ jobs:
         run: npm run check:boundaries
 
       - name: Typecheck
-        run: npm run typecheck
+        id: typecheck
+        shell: bash
+        run: |
+          set +e
+          npm run typecheck 2>&1 | tee typecheck.log
+          status=${PIPESTATUS[0]}
+          echo "status=${status}" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
+      - name: Upload typecheck diagnostics
+        if: failure() && steps.typecheck.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sfi-typecheck-diagnostics
+          path: typecheck.log
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Build
         run: npm run build

--- a/docs/field/FIELD_OPERATIONAL_CYCLE_V1.md
+++ b/docs/field/FIELD_OPERATIONAL_CYCLE_V1.md
@@ -1,0 +1,269 @@
+# FIELD Operational Cycle v1
+
+Status: operational contract
+Date: 2026-07-12
+Surface: `/field`
+
+## Purpose
+
+FIELD is the participant and organization surface of System Friction Institute. It is not a chat box and does not return an untraceable opinion. It opens a controlled observation cycle:
+
+1. establish the state at T0;
+2. generate a MOP-H structural reading;
+3. seal a provisional hypothesis;
+4. define one minimal, reversible intervention;
+5. create a return window and SHA-256 seal;
+6. wait for the participant to execute the intervention;
+7. accept return evidence;
+8. compare expected and observed movement;
+9. record a partial MIHM evidence reading;
+10. explain acceptance, limits and the next controlled step.
+
+## Existing persistence contracts used
+
+FIELD uses the tables already established by the system ownership foundation:
+
+- `field_cases`
+- `field_case_evidence`
+- `field_moph_runs`
+- `field_mihm_readings`
+- `field_hypotheses`
+- `field_interventions`
+- `field_returns`
+- `field_outcomes`
+- `field_lessons`
+- `sfi_audit_events`
+
+It also attempts to register each cycle in:
+
+- `sfi_reference_cases`
+- `sfi_case_evidence_links`
+
+A Reference Bank failure does not erase a valid participant cycle. It is reported as degraded and can be reconciled later.
+
+## T0 intake
+
+Required:
+
+- case title;
+- domain;
+- description of the stuck system;
+- observable objective;
+- baseline evidence;
+- consent to private persistence.
+
+Recommended:
+
+- previous attempts;
+- consequence if unchanged;
+- declared attractor or desired stable state;
+- source reference or private file;
+- reliability declaration.
+
+The initial evidence is persisted as declared evidence unless a traceable source is provided. A private file is stored in the existing `field-evidence` bucket under the authenticated user ID.
+
+## World context
+
+At T0 and at return, FIELD reads the latest available:
+
+- `worldspect_snapshots`;
+- `world_vector_observations`.
+
+World context supplies an observed environment, not a causal explanation. FIELD records:
+
+- source status;
+- observation timestamp;
+- confidence;
+- regime;
+- dominant signal and domain values where available;
+- degraded-source warnings.
+
+A change in WorldSpect or World Vector between T0 and return becomes context for interpretation. It does not automatically explain the outcome.
+
+## MOP-H
+
+The existing governed MOP-H agent receives:
+
+- stuck system;
+- objective;
+- attempts;
+- evidence;
+- consequence;
+- authenticated account ID.
+
+Its output is persisted in `field_moph_runs`. The reading may use AMV and graph evidence already present, but it remains provisional and does not execute an intervention automatically.
+
+## MIHM evidence evaluator
+
+FIELD does not falsely claim that participant text is equivalent to a calibrated, multimodal MIHM instrument.
+
+It therefore produces a transparent partial reading under:
+
+`FIELD_MIHM_EVIDENCE_PROXY_V1`
+
+At intake it may derive limited proxies for:
+
+- `C_s`: structural coherence proxy;
+- `G_f`: field-context confidence proxy;
+- `Phi`: evidence coherence-flow proxy.
+
+Variables requiring return evidence, multimodal features or repeated observations remain `MISSING`, including where appropriate:
+
+- `D_i`;
+- `E_r`;
+- `D_cog`;
+- `F_s`;
+- `V_i`;
+- `I_mc`.
+
+At return, the system may calculate transparent proxies from:
+
+- sealed expected normalized movement;
+- observed normalized movement;
+- source reliability;
+- intervention fidelity;
+- baseline coherence;
+- world context at return.
+
+Each metric retains:
+
+- value or `MISSING`;
+- status;
+- source;
+- confidence;
+- explanation;
+- formula version;
+- `canonicalCalibration: false`.
+
+No psychological state is inferred.
+
+## Hypothesis and intervention seal
+
+FIELD persists:
+
+- the provisional hypothesis;
+- target;
+- expected signal;
+- confidence;
+- verification window;
+- minimal intervention;
+- prohibited effects;
+- evidence references.
+
+It then creates a SHA-256 hash over the operational seal payload:
+
+- case ID;
+- owner ID;
+- T0 timestamp;
+- return due date;
+- verification window;
+- hypothesis ID;
+- intervention ID;
+- provisional expected value;
+- baseline evidence ID;
+- world observation timestamp.
+
+This hash establishes what was expected before the return evidence existed. It is not a cryptographic signature of identity and does not prove that the intervention was executed.
+
+## Verification windows
+
+Supported:
+
+- `72h`;
+- `7d`;
+- `30d`.
+
+The default and primary FIELD cycle is 72 hours. Longer windows exist for systems whose observable conversion cannot reasonably occur within 72 hours.
+
+## Return evidence
+
+The participant submits:
+
+- observed evidence note;
+- source;
+- optional private file;
+- source reliability;
+- normalized observed movement from 0 to 1;
+- intervention fidelity from 0 to 1;
+- optional observation timestamp.
+
+FIELD preserves the return even when it does not reach the acceptance threshold.
+
+Operational acceptance currently requires:
+
+- reliability at or above 0.55;
+- a minimally documented evidence note.
+
+A return is marked verified only when:
+
+- a traceable uploaded/source artifact exists;
+- reliability is at or above 0.75;
+- intervention fidelity is at or above 0.60.
+
+These thresholds govern workflow state. They do not establish universal scientific validity.
+
+## Comparison and outcome
+
+The system records:
+
+- sealed expected normalized movement;
+- observed normalized movement;
+- delta;
+- evidence acceptance;
+- verification state;
+- intervention fidelity;
+- return-time world context;
+- partial MIHM return reading;
+- learned statement;
+- next controlled step.
+
+Possible next steps include:
+
+- add better evidence when the current return is too thin;
+- open a second controlled cycle when deviation is large;
+- retain, revert or test the intervention elsewhere when the cycle closes coherently.
+
+## Reference Bank linkage
+
+A FIELD case is registered as a prospective case when possible. Its evidence relations include:
+
+- baseline evidence → `SUPPORTS`;
+- hypothesis → `CONTEXTUALIZES`;
+- intervention → `DOCUMENTS_INTERVENTION`;
+- return evidence → `VERIFIES_OUTCOME`.
+
+Closing a cycle updates its phase state but does not automatically calibrate an AMV model. Historical calibration still requires the governed corpus and model-specific promotion rules.
+
+## Privacy
+
+- Authentication is required for persistence and return.
+- Cases are private by default.
+- Files use the private `field-evidence` bucket.
+- The public homepage and Observatory never receive participant free text.
+- Analytics receive categorical workflow events only.
+- Evidence, objective, title, case ID, user ID and audit payload are not sent to Google Analytics.
+- Public publication requires a separate governance action.
+
+## Failure behavior
+
+- If WorldSpect or World Vector is unavailable, the cycle can continue with explicit degraded context.
+- If Reference Bank linkage fails, the FIELD cycle remains intact and reports a warning.
+- If required FIELD tables or the storage bucket are unavailable, the API returns a source-specific error and does not fabricate persistence.
+- Missing data remains missing.
+
+## Acceptance checklist
+
+1. User can see current public World State before opening a cycle.
+2. Unauthenticated visitors understand the four-step sequence and are directed to login.
+3. Authenticated users can create a private case.
+4. T0 evidence, MOP-H output, hypothesis, intervention and return window persist.
+5. A stable SHA-256 return seal is shown.
+6. Unsupported MIHM variables display `MISSING`.
+7. The user can upload private baseline and return evidence.
+8. The user can return after the selected window.
+9. Expected and observed values are contrasted.
+10. Evidence acceptance and verification are explained separately.
+11. World context at T0 and return remains traceable.
+12. The case closes with an outcome, lesson and next step.
+13. No private text is sent to GA4.
+14. No public prediction is represented as historically calibrated.

--- a/src/app/api/field/cases/[id]/return/route.ts
+++ b/src/app/api/field/cases/[id]/return/route.ts
@@ -16,9 +16,11 @@ function text(value: unknown, maximum = 6000) {
   return typeof value === 'string' ? value.trim().slice(0, maximum) : '';
 }
 
-function number01(value: unknown, fallback = 0.5) {
-  const parsed = typeof value === 'number' ? value : Number(value);
-  return Number.isFinite(parsed) ? Math.max(0, Math.min(1, parsed)) : fallback;
+function requiredNumber01(value: unknown, field: string) {
+  if (value === null || typeof value === 'undefined' || value === '') throw new Error(`${field}_REQUIRED`);
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' && value.trim() ? Number(value) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) throw new Error(`${field}_INVALID`);
+  return parsed;
 }
 
 export async function POST(request: Request, context: RouteContext) {
@@ -31,9 +33,9 @@ export async function POST(request: Request, context: RouteContext) {
       evidenceNote: text(body.evidenceNote),
       evidenceSource: text(body.evidenceSource, 180) || 'participant_return',
       evidenceUri: text(body.evidenceUri, 1000) || null,
-      reliability: number01(body.reliability, 0.5),
-      actualOutcome: number01(body.actualOutcome, 0),
-      interventionFidelity: number01(body.interventionFidelity, 0.5),
+      reliability: requiredNumber01(body.reliability, 'FIELD_RETURN_RELIABILITY'),
+      actualOutcome: requiredNumber01(body.actualOutcome, 'FIELD_RETURN_ACTUAL_OUTCOME'),
+      interventionFidelity: requiredNumber01(body.interventionFidelity, 'FIELD_RETURN_INTERVENTION_FIDELITY'),
       observedAt: text(body.observedAt, 80) || null,
     });
     return NextResponse.json({ ok: true, result }, { status: 201 });
@@ -42,7 +44,11 @@ export async function POST(request: Request, context: RouteContext) {
       return NextResponse.json({ ok: false, error: error.code, details: error.message }, { status: error.status });
     }
     const details = error instanceof Error ? error.message : String(error);
-    const status = details.includes('_REQUIRED') ? 400 : details.includes('NOT_FOUND') ? 404 : 500;
+    const status = details.includes('_REQUIRED') || details.includes('_INVALID') || details.includes('_NOT_OPEN') || details.includes('_NOT_READY')
+      ? 400
+      : details.includes('NOT_FOUND')
+        ? 404
+        : 500;
     return NextResponse.json({ ok: false, error: 'FIELD_RETURN_FAILED', details }, { status });
   }
 }

--- a/src/app/api/field/cases/[id]/return/route.ts
+++ b/src/app/api/field/cases/[id]/return/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { submitFieldReturn } from '@/lib/field/operationalCycle';
+import { AccessDeniedError, requireAuthenticatedUser } from '@/lib/system/access/server';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+type RouteContext = { params: Promise<{ id: string }> | { id: string } };
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function text(value: unknown, maximum = 6000) {
+  return typeof value === 'string' ? value.trim().slice(0, maximum) : '';
+}
+
+function number01(value: unknown, fallback = 0.5) {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, Math.min(1, parsed)) : fallback;
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const { id } = await Promise.resolve(context.params);
+    const caseId = decodeURIComponent(id);
+    const body = record(await request.json().catch(() => null));
+    const result = await submitFieldReturn(user.id, caseId, {
+      evidenceNote: text(body.evidenceNote),
+      evidenceSource: text(body.evidenceSource, 180) || 'participant_return',
+      evidenceUri: text(body.evidenceUri, 1000) || null,
+      reliability: number01(body.reliability, 0.5),
+      actualOutcome: number01(body.actualOutcome, 0),
+      interventionFidelity: number01(body.interventionFidelity, 0.5),
+      observedAt: text(body.observedAt, 80) || null,
+    });
+    return NextResponse.json({ ok: true, result }, { status: 201 });
+  } catch (error) {
+    if (error instanceof AccessDeniedError) {
+      return NextResponse.json({ ok: false, error: error.code, details: error.message }, { status: error.status });
+    }
+    const details = error instanceof Error ? error.message : String(error);
+    const status = details.includes('_REQUIRED') ? 400 : details.includes('NOT_FOUND') ? 404 : 500;
+    return NextResponse.json({ ok: false, error: 'FIELD_RETURN_FAILED', details }, { status });
+  }
+}

--- a/src/app/api/field/cases/route.ts
+++ b/src/app/api/field/cases/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+import { createFieldCycle, listFieldCycles, type FieldVerificationWindow } from '@/lib/field/operationalCycle';
+import { AccessDeniedError, requireAuthenticatedUser } from '@/lib/system/access/server';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function text(value: unknown, maximum = 6000) {
+  return typeof value === 'string' ? value.trim().slice(0, maximum) : '';
+}
+
+function number01(value: unknown, fallback = 0.5) {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, Math.min(1, parsed)) : fallback;
+}
+
+function windowValue(value: unknown): FieldVerificationWindow {
+  return value === '7d' || value === '30d' ? value : '72h';
+}
+
+function failure(error: unknown) {
+  if (error instanceof AccessDeniedError) {
+    return NextResponse.json({ ok: false, error: error.code, details: error.message }, { status: error.status });
+  }
+  const details = error instanceof Error ? error.message : String(error);
+  const status = details.includes('_REQUIRED') ? 400 : details.includes('NOT_FOUND') ? 404 : 500;
+  return NextResponse.json({ ok: false, error: 'FIELD_CYCLE_FAILED', details }, { status });
+}
+
+export async function GET() {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const result = await listFieldCycles(user.id);
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    return failure(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const body = record(await request.json().catch(() => null));
+    const result = await createFieldCycle(user.id, {
+      title: text(body.title, 180),
+      domain: text(body.domain, 80) || 'other',
+      stuckSystem: text(body.stuckSystem),
+      objective: text(body.objective),
+      attempts: text(body.attempts),
+      evidence: text(body.evidence),
+      consequence: text(body.consequence),
+      declaredAttractor: text(body.declaredAttractor),
+      evidenceSource: text(body.evidenceSource, 180) || 'participant_declared',
+      evidenceUri: text(body.evidenceUri, 1000) || null,
+      reliability: number01(body.reliability, 0.45),
+      verificationWindow: windowValue(body.verificationWindow),
+      consent: body.consent === true,
+    });
+    return NextResponse.json({ ok: true, result }, { status: 201 });
+  } catch (error) {
+    return failure(error);
+  }
+}

--- a/src/app/api/field/cases/route.ts
+++ b/src/app/api/field/cases/route.ts
@@ -6,8 +6,10 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 export const maxDuration = 60;
 
-function record(value: unknown): Record<string, unknown> {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+type Row = Record<string, unknown>;
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
 }
 
 function text(value: unknown, maximum = 6000) {
@@ -28,15 +30,37 @@ function failure(error: unknown) {
     return NextResponse.json({ ok: false, error: error.code, details: error.message }, { status: error.status });
   }
   const details = error instanceof Error ? error.message : String(error);
-  const status = details.includes('_REQUIRED') ? 400 : details.includes('NOT_FOUND') ? 404 : 500;
+  const status = details.includes('_REQUIRED') || details.includes('_INVALID') || details.includes('_NOT_OPEN') || details.includes('_NOT_READY')
+    ? 400
+    : details.includes('NOT_FOUND')
+      ? 404
+      : 500;
   return NextResponse.json({ ok: false, error: 'FIELD_CYCLE_FAILED', details }, { status });
+}
+
+function withReturnAvailability(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  const now = Date.now();
+  return value.map((item) => {
+    const row = record(item);
+    const metadata = record(row.metadata);
+    const expectedAt = typeof metadata.expectedAt === 'string' ? new Date(metadata.expectedAt).getTime() : Number.NaN;
+    const persistedStatus = text(row.status, 80) || 'UNKNOWN';
+    const returnAvailable = persistedStatus === 'WAITING_RETURN' && Number.isFinite(expectedAt) && now >= expectedAt;
+    return {
+      ...row,
+      persisted_status: persistedStatus,
+      status: persistedStatus === 'WAITING_RETURN' && !returnAvailable ? 'SEALED_WINDOW_ACTIVE' : persistedStatus,
+      return_available: returnAvailable,
+    };
+  });
 }
 
 export async function GET() {
   try {
     const { user } = await requireAuthenticatedUser();
     const result = await listFieldCycles(user.id);
-    return NextResponse.json({ ok: true, ...result });
+    return NextResponse.json({ ok: true, ...result, cases: withReturnAvailability(result.cases) });
   } catch (error) {
     return failure(error);
   }

--- a/src/app/api/field/evidence/upload/route.ts
+++ b/src/app/api/field/evidence/upload/route.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from 'node:crypto';
+import { NextResponse } from 'next/server';
+import { AccessDeniedError, requireAuthenticatedUser } from '@/lib/system/access/server';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+const MAX_BYTES = 25 * 1024 * 1024;
+const ALLOWED_PREFIXES = ['image/', 'audio/', 'video/', 'text/'];
+const ALLOWED_TYPES = new Set(['application/pdf', 'application/json', 'application/zip', 'application/vnd.ms-excel', 'text/csv']);
+
+function safeFilename(value: string) {
+  const cleaned = value
+    .normalize('NFKD')
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return cleaned.slice(-160) || 'evidence.bin';
+}
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const form = await request.formData();
+    const value = form.get('file');
+    if (!(value instanceof File)) {
+      return NextResponse.json({ ok: false, error: 'FIELD_FILE_REQUIRED' }, { status: 400 });
+    }
+    if (value.size <= 0 || value.size > MAX_BYTES) {
+      return NextResponse.json({ ok: false, error: 'FIELD_FILE_SIZE_INVALID', maxBytes: MAX_BYTES }, { status: 400 });
+    }
+    const contentType = value.type || 'application/octet-stream';
+    const allowed = ALLOWED_TYPES.has(contentType) || ALLOWED_PREFIXES.some((prefix) => contentType.startsWith(prefix));
+    if (!allowed) {
+      return NextResponse.json({ ok: false, error: 'FIELD_FILE_TYPE_NOT_ALLOWED', contentType }, { status: 415 });
+    }
+
+    const filename = safeFilename(value.name);
+    const storagePath = `${user.id}/field/${randomUUID()}/${filename}`;
+    const service = createServiceSupabaseClient();
+    const bytes = Buffer.from(await value.arrayBuffer());
+    const upload = await service.storage.from('field-evidence').upload(storagePath, bytes, {
+      contentType,
+      cacheControl: '3600',
+      upsert: false,
+    });
+    if (upload.error) {
+      return NextResponse.json({ ok: false, error: 'FIELD_FILE_UPLOAD_FAILED', details: upload.error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      file: {
+        filename,
+        size: value.size,
+        contentType,
+        storagePath,
+        uri: `storage://field-evidence/${storagePath}`,
+        visibility: 'private',
+      },
+    }, { status: 201 });
+  } catch (error) {
+    if (error instanceof AccessDeniedError) {
+      return NextResponse.json({ ok: false, error: error.code, details: error.message }, { status: error.status });
+    }
+    return NextResponse.json({ ok: false, error: 'FIELD_FILE_UPLOAD_FAILED', details: error instanceof Error ? error.message : String(error) }, { status: 500 });
+  }
+}

--- a/src/app/field/page.tsx
+++ b/src/app/field/page.tsx
@@ -1,101 +1,45 @@
-import Link from 'next/link';
-import { AmvPhaseStatusPanel } from '@/components/amv/AmvPhaseStatusPanel';
-import MiniMophField from '@/components/field/MiniMophField';
+import type { Metadata } from 'next';
+import { FieldOperationalConsole } from '@/components/field/FieldOperationalConsole';
+import { readPublicObservatoryState } from '@/lib/observatory/public/readPublicObservatoryState';
+import { createServerSupabaseClient } from '@/runtime/supabase/server';
 
 export const dynamic = 'force-dynamic';
 
-const stages = [
-  ['Signal intake', 'Sistema atorado'],
-  ['Agentic reading', 'MOP-H + AMV + Graph'],
-  ['Minimal perturbation', '72h reversible'],
-  ['SFI-DR01', 'Diagnostico trazable'],
-];
+export const metadata: Metadata = {
+  title: 'FIELD · MOP-H 72-hour operational cycle',
+  description: 'Declare a stuck system, seal a governed minimal intervention and return with evidence for MIHM, WorldSpect and World Vector contrast.',
+  alternates: { canonical: '/field' },
+};
 
-export default function FieldPage() {
+export default async function FieldPage() {
+  const supabase = await createServerSupabaseClient();
+  const [{ data: auth }, worldState] = await Promise.all([
+    supabase.auth.getUser(),
+    readPublicObservatoryState().catch(() => null),
+  ]);
+
+  const dominantDomains = worldState
+    ? worldState.vectors
+      .filter((item) => item.active)
+      .sort((left, right) => right.value - left.value)
+      .slice(0, 4)
+      .map((item) => ({ label: item.label, value: item.value }))
+    : [];
+
   return (
-    <main className="min-h-screen bg-[#060605] px-6 py-8 text-[#d8d2c2]">
-      <div className="mx-auto max-w-7xl space-y-6">
-        <header className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-            <div>
-              <p className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#c8a951]">SFI Field</p>
-              <h1 className="mt-3 max-w-4xl text-4xl font-semibold leading-tight text-[#f5eedc]">
-                Mini MOP-H para convertir friccion declarada en una perturbacion minima.
-              </h1>
-              <p className="mt-3 max-w-3xl text-sm leading-6 text-[#9f9788]">
-                FIELD es una superficie autenticada. Los casos, evidencias y retornos pertenecen al usuario y permanecen privados por defecto.
-              </p>
-            </div>
-            <nav className="flex flex-wrap gap-2 font-mono text-[10px] uppercase tracking-[0.14em]">
-              <Link href="/" className="border border-[#2f2a1e] px-3 py-2 text-[#d8d2c2]">SFI</Link>
-              <Link href="/world-vector" className="border border-[#2f2a1e] px-3 py-2 text-[#d8d2c2]">World Vector</Link>
-              <Link href="/repository" className="border border-[#2f2a1e] px-3 py-2 text-[#d8d2c2]">Repository</Link>
-            </nav>
-          </div>
-        </header>
-
-        <AmvPhaseStatusPanel endpoint="/api/observatory/instrument-status" compact title="FIELD · INSTRUMENT MATURITY" />
-
-        <section className="grid gap-3 md:grid-cols-4">
-          {stages.map(([label, value]) => (
-            <div key={label} className="border border-[#2f2a1e] bg-[#0b0b09] p-4">
-              <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-[#8f8878]">{label}</div>
-              <div className="mt-2 text-sm text-[#f5eedc]">{value}</div>
-            </div>
-          ))}
-        </section>
-
-        <MiniMophField />
-
-        <section className="grid gap-4 md:grid-cols-2">
-          <article className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
-            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Participant</div>
-            <h2 className="mt-2 text-2xl font-semibold text-[#f5eedc]">72-hour low-friction observation</h2>
-            <p className="mt-4 text-sm leading-6 text-[#9f9788]">
-              Participant Field aligns with WB-002: repeated signals, marks and reflections. Observation starts as PENDING and does not return technical phenotype interpretation by default.
-            </p>
-            <div className="mt-5 flex flex-wrap gap-3">
-              <Link href="/field/participant" className="border border-[#c8a95166] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951]">
-                Participant Field
-              </Link>
-              <Link href="/library/SFI-WB-002_Participant_Workbook.html" className="border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
-                WB-002
-              </Link>
-            </div>
-          </article>
-
-          <article className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
-            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Operator</div>
-            <h2 className="mt-2 text-2xl font-semibold text-[#f5eedc]">Evidence capture before hypothesis memory</h2>
-            <p className="mt-4 text-sm leading-6 text-[#9f9788]">
-              Operator Field aligns with WB-001: literal phrases, silences, contradictions, timestamps, source, operator note, explicit prediction and perturbation proposal.
-            </p>
-            <div className="mt-5 flex flex-wrap gap-3">
-              <Link href="/operator/field" className="border border-[#c8a95166] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951]">
-                Operator Field
-              </Link>
-              <Link href="/library/SFI-WB-001_Operator_Workbook.html" className="border border-[#2f2a1e] px-4 py-2 font-mono text-[10px] uppercase tracking-[0.16em] text-[#d8d2c2]">
-                WB-001
-              </Link>
-            </div>
-          </article>
-        </section>
-
-        <section className="grid gap-4 md:grid-cols-3">
-          <article className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
-            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">SFI-DR01</div>
-            <p className="mt-3 text-sm leading-6 text-[#9f9788]">Mapa de friccion, evidencia, Neural Graph, AMV scan, hipotesis, prediccion, perturbacion minima y reporte ejecutivo.</p>
-          </article>
-          <article className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
-            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">User Twin</div>
-            <p className="mt-3 text-sm leading-6 text-[#9f9788]">El historial conecta lecturas, perturbaciones y retornos únicamente dentro de la cuenta propietaria.</p>
-          </article>
-          <article className="border border-[#2f2a1e] bg-[#0b0b09] p-5">
-            <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c8a951]">Operational position</div>
-            <p className="mt-3 text-sm leading-6 text-[#9f9788]">Library formalizes the method. World Vector contextualizes the world. FIELD captures evidence. ROOT governs without exposing administrative actions to FIELD users.</p>
-          </article>
-        </section>
-      </div>
-    </main>
+    <FieldOperationalConsole
+      authenticated={Boolean(auth.user)}
+      world={{
+        observedAt: worldState?.publicContract.observedAt ?? null,
+        regime: worldState?.wsv.regime ?? 'MISSING',
+        wsv: worldState?.wsv.globalIndex ?? null,
+        tension: worldState?.wsv.tension ?? null,
+        confidence: worldState?.dailyReading.confidence ?? null,
+        dominantDomains,
+        warning: worldState && worldState.publicContract.sourceState !== 'observed'
+          ? `SOURCE ${worldState.publicContract.sourceState.toUpperCase()}`
+          : null,
+      }}
+    />
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,22 @@
-import { SfiWorldInterfaceHero as MapHome } from '@/components/sfi/SfiWorldInterfaceHero';
+import type { Metadata } from 'next';
+import { SfiHomeExperience } from '@/components/sfi/SfiHomeExperience';
 import { buildSfiWorldInterfaceState as buildHome } from '@/lib/sfi/worldInterfaceState';
 import { resolvePublicRuntimeState } from '@/lib/sfi/publicRuntimeSnapshot';
 
 export const revalidate = 300;
+
+export const metadata: Metadata = {
+  title: 'System Friction Institute · Choose an operational entry',
+  description: 'Enter through Observatory, FIELD, Studio, ScoreFriction or the Repository according to the signal, system or evidence you need to observe.',
+  alternates: { canonical: '/' },
+};
 
 export default async function HomePage() {
   const home = await resolvePublicRuntimeState('home', buildHome);
 
   return (
     <main className="min-h-screen bg-[#030302] text-[#e7dcc1]">
-      <MapHome state={home} />
+      <SfiHomeExperience state={home} />
     </main>
   );
 }

--- a/src/components/field/FieldOperationalConsole.tsx
+++ b/src/components/field/FieldOperationalConsole.tsx
@@ -1,0 +1,507 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Activity,
+  ArrowRight,
+  CheckCircle2,
+  Clock3,
+  FileUp,
+  Fingerprint,
+  Gauge,
+  Loader2,
+  Orbit,
+  RefreshCw,
+  ShieldCheck,
+} from 'lucide-react';
+import { trackEvent } from '@/lib/analytics/client';
+
+type WorldSummary = {
+  observedAt: string | null;
+  regime: string;
+  wsv: number | null;
+  tension: number | null;
+  confidence: number | null;
+  dominantDomains: Array<{ label: string; value: number }>;
+  warning: string | null;
+};
+
+type Row = Record<string, unknown>;
+
+type FieldCase = Row & {
+  id: string;
+  title: string;
+  domain: string;
+  status: string;
+  verification_window: string;
+  created_at: string;
+  metadata: Row;
+  hypothesis: Row | null;
+  intervention: Row | null;
+  return: Row | null;
+  outcome: Row | null;
+  latestMihm: Row | null;
+  evidence: Row[];
+};
+
+type CycleListResponse = {
+  ok: boolean;
+  cases?: FieldCase[];
+  summary?: { total: number; waitingReturn: number; closed: number; verified: number };
+  warnings?: string[];
+  error?: string;
+  details?: string;
+};
+
+type CreateResult = {
+  case: FieldCase;
+  seal: string;
+  expectedAt: string;
+  expectedValue: number;
+  hypothesis: Row;
+  intervention: Row;
+  mihm: Row;
+  world: Row;
+  warnings: string[];
+};
+
+type ReturnResult = {
+  caseId: string;
+  expectedValue: number;
+  actualValue: number;
+  delta: number;
+  accepted: boolean;
+  verified: boolean;
+  explanation: string;
+  nextStep: string;
+  mihm: Row;
+};
+
+type CreateForm = {
+  title: string;
+  domain: string;
+  stuckSystem: string;
+  objective: string;
+  attempts: string;
+  evidence: string;
+  consequence: string;
+  declaredAttractor: string;
+  evidenceSource: string;
+  evidenceUri: string;
+  reliability: number;
+  verificationWindow: '72h' | '7d' | '30d';
+  consent: boolean;
+};
+
+type ReturnForm = {
+  evidenceNote: string;
+  evidenceSource: string;
+  evidenceUri: string;
+  reliability: number;
+  actualOutcome: number;
+  interventionFidelity: number;
+};
+
+const INITIAL_CREATE: CreateForm = {
+  title: '',
+  domain: 'personal_system',
+  stuckSystem: '',
+  objective: '',
+  attempts: '',
+  evidence: '',
+  consequence: '',
+  declaredAttractor: '',
+  evidenceSource: 'participant_declared',
+  evidenceUri: '',
+  reliability: 0.45,
+  verificationWindow: '72h',
+  consent: false,
+};
+
+const INITIAL_RETURN: ReturnForm = {
+  evidenceNote: '',
+  evidenceSource: 'participant_return',
+  evidenceUri: '',
+  reliability: 0.55,
+  actualOutcome: 0.5,
+  interventionFidelity: 0.7,
+};
+
+function numeric(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function text(value: unknown, fallback = '—') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function dateLabel(value: unknown) {
+  if (typeof value !== 'string') return 'SIN FECHA';
+  const date = new Date(value);
+  return Number.isFinite(date.getTime())
+    ? new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(date)
+    : value;
+}
+
+function percent(value: number | null) {
+  return value === null ? 'NO MEDIDO' : `${Math.round(value * 100)}%`;
+}
+
+function Metric({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="border border-[#3a321f] bg-[#090806cc] p-4 backdrop-blur-sm">
+      <div className="font-mono text-[9px] uppercase tracking-[0.18em] text-[#8e846d]">{label}</div>
+      <strong className="mt-2 block text-xl font-medium text-[#f4e8c9]">{value}</strong>
+      <p className="mt-2 text-xs leading-5 text-[#928976]">{detail}</p>
+    </div>
+  );
+}
+
+function TextArea({ label, value, onChange, placeholder, rows = 3 }: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  rows?: number;
+}) {
+  return (
+    <label className="grid gap-2">
+      <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[#a49572]">{label}</span>
+      <textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        rows={rows}
+        className="resize-y border border-[#312b1d] bg-[#050504] px-4 py-3 text-sm leading-6 text-[#eee4cb] outline-none placeholder:text-[#5d574a] focus:border-[#c9aa54]"
+      />
+    </label>
+  );
+}
+
+function RangeField({ label, value, onChange, low, high }: {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  low: string;
+  high: string;
+}) {
+  return (
+    <label className="grid gap-2">
+      <span className="flex items-center justify-between font-mono text-[9px] uppercase tracking-[0.16em] text-[#a49572]">
+        {label}<b className="text-[#e5ca81]">{Math.round(value * 100)}%</b>
+      </span>
+      <input type="range" min="0" max="1" step="0.05" value={value} onChange={(event) => onChange(Number(event.target.value))} />
+      <span className="flex justify-between text-[10px] text-[#655f52]"><i>{low}</i><i>{high}</i></span>
+    </label>
+  );
+}
+
+function MihmReadout({ reading }: { reading: Row | null }) {
+  const metrics = Array.isArray(reading?.metrics) ? reading.metrics.filter((item): item is Row => Boolean(item) && typeof item === 'object') : [];
+  return (
+    <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+      {metrics.length ? metrics.map((metric) => {
+        const value = numeric(metric.value);
+        return (
+          <div key={text(metric.key)} className="border border-[#2e281c] bg-[#070705] p-3">
+            <div className="flex items-center justify-between gap-3 font-mono text-[9px] uppercase tracking-[0.14em] text-[#8f856d]">
+              <span>{text(metric.key)}</span><span>{text(metric.status)}</span>
+            </div>
+            <strong className="mt-2 block text-lg text-[#f0dfb4]">{value === null ? 'MISSING' : value.toFixed(3)}</strong>
+            <p className="mt-2 text-[11px] leading-5 text-[#817968]">{text(metric.explanation, 'Sin explicación disponible.')}</p>
+          </div>
+        );
+      }) : <div className="border border-[#2e281c] bg-[#070705] p-4 text-sm text-[#817968]">Sin lectura MIHM persistida.</div>}
+    </div>
+  );
+}
+
+export function FieldOperationalConsole({ authenticated, world }: { authenticated: boolean; world: WorldSummary }) {
+  const [mode, setMode] = useState<'new' | 'cases'>('new');
+  const [form, setForm] = useState<CreateForm>(INITIAL_CREATE);
+  const [returnForm, setReturnForm] = useState<ReturnForm>(INITIAL_RETURN);
+  const [cases, setCases] = useState<FieldCase[]>([]);
+  const [summary, setSummary] = useState({ total: 0, waitingReturn: 0, closed: 0, verified: 0 });
+  const [selected, setSelected] = useState<FieldCase | null>(null);
+  const [createResult, setCreateResult] = useState<CreateResult | null>(null);
+  const [returnResult, setReturnResult] = useState<ReturnResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [uploading, setUploading] = useState<'baseline' | 'return' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [warnings, setWarnings] = useState<string[]>([]);
+
+  const loadCases = useCallback(async () => {
+    if (!authenticated) return;
+    setLoading(true);
+    try {
+      const response = await fetch('/api/field/cases', { cache: 'no-store', credentials: 'include' });
+      const body = await response.json().catch(() => null) as CycleListResponse | null;
+      if (!response.ok || !body?.ok) throw new Error(body?.details ?? body?.error ?? `HTTP ${response.status}`);
+      setCases(body.cases ?? []);
+      setSummary(body.summary ?? { total: 0, waitingReturn: 0, closed: 0, verified: 0 });
+      setWarnings(body.warnings ?? []);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'field_cases_failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [authenticated]);
+
+  useEffect(() => { void loadCases(); }, [loadCases]);
+
+  const dueCases = useMemo(() => cases.filter((item) => String(item.status).includes('WAITING')), [cases]);
+
+  async function uploadFile(file: File, target: 'baseline' | 'return') {
+    setUploading(target);
+    setError(null);
+    trackEvent('evidence_intake_start', { evidence_stage: target, surface: 'field' });
+    try {
+      const data = new FormData();
+      data.set('file', file);
+      const response = await fetch('/api/field/evidence/upload', { method: 'POST', credentials: 'include', body: data });
+      const body = await response.json().catch(() => null) as { ok?: boolean; file?: { uri?: string; filename?: string }; error?: string; details?: string } | null;
+      if (!response.ok || !body?.ok || !body.file?.uri) throw new Error(body?.details ?? body?.error ?? `HTTP ${response.status}`);
+      if (target === 'baseline') setForm((current) => ({ ...current, evidenceUri: body.file?.uri ?? '', evidenceSource: `private_upload:${body.file?.filename ?? 'file'}` }));
+      else setReturnForm((current) => ({ ...current, evidenceUri: body.file?.uri ?? '', evidenceSource: `private_upload:${body.file?.filename ?? 'file'}` }));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'field_upload_failed');
+    } finally {
+      setUploading(null);
+    }
+  }
+
+  async function createCycle() {
+    setLoading(true);
+    setError(null);
+    setReturnResult(null);
+    trackEvent('field_flow_start', { domain: form.domain, verification_window: form.verificationWindow });
+    try {
+      const response = await fetch('/api/field/cases', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      const body = await response.json().catch(() => null) as { ok?: boolean; result?: CreateResult; error?: string; details?: string } | null;
+      if (!response.ok || !body?.ok || !body.result) throw new Error(body?.details ?? body?.error ?? `HTTP ${response.status}`);
+      setCreateResult(body.result);
+      setWarnings(body.result.warnings ?? []);
+      trackEvent('field_step_complete', { field_step: 'cycle_sealed', verification_window: form.verificationWindow, domain: form.domain });
+      await loadCases();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'field_cycle_failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function submitReturn() {
+    if (!selected) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/field/cases/${encodeURIComponent(selected.id)}/return`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(returnForm),
+      });
+      const body = await response.json().catch(() => null) as { ok?: boolean; result?: ReturnResult; error?: string; details?: string } | null;
+      if (!response.ok || !body?.ok || !body.result) throw new Error(body?.details ?? body?.error ?? `HTTP ${response.status}`);
+      setReturnResult(body.result);
+      trackEvent('field_step_complete', { field_step: 'return_recorded', accepted: body.result.accepted, verified: body.result.verified });
+      await loadCases();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'field_return_failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function openReturn(item: FieldCase) {
+    setSelected(item);
+    setReturnResult(null);
+    setReturnForm(INITIAL_RETURN);
+    trackEvent('field_return_open', { case_status: item.status, verification_window: item.verification_window });
+  }
+
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-[#030302] text-[#e9dfc8]">
+      <div className="pointer-events-none absolute inset-0 opacity-70" aria-hidden="true">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_12%,rgba(201,170,84,0.16),transparent_30%),radial-gradient(circle_at_12%_64%,rgba(109,59,39,0.2),transparent_32%),linear-gradient(rgba(201,170,84,0.035)_1px,transparent_1px),linear-gradient(90deg,rgba(201,170,84,0.035)_1px,transparent_1px)] bg-[size:auto,auto,48px_48px,48px_48px]" />
+        <div className="absolute left-[12%] top-[24%] h-72 w-72 animate-pulse rounded-full border border-[#c9aa5422]" />
+        <div className="absolute right-[10%] top-[18%] h-48 w-48 animate-pulse rounded-full border border-[#c9aa5420] [animation-delay:1.4s]" />
+      </div>
+
+      <div className="relative mx-auto max-w-[1500px] px-5 py-6 lg:px-8">
+        <header className="border border-[#352f21] bg-[#070705d9] px-5 py-5 backdrop-blur-xl">
+          <div className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
+            <div className="max-w-4xl">
+              <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.24em] text-[#c9aa54]"><Orbit className="h-4 w-4" /> SFI FIELD · MOP-H 72H</div>
+              <h1 className="mt-4 text-4xl font-semibold leading-[1.03] text-[#fff4d8] md:text-6xl">No te entrega una opinión. Cierra una hipótesis y espera evidencia.</h1>
+              <p className="mt-5 max-w-3xl text-sm leading-7 text-[#9c9380] md:text-base">Declara el sistema, observa el estado del mundo, ejecuta una sola perturbación reversible y regresa con evidencia. FIELD conserva T0, hash, hipótesis, intervención, retorno, MIHM provisional y diferencia entre lo esperado y lo observado.</p>
+            </div>
+            <div className="flex flex-wrap gap-2 font-mono text-[10px] uppercase tracking-[0.12em]">
+              <Link href="/observatory" className="border border-[#3a321f] px-4 py-3 text-[#d9c58e]">World State</Link>
+              <Link href="/repository" className="border border-[#3a321f] px-4 py-3 text-[#d9c58e]">Method</Link>
+              <Link href="/privacy" className="border border-[#3a321f] px-4 py-3 text-[#d9c58e]">Privacy</Link>
+            </div>
+          </div>
+        </header>
+
+        <section className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+          <Metric label="World regime" value={world.regime} detail={world.observedAt ? `Observed ${dateLabel(world.observedAt)}` : 'No current observation'} />
+          <Metric label="World persistence" value={world.wsv === null ? 'MISSING' : world.wsv.toFixed(3)} detail="Context, not wellbeing or crisis probability." />
+          <Metric label="World tension" value={world.tension === null ? 'MISSING' : world.tension.toFixed(3)} detail="Used as contextual field state, not causal proof." />
+          <Metric label="Source confidence" value={percent(world.confidence)} detail={world.warning ?? 'Current public source state.'} />
+          <Metric label="Your corpus" value={authenticated ? `${summary.closed}/${summary.total}` : 'LOGIN'} detail={authenticated ? `${summary.waitingReturn} awaiting return · ${summary.verified} verified` : 'Persistence begins after authentication.'} />
+        </section>
+
+        {world.dominantDomains.length ? (
+          <div className="mt-3 flex flex-wrap gap-2 border border-[#2d281c] bg-[#060604b8] p-3 font-mono text-[9px] uppercase tracking-[0.14em] text-[#8f856d]">
+            <span className="text-[#c9aa54]">Dominant observed context</span>
+            {world.dominantDomains.map((item) => <span key={item.label} className="border-l border-[#3a321f] pl-3">{item.label} {item.value.toFixed(3)}</span>)}
+          </div>
+        ) : null}
+
+        {!authenticated ? (
+          <section className="mt-6 grid gap-5 lg:grid-cols-[1.2fr_.8fr]">
+            <article className="border border-[#42371e] bg-[#080704e8] p-7 backdrop-blur-xl">
+              <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#c9aa54]">Operational sequence</span>
+              <div className="mt-6 grid gap-3 md:grid-cols-4">
+                {[
+                  ['01', 'Declare', 'System, objective, evidence and consequence.'],
+                  ['02', 'Seal', 'Hypothesis, minimal intervention, T0 and SHA-256 return hash.'],
+                  ['03', 'Execute', 'One reversible variable during the selected window.'],
+                  ['04', 'Return', 'Evidence, MIHM comparison, outcome and next controlled step.'],
+                ].map(([number, title, detail]) => <div key={number} className="border border-[#312a1c] bg-[#050504] p-4"><b className="font-mono text-xs text-[#c9aa54]">{number}</b><strong className="mt-3 block text-lg text-[#f2e4bf]">{title}</strong><p className="mt-2 text-xs leading-5 text-[#817968]">{detail}</p></div>)}
+              </div>
+            </article>
+            <article className="flex flex-col justify-between border border-[#c9aa5555] bg-[radial-gradient(circle_at_top_right,rgba(201,170,84,0.18),transparent_45%),#090806] p-7">
+              <div><ShieldCheck className="h-8 w-8 text-[#c9aa54]" /><h2 className="mt-5 text-3xl text-[#fff0c9]">Private by default.</h2><p className="mt-4 text-sm leading-7 text-[#9d927b]">Your objective, evidence and return remain inside your account. Public output requires a separate governance decision.</p></div>
+              <Link href="/login?next=%2Ffield" data-analytics-label="field_login" className="mt-8 inline-flex items-center justify-center gap-2 border border-[#c9aa54] bg-[#c9aa54] px-5 py-4 font-mono text-[11px] uppercase tracking-[0.16em] text-[#050504]">Enter FIELD <ArrowRight className="h-4 w-4" /></Link>
+            </article>
+          </section>
+        ) : (
+          <>
+            <nav className="mt-5 flex flex-wrap gap-2 border-b border-[#332d20] pb-3 font-mono text-[10px] uppercase tracking-[0.14em]">
+              <button type="button" onClick={() => setMode('new')} className={`px-4 py-3 ${mode === 'new' ? 'bg-[#c9aa54] text-[#050504]' : 'border border-[#332d20] text-[#a99d83]'}`}>New cycle</button>
+              <button type="button" onClick={() => setMode('cases')} className={`px-4 py-3 ${mode === 'cases' ? 'bg-[#c9aa54] text-[#050504]' : 'border border-[#332d20] text-[#a99d83]'}`}>Cases · {summary.total}</button>
+              <button type="button" onClick={() => void loadCases()} disabled={loading} className="ml-auto inline-flex items-center gap-2 border border-[#332d20] px-4 py-3 text-[#a99d83]"><RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} /> Refresh</button>
+            </nav>
+
+            {error ? <div className="mt-4 border border-[#733d31] bg-[#180d09] p-4 text-sm text-[#e0a18d]">{error}</div> : null}
+            {warnings.length ? <div className="mt-4 border border-[#6e5729] bg-[#151006] p-4 font-mono text-[10px] leading-5 text-[#c6a85d]">DEGRADED · {warnings.join(' | ')}</div> : null}
+
+            {mode === 'new' ? (
+              <section className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1fr)_470px]">
+                <article className="border border-[#373020] bg-[#080705e8] p-5 backdrop-blur-xl md:p-7">
+                  <div className="flex items-start justify-between gap-5"><div><span className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#c9aa54]">T0 · Intake</span><h2 className="mt-2 text-3xl text-[#f4e7c5]">Define exactly what is stuck.</h2></div><Fingerprint className="h-7 w-7 text-[#c9aa54]" /></div>
+                  <div className="mt-7 grid gap-5 md:grid-cols-2">
+                    <label className="grid gap-2"><span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[#a49572]">Case title</span><input value={form.title} onChange={(event) => setForm((current) => ({ ...current, title: event.target.value }))} className="border border-[#312b1d] bg-[#050504] px-4 py-3 text-sm text-[#eee4cb] outline-none focus:border-[#c9aa54]" placeholder="Example: publication approval bottleneck" /></label>
+                    <label className="grid gap-2"><span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[#a49572]">Domain</span><select value={form.domain} onChange={(event) => setForm((current) => ({ ...current, domain: event.target.value }))} className="border border-[#312b1d] bg-[#050504] px-4 py-3 text-sm text-[#eee4cb] outline-none focus:border-[#c9aa54]"><option value="personal_system">Personal system</option><option value="team">Team</option><option value="organization">Organization</option><option value="institution">Institution</option><option value="company">Company</option><option value="project">Project</option><option value="cultural_signal">Cultural signal</option><option value="other">Other</option></select></label>
+                  </div>
+                  <div className="mt-5 grid gap-5">
+                    <TextArea label="System currently stuck" value={form.stuckSystem} onChange={(value) => setForm((current) => ({ ...current, stuckSystem: value }))} placeholder="Describe the process, relation or decision that is not converting into movement." rows={4} />
+                    <TextArea label="Observable objective" value={form.objective} onChange={(value) => setForm((current) => ({ ...current, objective: value }))} placeholder="What must be observably different at the end of the window?" />
+                    <TextArea label="Previous attempts" value={form.attempts} onChange={(value) => setForm((current) => ({ ...current, attempts: value }))} placeholder="What has already been tried and what happened?" />
+                    <TextArea label="Baseline evidence" value={form.evidence} onChange={(value) => setForm((current) => ({ ...current, evidence: value }))} placeholder="Document what is true now. Use dates, counts, artifacts or direct observations." rows={4} />
+                    <TextArea label="Consequence if unchanged" value={form.consequence} onChange={(value) => setForm((current) => ({ ...current, consequence: value }))} placeholder="What becomes more expensive, slow, unstable or irreversible?" />
+                    <TextArea label="Declared attractor / desired stable state" value={form.declaredAttractor} onChange={(value) => setForm((current) => ({ ...current, declaredAttractor: value }))} placeholder="What stable behavior should the system move toward?" />
+                  </div>
+
+                  <div className="mt-6 grid gap-5 border-t border-[#302a1d] pt-6 md:grid-cols-2">
+                    <label className="grid gap-2"><span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[#a49572]">Evidence source</span><input value={form.evidenceSource} onChange={(event) => setForm((current) => ({ ...current, evidenceSource: event.target.value }))} className="border border-[#312b1d] bg-[#050504] px-4 py-3 text-sm text-[#eee4cb] outline-none focus:border-[#c9aa54]" /></label>
+                    <label className="grid gap-2"><span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[#a49572]">Verification window</span><select value={form.verificationWindow} onChange={(event) => setForm((current) => ({ ...current, verificationWindow: event.target.value as CreateForm['verificationWindow'] }))} className="border border-[#312b1d] bg-[#050504] px-4 py-3 text-sm text-[#eee4cb] outline-none focus:border-[#c9aa54]"><option value="72h">72 hours</option><option value="7d">7 days</option><option value="30d">30 days</option></select></label>
+                    <RangeField label="Declared source reliability" value={form.reliability} onChange={(value) => setForm((current) => ({ ...current, reliability: value }))} low="thin" high="verified" />
+                    <label className="grid gap-2"><span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[#a49572]">Private evidence file</span><span className="flex items-center gap-3"><input type="file" className="min-w-0 flex-1 text-xs text-[#817968]" onChange={(event) => { const file = event.target.files?.[0]; if (file) void uploadFile(file, 'baseline'); }} /><FileUp className="h-4 w-4 text-[#c9aa54]" /></span><em className="break-all text-[10px] text-[#655f52]">{uploading === 'baseline' ? 'UPLOADING…' : form.evidenceUri || 'No private file uploaded'}</em></label>
+                  </div>
+
+                  <label className="mt-6 flex items-start gap-3 border border-[#3a321f] bg-[#060604] p-4 text-sm leading-6 text-[#9a927f]"><input type="checkbox" checked={form.consent} onChange={(event) => setForm((current) => ({ ...current, consent: event.target.checked }))} className="mt-1" /><span>I consent to private persistence of this cycle and confirm that I have authority to submit the described system and evidence. Organization or institution observation must be authorized.</span></label>
+
+                  <button type="button" onClick={() => void createCycle()} disabled={loading || !form.consent || form.stuckSystem.trim().length < 12 || form.objective.trim().length < 8 || form.evidence.trim().length < 8} className="mt-6 inline-flex w-full items-center justify-center gap-3 border border-[#c9aa54] bg-[#c9aa54] px-6 py-4 font-mono text-[11px] uppercase tracking-[0.18em] text-[#050504] disabled:cursor-not-allowed disabled:opacity-40">{loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Fingerprint className="h-4 w-4" />} Seal T0, hypothesis and return hash</button>
+                </article>
+
+                <aside className="space-y-4">
+                  <article className="border border-[#3a321f] bg-[#080705e8] p-5 backdrop-blur-xl"><div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-[#c9aa54]"><Gauge className="h-4 w-4" /> MIHM evidence evaluator</div><p className="mt-4 text-sm leading-6 text-[#8e8573]">FIELD computes transparent evidence proxies and leaves unsupported MIHM variables as MISSING. It does not infer psychology or present a textual proxy as calibrated MIHM.</p></article>
+                  {createResult ? (
+                    <article className="border border-[#c9aa5555] bg-[radial-gradient(circle_at_top_right,rgba(201,170,84,0.13),transparent_38%),#080705] p-5">
+                      <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-[#c9aa54]"><CheckCircle2 className="h-4 w-4" /> Cycle sealed</div>
+                      <h3 className="mt-4 text-2xl text-[#f7e8bf]">{text(createResult.case.title)}</h3>
+                      <dl className="mt-5 grid gap-3 text-sm">
+                        <div><dt className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#786f5e]">Return due</dt><dd className="mt-1 text-[#d9c99f]">{dateLabel(createResult.expectedAt)}</dd></div>
+                        <div><dt className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#786f5e]">Provisional expected movement</dt><dd className="mt-1 text-[#d9c99f]">{createResult.expectedValue.toFixed(3)}</dd></div>
+                        <div><dt className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#786f5e]">Hypothesis</dt><dd className="mt-1 leading-6 text-[#aaa08b]">{text(createResult.hypothesis.statement)}</dd></div>
+                        <div><dt className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#786f5e]">Minimal intervention</dt><dd className="mt-1 leading-6 text-[#aaa08b]">{text(createResult.intervention.minimum_change)}</dd></div>
+                        <div><dt className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#786f5e]">SHA-256 return seal</dt><dd className="mt-1 break-all font-mono text-[10px] leading-5 text-[#c9aa54]">{createResult.seal}</dd></div>
+                      </dl>
+                      <div className="mt-5"><MihmReadout reading={createResult.mihm} /></div>
+                    </article>
+                  ) : (
+                    <article className="border border-[#2f291d] bg-[#070705] p-5 text-sm leading-6 text-[#756e60]"><Clock3 className="h-5 w-5 text-[#8e7a48]" /><p className="mt-4">Nothing is sealed yet. The system will not display a clean prediction until T0, evidence, intervention and return conditions exist.</p></article>
+                  )}
+                </aside>
+              </section>
+            ) : (
+              <section className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1fr)_480px]">
+                <article className="border border-[#373020] bg-[#080705e8] p-5 backdrop-blur-xl">
+                  <header className="flex items-center justify-between gap-4"><div><span className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#c9aa54]">Longitudinal cases</span><h2 className="mt-2 text-3xl text-[#f4e7c5]">Your controlled cycles</h2></div><Activity className="h-6 w-6 text-[#c9aa54]" /></header>
+                  <div className="mt-6 grid gap-3">
+                    {cases.length ? cases.map((item) => {
+                      const metadata = item.metadata ?? {};
+                      const expectedAt = metadata.expectedAt;
+                      const returnReady = String(item.status).includes('WAITING');
+                      return (
+                        <button type="button" key={item.id} onClick={() => returnReady ? openReturn(item) : setSelected(item)} className="grid gap-4 border border-[#302a1d] bg-[#050504] p-4 text-left transition hover:border-[#8f783c] md:grid-cols-[1fr_auto]">
+                          <div><div className="flex flex-wrap items-center gap-2 font-mono text-[9px] uppercase tracking-[0.13em] text-[#897f6a]"><span className="text-[#c9aa54]">{item.status}</span><span>{item.domain}</span><span>{item.verification_window}</span></div><strong className="mt-2 block text-lg text-[#eee0bb]">{item.title}</strong><p className="mt-2 line-clamp-2 text-xs leading-5 text-[#7f7767]">{text(item.hypothesis?.statement, 'Hypothesis not available')}</p></div>
+                          <div className="flex min-w-44 flex-col justify-between text-right font-mono text-[9px] uppercase tracking-[0.12em] text-[#746d5e]"><span>{expectedAt ? dateLabel(expectedAt) : dateLabel(item.created_at)}</span><b className={returnReady ? 'text-[#c9aa54]' : 'text-[#8e856f]'}>{returnReady ? 'OPEN RETURN →' : text(item.outcome?.verified, 'CLOSED')}</b></div>
+                        </button>
+                      );
+                    }) : <div className="border border-[#302a1d] bg-[#050504] p-8 text-center text-sm text-[#766f61]">No cycles yet.</div>}
+                  </div>
+                </article>
+
+                <aside className="space-y-4">
+                  {selected ? (
+                    <article className="border border-[#c9aa5544] bg-[#080705] p-5">
+                      <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-[#c9aa54]"><Clock3 className="h-4 w-4" /> Return evidence</div>
+                      <h3 className="mt-3 text-2xl text-[#f1e1b8]">{selected.title}</h3>
+                      <p className="mt-3 text-sm leading-6 text-[#8d8472]">Sealed hypothesis: {text(selected.hypothesis?.statement, 'MISSING')}</p>
+                      <p className="mt-3 text-sm leading-6 text-[#8d8472]">Intervention: {text(selected.intervention?.minimum_change, 'MISSING')}</p>
+                      {String(selected.status).includes('WAITING') ? (
+                        <div className="mt-6 grid gap-5">
+                          <TextArea label="What was actually observed?" value={returnForm.evidenceNote} onChange={(value) => setReturnForm((current) => ({ ...current, evidenceNote: value }))} placeholder="Document outcome, timestamp, counts, artifact or direct observation." rows={5} />
+                          <label className="grid gap-2"><span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[#a49572]">Return source</span><input value={returnForm.evidenceSource} onChange={(event) => setReturnForm((current) => ({ ...current, evidenceSource: event.target.value }))} className="border border-[#312b1d] bg-[#050504] px-4 py-3 text-sm text-[#eee4cb] outline-none focus:border-[#c9aa54]" /></label>
+                          <label className="grid gap-2"><span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[#a49572]">Private return file</span><span className="flex items-center gap-3"><input type="file" className="min-w-0 flex-1 text-xs text-[#817968]" onChange={(event) => { const file = event.target.files?.[0]; if (file) void uploadFile(file, 'return'); }} /><FileUp className="h-4 w-4 text-[#c9aa54]" /></span><em className="break-all text-[10px] text-[#655f52]">{uploading === 'return' ? 'UPLOADING…' : returnForm.evidenceUri || 'No private file uploaded'}</em></label>
+                          <RangeField label="Observed normalized movement" value={returnForm.actualOutcome} onChange={(value) => setReturnForm((current) => ({ ...current, actualOutcome: value }))} low="no movement" high="objective reached" />
+                          <RangeField label="Intervention fidelity" value={returnForm.interventionFidelity} onChange={(value) => setReturnForm((current) => ({ ...current, interventionFidelity: value }))} low="changed substantially" high="executed as sealed" />
+                          <RangeField label="Return source reliability" value={returnForm.reliability} onChange={(value) => setReturnForm((current) => ({ ...current, reliability: value }))} low="declared" high="verifiable" />
+                          <button type="button" onClick={() => void submitReturn()} disabled={loading || returnForm.evidenceNote.trim().length < 12} className="inline-flex items-center justify-center gap-2 border border-[#c9aa54] bg-[#c9aa54] px-5 py-4 font-mono text-[11px] uppercase tracking-[0.16em] text-[#050504] disabled:opacity-40">{loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />} Contrast and close return</button>
+                        </div>
+                      ) : (
+                        <div className="mt-5"><MihmReadout reading={selected.latestMihm} /></div>
+                      )}
+                    </article>
+                  ) : <article className="border border-[#302a1d] bg-[#070705] p-5 text-sm leading-6 text-[#756e60]">Select an open case to submit return evidence.</article>}
+
+                  {returnResult ? (
+                    <article className="border border-[#5f6d3d] bg-[#0a1007] p-5">
+                      <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-[#b7c979]"><CheckCircle2 className="h-4 w-4" /> Return processed</div>
+                      <div className="mt-5 grid grid-cols-3 gap-2"><Metric label="Expected" value={returnResult.expectedValue.toFixed(3)} detail="Sealed at T0" /><Metric label="Observed" value={returnResult.actualValue.toFixed(3)} detail={returnResult.accepted ? 'Accepted' : 'Unverified'} /><Metric label="Delta" value={returnResult.delta.toFixed(3)} detail={returnResult.verified ? 'Verified source' : 'Not independently verified'} /></div>
+                      <p className="mt-5 text-sm leading-7 text-[#b8bea5]">{returnResult.explanation}</p>
+                      <p className="mt-4 border-l border-[#b7c979] pl-4 text-sm leading-7 text-[#d8dfc0]">{returnResult.nextStep}</p>
+                      <div className="mt-5"><MihmReadout reading={returnResult.mihm} /></div>
+                    </article>
+                  ) : null}
+                </aside>
+              </section>
+            )}
+          </>
+        )}
+
+        <footer className="mt-8 flex flex-col gap-3 border-t border-[#2f291d] py-5 font-mono text-[9px] uppercase tracking-[0.14em] text-[#655f51] md:flex-row md:items-center md:justify-between"><span>FIELD · PRIVATE EVIDENCE · EXPLICIT RETURN</span><span>PROVISIONAL UNTIL CLOSED CASES SUPPORT CALIBRATION</span></footer>
+      </div>
+    </main>
+  );
+}

--- a/src/components/sfi/SfiHomeExperience.tsx
+++ b/src/components/sfi/SfiHomeExperience.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import {
+  Activity,
+  ArrowRight,
+  BookOpen,
+  FlaskConical,
+  Radar,
+  ScanSearch,
+  X,
+} from 'lucide-react';
+import type { SfiWorldInterfaceState } from '@/lib/sfi/worldInterfaceState';
+import { trackEvent } from '@/lib/analytics/client';
+import { SfiWorldInterfaceHero } from './SfiWorldInterfaceHero';
+
+type Hub = {
+  id: string;
+  title: string;
+  question: string;
+  description: string;
+  route: string;
+  action: string;
+  icon: typeof Radar;
+  primary?: boolean;
+};
+
+const HUBS: Hub[] = [
+  {
+    id: 'observatory',
+    title: 'OBSERVATORY',
+    question: '¿Qué está pasando en el campo?',
+    description: 'Lee el estado observado del mundo, sus tensiones, persistencia y trayectoria sin convertirlo en pronóstico.',
+    route: '/observatory',
+    action: 'LEER EL CAMPO',
+    icon: Radar,
+  },
+  {
+    id: 'field',
+    title: 'FIELD',
+    question: '¿Qué sistema real necesitas mover?',
+    description: 'Aplica MOP-H, sella una hipótesis, ejecuta una perturbación mínima y regresa con evidencia a las 72 horas.',
+    route: '/field',
+    action: 'ABRIR UN CICLO',
+    icon: Activity,
+    primary: true,
+  },
+  {
+    id: 'studio',
+    title: 'STUDIO',
+    question: '¿Qué objeto o señal necesitas medir?',
+    description: 'Ingiere texto, audio, imagen o video; sintetiza variables MIHM y proyecta su relación con el campo.',
+    route: '/login?next=%2Fstudio',
+    action: 'ANALIZAR OBJETO',
+    icon: FlaskConical,
+  },
+  {
+    id: 'scorefriction',
+    title: 'SCOREFRICTION',
+    question: '¿Qué señal cultural quieres seguir?',
+    description: 'Observa propagación, persistencia, transformación y tensión cultural sin reducirlas a popularidad.',
+    route: '/scorefriction',
+    action: 'OBSERVAR SEÑAL',
+    icon: ScanSearch,
+  },
+  {
+    id: 'repository',
+    title: 'REPOSITORY',
+    question: '¿Necesitas método, evidencia o definición?',
+    description: 'Consulta documentos, contratos, manuales, variables y límites epistemológicos del Instituto.',
+    route: '/repository',
+    action: 'ABRIR EL MÉTODO',
+    icon: BookOpen,
+  },
+];
+
+function HubCard({ hub }: { hub: Hub }) {
+  const Icon = hub.icon;
+  return (
+    <Link
+      href={hub.route}
+      data-analytics-label={`home_hub_${hub.id}`}
+      onClick={() => trackEvent('hub_open', { hub: hub.id, destination: hub.route.split('?')[0] })}
+      className={`group relative flex min-h-[184px] flex-col border p-4 transition duration-300 focus:outline-none focus-visible:ring-1 focus-visible:ring-[#d9bb67] ${hub.primary
+        ? 'border-[#c9aa5488] bg-[radial-gradient(circle_at_top_right,rgba(201,170,84,0.19),transparent_50%),rgba(12,10,6,0.94)] hover:border-[#e5c774]'
+        : 'border-[#3c3424] bg-[rgba(7,7,5,0.91)] hover:border-[#8d783f] hover:bg-[rgba(12,10,6,0.96)]'
+      }`}
+    >
+      <div className="flex items-center justify-between gap-4">
+        <span className="inline-flex h-9 w-9 items-center justify-center border border-[#4a3f28] bg-[#060604] text-[#c9aa54]">
+          <Icon className="h-4 w-4" aria-hidden="true" />
+        </span>
+        <span className="font-mono text-[9px] uppercase tracking-[0.18em] text-[#746b59]">{hub.primary ? 'RECOMMENDED ENTRY' : 'PUBLIC HUB'}</span>
+      </div>
+      <strong className="mt-4 font-mono text-[11px] uppercase tracking-[0.18em] text-[#dfc778]">{hub.title}</strong>
+      <h2 className="mt-2 text-base font-medium leading-6 text-[#f2e7cc]">{hub.question}</h2>
+      <p className="mt-2 flex-1 text-[11px] leading-5 text-[#918876]">{hub.description}</p>
+      <span className="mt-4 inline-flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.16em] text-[#b8a166] transition group-hover:text-[#f0d487]">
+        {hub.action}<ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-1" aria-hidden="true" />
+      </span>
+    </Link>
+  );
+}
+
+export function SfiHomeExperience({ state }: { state: SfiWorldInterfaceState }) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="sfi-home-experience">
+      <SfiWorldInterfaceHero state={state} />
+
+      {open ? (
+        <section className="sfi-entry-layer" aria-label="Orientación de hubs de System Friction Institute">
+          <div className="sfi-entry-backdrop" aria-hidden="true" />
+          <div className="sfi-entry-panel">
+            <header className="sfi-entry-header">
+              <div>
+                <span>SELECT OPERATIONAL ENTRY</span>
+                <h1>¿Qué necesitas hacer?</h1>
+                <p>Cada hub responde una pregunta distinta. Elige por objetivo, no por nombre.</p>
+              </div>
+              <button type="button" onClick={() => setOpen(false)} aria-label="Cerrar orientación y observar el campo">
+                <X className="h-4 w-4" />
+                <span>OBSERVAR CAMPO</span>
+              </button>
+            </header>
+            <div className="sfi-hub-grid">
+              {HUBS.map((hub) => <HubCard key={hub.id} hub={hub} />)}
+            </div>
+            <footer>
+              <span>WORLD STATE → OBJECT / SYSTEM → EVIDENCE → HYPOTHESIS → RETURN</span>
+              <Link href="/contact?offer=SFI-DR01" onClick={() => trackEvent('contact_intent', { source_surface: 'home_orientation', offer: 'SFI-DR01' })}>NO SÉ POR DÓNDE EMPEZAR</Link>
+            </footer>
+          </div>
+        </section>
+      ) : (
+        <button type="button" className="sfi-entry-launcher" onClick={() => setOpen(true)}>
+          <ScanSearch className="h-4 w-4" />
+          <span>¿A DÓNDE VOY?</span>
+        </button>
+      )}
+
+      <style jsx global>{`
+        .sfi-home-experience {
+          position: relative;
+          min-height: 100svh;
+          background: #030302;
+        }
+
+        .sfi-entry-layer {
+          position: absolute;
+          inset: 0;
+          z-index: 80;
+          display: grid;
+          place-items: center;
+          padding: 96px 24px 190px;
+          pointer-events: none;
+        }
+
+        .sfi-entry-backdrop {
+          position: absolute;
+          inset: 0;
+          background:
+            radial-gradient(circle at 50% 42%, rgba(6, 6, 4, 0.27), rgba(2, 2, 1, 0.64) 44%, rgba(2, 2, 1, 0.28) 74%),
+            linear-gradient(180deg, rgba(2, 2, 1, 0.16), rgba(2, 2, 1, 0.43));
+          backdrop-filter: blur(2.5px);
+        }
+
+        .sfi-entry-panel {
+          position: relative;
+          width: min(1180px, calc(100vw - 48px));
+          border: 1px solid rgba(201, 170, 84, 0.31);
+          background: rgba(4, 4, 3, 0.91);
+          box-shadow: 0 32px 120px rgba(0, 0, 0, 0.62), inset 0 1px rgba(255,255,255,0.025);
+          pointer-events: auto;
+          font-family: var(--sfi-font-mono), 'JetBrains Mono', monospace;
+        }
+
+        .sfi-entry-header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: 24px;
+          padding: 22px 24px 18px;
+          border-bottom: 1px solid rgba(201, 170, 84, 0.18);
+        }
+
+        .sfi-entry-header > div > span {
+          display: block;
+          color: #c9aa54;
+          font-size: 9px;
+          letter-spacing: 0.22em;
+        }
+
+        .sfi-entry-header h1 {
+          margin: 7px 0 0;
+          color: #f5ead0;
+          font-family: Georgia, 'Times New Roman', serif;
+          font-size: clamp(28px, 3vw, 46px);
+          font-weight: 500;
+          letter-spacing: -0.025em;
+        }
+
+        .sfi-entry-header p {
+          margin: 7px 0 0;
+          color: rgba(226, 214, 187, 0.58);
+          font-size: 11px;
+          line-height: 1.6;
+        }
+
+        .sfi-entry-header button {
+          display: inline-flex;
+          align-items: center;
+          gap: 9px;
+          border: 1px solid rgba(201, 170, 84, 0.25);
+          padding: 10px 12px;
+          background: rgba(2, 2, 1, 0.72);
+          color: rgba(226, 214, 187, 0.64);
+          font-size: 8px;
+          letter-spacing: 0.16em;
+          cursor: pointer;
+        }
+
+        .sfi-entry-header button:hover {
+          border-color: rgba(201, 170, 84, 0.62);
+          color: #ead391;
+        }
+
+        .sfi-hub-grid {
+          display: grid;
+          grid-template-columns: repeat(5, minmax(0, 1fr));
+          gap: 8px;
+          padding: 12px;
+        }
+
+        .sfi-entry-panel footer {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 18px;
+          border-top: 1px solid rgba(201, 170, 84, 0.16);
+          padding: 12px 18px;
+          color: rgba(226, 214, 187, 0.42);
+          font-size: 8px;
+          letter-spacing: 0.13em;
+        }
+
+        .sfi-entry-panel footer a {
+          border-left: 1px solid rgba(201, 170, 84, 0.25);
+          padding-left: 18px;
+          color: #c9aa54;
+          white-space: nowrap;
+        }
+
+        .sfi-entry-launcher {
+          position: absolute;
+          z-index: 80;
+          top: 118px;
+          left: 50%;
+          display: inline-flex;
+          transform: translateX(-50%);
+          align-items: center;
+          gap: 10px;
+          border: 1px solid rgba(201, 170, 84, 0.46);
+          background: rgba(4, 4, 3, 0.9);
+          padding: 11px 15px;
+          color: #d8bd70;
+          font-family: var(--sfi-font-mono), monospace;
+          font-size: 9px;
+          letter-spacing: 0.18em;
+          cursor: pointer;
+          box-shadow: 0 16px 60px rgba(0,0,0,.45);
+        }
+
+        @media (max-width: 1180px) {
+          .sfi-entry-layer {
+            align-items: start;
+            overflow: auto;
+            padding: 104px 18px 70px;
+          }
+          .sfi-hub-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+          .sfi-hub-grid > :last-child { grid-column: span 2; min-height: 150px; }
+        }
+
+        @media (max-width: 680px) {
+          .sfi-entry-layer { padding: 92px 10px 36px; }
+          .sfi-entry-panel { width: calc(100vw - 20px); }
+          .sfi-entry-header { padding: 17px 15px 14px; }
+          .sfi-entry-header button span { display: none; }
+          .sfi-hub-grid { grid-template-columns: 1fr; padding: 8px; }
+          .sfi-hub-grid > :last-child { grid-column: auto; }
+          .sfi-entry-panel footer { align-items: flex-start; flex-direction: column; }
+          .sfi-entry-panel footer a { border-left: 0; border-top: 1px solid rgba(201,170,84,.2); padding: 10px 0 0; }
+          .sfi-entry-launcher { top: 92px; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .sfi-home-experience *, .sfi-home-experience *::before, .sfi-home-experience *::after {
+            animation-duration: 0.001ms !important;
+            animation-iteration-count: 1 !important;
+            scroll-behavior: auto !important;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/sfi/SfiLiveWorldMap.tsx
+++ b/src/components/sfi/SfiLiveWorldMap.tsx
@@ -23,6 +23,16 @@ function solarX(date: Date) {
   return (hour / 24) * 1200;
 }
 
+function mapPoint(node: { x: number; y: number }) {
+  return { x: clamp01(node.x / 100) * 1200, y: clamp01(node.y / 100) * 600 };
+}
+
+function flowPath(from: { x: number; y: number }, to: { x: number; y: number }) {
+  const middleX = (from.x + to.x) / 2;
+  const lift = Math.max(18, Math.min(90, Math.abs(to.x - from.x) * 0.12));
+  return `M ${from.x.toFixed(1)} ${from.y.toFixed(1)} Q ${middleX.toFixed(1)} ${(Math.min(from.y, to.y) - lift).toFixed(1)} ${to.x.toFixed(1)} ${to.y.toFixed(1)}`;
+}
+
 export function SfiLiveWorldMap({ state }: Props) {
   const generated = useMemo(() => {
     const parsed = new Date(state.generatedAt);
@@ -33,8 +43,11 @@ export function SfiLiveWorldMap({ state }: Props) {
   const viscosity = clamp01(
     0.35 + nodeTone(state.systemStrain.status) * 0.28 + nodeTone(state.frictionLevel.status) * 0.22 + (state.warnings.length > 0 ? 0.15 : 0),
   );
-
   const densityNodes = state.nodes.slice(0, 28);
+  const nodeById = new Map(densityNodes.map((node) => [node.id, node]));
+  const observedConnections = state.connections
+    .filter((connection) => nodeById.has(connection.from) && nodeById.has(connection.to))
+    .slice(0, 30);
 
   return (
     <div className="sfi-live-world-map" aria-hidden="true">
@@ -75,10 +88,30 @@ export function SfiLiveWorldMap({ state }: Props) {
         <rect className="night-band" width="1200" height="600" />
         <circle className="solar-bloom" cx={sunX} cy="235" r="300" />
 
+        <g className="map-flow-layer">
+          {observedConnections.map((connection, index) => {
+            const fromNode = nodeById.get(connection.from);
+            const toNode = nodeById.get(connection.to);
+            if (!fromNode || !toNode) return null;
+            const path = flowPath(mapPoint(fromNode), mapPoint(toNode));
+            return (
+              <path
+                key={`${connection.from}-${connection.to}-${index}`}
+                className="map-flow"
+                d={path}
+                style={{
+                  opacity: 0.12 + clamp01(connection.strength) * 0.36,
+                  strokeWidth: 0.45 + clamp01(connection.strength) * 0.85,
+                  animationDelay: `${index * -0.41}s`,
+                }}
+              />
+            );
+          })}
+        </g>
+
         <g className="night-lights" filter="url(#sfiMapGlow)">
           {densityNodes.map((node, index) => {
-            const x = clamp01(node.x / 100) * 1200;
-            const y = clamp01(node.y / 100) * 600;
+            const { x, y } = mapPoint(node);
             const intensity = clamp01(node.intensity);
             return (
               <g key={`density-${node.id}`} className={`real-density real-density-${node.state}`} style={{ animationDelay: `${index * -0.22}s` }}>
@@ -91,8 +124,7 @@ export function SfiLiveWorldMap({ state }: Props) {
 
         <g className="map-node-layer">
           {densityNodes.map((node, index) => {
-            const x = clamp01(node.x / 100) * 1200;
-            const y = clamp01(node.y / 100) * 600;
+            const { x, y } = mapPoint(node);
             const intensity = clamp01(node.intensity);
             return (
               <g key={node.id} className={`live-map-node live-map-node-${node.state}`} transform={`translate(${x.toFixed(1)} ${y.toFixed(1)})`}>
@@ -103,7 +135,7 @@ export function SfiLiveWorldMap({ state }: Props) {
           })}
         </g>
 
-        <text className="map-meta" x="34" y="552">SFI NODE DENSITY LAYER · VISCOSITY {Math.round(viscosity * 100)}%</text>
+        <text className="map-meta" x="34" y="552">SFI NODE DENSITY · REAL CONNECTIONS {observedConnections.length} · VISCOSITY {Math.round(viscosity * 100)}%</text>
         <text className="map-meta right" x="1166" y="552">SNAPSHOT · {generated.toISOString().slice(0, 19)}Z</text>
       </svg>
     </div>

--- a/src/lib/field/operationalCycle.ts
+++ b/src/lib/field/operationalCycle.ts
@@ -43,7 +43,18 @@ type WorldContext = {
   warnings: string[];
 };
 
+type FieldCaseWithRelations = Row & {
+  status: string;
+  hypothesis: Row | null;
+  intervention: Row | null;
+  return: Row | null;
+  outcome: Row | null;
+  latestMihm: Row | null;
+  evidence: Row[];
+};
+
 const FORMULA_VERSION = 'FIELD_MIHM_EVIDENCE_PROXY_V1';
+const OPEN_RETURN_STATUS = 'WAITING_RETURN';
 
 function record(value: unknown): Row {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
@@ -59,9 +70,21 @@ function text(value: unknown) {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function stringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
+}
+
 function clamp01(value: unknown) {
   const parsed = typeof value === 'number' ? value : Number(value);
   return Number.isFinite(parsed) ? Math.max(0, Math.min(1, parsed)) : 0;
+}
+
+function nullableNumber(value: unknown) {
+  if (value === null || typeof value === 'undefined' || value === '') return null;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function iso(value?: string | null) {
@@ -70,9 +93,16 @@ function iso(value?: string | null) {
   return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : new Date().toISOString();
 }
 
+function windowHours(window: FieldVerificationWindow) {
+  return window === '72h' ? 72 : window === '7d' ? 168 : 720;
+}
+
+function windowLabel(window: FieldVerificationWindow) {
+  return window === '72h' ? '72 horas' : window === '7d' ? '7 días' : '30 días';
+}
+
 function dueAt(window: FieldVerificationWindow) {
-  const hours = window === '72h' ? 72 : window === '7d' ? 168 : 720;
-  return new Date(Date.now() + hours * 60 * 60 * 1000).toISOString();
+  return new Date(Date.now() + windowHours(window) * 60 * 60 * 1000).toISOString();
 }
 
 function tokens(value: string) {
@@ -129,7 +159,7 @@ function baselineMihm(input: CreateFieldCycleInput, world: WorldContext) {
     (input.evidence.trim().length >= 24 ? 0.45 : 0.1)
       + (input.evidenceSource.trim() ? 0.25 : 0)
       + (input.evidenceUri ? 0.2 : 0)
-      + input.reliability * 0.1,
+      + clamp01(input.reliability) * 0.1,
   );
   const coherence = clamp01(
     overlap(input.objective, `${input.stuckSystem} ${input.evidence}`) * 0.45
@@ -138,7 +168,6 @@ function baselineMihm(input: CreateFieldCycleInput, world: WorldContext) {
       + traceability * 0.15,
   );
   const phi = clamp01(coherence * 0.55 + coverage * 0.25 + traceability * 0.2);
-  const worldGradient = world.confidence;
 
   return {
     status: 'PARTIAL',
@@ -147,11 +176,11 @@ function baselineMihm(input: CreateFieldCycleInput, world: WorldContext) {
     coverage,
     traceability,
     metrics: [
-      metric({ key: 'C_s', label: 'Structural coherence proxy', value: coherence, source: 'declared objective + baseline evidence', confidence: 0.45, explanation: 'Lexical alignment, specificity, coverage and evidence traceability. This is an auditable FIELD proxy, not historically calibrated MIHM.' }),
+      metric({ key: 'C_s', label: 'Structural coherence proxy', value: coherence, source: 'declared objective + baseline evidence', confidence: 0.45, explanation: 'Lexical alignment, specificity, coverage and traceability. This is an auditable FIELD proxy, not historically calibrated MIHM.' }),
       metric({ key: 'D_i', label: 'Internal dispersion', value: null, source: 'return evidence required', confidence: null, explanation: 'Cannot be estimated before a comparable return observation exists.' }),
       metric({ key: 'E_r', label: 'Residual energy', value: null, source: 'return evidence required', confidence: null, explanation: 'Requires an observed outcome after the intervention window.' }),
-      metric({ key: 'G_f', label: 'Field gradient proxy', value: worldGradient, source: 'latest WorldSpect / World Vector context', confidence: world.confidence, explanation: 'Uses only the current persisted world-context confidence. It is not a domain-specific causal estimate.' }),
-      metric({ key: 'D_cog', label: 'Cognitive discontinuity', value: null, source: 'insufficient evidence', confidence: null, explanation: 'FIELD does not infer undisclosed psychological state from participant text.' }),
+      metric({ key: 'G_f', label: 'Field gradient proxy', value: world.confidence, source: 'latest WorldSpect / World Vector context', confidence: world.confidence, explanation: 'Uses only persisted world-context confidence; it is not a domain-specific causal estimate.' }),
+      metric({ key: 'D_cog', label: 'Cognitive discontinuity', value: null, source: 'not inferred', confidence: null, explanation: 'FIELD does not infer undisclosed psychological state from participant text.' }),
       metric({ key: 'Phi', label: 'Evidence coherence flow proxy', value: phi, source: 'baseline evidence contract', confidence: 0.42, explanation: 'Combines structural coherence, required-field coverage and traceability.' }),
       metric({ key: 'F_s', label: 'Structural friction', value: null, source: 'insufficient multimodal evidence', confidence: null, explanation: 'No canonical multimodal measurement is available at intake.' }),
       metric({ key: 'V_i', label: 'Intervention variability', value: null, source: 'intervention not executed', confidence: null, explanation: 'Requires return evidence and intervention fidelity.' }),
@@ -161,7 +190,7 @@ function baselineMihm(input: CreateFieldCycleInput, world: WorldContext) {
       coverage < 1 ? 'BASELINE_FIELDS_INCOMPLETE' : null,
       traceability < 0.55 ? 'EVIDENCE_TRACEABILITY_THIN' : null,
       world.warnings.length ? 'WORLD_CONTEXT_DEGRADED' : null,
-    ].filter(Boolean),
+    ].filter((item): item is string => Boolean(item)),
   };
 }
 
@@ -187,12 +216,12 @@ function returnMihm(input: ReturnFieldCycleInput, expectedValue: number, baselin
     absoluteError: dispersion,
     metrics: [
       metric({ key: 'C_s', label: 'Structural coherence proxy', value: coherence, source: 'baseline + return evidence', confidence: 0.55, explanation: 'Combines baseline coherence, source reliability, intervention fidelity and prediction alignment.' }),
-      metric({ key: 'D_i', label: 'Outcome dispersion proxy', value: dispersion, source: 'expected versus observed outcome', confidence: 0.58, explanation: 'Absolute difference between the sealed provisional expectation and the declared/observed return value.' }),
-      metric({ key: 'E_r', label: 'Residual unresolved friction proxy', value: remaining, source: 'observed outcome', confidence: reliability * 0.7, explanation: 'Represents the unresolved normalized portion after the return window; it is not an energy measurement from a physical sensor.' }),
+      metric({ key: 'D_i', label: 'Outcome dispersion proxy', value: dispersion, source: 'expected versus observed outcome', confidence: 0.58, explanation: 'Absolute difference between the sealed provisional expectation and the observed return value.' }),
+      metric({ key: 'E_r', label: 'Residual unresolved friction proxy', value: remaining, source: 'observed outcome', confidence: reliability * 0.7, explanation: 'Normalized unresolved portion after the return window; not a physical energy measurement.' }),
       metric({ key: 'G_f', label: 'Field gradient proxy', value: world.confidence, source: 'return-time WorldSpect / World Vector context', confidence: world.confidence, explanation: 'Context confidence at return time; no causal attribution is made.' }),
       metric({ key: 'D_cog', label: 'Cognitive discontinuity', value: null, source: 'not inferred', confidence: null, explanation: 'FIELD does not infer a private psychological state.' }),
       metric({ key: 'Phi', label: 'Evidence coherence flow proxy', value: phi, source: 'return evidence contract', confidence: 0.52, explanation: 'Combines coherence, prediction alignment and source reliability.' }),
-      metric({ key: 'F_s', label: 'Structural friction', value: dispersion, source: 'prediction error proxy', confidence: 0.48, explanation: 'Provisional proxy based on observed deviation; not a calibrated cross-domain MIHM value.' }),
+      metric({ key: 'F_s', label: 'Structural friction proxy', value: dispersion, source: 'prediction error proxy', confidence: 0.48, explanation: 'Provisional observed-deviation proxy; not a calibrated cross-domain MIHM value.' }),
       metric({ key: 'V_i', label: 'Intervention variability proxy', value: 1 - fidelity, source: 'operator-declared intervention fidelity', confidence: reliability * 0.65, explanation: 'Higher value indicates lower fidelity to the sealed intervention.' }),
       metric({ key: 'I_mc', label: 'Micro-coherence index', value: null, source: 'repeated returns required', confidence: null, explanation: 'One return does not establish repeated micro-coherence.' }),
     ],
@@ -201,8 +230,17 @@ function returnMihm(input: ReturnFieldCycleInput, expectedValue: number, baselin
       fidelity < 0.6 ? 'INTERVENTION_FIDELITY_LOW' : null,
       dispersion > 0.35 ? 'PREDICTION_DEVIATION_HIGH' : null,
       world.warnings.length ? 'WORLD_CONTEXT_DEGRADED' : null,
-    ].filter(Boolean),
+    ].filter((item): item is string => Boolean(item)),
   };
+}
+
+function deriveWorldspectRegime(wsi: number | null, nti: number | null) {
+  if (wsi === null && nti === null) return 'MISSING';
+  if ((nti ?? 0) >= 0.7) return 'HIGH_TENSION';
+  if ((wsi ?? 0) >= 0.65 && (nti ?? 0) >= 0.4) return 'PERSISTENT_TENSION';
+  if ((wsi ?? 0) >= 0.65) return 'PERSISTENT';
+  if ((nti ?? 0) >= 0.4) return 'ELEVATED_TENSION';
+  return 'LOW_SIGNAL';
 }
 
 async function readWorldContext(): Promise<WorldContext> {
@@ -210,7 +248,7 @@ async function readWorldContext(): Promise<WorldContext> {
   const [worldspect, vector] = await Promise.all([
     service
       .from('worldspect_snapshots')
-      .select('id,observed_at,source_state,confidence,wsi,nti,regime,vectors,source_coverage,degraded_sources')
+      .select('id,observed_at,source_state,confidence,wsi,nti,sources,raw_payload,source_health,degraded_sources,ingest_mode')
       .order('observed_at', { ascending: false })
       .limit(1)
       .maybeSingle(),
@@ -221,15 +259,27 @@ async function readWorldContext(): Promise<WorldContext> {
       .limit(1)
       .maybeSingle(),
   ]);
+
   const warnings = [
     worldspect.error ? `WORLDSPECT:${worldspect.error.message}` : null,
     vector.error ? `WORLD_VECTOR:${vector.error.message}` : null,
   ].filter((item): item is string => Boolean(item));
-  const ws = worldspect.data ? record(worldspect.data) : null;
+
+  const rawWs = worldspect.data ? record(worldspect.data) : null;
+  const wsi = nullableNumber(rawWs?.wsi);
+  const nti = nullableNumber(rawWs?.nti);
+  const ws = rawWs ? {
+    ...rawWs,
+    regime: deriveWorldspectRegime(wsi, nti),
+    wsi,
+    nti,
+    sourceCoverage: rows(rawWs.sources).length,
+    degradedSources: stringArray(rawWs.degraded_sources),
+  } : null;
   const wv = vector.data ? record(vector.data) : null;
-  const confidenceValues = [ws?.confidence, wv?.confidence]
-    .map((item) => typeof item === 'number' ? item : null)
+  const confidenceValues = [nullableNumber(ws?.confidence), nullableNumber(wv?.confidence)]
     .filter((item): item is number => item !== null);
+
   return {
     worldspect: ws,
     worldVector: wv,
@@ -244,6 +294,7 @@ function objectClass(domain: string) {
   if (normalized.includes('organiz')) return 'organization';
   if (normalized.includes('instit')) return 'institution';
   if (normalized.includes('company') || normalized.includes('empresa')) return 'company';
+  if (normalized.includes('cultural')) return 'cultural_signal';
   return 'other';
 }
 
@@ -251,9 +302,18 @@ function returnHash(payload: Row) {
   return createHash('sha256').update(JSON.stringify(payload)).digest('hex');
 }
 
+function interventionForWindow(base: string, window: FieldVerificationWindow) {
+  const label = windowLabel(window);
+  const normalized = base
+    .replace(/72\s*horas/gi, label)
+    .replace(/72-hour/gi, label)
+    .trim();
+  return `${normalized || 'Ejecuta una sola acción reversible.'} Mantén una sola variable primaria durante ${label} y registra evidencia antes y después.`;
+}
+
 async function audit(actorId: string, action: string, targetId: string, afterState: Row) {
   const service = createServiceSupabaseClient();
-  await service.from('sfi_audit_events').insert({
+  const result = await service.from('sfi_audit_events').insert({
     actor_id: actorId,
     action,
     target_type: 'field_case',
@@ -261,6 +321,7 @@ async function audit(actorId: string, action: string, targetId: string, afterSta
     after_state: afterState,
     context: { surface: 'field', version: 'FIELD_OPERATIONAL_CYCLE_V1' },
   });
+  if (result.error) throw new Error(`FIELD_AUDIT_FAILED:${result.error.message}`);
 }
 
 export async function createFieldCycle(ownerId: string, input: CreateFieldCycleInput) {
@@ -283,6 +344,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
   const baseline = baselineMihm(input, world);
   const openedAt = new Date().toISOString();
   const expectedAt = dueAt(input.verificationWindow);
+  const minimumChange = interventionForWindow(moph.minimal_perturbation, input.verificationWindow);
 
   const caseInsert = await service.from('field_cases').insert({
     owner_id: ownerId,
@@ -317,7 +379,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
     visibility: 'private',
     payload: {
       note: input.evidence.trim(),
-      epistemicClass: 'declared',
+      epistemicClass: input.evidenceUri ? 'observed' : 'declared',
       objective: input.objective.trim(),
       observedBeforeIntervention: true,
     },
@@ -336,8 +398,9 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
       objective: input.objective,
       attempts: input.attempts,
       consequence: input.consequence,
+      verificationWindow: input.verificationWindow,
     },
-    output: moph,
+    output: { ...moph, minimal_perturbation: minimumChange },
     evidence_ids: [evidenceId],
     started_at: openedAt,
     completed_at: new Date().toISOString(),
@@ -378,7 +441,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
     case_id: caseId,
     owner_id: ownerId,
     hypothesis_id: String(hypothesis.id),
-    minimum_change: moph.minimal_perturbation,
+    minimum_change: minimumChange,
     prohibited_effects: [
       'Do not change more than one primary variable.',
       'Do not expose private evidence.',
@@ -411,7 +474,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
     intervention_id: String(intervention.id),
     verification_window: input.verificationWindow,
     expected_at: expectedAt,
-    status: 'WAITING_RETURN',
+    status: OPEN_RETURN_STATUS,
     evidence_ids: [evidenceId],
     payload: { seal, sealPayload },
   }).select('*').single();
@@ -419,7 +482,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
   const returnRow = record(returnInsert.data);
 
   const caseUpdate = await service.from('field_cases').update({
-    status: 'WAITING_RETURN',
+    status: OPEN_RETURN_STATUS,
     metadata: {
       ...record(fieldCase.metadata),
       objective: input.objective.trim(),
@@ -436,7 +499,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
       interventionId: intervention.id,
       returnId: returnRow.id,
     },
-  }).eq('id', caseId).eq('owner_id', ownerId).select('*').single();
+  }).eq('id', caseId).eq('owner_id', ownerId).eq('status', 'BUILDING').select('*').single();
   if (caseUpdate.error || !caseUpdate.data) throw new Error(`FIELD_CASE_SEAL_FAILED:${caseUpdate.error?.message ?? 'unknown'}`);
 
   const warnings = [...world.warnings, ...moph.warnings];
@@ -446,7 +509,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
       objectId: caseId,
       objectClass: objectClass(input.domain),
       title: input.title,
-      manifestation: 'moph_72h_operational_cycle',
+      manifestation: 'moph_operational_cycle',
       cohort: input.domain || 'field',
       prospective: true,
       status: 'WAITING_OUTCOME',
@@ -466,7 +529,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
       operatorId: ownerId,
       consentRequired: objectClass(input.domain) === 'organization',
       consentEvidenceId: objectClass(input.domain) === 'organization' ? evidenceId : null,
-      metadata: { fieldCaseId: caseId, returnHash: seal, expectedAt, expectedValue },
+      metadata: { fieldCaseId: caseId, returnHash: seal, expectedAt, expectedValue, verificationWindow: input.verificationWindow },
     });
     await Promise.all([
       linkCaseEvidence({ caseId: String(reference.id), evidenceSource: 'field_case_evidence', evidenceId, relationType: 'SUPPORTS', createdBy: ownerId }),
@@ -482,7 +545,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
   return {
     case: caseUpdate.data,
     baselineEvidence: evidenceRow,
-    moph,
+    moph: { ...moph, minimal_perturbation: minimumChange },
     mihm: baseline,
     hypothesis,
     intervention,
@@ -498,20 +561,25 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
 export async function submitFieldReturn(ownerId: string, caseId: string, input: ReturnFieldCycleInput) {
   if (input.evidenceNote.trim().length < 12) throw new Error('FIELD_RETURN_EVIDENCE_REQUIRED');
   const service = createServiceSupabaseClient();
+
   const caseResult = await service.from('field_cases').select('*').eq('id', caseId).eq('owner_id', ownerId).maybeSingle();
   if (caseResult.error || !caseResult.data) throw new Error('FIELD_CASE_NOT_FOUND');
   const fieldCase = record(caseResult.data);
+  if (text(fieldCase.status) !== OPEN_RETURN_STATUS) throw new Error('FIELD_RETURN_ALREADY_CLOSED_OR_NOT_READY');
+
   const metadata = record(fieldCase.metadata);
   const expectedValue = clamp01(metadata.expectedValue);
   const world = await readWorldContext();
 
-  const [hypothesisResult, interventionResult, returnResult, baselineResult] = await Promise.all([
+  const [hypothesisResult, interventionResult, returnResult, baselineResult, existingOutcome] = await Promise.all([
     service.from('field_hypotheses').select('*').eq('case_id', caseId).eq('owner_id', ownerId).order('created_at', { ascending: false }).limit(1).maybeSingle(),
     service.from('field_interventions').select('*').eq('case_id', caseId).eq('owner_id', ownerId).order('created_at', { ascending: false }).limit(1).maybeSingle(),
     service.from('field_returns').select('*').eq('case_id', caseId).eq('owner_id', ownerId).order('created_at', { ascending: false }).limit(1).maybeSingle(),
     service.from('field_mihm_readings').select('*').eq('case_id', caseId).eq('owner_id', ownerId).order('created_at', { ascending: true }).limit(1).maybeSingle(),
+    service.from('field_outcomes').select('id').eq('case_id', caseId).eq('owner_id', ownerId).limit(1).maybeSingle(),
   ]);
   if (!hypothesisResult.data || !interventionResult.data || !returnResult.data) throw new Error('FIELD_CYCLE_INCOMPLETE');
+  if (text(returnResult.data.status) !== OPEN_RETURN_STATUS || existingOutcome.data) throw new Error('FIELD_RETURN_ALREADY_CLOSED_OR_NOT_READY');
 
   const observedAt = iso(input.observedAt);
   const evidenceInsert = await service.from('field_case_evidence').insert({
@@ -574,23 +642,41 @@ export async function submitFieldReturn(ownerId: string, caseId: string, input: 
   if (outcomeInsert.error || !outcomeInsert.data) throw new Error(`FIELD_OUTCOME_CREATE_FAILED:${outcomeInsert.error?.message ?? 'unknown'}`);
   const outcome = record(outcomeInsert.data);
 
+  const returnUpdate = await service.from('field_returns').update({
+    returned_at: observedAt,
+    status: accepted ? 'RETURN_ACCEPTED' : 'RETURN_RECORDED_UNVERIFIED',
+    evidence_ids: [evidenceId],
+    payload: {
+      ...record(returnResult.data.payload),
+      actualValue,
+      expectedValue,
+      delta,
+      accepted,
+      verified,
+      reliability: clamp01(input.reliability),
+      interventionFidelity: clamp01(input.interventionFidelity),
+      worldAtReturn: world,
+    },
+  }).eq('id', returnResult.data.id).eq('owner_id', ownerId).eq('status', OPEN_RETURN_STATUS);
+  if (returnUpdate.error) throw new Error(`FIELD_RETURN_CLOSE_FAILED:${returnUpdate.error.message}`);
+
+  const caseClose = await service.from('field_cases').update({
+    status: verified ? 'CLOSED_VERIFIED' : accepted ? 'CLOSED_OBSERVED' : 'CLOSED_UNVERIFIED',
+    metadata: {
+      ...metadata,
+      returnedAt: observedAt,
+      returnEvidenceId: evidenceId,
+      fieldOutcomeId: outcome.id,
+      actualValue,
+      delta,
+      accepted,
+      verified,
+      worldAtReturn: world,
+    },
+  }).eq('id', caseId).eq('owner_id', ownerId).eq('status', OPEN_RETURN_STATUS);
+  if (caseClose.error) throw new Error(`FIELD_CASE_CLOSE_FAILED:${caseClose.error.message}`);
+
   await Promise.all([
-    service.from('field_returns').update({
-      returned_at: observedAt,
-      status: accepted ? 'RETURN_ACCEPTED' : 'RETURN_RECORDED_UNVERIFIED',
-      evidence_ids: [evidenceId],
-      payload: {
-        ...record(returnResult.data.payload),
-        actualValue,
-        expectedValue,
-        delta,
-        accepted,
-        verified,
-        reliability: clamp01(input.reliability),
-        interventionFidelity: clamp01(input.interventionFidelity),
-        worldAtReturn: world,
-      },
-    }).eq('id', returnResult.data.id).eq('owner_id', ownerId),
     service.from('field_interventions').update({
       status: 'COMPLETED',
       completed_at: observedAt,
@@ -600,20 +686,6 @@ export async function submitFieldReturn(ownerId: string, caseId: string, input: 
       status: verified ? 'VERIFIED_RETURN' : accepted ? 'OBSERVED_RETURN' : 'UNVERIFIED_RETURN',
       evidence_ids: [evidenceId],
     }).eq('id', hypothesisResult.data.id).eq('owner_id', ownerId),
-    service.from('field_cases').update({
-      status: verified ? 'CLOSED_VERIFIED' : accepted ? 'CLOSED_OBSERVED' : 'CLOSED_UNVERIFIED',
-      metadata: {
-        ...metadata,
-        returnedAt: observedAt,
-        returnEvidenceId: evidenceId,
-        outcomeId: outcome.id,
-        actualValue,
-        delta,
-        accepted,
-        verified,
-        worldAtReturn: world,
-      },
-    }).eq('id', caseId).eq('owner_id', ownerId),
     service.from('field_lessons').insert({
       case_id: caseId,
       owner_id: ownerId,
@@ -624,12 +696,11 @@ export async function submitFieldReturn(ownerId: string, caseId: string, input: 
   ]);
 
   try {
-    const referenceResult = await service.from('sfi_reference_cases').select('id').eq('object_id', caseId).maybeSingle();
+    const referenceResult = await service.from('sfi_reference_cases').select('id,metadata').eq('object_id', caseId).maybeSingle();
     if (referenceResult.data?.id) {
-      await service.from('sfi_reference_cases').update({
+      const referenceUpdate = await service.from('sfi_reference_cases').update({
         status: verified || accepted ? 'CLOSED' : 'UNVERIFIABLE',
         closed_at: observedAt,
-        outcome_id: outcome.id,
         phase_status: {
           phase0: 'READY',
           phase1: 'PARTIAL_FIELD_PROXY',
@@ -641,7 +712,9 @@ export async function submitFieldReturn(ownerId: string, caseId: string, input: 
         },
         missing_fields: accepted ? [] : ['field.verified_return_source'],
         metadata: {
+          ...record(referenceResult.data.metadata),
           fieldCaseId: caseId,
+          fieldOutcomeId: outcome.id,
           returnHash: metadata.returnHash,
           expectedValue,
           actualValue,
@@ -650,19 +723,29 @@ export async function submitFieldReturn(ownerId: string, caseId: string, input: 
           verified,
         },
       }).eq('id', referenceResult.data.id);
-      await linkCaseEvidence({
-        caseId: String(referenceResult.data.id),
-        evidenceSource: 'field_case_evidence',
-        evidenceId,
-        relationType: 'VERIFIES_OUTCOME',
-        createdBy: ownerId,
-      });
+      if (referenceUpdate.error) throw new Error(referenceUpdate.error.message);
+      await Promise.all([
+        linkCaseEvidence({
+          caseId: String(referenceResult.data.id),
+          evidenceSource: 'field_case_evidence',
+          evidenceId,
+          relationType: 'VERIFIES_OUTCOME',
+          createdBy: ownerId,
+        }),
+        linkCaseEvidence({
+          caseId: String(referenceResult.data.id),
+          evidenceSource: 'field_outcomes',
+          evidenceId: String(outcome.id),
+          relationType: 'VERIFIES_OUTCOME',
+          createdBy: ownerId,
+        }),
+      ]);
     }
   } catch {
-    // Reference Bank degradation must not erase the participant return.
+    // Reference Bank degradation must not erase a valid participant return.
   }
 
-  await audit(ownerId, 'field.cycle.returned', caseId, { evidenceId, outcomeId: outcome.id, actualValue, expectedValue, delta, accepted, verified });
+  await audit(ownerId, 'field.cycle.returned', caseId, { evidenceId, fieldOutcomeId: outcome.id, actualValue, expectedValue, delta, accepted, verified });
 
   return {
     caseId,
@@ -690,7 +773,7 @@ export async function listFieldCycles(ownerId: string) {
   if (caseResult.error) throw new Error(`FIELD_CASE_LIST_FAILED:${caseResult.error.message}`);
   const cases = rows(caseResult.data);
   const ids = cases.map((item) => String(item.id));
-  if (!ids.length) return { cases: [], summary: { total: 0, waitingReturn: 0, closed: 0, verified: 0 } };
+  if (!ids.length) return { cases: [], summary: { total: 0, waitingReturn: 0, closed: 0, verified: 0 }, warnings: [] as string[] };
 
   const [hypotheses, interventions, returns, outcomes, readings, evidence] = await Promise.all([
     service.from('field_hypotheses').select('*').eq('owner_id', ownerId).in('case_id', ids).order('created_at', { ascending: false }),
@@ -707,6 +790,7 @@ export async function listFieldCycles(ownerId: string) {
   function latest(collection: Row[], caseId: string) {
     return collection.find((item) => String(item.case_id) === caseId) ?? null;
   }
+
   const hypothesisRows = rows(hypotheses.data);
   const interventionRows = rows(interventions.data);
   const returnRows = rows(returns.data);
@@ -714,10 +798,11 @@ export async function listFieldCycles(ownerId: string) {
   const readingRows = rows(readings.data);
   const evidenceRows = rows(evidence.data);
 
-  const items = cases.map((item) => {
+  const items: FieldCaseWithRelations[] = cases.map((item) => {
     const caseId = String(item.id);
     return {
       ...item,
+      status: text(item.status) || 'UNKNOWN',
       hypothesis: latest(hypothesisRows, caseId),
       intervention: latest(interventionRows, caseId),
       return: latest(returnRows, caseId),
@@ -731,8 +816,8 @@ export async function listFieldCycles(ownerId: string) {
     cases: items,
     summary: {
       total: items.length,
-      waitingReturn: items.filter((item) => String(item.status).includes('WAITING')).length,
-      closed: items.filter((item) => String(item.status).startsWith('CLOSED')).length,
+      waitingReturn: items.filter((item) => item.status === OPEN_RETURN_STATUS).length,
+      closed: items.filter((item) => item.status.startsWith('CLOSED')).length,
       verified: items.filter((item) => item.status === 'CLOSED_VERIFIED').length,
     },
     warnings,

--- a/src/lib/field/operationalCycle.ts
+++ b/src/lib/field/operationalCycle.ts
@@ -268,7 +268,7 @@ async function readWorldContext(): Promise<WorldContext> {
   const rawWs = worldspect.data ? record(worldspect.data) : null;
   const wsi = nullableNumber(rawWs?.wsi);
   const nti = nullableNumber(rawWs?.nti);
-  const ws = rawWs ? {
+  const ws: Row | null = rawWs ? {
     ...rawWs,
     regime: deriveWorldspectRegime(wsi, nti),
     wsi,

--- a/src/lib/field/operationalCycle.ts
+++ b/src/lib/field/operationalCycle.ts
@@ -1,0 +1,740 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+import { linkCaseEvidence, registerReferenceCase } from '@/lib/amv/referenceBank';
+import { runMophAgent } from '@/lib/agents/sfiAgents';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+export type FieldVerificationWindow = '72h' | '7d' | '30d';
+
+export type CreateFieldCycleInput = {
+  title: string;
+  domain: string;
+  stuckSystem: string;
+  objective: string;
+  attempts: string;
+  evidence: string;
+  consequence: string;
+  declaredAttractor: string;
+  evidenceSource: string;
+  evidenceUri?: string | null;
+  reliability: number;
+  verificationWindow: FieldVerificationWindow;
+  consent: boolean;
+};
+
+export type ReturnFieldCycleInput = {
+  evidenceNote: string;
+  evidenceSource: string;
+  evidenceUri?: string | null;
+  reliability: number;
+  actualOutcome: number;
+  interventionFidelity: number;
+  observedAt?: string | null;
+};
+
+type Row = Record<string, unknown>;
+
+type WorldContext = {
+  worldspect: Row | null;
+  worldVector: Row | null;
+  observedAt: string | null;
+  confidence: number | null;
+  warnings: string[];
+};
+
+const FORMULA_VERSION = 'FIELD_MIHM_EVIDENCE_PROXY_V1';
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function rows(value: unknown): Row[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is Row => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+    : [];
+}
+
+function text(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function clamp01(value: unknown) {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, Math.min(1, parsed)) : 0;
+}
+
+function iso(value?: string | null) {
+  if (!value) return new Date().toISOString();
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : new Date().toISOString();
+}
+
+function dueAt(window: FieldVerificationWindow) {
+  const hours = window === '72h' ? 72 : window === '7d' ? 168 : 720;
+  return new Date(Date.now() + hours * 60 * 60 * 1000).toISOString();
+}
+
+function tokens(value: string) {
+  return new Set(
+    value
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .split(/[^a-z0-9]+/)
+      .filter((item) => item.length >= 4)
+      .slice(0, 240),
+  );
+}
+
+function overlap(left: string, right: string) {
+  const a = tokens(left);
+  const b = tokens(right);
+  if (!a.size || !b.size) return 0;
+  let shared = 0;
+  for (const item of a) if (b.has(item)) shared += 1;
+  return shared / Math.max(a.size, b.size);
+}
+
+function specificity(value: string) {
+  const words = value.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(0, Math.min(1, words / 45));
+}
+
+function metric(input: {
+  key: string;
+  label: string;
+  value: number | null;
+  source: string;
+  confidence: number | null;
+  explanation: string;
+}) {
+  return {
+    key: input.key,
+    label: input.label,
+    value: input.value,
+    status: input.value === null ? 'MISSING' : 'DERIVED_PROXY',
+    source: input.source,
+    confidence: input.confidence,
+    explanation: input.explanation,
+    formulaVersion: FORMULA_VERSION,
+    canonicalCalibration: false,
+  };
+}
+
+function baselineMihm(input: CreateFieldCycleInput, world: WorldContext) {
+  const required = [input.stuckSystem, input.objective, input.attempts, input.evidence, input.consequence];
+  const coverage = required.filter((item) => item.trim().length >= 8).length / required.length;
+  const traceability = clamp01(
+    (input.evidence.trim().length >= 24 ? 0.45 : 0.1)
+      + (input.evidenceSource.trim() ? 0.25 : 0)
+      + (input.evidenceUri ? 0.2 : 0)
+      + input.reliability * 0.1,
+  );
+  const coherence = clamp01(
+    overlap(input.objective, `${input.stuckSystem} ${input.evidence}`) * 0.45
+      + specificity(input.objective) * 0.25
+      + coverage * 0.15
+      + traceability * 0.15,
+  );
+  const phi = clamp01(coherence * 0.55 + coverage * 0.25 + traceability * 0.2);
+  const worldGradient = world.confidence;
+
+  return {
+    status: 'PARTIAL',
+    formulaVersion: FORMULA_VERSION,
+    canonicalCalibration: false,
+    coverage,
+    traceability,
+    metrics: [
+      metric({ key: 'C_s', label: 'Structural coherence proxy', value: coherence, source: 'declared objective + baseline evidence', confidence: 0.45, explanation: 'Lexical alignment, specificity, coverage and evidence traceability. This is an auditable FIELD proxy, not historically calibrated MIHM.' }),
+      metric({ key: 'D_i', label: 'Internal dispersion', value: null, source: 'return evidence required', confidence: null, explanation: 'Cannot be estimated before a comparable return observation exists.' }),
+      metric({ key: 'E_r', label: 'Residual energy', value: null, source: 'return evidence required', confidence: null, explanation: 'Requires an observed outcome after the intervention window.' }),
+      metric({ key: 'G_f', label: 'Field gradient proxy', value: worldGradient, source: 'latest WorldSpect / World Vector context', confidence: world.confidence, explanation: 'Uses only the current persisted world-context confidence. It is not a domain-specific causal estimate.' }),
+      metric({ key: 'D_cog', label: 'Cognitive discontinuity', value: null, source: 'insufficient evidence', confidence: null, explanation: 'FIELD does not infer undisclosed psychological state from participant text.' }),
+      metric({ key: 'Phi', label: 'Evidence coherence flow proxy', value: phi, source: 'baseline evidence contract', confidence: 0.42, explanation: 'Combines structural coherence, required-field coverage and traceability.' }),
+      metric({ key: 'F_s', label: 'Structural friction', value: null, source: 'insufficient multimodal evidence', confidence: null, explanation: 'No canonical multimodal measurement is available at intake.' }),
+      metric({ key: 'V_i', label: 'Intervention variability', value: null, source: 'intervention not executed', confidence: null, explanation: 'Requires return evidence and intervention fidelity.' }),
+      metric({ key: 'I_mc', label: 'Micro-coherence index', value: null, source: 'insufficient repeated observations', confidence: null, explanation: 'Requires multiple comparable observations.' }),
+    ],
+    tensions: [
+      coverage < 1 ? 'BASELINE_FIELDS_INCOMPLETE' : null,
+      traceability < 0.55 ? 'EVIDENCE_TRACEABILITY_THIN' : null,
+      world.warnings.length ? 'WORLD_CONTEXT_DEGRADED' : null,
+    ].filter(Boolean),
+  };
+}
+
+function returnMihm(input: ReturnFieldCycleInput, expectedValue: number, baseline: Row, world: WorldContext) {
+  const actual = clamp01(input.actualOutcome);
+  const fidelity = clamp01(input.interventionFidelity);
+  const reliability = clamp01(input.reliability);
+  const residual = expectedValue - actual;
+  const dispersion = Math.abs(residual);
+  const remaining = 1 - actual;
+  const baselineMetrics = rows(baseline.metrics);
+  const baselineCoherence = clamp01(baselineMetrics.find((item) => item.key === 'C_s')?.value);
+  const coherence = clamp01(baselineCoherence * 0.35 + reliability * 0.25 + fidelity * 0.25 + (1 - dispersion) * 0.15);
+  const phi = clamp01(coherence * 0.5 + (1 - dispersion) * 0.3 + reliability * 0.2);
+
+  return {
+    status: 'PARTIAL_RETURN',
+    formulaVersion: FORMULA_VERSION,
+    canonicalCalibration: false,
+    expectedValue,
+    actualValue: actual,
+    residual,
+    absoluteError: dispersion,
+    metrics: [
+      metric({ key: 'C_s', label: 'Structural coherence proxy', value: coherence, source: 'baseline + return evidence', confidence: 0.55, explanation: 'Combines baseline coherence, source reliability, intervention fidelity and prediction alignment.' }),
+      metric({ key: 'D_i', label: 'Outcome dispersion proxy', value: dispersion, source: 'expected versus observed outcome', confidence: 0.58, explanation: 'Absolute difference between the sealed provisional expectation and the declared/observed return value.' }),
+      metric({ key: 'E_r', label: 'Residual unresolved friction proxy', value: remaining, source: 'observed outcome', confidence: reliability * 0.7, explanation: 'Represents the unresolved normalized portion after the return window; it is not an energy measurement from a physical sensor.' }),
+      metric({ key: 'G_f', label: 'Field gradient proxy', value: world.confidence, source: 'return-time WorldSpect / World Vector context', confidence: world.confidence, explanation: 'Context confidence at return time; no causal attribution is made.' }),
+      metric({ key: 'D_cog', label: 'Cognitive discontinuity', value: null, source: 'not inferred', confidence: null, explanation: 'FIELD does not infer a private psychological state.' }),
+      metric({ key: 'Phi', label: 'Evidence coherence flow proxy', value: phi, source: 'return evidence contract', confidence: 0.52, explanation: 'Combines coherence, prediction alignment and source reliability.' }),
+      metric({ key: 'F_s', label: 'Structural friction', value: dispersion, source: 'prediction error proxy', confidence: 0.48, explanation: 'Provisional proxy based on observed deviation; not a calibrated cross-domain MIHM value.' }),
+      metric({ key: 'V_i', label: 'Intervention variability proxy', value: 1 - fidelity, source: 'operator-declared intervention fidelity', confidence: reliability * 0.65, explanation: 'Higher value indicates lower fidelity to the sealed intervention.' }),
+      metric({ key: 'I_mc', label: 'Micro-coherence index', value: null, source: 'repeated returns required', confidence: null, explanation: 'One return does not establish repeated micro-coherence.' }),
+    ],
+    tensions: [
+      reliability < 0.55 ? 'RETURN_SOURCE_RELIABILITY_LOW' : null,
+      fidelity < 0.6 ? 'INTERVENTION_FIDELITY_LOW' : null,
+      dispersion > 0.35 ? 'PREDICTION_DEVIATION_HIGH' : null,
+      world.warnings.length ? 'WORLD_CONTEXT_DEGRADED' : null,
+    ].filter(Boolean),
+  };
+}
+
+async function readWorldContext(): Promise<WorldContext> {
+  const service = createServiceSupabaseClient();
+  const [worldspect, vector] = await Promise.all([
+    service
+      .from('worldspect_snapshots')
+      .select('id,observed_at,source_state,confidence,wsi,nti,regime,vectors,source_coverage,degraded_sources')
+      .order('observed_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    service
+      .from('world_vector_observations')
+      .select('id,observed_at,status,confidence,sector,dominant_signal,domain_values,warnings,interpretation,source_snapshot_id')
+      .order('observed_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+  const warnings = [
+    worldspect.error ? `WORLDSPECT:${worldspect.error.message}` : null,
+    vector.error ? `WORLD_VECTOR:${vector.error.message}` : null,
+  ].filter((item): item is string => Boolean(item));
+  const ws = worldspect.data ? record(worldspect.data) : null;
+  const wv = vector.data ? record(vector.data) : null;
+  const confidenceValues = [ws?.confidence, wv?.confidence]
+    .map((item) => typeof item === 'number' ? item : null)
+    .filter((item): item is number => item !== null);
+  return {
+    worldspect: ws,
+    worldVector: wv,
+    observedAt: text(wv?.observed_at) || text(ws?.observed_at) || null,
+    confidence: confidenceValues.length ? confidenceValues.reduce((sum, item) => sum + item, 0) / confidenceValues.length : null,
+    warnings,
+  };
+}
+
+function objectClass(domain: string) {
+  const normalized = domain.toLowerCase();
+  if (normalized.includes('organiz')) return 'organization';
+  if (normalized.includes('instit')) return 'institution';
+  if (normalized.includes('company') || normalized.includes('empresa')) return 'company';
+  return 'other';
+}
+
+function returnHash(payload: Row) {
+  return createHash('sha256').update(JSON.stringify(payload)).digest('hex');
+}
+
+async function audit(actorId: string, action: string, targetId: string, afterState: Row) {
+  const service = createServiceSupabaseClient();
+  await service.from('sfi_audit_events').insert({
+    actor_id: actorId,
+    action,
+    target_type: 'field_case',
+    target_id: targetId,
+    after_state: afterState,
+    context: { surface: 'field', version: 'FIELD_OPERATIONAL_CYCLE_V1' },
+  });
+}
+
+export async function createFieldCycle(ownerId: string, input: CreateFieldCycleInput) {
+  if (!input.consent) throw new Error('FIELD_CONSENT_REQUIRED');
+  if (input.title.trim().length < 3) throw new Error('FIELD_TITLE_REQUIRED');
+  if (input.stuckSystem.trim().length < 12) throw new Error('FIELD_SYSTEM_REQUIRED');
+  if (input.objective.trim().length < 8) throw new Error('FIELD_OBJECTIVE_REQUIRED');
+  if (input.evidence.trim().length < 8) throw new Error('FIELD_BASELINE_EVIDENCE_REQUIRED');
+
+  const service = createServiceSupabaseClient();
+  const world = await readWorldContext();
+  const moph = await runMophAgent({
+    stuckSystem: input.stuckSystem,
+    objective: input.objective,
+    attempts: input.attempts,
+    evidence: input.evidence,
+    consequence: input.consequence,
+    accountId: ownerId,
+  });
+  const baseline = baselineMihm(input, world);
+  const openedAt = new Date().toISOString();
+  const expectedAt = dueAt(input.verificationWindow);
+
+  const caseInsert = await service.from('field_cases').insert({
+    owner_id: ownerId,
+    title: input.title.trim(),
+    domain: input.domain.trim() || 'other',
+    declared_attractor: input.declaredAttractor.trim() || input.objective.trim(),
+    baseline: input.stuckSystem.trim(),
+    consent: true,
+    visibility: 'private',
+    verification_window: input.verificationWindow,
+    status: 'BUILDING',
+    metadata: {
+      objective: input.objective.trim(),
+      attempts: input.attempts.trim(),
+      consequence: input.consequence.trim(),
+      workflowVersion: 'FIELD_OPERATIONAL_CYCLE_V1',
+      worldAtT0: world,
+    },
+  }).select('*').single();
+  if (caseInsert.error || !caseInsert.data) throw new Error(`FIELD_CASE_CREATE_FAILED:${caseInsert.error?.message ?? 'unknown'}`);
+  const fieldCase = record(caseInsert.data);
+  const caseId = String(fieldCase.id);
+
+  const evidenceInsert = await service.from('field_case_evidence').insert({
+    case_id: caseId,
+    owner_id: ownerId,
+    evidence_type: 'declared_baseline',
+    label: 'T0 baseline evidence',
+    source: input.evidenceSource.trim() || 'participant_declared',
+    reliability: clamp01(input.reliability),
+    uri: input.evidenceUri?.trim() || null,
+    visibility: 'private',
+    payload: {
+      note: input.evidence.trim(),
+      epistemicClass: 'declared',
+      objective: input.objective.trim(),
+      observedBeforeIntervention: true,
+    },
+    observed_at: openedAt,
+  }).select('*').single();
+  if (evidenceInsert.error || !evidenceInsert.data) throw new Error(`FIELD_EVIDENCE_CREATE_FAILED:${evidenceInsert.error?.message ?? 'unknown'}`);
+  const evidenceRow = record(evidenceInsert.data);
+  const evidenceId = String(evidenceRow.id);
+
+  const mophInsert = await service.from('field_moph_runs').insert({
+    case_id: caseId,
+    owner_id: ownerId,
+    status: 'COMPLETED_PROVISIONAL',
+    input: {
+      stuckSystem: input.stuckSystem,
+      objective: input.objective,
+      attempts: input.attempts,
+      consequence: input.consequence,
+    },
+    output: moph,
+    evidence_ids: [evidenceId],
+    started_at: openedAt,
+    completed_at: new Date().toISOString(),
+  }).select('*').single();
+  if (mophInsert.error || !mophInsert.data) throw new Error(`FIELD_MOPH_CREATE_FAILED:${mophInsert.error?.message ?? 'unknown'}`);
+
+  const mihmInsert = await service.from('field_mihm_readings').insert({
+    case_id: caseId,
+    owner_id: ownerId,
+    status: baseline.status,
+    metrics: baseline.metrics,
+    tensions: baseline.tensions,
+    formula_version: FORMULA_VERSION,
+    evidence_ids: [evidenceId],
+  }).select('*').single();
+  if (mihmInsert.error || !mihmInsert.data) throw new Error(`FIELD_MIHM_CREATE_FAILED:${mihmInsert.error?.message ?? 'unknown'}`);
+
+  const expectedValue = clamp01(
+    moph.confidence * 0.55
+      + clamp01(baseline.coverage) * 0.25
+      + clamp01(input.reliability) * 0.2,
+  );
+  const hypothesisInsert = await service.from('field_hypotheses').insert({
+    case_id: caseId,
+    owner_id: ownerId,
+    statement: moph.friction_reading,
+    target: input.objective.trim(),
+    expected_signal: `Observable normalized movement near ${expectedValue.toFixed(3)} after the sealed minimal intervention.`,
+    verification_window: input.verificationWindow,
+    confidence: moph.confidence,
+    status: 'SEALED_PROVISIONAL',
+    evidence_ids: [evidenceId],
+  }).select('*').single();
+  if (hypothesisInsert.error || !hypothesisInsert.data) throw new Error(`FIELD_HYPOTHESIS_CREATE_FAILED:${hypothesisInsert.error?.message ?? 'unknown'}`);
+  const hypothesis = record(hypothesisInsert.data);
+
+  const interventionInsert = await service.from('field_interventions').insert({
+    case_id: caseId,
+    owner_id: ownerId,
+    hypothesis_id: String(hypothesis.id),
+    minimum_change: moph.minimal_perturbation,
+    prohibited_effects: [
+      'Do not change more than one primary variable.',
+      'Do not expose private evidence.',
+      'Do not continue if legal, medical, safety or irreversible risk appears.',
+    ],
+    status: 'READY_FOR_EXECUTION',
+    started_at: openedAt,
+    evidence_ids: [evidenceId],
+  }).select('*').single();
+  if (interventionInsert.error || !interventionInsert.data) throw new Error(`FIELD_INTERVENTION_CREATE_FAILED:${interventionInsert.error?.message ?? 'unknown'}`);
+  const intervention = record(interventionInsert.data);
+
+  const sealPayload = {
+    caseId,
+    ownerId,
+    openedAt,
+    expectedAt,
+    verificationWindow: input.verificationWindow,
+    hypothesisId: hypothesis.id,
+    interventionId: intervention.id,
+    expectedValue,
+    evidenceId,
+    worldObservedAt: world.observedAt,
+  };
+  const seal = returnHash(sealPayload);
+
+  const returnInsert = await service.from('field_returns').insert({
+    case_id: caseId,
+    owner_id: ownerId,
+    intervention_id: String(intervention.id),
+    verification_window: input.verificationWindow,
+    expected_at: expectedAt,
+    status: 'WAITING_RETURN',
+    evidence_ids: [evidenceId],
+    payload: { seal, sealPayload },
+  }).select('*').single();
+  if (returnInsert.error || !returnInsert.data) throw new Error(`FIELD_RETURN_CREATE_FAILED:${returnInsert.error?.message ?? 'unknown'}`);
+  const returnRow = record(returnInsert.data);
+
+  const caseUpdate = await service.from('field_cases').update({
+    status: 'WAITING_RETURN',
+    metadata: {
+      ...record(fieldCase.metadata),
+      objective: input.objective.trim(),
+      attempts: input.attempts.trim(),
+      consequence: input.consequence.trim(),
+      workflowVersion: 'FIELD_OPERATIONAL_CYCLE_V1',
+      returnHash: seal,
+      expectedValue,
+      expectedAt,
+      worldAtT0: world,
+      mophRunId: mophInsert.data.id,
+      mihmReadingId: mihmInsert.data.id,
+      hypothesisId: hypothesis.id,
+      interventionId: intervention.id,
+      returnId: returnRow.id,
+    },
+  }).eq('id', caseId).eq('owner_id', ownerId).select('*').single();
+  if (caseUpdate.error || !caseUpdate.data) throw new Error(`FIELD_CASE_SEAL_FAILED:${caseUpdate.error?.message ?? 'unknown'}`);
+
+  const warnings = [...world.warnings, ...moph.warnings];
+  try {
+    const reference = await registerReferenceCase({
+      caseCode: `FIELD-${caseId.slice(0, 8)}`,
+      objectId: caseId,
+      objectClass: objectClass(input.domain),
+      title: input.title,
+      manifestation: 'moph_72h_operational_cycle',
+      cohort: input.domain || 'field',
+      prospective: true,
+      status: 'WAITING_OUTCOME',
+      openedAt,
+      t0Cutoff: openedAt,
+      phaseStatus: {
+        phase0: 'READY',
+        phase1: 'PARTIAL_FIELD_PROXY',
+        phase2: 'DECLARED_BASELINE',
+        phase3: 'PROVISIONAL_NO_HISTORICAL_CALIBRATION',
+        phase4: 'SEALED_READY',
+        phase5: 'WAITING_RETURN',
+        phase6: 'NOT_CALIBRATED',
+      },
+      fieldsDocumented: ['field.baseline', 'field.objective', 'field.moph', 'field.hypothesis', 'field.intervention'],
+      missingFields: ['field.return_evidence', 'field.outcome'],
+      operatorId: ownerId,
+      consentRequired: objectClass(input.domain) === 'organization',
+      consentEvidenceId: objectClass(input.domain) === 'organization' ? evidenceId : null,
+      metadata: { fieldCaseId: caseId, returnHash: seal, expectedAt, expectedValue },
+    });
+    await Promise.all([
+      linkCaseEvidence({ caseId: String(reference.id), evidenceSource: 'field_case_evidence', evidenceId, relationType: 'SUPPORTS', createdBy: ownerId }),
+      linkCaseEvidence({ caseId: String(reference.id), evidenceSource: 'field_hypotheses', evidenceId: String(hypothesis.id), relationType: 'CONTEXTUALIZES', createdBy: ownerId }),
+      linkCaseEvidence({ caseId: String(reference.id), evidenceSource: 'field_interventions', evidenceId: String(intervention.id), relationType: 'DOCUMENTS_INTERVENTION', createdBy: ownerId }),
+    ]);
+  } catch (error) {
+    warnings.push(`REFERENCE_BANK_DEGRADED:${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  await audit(ownerId, 'field.cycle.sealed', caseId, { returnHash: seal, expectedAt, expectedValue, hypothesisId: hypothesis.id, interventionId: intervention.id });
+
+  return {
+    case: caseUpdate.data,
+    baselineEvidence: evidenceRow,
+    moph,
+    mihm: baseline,
+    hypothesis,
+    intervention,
+    return: returnRow,
+    seal,
+    expectedAt,
+    expectedValue,
+    world,
+    warnings,
+  };
+}
+
+export async function submitFieldReturn(ownerId: string, caseId: string, input: ReturnFieldCycleInput) {
+  if (input.evidenceNote.trim().length < 12) throw new Error('FIELD_RETURN_EVIDENCE_REQUIRED');
+  const service = createServiceSupabaseClient();
+  const caseResult = await service.from('field_cases').select('*').eq('id', caseId).eq('owner_id', ownerId).maybeSingle();
+  if (caseResult.error || !caseResult.data) throw new Error('FIELD_CASE_NOT_FOUND');
+  const fieldCase = record(caseResult.data);
+  const metadata = record(fieldCase.metadata);
+  const expectedValue = clamp01(metadata.expectedValue);
+  const world = await readWorldContext();
+
+  const [hypothesisResult, interventionResult, returnResult, baselineResult] = await Promise.all([
+    service.from('field_hypotheses').select('*').eq('case_id', caseId).eq('owner_id', ownerId).order('created_at', { ascending: false }).limit(1).maybeSingle(),
+    service.from('field_interventions').select('*').eq('case_id', caseId).eq('owner_id', ownerId).order('created_at', { ascending: false }).limit(1).maybeSingle(),
+    service.from('field_returns').select('*').eq('case_id', caseId).eq('owner_id', ownerId).order('created_at', { ascending: false }).limit(1).maybeSingle(),
+    service.from('field_mihm_readings').select('*').eq('case_id', caseId).eq('owner_id', ownerId).order('created_at', { ascending: true }).limit(1).maybeSingle(),
+  ]);
+  if (!hypothesisResult.data || !interventionResult.data || !returnResult.data) throw new Error('FIELD_CYCLE_INCOMPLETE');
+
+  const observedAt = iso(input.observedAt);
+  const evidenceInsert = await service.from('field_case_evidence').insert({
+    case_id: caseId,
+    owner_id: ownerId,
+    evidence_type: 'return_observation',
+    label: 'Return-window evidence',
+    source: input.evidenceSource.trim() || 'participant_return',
+    reliability: clamp01(input.reliability),
+    uri: input.evidenceUri?.trim() || null,
+    visibility: 'private',
+    payload: {
+      note: input.evidenceNote.trim(),
+      epistemicClass: input.evidenceUri ? 'observed' : 'declared',
+      actualOutcome: clamp01(input.actualOutcome),
+      interventionFidelity: clamp01(input.interventionFidelity),
+      sealedHash: metadata.returnHash ?? null,
+    },
+    observed_at: observedAt,
+  }).select('*').single();
+  if (evidenceInsert.error || !evidenceInsert.data) throw new Error(`FIELD_RETURN_EVIDENCE_CREATE_FAILED:${evidenceInsert.error?.message ?? 'unknown'}`);
+  const evidence = record(evidenceInsert.data);
+  const evidenceId = String(evidence.id);
+
+  const returnReading = returnMihm(input, expectedValue, record(baselineResult.data), world);
+  const readingInsert = await service.from('field_mihm_readings').insert({
+    case_id: caseId,
+    owner_id: ownerId,
+    status: returnReading.status,
+    metrics: returnReading.metrics,
+    tensions: returnReading.tensions,
+    formula_version: FORMULA_VERSION,
+    evidence_ids: [evidenceId],
+  }).select('*').single();
+  if (readingInsert.error || !readingInsert.data) throw new Error(`FIELD_RETURN_MIHM_FAILED:${readingInsert.error?.message ?? 'unknown'}`);
+
+  const actualValue = clamp01(input.actualOutcome);
+  const delta = actualValue - expectedValue;
+  const accepted = clamp01(input.reliability) >= 0.55 && input.evidenceNote.trim().length >= 12;
+  const verified = Boolean(input.evidenceUri) && clamp01(input.reliability) >= 0.75 && clamp01(input.interventionFidelity) >= 0.6;
+  const learned = !accepted
+    ? 'La evidencia se conserva como declarada, pero no alcanza el umbral operativo de aceptación.'
+    : Math.abs(delta) <= 0.15
+      ? 'El resultado observado quedó dentro del rango operativo esperado; requiere más casos antes de calibrar.'
+      : delta > 0
+        ? 'El resultado superó la expectativa provisional. Revisar qué parte de la intervención y del campo explica la diferencia.'
+        : 'El resultado quedó por debajo de la expectativa provisional. Revisar fidelidad, evidencia faltante y cambio de campo.';
+
+  const outcomeInsert = await service.from('field_outcomes').insert({
+    case_id: caseId,
+    owner_id: ownerId,
+    intervention_id: interventionResult.data.id,
+    expected: `normalized movement ${expectedValue.toFixed(3)}`,
+    actual: `normalized movement ${actualValue.toFixed(3)}`,
+    delta,
+    verified,
+    learned,
+    evidence_ids: [evidenceId],
+  }).select('*').single();
+  if (outcomeInsert.error || !outcomeInsert.data) throw new Error(`FIELD_OUTCOME_CREATE_FAILED:${outcomeInsert.error?.message ?? 'unknown'}`);
+  const outcome = record(outcomeInsert.data);
+
+  await Promise.all([
+    service.from('field_returns').update({
+      returned_at: observedAt,
+      status: accepted ? 'RETURN_ACCEPTED' : 'RETURN_RECORDED_UNVERIFIED',
+      evidence_ids: [evidenceId],
+      payload: {
+        ...record(returnResult.data.payload),
+        actualValue,
+        expectedValue,
+        delta,
+        accepted,
+        verified,
+        reliability: clamp01(input.reliability),
+        interventionFidelity: clamp01(input.interventionFidelity),
+        worldAtReturn: world,
+      },
+    }).eq('id', returnResult.data.id).eq('owner_id', ownerId),
+    service.from('field_interventions').update({
+      status: 'COMPLETED',
+      completed_at: observedAt,
+      evidence_ids: [evidenceId],
+    }).eq('id', interventionResult.data.id).eq('owner_id', ownerId),
+    service.from('field_hypotheses').update({
+      status: verified ? 'VERIFIED_RETURN' : accepted ? 'OBSERVED_RETURN' : 'UNVERIFIED_RETURN',
+      evidence_ids: [evidenceId],
+    }).eq('id', hypothesisResult.data.id).eq('owner_id', ownerId),
+    service.from('field_cases').update({
+      status: verified ? 'CLOSED_VERIFIED' : accepted ? 'CLOSED_OBSERVED' : 'CLOSED_UNVERIFIED',
+      metadata: {
+        ...metadata,
+        returnedAt: observedAt,
+        returnEvidenceId: evidenceId,
+        outcomeId: outcome.id,
+        actualValue,
+        delta,
+        accepted,
+        verified,
+        worldAtReturn: world,
+      },
+    }).eq('id', caseId).eq('owner_id', ownerId),
+    service.from('field_lessons').insert({
+      case_id: caseId,
+      owner_id: ownerId,
+      outcome_id: outcome.id,
+      statement: learned,
+      evidence_ids: [evidenceId],
+    }),
+  ]);
+
+  try {
+    const referenceResult = await service.from('sfi_reference_cases').select('id').eq('object_id', caseId).maybeSingle();
+    if (referenceResult.data?.id) {
+      await service.from('sfi_reference_cases').update({
+        status: verified || accepted ? 'CLOSED' : 'UNVERIFIABLE',
+        closed_at: observedAt,
+        outcome_id: outcome.id,
+        phase_status: {
+          phase0: 'READY',
+          phase1: 'PARTIAL_FIELD_PROXY',
+          phase2: accepted ? 'RETURN_EVIDENCE_ACCEPTED' : 'RETURN_EVIDENCE_THIN',
+          phase3: 'PROVISIONAL_NO_HISTORICAL_CALIBRATION',
+          phase4: 'EXECUTED',
+          phase5: verified ? 'VERIFIED' : accepted ? 'OBSERVED' : 'UNVERIFIABLE',
+          phase6: 'ACCUMULATING_CALIBRATION_CORPUS',
+        },
+        missing_fields: accepted ? [] : ['field.verified_return_source'],
+        metadata: {
+          fieldCaseId: caseId,
+          returnHash: metadata.returnHash,
+          expectedValue,
+          actualValue,
+          delta,
+          accepted,
+          verified,
+        },
+      }).eq('id', referenceResult.data.id);
+      await linkCaseEvidence({
+        caseId: String(referenceResult.data.id),
+        evidenceSource: 'field_case_evidence',
+        evidenceId,
+        relationType: 'VERIFIES_OUTCOME',
+        createdBy: ownerId,
+      });
+    }
+  } catch {
+    // Reference Bank degradation must not erase the participant return.
+  }
+
+  await audit(ownerId, 'field.cycle.returned', caseId, { evidenceId, outcomeId: outcome.id, actualValue, expectedValue, delta, accepted, verified });
+
+  return {
+    caseId,
+    evidence,
+    mihm: returnReading,
+    expectedValue,
+    actualValue,
+    delta,
+    accepted,
+    verified,
+    explanation: learned,
+    nextStep: !accepted
+      ? 'Add a traceable source or a clearer observed result; the current return remains preserved but unverified.'
+      : Math.abs(delta) > 0.25
+        ? 'Open a second controlled cycle with only one revised variable and preserve this case as the baseline.'
+        : 'Close this cycle and decide whether the intervention should be retained, reverted or tested in another comparable case.',
+    world,
+    outcome,
+  };
+}
+
+export async function listFieldCycles(ownerId: string) {
+  const service = createServiceSupabaseClient();
+  const caseResult = await service.from('field_cases').select('*').eq('owner_id', ownerId).is('deleted_at', null).order('updated_at', { ascending: false }).limit(50);
+  if (caseResult.error) throw new Error(`FIELD_CASE_LIST_FAILED:${caseResult.error.message}`);
+  const cases = rows(caseResult.data);
+  const ids = cases.map((item) => String(item.id));
+  if (!ids.length) return { cases: [], summary: { total: 0, waitingReturn: 0, closed: 0, verified: 0 } };
+
+  const [hypotheses, interventions, returns, outcomes, readings, evidence] = await Promise.all([
+    service.from('field_hypotheses').select('*').eq('owner_id', ownerId).in('case_id', ids).order('created_at', { ascending: false }),
+    service.from('field_interventions').select('*').eq('owner_id', ownerId).in('case_id', ids).order('created_at', { ascending: false }),
+    service.from('field_returns').select('*').eq('owner_id', ownerId).in('case_id', ids).order('created_at', { ascending: false }),
+    service.from('field_outcomes').select('*').eq('owner_id', ownerId).in('case_id', ids).order('recorded_at', { ascending: false }),
+    service.from('field_mihm_readings').select('*').eq('owner_id', ownerId).in('case_id', ids).order('created_at', { ascending: false }),
+    service.from('field_case_evidence').select('id,case_id,evidence_type,label,source,reliability,uri,observed_at,created_at').eq('owner_id', ownerId).in('case_id', ids).order('created_at', { ascending: false }),
+  ]);
+  const warnings = [hypotheses.error, interventions.error, returns.error, outcomes.error, readings.error, evidence.error]
+    .filter(Boolean)
+    .map((item) => item?.message ?? 'field_source_failed');
+
+  function latest(collection: Row[], caseId: string) {
+    return collection.find((item) => String(item.case_id) === caseId) ?? null;
+  }
+  const hypothesisRows = rows(hypotheses.data);
+  const interventionRows = rows(interventions.data);
+  const returnRows = rows(returns.data);
+  const outcomeRows = rows(outcomes.data);
+  const readingRows = rows(readings.data);
+  const evidenceRows = rows(evidence.data);
+
+  const items = cases.map((item) => {
+    const caseId = String(item.id);
+    return {
+      ...item,
+      hypothesis: latest(hypothesisRows, caseId),
+      intervention: latest(interventionRows, caseId),
+      return: latest(returnRows, caseId),
+      outcome: latest(outcomeRows, caseId),
+      latestMihm: latest(readingRows, caseId),
+      evidence: evidenceRows.filter((row) => String(row.case_id) === caseId),
+    };
+  });
+
+  return {
+    cases: items,
+    summary: {
+      total: items.length,
+      waitingReturn: items.filter((item) => String(item.status).includes('WAITING')).length,
+      closed: items.filter((item) => String(item.status).startsWith('CLOSED')).length,
+      verified: items.filter((item) => item.status === 'CLOSED_VERIFIED').length,
+    },
+    warnings,
+  };
+}

--- a/src/lib/field/operationalCycle.ts
+++ b/src/lib/field/operationalCycle.ts
@@ -34,6 +34,7 @@ export type ReturnFieldCycleInput = {
 };
 
 type Row = Record<string, unknown>;
+type ServiceClient = ReturnType<typeof createServiceSupabaseClient>;
 
 type WorldContext = {
   worldspect: Row | null;
@@ -55,6 +56,10 @@ type FieldCaseWithRelations = Row & {
 
 const FORMULA_VERSION = 'FIELD_MIHM_EVIDENCE_PROXY_V1';
 const OPEN_RETURN_STATUS = 'WAITING_RETURN';
+const PROCESSING_RETURN_STATUS = 'PROCESSING_RETURN';
+const PROCESSING_CASE_STATUS = 'RETURN_PROCESSING';
+const FIELD_BUCKET = 'field-evidence';
+const FIELD_STORAGE_PREFIX = `storage://${FIELD_BUCKET}/`;
 
 function record(value: unknown): Row {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
@@ -84,6 +89,12 @@ function clamp01(value: unknown) {
 function nullableNumber(value: unknown) {
   if (value === null || typeof value === 'undefined' || value === '') return null;
   const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseTimestamp(value: unknown) {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const parsed = new Date(value).getTime();
   return Number.isFinite(parsed) ? parsed : null;
 }
 
@@ -152,13 +163,28 @@ function metric(input: {
   };
 }
 
-function baselineMihm(input: CreateFieldCycleInput, world: WorldContext) {
+async function validateOwnedFieldArtifact(service: ServiceClient, ownerId: string, uri?: string | null) {
+  const value = uri?.trim() ?? '';
+  if (!value.startsWith(FIELD_STORAGE_PREFIX)) return false;
+  const storagePath = value.slice(FIELD_STORAGE_PREFIX.length);
+  if (!storagePath.startsWith(`${ownerId}/field/`) || storagePath.includes('..')) return false;
+  const parts = storagePath.split('/').filter(Boolean);
+  if (parts.length < 4) return false;
+  const filename = parts.pop();
+  if (!filename) return false;
+  const directory = parts.join('/');
+  const listed = await service.storage.from(FIELD_BUCKET).list(directory, { limit: 20, search: filename });
+  if (listed.error) return false;
+  return (listed.data ?? []).some((item) => item.name === filename);
+}
+
+function baselineMihm(input: CreateFieldCycleInput, world: WorldContext, artifactVerified: boolean) {
   const required = [input.stuckSystem, input.objective, input.attempts, input.evidence, input.consequence];
   const coverage = required.filter((item) => item.trim().length >= 8).length / required.length;
   const traceability = clamp01(
     (input.evidence.trim().length >= 24 ? 0.45 : 0.1)
       + (input.evidenceSource.trim() ? 0.25 : 0)
-      + (input.evidenceUri ? 0.2 : 0)
+      + (artifactVerified ? 0.2 : 0)
       + clamp01(input.reliability) * 0.1,
   );
   const coherence = clamp01(
@@ -189,6 +215,7 @@ function baselineMihm(input: CreateFieldCycleInput, world: WorldContext) {
     tensions: [
       coverage < 1 ? 'BASELINE_FIELDS_INCOMPLETE' : null,
       traceability < 0.55 ? 'EVIDENCE_TRACEABILITY_THIN' : null,
+      input.evidenceUri && !artifactVerified ? 'BASELINE_ARTIFACT_NOT_VERIFIED' : null,
       world.warnings.length ? 'WORLD_CONTEXT_DEGRADED' : null,
     ].filter((item): item is string => Boolean(item)),
   };
@@ -324,6 +351,40 @@ async function audit(actorId: string, action: string, targetId: string, afterSta
   if (result.error) throw new Error(`FIELD_AUDIT_FAILED:${result.error.message}`);
 }
 
+async function claimReturn(service: ServiceClient, ownerId: string, caseId: string, returnId: string) {
+  const returnClaim = await service.from('field_returns')
+    .update({ status: PROCESSING_RETURN_STATUS })
+    .eq('id', returnId)
+    .eq('owner_id', ownerId)
+    .eq('case_id', caseId)
+    .eq('status', OPEN_RETURN_STATUS)
+    .select('id')
+    .maybeSingle();
+  if (returnClaim.error || !returnClaim.data) throw new Error('FIELD_RETURN_ALREADY_CLOSED_OR_NOT_READY');
+
+  const now = new Date().toISOString();
+  const caseClaim = await service.from('field_cases')
+    .update({ status: PROCESSING_CASE_STATUS, updated_at: now })
+    .eq('id', caseId)
+    .eq('owner_id', ownerId)
+    .eq('status', OPEN_RETURN_STATUS)
+    .select('id')
+    .maybeSingle();
+  if (caseClaim.error || !caseClaim.data) {
+    await service.from('field_returns').update({ status: OPEN_RETURN_STATUS }).eq('id', returnId).eq('owner_id', ownerId).eq('status', PROCESSING_RETURN_STATUS);
+    throw new Error('FIELD_RETURN_ALREADY_CLOSED_OR_NOT_READY');
+  }
+}
+
+async function releaseReturnClaim(service: ServiceClient, ownerId: string, caseId: string, returnId: string) {
+  const existingOutcome = await service.from('field_outcomes').select('id').eq('case_id', caseId).eq('owner_id', ownerId).limit(1).maybeSingle();
+  if (existingOutcome.data) return;
+  await Promise.all([
+    service.from('field_returns').update({ status: OPEN_RETURN_STATUS }).eq('id', returnId).eq('owner_id', ownerId).eq('status', PROCESSING_RETURN_STATUS),
+    service.from('field_cases').update({ status: OPEN_RETURN_STATUS, updated_at: new Date().toISOString() }).eq('id', caseId).eq('owner_id', ownerId).eq('status', PROCESSING_CASE_STATUS),
+  ]);
+}
+
 export async function createFieldCycle(ownerId: string, input: CreateFieldCycleInput) {
   if (!input.consent) throw new Error('FIELD_CONSENT_REQUIRED');
   if (input.title.trim().length < 3) throw new Error('FIELD_TITLE_REQUIRED');
@@ -332,6 +393,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
   if (input.evidence.trim().length < 8) throw new Error('FIELD_BASELINE_EVIDENCE_REQUIRED');
 
   const service = createServiceSupabaseClient();
+  const baselineArtifactVerified = await validateOwnedFieldArtifact(service, ownerId, input.evidenceUri);
   const world = await readWorldContext();
   const moph = await runMophAgent({
     stuckSystem: input.stuckSystem,
@@ -341,7 +403,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
     consequence: input.consequence,
     accountId: ownerId,
   });
-  const baseline = baselineMihm(input, world);
+  const baseline = baselineMihm(input, world, baselineArtifactVerified);
   const openedAt = new Date().toISOString();
   const expectedAt = dueAt(input.verificationWindow);
   const minimumChange = interventionForWindow(moph.minimal_perturbation, input.verificationWindow);
@@ -361,6 +423,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
       attempts: input.attempts.trim(),
       consequence: input.consequence.trim(),
       workflowVersion: 'FIELD_OPERATIONAL_CYCLE_V1',
+      baselineArtifactVerified,
       worldAtT0: world,
     },
   }).select('*').single();
@@ -379,7 +442,8 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
     visibility: 'private',
     payload: {
       note: input.evidence.trim(),
-      epistemicClass: input.evidenceUri ? 'observed' : 'declared',
+      epistemicClass: baselineArtifactVerified ? 'observed' : 'declared',
+      artifactVerified: baselineArtifactVerified,
       objective: input.objective.trim(),
       observedBeforeIntervention: true,
     },
@@ -466,7 +530,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
     evidenceId,
     worldObservedAt: world.observedAt,
   };
-  const seal = returnHash(sealPayload);
+  const seal = createHash('sha256').update(JSON.stringify(sealPayload)).digest('hex');
 
   const returnInsert = await service.from('field_returns').insert({
     case_id: caseId,
@@ -483,12 +547,14 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
 
   const caseUpdate = await service.from('field_cases').update({
     status: OPEN_RETURN_STATUS,
+    updated_at: openedAt,
     metadata: {
       ...record(fieldCase.metadata),
       objective: input.objective.trim(),
       attempts: input.attempts.trim(),
       consequence: input.consequence.trim(),
       workflowVersion: 'FIELD_OPERATIONAL_CYCLE_V1',
+      baselineArtifactVerified,
       returnHash: seal,
       expectedValue,
       expectedAt,
@@ -503,6 +569,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
   if (caseUpdate.error || !caseUpdate.data) throw new Error(`FIELD_CASE_SEAL_FAILED:${caseUpdate.error?.message ?? 'unknown'}`);
 
   const warnings = [...world.warnings, ...moph.warnings];
+  if (input.evidenceUri && !baselineArtifactVerified) warnings.push('BASELINE_ARTIFACT_NOT_VERIFIED');
   try {
     const reference = await registerReferenceCase({
       caseCode: `FIELD-${caseId.slice(0, 8)}`,
@@ -518,7 +585,7 @@ export async function createFieldCycle(ownerId: string, input: CreateFieldCycleI
       phaseStatus: {
         phase0: 'READY',
         phase1: 'PARTIAL_FIELD_PROXY',
-        phase2: 'DECLARED_BASELINE',
+        phase2: baselineArtifactVerified ? 'OBSERVED_BASELINE' : 'DECLARED_BASELINE',
         phase3: 'PROVISIONAL_NO_HISTORICAL_CALIBRATION',
         phase4: 'SEALED_READY',
         phase5: 'WAITING_RETURN',
@@ -581,190 +648,213 @@ export async function submitFieldReturn(ownerId: string, caseId: string, input: 
   if (!hypothesisResult.data || !interventionResult.data || !returnResult.data) throw new Error('FIELD_CYCLE_INCOMPLETE');
   if (text(returnResult.data.status) !== OPEN_RETURN_STATUS || existingOutcome.data) throw new Error('FIELD_RETURN_ALREADY_CLOSED_OR_NOT_READY');
 
+  const expectedAtMs = parseTimestamp(returnResult.data.expected_at) ?? parseTimestamp(metadata.expectedAt);
+  if (expectedAtMs === null) throw new Error('FIELD_RETURN_WINDOW_INVALID');
+  const serverNow = Date.now();
+  if (serverNow < expectedAtMs) throw new Error(`FIELD_RETURN_WINDOW_NOT_OPEN:${new Date(expectedAtMs).toISOString()}`);
+
   const observedAt = iso(input.observedAt);
-  const evidenceInsert = await service.from('field_case_evidence').insert({
-    case_id: caseId,
-    owner_id: ownerId,
-    evidence_type: 'return_observation',
-    label: 'Return-window evidence',
-    source: input.evidenceSource.trim() || 'participant_return',
-    reliability: clamp01(input.reliability),
-    uri: input.evidenceUri?.trim() || null,
-    visibility: 'private',
-    payload: {
-      note: input.evidenceNote.trim(),
-      epistemicClass: input.evidenceUri ? 'observed' : 'declared',
-      actualOutcome: clamp01(input.actualOutcome),
-      interventionFidelity: clamp01(input.interventionFidelity),
-      sealedHash: metadata.returnHash ?? null,
-    },
-    observed_at: observedAt,
-  }).select('*').single();
-  if (evidenceInsert.error || !evidenceInsert.data) throw new Error(`FIELD_RETURN_EVIDENCE_CREATE_FAILED:${evidenceInsert.error?.message ?? 'unknown'}`);
-  const evidence = record(evidenceInsert.data);
-  const evidenceId = String(evidence.id);
+  const observedAtMs = parseTimestamp(observedAt) ?? serverNow;
+  if (observedAtMs < expectedAtMs) throw new Error('FIELD_RETURN_OBSERVED_BEFORE_WINDOW');
+  if (observedAtMs > serverNow + 5 * 60 * 1000) throw new Error('FIELD_RETURN_OBSERVED_IN_FUTURE');
 
-  const returnReading = returnMihm(input, expectedValue, record(baselineResult.data), world);
-  const readingInsert = await service.from('field_mihm_readings').insert({
-    case_id: caseId,
-    owner_id: ownerId,
-    status: returnReading.status,
-    metrics: returnReading.metrics,
-    tensions: returnReading.tensions,
-    formula_version: FORMULA_VERSION,
-    evidence_ids: [evidenceId],
-  }).select('*').single();
-  if (readingInsert.error || !readingInsert.data) throw new Error(`FIELD_RETURN_MIHM_FAILED:${readingInsert.error?.message ?? 'unknown'}`);
-
-  const actualValue = clamp01(input.actualOutcome);
-  const delta = actualValue - expectedValue;
-  const accepted = clamp01(input.reliability) >= 0.55 && input.evidenceNote.trim().length >= 12;
-  const verified = Boolean(input.evidenceUri) && clamp01(input.reliability) >= 0.75 && clamp01(input.interventionFidelity) >= 0.6;
-  const learned = !accepted
-    ? 'La evidencia se conserva como declarada, pero no alcanza el umbral operativo de aceptación.'
-    : Math.abs(delta) <= 0.15
-      ? 'El resultado observado quedó dentro del rango operativo esperado; requiere más casos antes de calibrar.'
-      : delta > 0
-        ? 'El resultado superó la expectativa provisional. Revisar qué parte de la intervención y del campo explica la diferencia.'
-        : 'El resultado quedó por debajo de la expectativa provisional. Revisar fidelidad, evidencia faltante y cambio de campo.';
-
-  const outcomeInsert = await service.from('field_outcomes').insert({
-    case_id: caseId,
-    owner_id: ownerId,
-    intervention_id: interventionResult.data.id,
-    expected: `normalized movement ${expectedValue.toFixed(3)}`,
-    actual: `normalized movement ${actualValue.toFixed(3)}`,
-    delta,
-    verified,
-    learned,
-    evidence_ids: [evidenceId],
-  }).select('*').single();
-  if (outcomeInsert.error || !outcomeInsert.data) throw new Error(`FIELD_OUTCOME_CREATE_FAILED:${outcomeInsert.error?.message ?? 'unknown'}`);
-  const outcome = record(outcomeInsert.data);
-
-  const returnUpdate = await service.from('field_returns').update({
-    returned_at: observedAt,
-    status: accepted ? 'RETURN_ACCEPTED' : 'RETURN_RECORDED_UNVERIFIED',
-    evidence_ids: [evidenceId],
-    payload: {
-      ...record(returnResult.data.payload),
-      actualValue,
-      expectedValue,
-      delta,
-      accepted,
-      verified,
-      reliability: clamp01(input.reliability),
-      interventionFidelity: clamp01(input.interventionFidelity),
-      worldAtReturn: world,
-    },
-  }).eq('id', returnResult.data.id).eq('owner_id', ownerId).eq('status', OPEN_RETURN_STATUS);
-  if (returnUpdate.error) throw new Error(`FIELD_RETURN_CLOSE_FAILED:${returnUpdate.error.message}`);
-
-  const caseClose = await service.from('field_cases').update({
-    status: verified ? 'CLOSED_VERIFIED' : accepted ? 'CLOSED_OBSERVED' : 'CLOSED_UNVERIFIED',
-    metadata: {
-      ...metadata,
-      returnedAt: observedAt,
-      returnEvidenceId: evidenceId,
-      fieldOutcomeId: outcome.id,
-      actualValue,
-      delta,
-      accepted,
-      verified,
-      worldAtReturn: world,
-    },
-  }).eq('id', caseId).eq('owner_id', ownerId).eq('status', OPEN_RETURN_STATUS);
-  if (caseClose.error) throw new Error(`FIELD_CASE_CLOSE_FAILED:${caseClose.error.message}`);
-
-  await Promise.all([
-    service.from('field_interventions').update({
-      status: 'COMPLETED',
-      completed_at: observedAt,
-      evidence_ids: [evidenceId],
-    }).eq('id', interventionResult.data.id).eq('owner_id', ownerId),
-    service.from('field_hypotheses').update({
-      status: verified ? 'VERIFIED_RETURN' : accepted ? 'OBSERVED_RETURN' : 'UNVERIFIED_RETURN',
-      evidence_ids: [evidenceId],
-    }).eq('id', hypothesisResult.data.id).eq('owner_id', ownerId),
-    service.from('field_lessons').insert({
-      case_id: caseId,
-      owner_id: ownerId,
-      outcome_id: outcome.id,
-      statement: learned,
-      evidence_ids: [evidenceId],
-    }),
-  ]);
+  const artifactVerified = await validateOwnedFieldArtifact(service, ownerId, input.evidenceUri);
+  await claimReturn(service, ownerId, caseId, String(returnResult.data.id));
 
   try {
-    const referenceResult = await service.from('sfi_reference_cases').select('id,metadata').eq('object_id', caseId).maybeSingle();
-    if (referenceResult.data?.id) {
-      const referenceUpdate = await service.from('sfi_reference_cases').update({
-        status: verified || accepted ? 'CLOSED' : 'UNVERIFIABLE',
-        closed_at: observedAt,
-        phase_status: {
-          phase0: 'READY',
-          phase1: 'PARTIAL_FIELD_PROXY',
-          phase2: accepted ? 'RETURN_EVIDENCE_ACCEPTED' : 'RETURN_EVIDENCE_THIN',
-          phase3: 'PROVISIONAL_NO_HISTORICAL_CALIBRATION',
-          phase4: 'EXECUTED',
-          phase5: verified ? 'VERIFIED' : accepted ? 'OBSERVED' : 'UNVERIFIABLE',
-          phase6: 'ACCUMULATING_CALIBRATION_CORPUS',
-        },
-        missing_fields: accepted ? [] : ['field.verified_return_source'],
-        metadata: {
-          ...record(referenceResult.data.metadata),
-          fieldCaseId: caseId,
-          fieldOutcomeId: outcome.id,
-          returnHash: metadata.returnHash,
-          expectedValue,
-          actualValue,
-          delta,
-          accepted,
-          verified,
-        },
-      }).eq('id', referenceResult.data.id);
-      if (referenceUpdate.error) throw new Error(referenceUpdate.error.message);
-      await Promise.all([
-        linkCaseEvidence({
-          caseId: String(referenceResult.data.id),
-          evidenceSource: 'field_case_evidence',
-          evidenceId,
-          relationType: 'VERIFIES_OUTCOME',
-          createdBy: ownerId,
-        }),
-        linkCaseEvidence({
-          caseId: String(referenceResult.data.id),
-          evidenceSource: 'field_outcomes',
-          evidenceId: String(outcome.id),
-          relationType: 'VERIFIES_OUTCOME',
-          createdBy: ownerId,
-        }),
-      ]);
+    const evidenceInsert = await service.from('field_case_evidence').insert({
+      case_id: caseId,
+      owner_id: ownerId,
+      evidence_type: 'return_observation',
+      label: 'Return-window evidence',
+      source: input.evidenceSource.trim() || 'participant_return',
+      reliability: clamp01(input.reliability),
+      uri: input.evidenceUri?.trim() || null,
+      visibility: 'private',
+      payload: {
+        note: input.evidenceNote.trim(),
+        epistemicClass: artifactVerified ? 'observed' : 'declared',
+        artifactVerified,
+        actualOutcome: clamp01(input.actualOutcome),
+        interventionFidelity: clamp01(input.interventionFidelity),
+        sealedHash: metadata.returnHash ?? null,
+      },
+      observed_at: observedAt,
+    }).select('*').single();
+    if (evidenceInsert.error || !evidenceInsert.data) throw new Error(`FIELD_RETURN_EVIDENCE_CREATE_FAILED:${evidenceInsert.error?.message ?? 'unknown'}`);
+    const evidence = record(evidenceInsert.data);
+    const evidenceId = String(evidence.id);
+
+    const returnReading = returnMihm(input, expectedValue, record(baselineResult.data), world);
+    const readingInsert = await service.from('field_mihm_readings').insert({
+      case_id: caseId,
+      owner_id: ownerId,
+      status: returnReading.status,
+      metrics: returnReading.metrics,
+      tensions: returnReading.tensions,
+      formula_version: FORMULA_VERSION,
+      evidence_ids: [evidenceId],
+    }).select('*').single();
+    if (readingInsert.error || !readingInsert.data) throw new Error(`FIELD_RETURN_MIHM_FAILED:${readingInsert.error?.message ?? 'unknown'}`);
+
+    const actualValue = clamp01(input.actualOutcome);
+    const delta = actualValue - expectedValue;
+    const accepted = clamp01(input.reliability) >= 0.55 && input.evidenceNote.trim().length >= 12;
+    const verified = artifactVerified && clamp01(input.reliability) >= 0.75 && clamp01(input.interventionFidelity) >= 0.6;
+    const learned = !accepted
+      ? 'La evidencia se conserva como declarada, pero no alcanza el umbral operativo de aceptación.'
+      : Math.abs(delta) <= 0.15
+        ? 'El resultado observado quedó dentro del rango operativo esperado; requiere más casos antes de calibrar.'
+        : delta > 0
+          ? 'El resultado superó la expectativa provisional. Revisar qué parte de la intervención y del campo explica la diferencia.'
+          : 'El resultado quedó por debajo de la expectativa provisional. Revisar fidelidad, evidencia faltante y cambio de campo.';
+
+    const outcomeInsert = await service.from('field_outcomes').insert({
+      case_id: caseId,
+      owner_id: ownerId,
+      intervention_id: interventionResult.data.id,
+      expected: `normalized movement ${expectedValue.toFixed(3)}`,
+      actual: `normalized movement ${actualValue.toFixed(3)}`,
+      delta,
+      verified,
+      learned,
+      evidence_ids: [evidenceId],
+    }).select('*').single();
+    if (outcomeInsert.error || !outcomeInsert.data) throw new Error(`FIELD_OUTCOME_CREATE_FAILED:${outcomeInsert.error?.message ?? 'unknown'}`);
+    const outcome = record(outcomeInsert.data);
+
+    const returnUpdate = await service.from('field_returns').update({
+      returned_at: observedAt,
+      status: accepted ? 'RETURN_ACCEPTED' : 'RETURN_RECORDED_UNVERIFIED',
+      evidence_ids: [evidenceId],
+      payload: {
+        ...record(returnResult.data.payload),
+        actualValue,
+        expectedValue,
+        delta,
+        accepted,
+        verified,
+        artifactVerified,
+        reliability: clamp01(input.reliability),
+        interventionFidelity: clamp01(input.interventionFidelity),
+        worldAtReturn: world,
+      },
+    }).eq('id', returnResult.data.id).eq('owner_id', ownerId).eq('status', PROCESSING_RETURN_STATUS);
+    if (returnUpdate.error) throw new Error(`FIELD_RETURN_CLOSE_FAILED:${returnUpdate.error.message}`);
+
+    const caseClose = await service.from('field_cases').update({
+      status: verified ? 'CLOSED_VERIFIED' : accepted ? 'CLOSED_OBSERVED' : 'CLOSED_UNVERIFIED',
+      updated_at: observedAt,
+      metadata: {
+        ...metadata,
+        returnedAt: observedAt,
+        returnEvidenceId: evidenceId,
+        fieldOutcomeId: outcome.id,
+        actualValue,
+        delta,
+        accepted,
+        verified,
+        artifactVerified,
+        worldAtReturn: world,
+      },
+    }).eq('id', caseId).eq('owner_id', ownerId).eq('status', PROCESSING_CASE_STATUS);
+    if (caseClose.error) throw new Error(`FIELD_CASE_CLOSE_FAILED:${caseClose.error.message}`);
+
+    await Promise.all([
+      service.from('field_interventions').update({
+        status: 'COMPLETED',
+        completed_at: observedAt,
+        evidence_ids: [evidenceId],
+      }).eq('id', interventionResult.data.id).eq('owner_id', ownerId),
+      service.from('field_hypotheses').update({
+        status: verified ? 'VERIFIED_RETURN' : accepted ? 'OBSERVED_RETURN' : 'UNVERIFIED_RETURN',
+        evidence_ids: [evidenceId],
+      }).eq('id', hypothesisResult.data.id).eq('owner_id', ownerId),
+      service.from('field_lessons').insert({
+        case_id: caseId,
+        owner_id: ownerId,
+        outcome_id: outcome.id,
+        statement: learned,
+        evidence_ids: [evidenceId],
+      }),
+    ]);
+
+    try {
+      const referenceResult = await service.from('sfi_reference_cases').select('id,metadata').eq('object_id', caseId).maybeSingle();
+      if (referenceResult.data?.id) {
+        const referenceUpdate = await service.from('sfi_reference_cases').update({
+          status: verified || accepted ? 'CLOSED' : 'UNVERIFIABLE',
+          closed_at: observedAt,
+          phase_status: {
+            phase0: 'READY',
+            phase1: 'PARTIAL_FIELD_PROXY',
+            phase2: accepted ? 'RETURN_EVIDENCE_ACCEPTED' : 'RETURN_EVIDENCE_THIN',
+            phase3: 'PROVISIONAL_NO_HISTORICAL_CALIBRATION',
+            phase4: 'EXECUTED',
+            phase5: verified ? 'VERIFIED' : accepted ? 'OBSERVED' : 'UNVERIFIABLE',
+            phase6: 'ACCUMULATING_CALIBRATION_CORPUS',
+          },
+          missing_fields: accepted ? [] : ['field.verified_return_source'],
+          metadata: {
+            ...record(referenceResult.data.metadata),
+            fieldCaseId: caseId,
+            fieldOutcomeId: outcome.id,
+            returnHash: metadata.returnHash,
+            expectedValue,
+            actualValue,
+            delta,
+            accepted,
+            verified,
+            artifactVerified,
+          },
+        }).eq('id', referenceResult.data.id);
+        if (referenceUpdate.error) throw new Error(referenceUpdate.error.message);
+        await Promise.all([
+          linkCaseEvidence({
+            caseId: String(referenceResult.data.id),
+            evidenceSource: 'field_case_evidence',
+            evidenceId,
+            relationType: 'VERIFIES_OUTCOME',
+            createdBy: ownerId,
+          }),
+          linkCaseEvidence({
+            caseId: String(referenceResult.data.id),
+            evidenceSource: 'field_outcomes',
+            evidenceId: String(outcome.id),
+            relationType: 'VERIFIES_OUTCOME',
+            createdBy: ownerId,
+          }),
+        ]);
+      }
+    } catch {
+      // Reference Bank degradation must not erase a valid participant return.
     }
-  } catch {
-    // Reference Bank degradation must not erase a valid participant return.
+
+    await audit(ownerId, 'field.cycle.returned', caseId, { evidenceId, fieldOutcomeId: outcome.id, actualValue, expectedValue, delta, accepted, verified, artifactVerified });
+
+    return {
+      caseId,
+      evidence,
+      mihm: returnReading,
+      expectedValue,
+      actualValue,
+      delta,
+      accepted,
+      verified,
+      artifactVerified,
+      explanation: learned,
+      nextStep: !accepted
+        ? 'Add a traceable source or a clearer observed result; the current return remains preserved but unverified.'
+        : Math.abs(delta) > 0.25
+          ? 'Open a second controlled cycle with only one revised variable and preserve this case as the baseline.'
+          : 'Close this cycle and decide whether the intervention should be retained, reverted or tested in another comparable case.',
+      world,
+      outcome,
+    };
+  } catch (error) {
+    await releaseReturnClaim(service, ownerId, caseId, String(returnResult.data.id));
+    throw error;
   }
-
-  await audit(ownerId, 'field.cycle.returned', caseId, { evidenceId, fieldOutcomeId: outcome.id, actualValue, expectedValue, delta, accepted, verified });
-
-  return {
-    caseId,
-    evidence,
-    mihm: returnReading,
-    expectedValue,
-    actualValue,
-    delta,
-    accepted,
-    verified,
-    explanation: learned,
-    nextStep: !accepted
-      ? 'Add a traceable source or a clearer observed result; the current return remains preserved but unverified.'
-      : Math.abs(delta) > 0.25
-        ? 'Open a second controlled cycle with only one revised variable and preserve this case as the baseline.'
-        : 'Close this cycle and decide whether the intervention should be retained, reverted or tested in another comparable case.',
-    world,
-    outcome,
-  };
 }
 
 export async function listFieldCycles(ownerId: string) {


### PR DESCRIPTION
## Scope

Completes the public orientation layer and turns FIELD from a preview form into a private, longitudinal MOP-H operational cycle.

## Home

- Adds an immediate operational-entry selector over the live field.
- Explains what Observatory, FIELD, Studio, ScoreFriction and Repository actually do.
- Directs users by question and objective rather than unexplained hub names.
- Preserves the existing live interface underneath and provides a close/reopen control.
- Adds privacy-safe hub analytics.
- Animates only persisted `state.connections` in the world background; no random mock flows are created.

## FIELD

- Shows the current public World State before intake.
- Requires authentication for persistence.
- Creates a private FIELD case at T0.
- Persists baseline evidence, MOP-H run, partial MIHM evidence reading, hypothesis, minimal intervention and return window.
- Seals the pre-outcome contract with SHA-256.
- Supports 72h, 7d and 30d cycles.
- Adds private file upload to the existing `field-evidence` bucket.
- Allows the participant to return with evidence, source reliability, normalized observed movement and intervention fidelity.
- Contrasts expected and observed movement.
- Records outcome, delta, evidence acceptance, verification status, lesson and next step.
- Captures WorldSpect and World Vector context at T0 and return.
- Registers and closes Reference Bank cases when that subsystem is available.

## MIHM boundary

FIELD uses an explicit partial proxy contract named `FIELD_MIHM_EVIDENCE_PROXY_V1`. It leaves unsupported variables as `MISSING`, identifies every source and explanation, marks the reading as non-calibrated and does not infer psychological state.

## Persistence

Uses the existing FIELD ownership foundation tables and existing private storage bucket. No destructive migration and no synthetic corpus are included.

## Documentation

Adds `docs/field/FIELD_OPERATIONAL_CYCLE_V1.md` with persistence, hash, evidence, MIHM, return and privacy contracts.

## Validation

Domain boundaries, TypeScript and production build must pass before merge.