### PR TITLE
Implement governed client proposals workspace

### DIFF
--- a/docs/architecture/COMMERCIAL_CONVERSION_LAYER_V1.md
+++ b/docs/architecture/COMMERCIAL_CONVERSION_LAYER_V1.md
@@ -1,0 +1,51 @@
+# Commercial Conversion Layer v1
+
+## Purpose
+
+This layer converts approved institutional analysis into a governed commercial record without reusing `action_proposals` as a sales table.
+
+`action_proposals` remains an internal operational/governance artifact.
+
+`commercial_proposals` is a client-facing commercial artifact with explicit scope, price, validity, versions, and lifecycle.
+
+## Canonical flow
+
+```text
+PUBLIC OR FIELD SIGNAL
+→ CLIENT FINDER / IFNORM
+→ COMMERCIAL CLIENT
+→ COMMERCIAL OPPORTUNITY
+→ COMMERCIAL PROPOSAL
+→ INTERNAL REVIEW
+→ APPROVAL
+→ HUMAN-RECORDED SEND
+→ NEGOTIATION
+→ ACCEPT / REJECT / EXPIRE
+→ CONVERT
+```
+
+No external outreach, email, publication, or document delivery is executed by this module.
+
+## Tables
+
+- `commercial_clients`
+- `commercial_opportunities`
+- `commercial_proposals`
+- `commercial_proposal_versions`
+- `commercial_proposal_events`
+
+## ROOT surface
+
+- Page: `/root/commercial`
+- API: `/api/root/commercial`
+- Existing source agent: `/api/root/agentic/client-finder`
+
+## Governance
+
+Every mutation requires ROOT authentication and produces:
+
+1. the commercial domain record;
+2. a `commercial_proposal_events` record;
+3. a ROOT audit event and epistemic event through `auditRootAction`.
+
+The `sent` state records a human-confirmed external send. It does not send anything.

--- a/src/app/api/root/commercial/route.ts
+++ b/src/app/api/root/commercial/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+
+import {
+  createCommercialClient,
+  createCommercialOpportunity,
+  createCommercialProposal,
+  readCommercialWorkspace,
+  transitionCommercialProposal,
+} from '@/lib/commercial/commercialService';
+import { asRecord, auditRootAction, requireRootActor, stringValue } from '@/lib/root/server';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const gate = await requireRootActor('root.commercial.read');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  const data = await readCommercialWorkspace();
+  return NextResponse.json({ ok: true, data });
+}
+
+export async function POST(request: Request) {
+  const gate = await requireRootActor('root.commercial.mutate');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  const body = asRecord(await request.json().catch(() => ({})));
+  const intent = stringValue(body.intent);
+  const payload = asRecord(body.payload);
+  if (!intent) return NextResponse.json({ ok: false, error: 'commercial_intent_required' }, { status: 400 });
+
+  const result =
+    intent === 'create_client' ? await createCommercialClient(payload, gate.ctx.user.id)
+      : intent === 'create_opportunity' ? await createCommercialOpportunity(payload, gate.ctx.user.id)
+        : intent === 'create_proposal' ? await createCommercialProposal(payload, gate.ctx.user.id)
+          : intent === 'transition_proposal' ? await transitionCommercialProposal(payload, gate.ctx.user.id)
+            : { ok: false as const, error: 'commercial_intent_unknown' };
+
+  if (!result.ok) return NextResponse.json(result, { status: 400 });
+
+  const target =
+    stringValue(payload.proposalId)
+    ?? stringValue(payload.opportunityId)
+    ?? stringValue(payload.clientId)
+    ?? 'commercial_workspace';
+
+  const audit = await auditRootAction({
+    actorId: gate.ctx.user.id,
+    action: `commercial.${intent}`,
+    target,
+    payload: { intent, target },
+    request,
+  });
+
+  if (!audit.ok) {
+    return NextResponse.json({
+      ok: false,
+      error: 'commercial_mutation_persisted_but_audit_failed',
+      mutation: result.data,
+      audit,
+    }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, data: result.data, audit });
+}

--- a/src/app/root/commercial/page.tsx
+++ b/src/app/root/commercial/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+
+import { RootCommercialWorkspace } from '@/components/root/commercial/RootCommercialWorkspace';
+import { requireFounderPage } from '@/lib/root/server';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Commercial Conversion · ROOT',
+  robots: {
+    index: false,
+    follow: false,
+    nocache: true,
+  },
+};
+
+export default async function RootCommercialPage() {
+  await requireFounderPage('/root/commercial');
+  return <RootCommercialWorkspace />;
+}

--- a/src/components/root/commercial/RootCommercialWorkspace.tsx
+++ b/src/components/root/commercial/RootCommercialWorkspace.tsx
@@ -1,0 +1,345 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { FormEvent } from 'react';
+
+import './root-commercial.css';
+
+type CommercialProposalStatus =
+  | 'draft'
+  | 'internal_review'
+  | 'approved'
+  | 'sent'
+  | 'viewed'
+  | 'negotiation'
+  | 'accepted'
+  | 'rejected'
+  | 'expired'
+  | 'converted';
+
+type Row = Record<string, unknown>;
+
+type Workspace = {
+  schemaReady: boolean;
+  warnings: string[];
+  clients: Row[];
+  opportunities: Row[];
+  proposals: Row[];
+  sourceProposals: Row[];
+  counts: {
+    clients: number;
+    openOpportunities: number;
+    draftProposals: number;
+    activeProposals: number;
+    acceptedProposals: number;
+  };
+};
+
+type FinderResult = {
+  ifnorm?: {
+    entity_name?: string;
+    person_or_role?: string;
+    sector?: string;
+    detected_pain?: string;
+    recommended_offer?: string;
+    recommended_action?: string;
+    p_response?: number;
+    p_meeting?: number;
+    p_paid_diagnostic?: number;
+    status?: string;
+  };
+  warnings?: string[];
+};
+
+const EMPTY_WORKSPACE: Workspace = {
+  schemaReady: false,
+  warnings: [],
+  clients: [],
+  opportunities: [],
+  proposals: [],
+  sourceProposals: [],
+  counts: {
+    clients: 0,
+    openOpportunities: 0,
+    draftProposals: 0,
+    activeProposals: 0,
+    acceptedProposals: 0,
+  },
+};
+
+const TRANSITIONS: Record<string, CommercialProposalStatus[]> = {
+  draft: ['internal_review'],
+  internal_review: ['draft', 'approved'],
+  approved: ['sent'],
+  sent: ['viewed', 'negotiation', 'accepted', 'rejected', 'expired'],
+  viewed: ['negotiation', 'accepted', 'rejected', 'expired'],
+  negotiation: ['accepted', 'rejected', 'expired'],
+  accepted: ['converted'],
+};
+
+function value(row: Row, key: string) {
+  const item = row[key];
+  return typeof item === 'string' || typeof item === 'number' ? String(item) : '';
+}
+
+function numberValue(row: Row, key: string) {
+  const item = row[key];
+  return typeof item === 'number' ? item : Number(item ?? 0);
+}
+
+function money(amount: unknown, currency: unknown) {
+  const number = typeof amount === 'number' ? amount : Number(amount ?? 0);
+  if (!Number.isFinite(number)) return 'NO MEDIDO';
+  return new Intl.NumberFormat('es-MX', {
+    style: 'currency',
+    currency: typeof currency === 'string' && currency ? currency : 'MXN',
+    maximumFractionDigits: 0,
+  }).format(number);
+}
+
+function shortDate(input: unknown) {
+  return typeof input === 'string' ? input.slice(0, 10) : 'NO MEDIDO';
+}
+
+export function RootCommercialWorkspace() {
+  const [workspace, setWorkspace] = useState<Workspace>(EMPTY_WORKSPACE);
+  const [loading, setLoading] = useState(true);
+  const [running, setRunning] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [finder, setFinder] = useState<FinderResult | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/root/commercial', { cache: 'no-store', credentials: 'include' });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok || !body.data) throw new Error(body?.error ?? `HTTP ${response.status}`);
+      setWorkspace(body.data);
+      setMessage(null);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'commercial_workspace_failed');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function mutate(intent: string, payload: Row) {
+    if (!window.confirm('Confirmar mutación comercial gobernada. Esta acción no envía mensajes ni documentos externos.')) return;
+    setRunning(intent);
+    setMessage(null);
+    try {
+      const response = await fetch('/api/root/commercial', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ intent, payload }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok) throw new Error(body?.details ?? body?.error ?? `HTTP ${response.status}`);
+      setMessage(`${intent}: persisted`);
+      await load();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'commercial_mutation_failed');
+    } finally {
+      setRunning(null);
+    }
+  }
+
+  async function runFinder(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const form = new FormData(event.currentTarget);
+    setRunning('client_finder');
+    setMessage(null);
+    try {
+      const response = await fetch('/api/root/agentic/client-finder', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(Object.fromEntries(form.entries())),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok || !body?.ok) throw new Error(body?.error ?? `HTTP ${response.status}`);
+      setFinder(body);
+      setMessage('IFNORM candidate generated. No outreach was executed.');
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'client_finder_failed');
+    } finally {
+      setRunning(null);
+    }
+  }
+
+  const clientsById = useMemo(
+    () => new Map(workspace.clients.map((client) => [value(client, 'id'), value(client, 'name')])),
+    [workspace.clients],
+  );
+
+  const opportunitiesById = useMemo(
+    () => new Map(workspace.opportunities.map((opportunity) => [value(opportunity, 'id'), opportunity])),
+    [workspace.opportunities],
+  );
+
+  return (
+    <main className="commercial-shell">
+      <header className="commercial-topbar">
+        <div>
+          <span>ROOT / COMMERCIAL CONVERSION</span>
+          <h1>CLIENT PROPOSALS</h1>
+        </div>
+        <div className="commercial-topbar-actions">
+          <span className={workspace.schemaReady ? 'ready' : 'blocked'}>
+            {workspace.schemaReady ? 'SCHEMA READY' : 'SCHEMA NOT APPLIED'}
+          </span>
+          <button type="button" onClick={() => void load()} disabled={loading}>REFRESH</button>
+          <a href="/root">RETURN TO ROOT</a>
+        </div>
+      </header>
+
+      <section className="commercial-metrics">
+        <article><span>CLIENTS</span><strong>{workspace.counts.clients}</strong></article>
+        <article><span>OPEN OPPORTUNITIES</span><strong>{workspace.counts.openOpportunities}</strong></article>
+        <article><span>DRAFT / REVIEW</span><strong>{workspace.counts.draftProposals}</strong></article>
+        <article><span>ACTIVE PROPOSALS</span><strong>{workspace.counts.activeProposals}</strong></article>
+        <article><span>ACCEPTED / CONVERTED</span><strong>{workspace.counts.acceptedProposals}</strong></article>
+      </section>
+
+      {workspace.warnings.length > 0 ? (
+        <aside className="commercial-warning">
+          <strong>DATABASE READINESS</strong>
+          {workspace.warnings.map((warning) => <code key={warning}>{warning}</code>)}
+          <p>Apply migration: supabase/migrations/20260802144500_root_commercial_proposals.sql</p>
+        </aside>
+      ) : null}
+
+      {message ? <div className="commercial-message">{message}</div> : null}
+
+      <section className="commercial-grid">
+        <article className="commercial-panel finder">
+          <header><span>01</span><h2>CLIENT FINDER → IFNORM</h2></header>
+          <form onSubmit={runFinder}>
+            <label>ENTITY<input name="entityName" placeholder="Company or institution" /></label>
+            <label>PERSON / ROLE<input name="personOrRole" placeholder="Decision role" /></label>
+            <label>SECTOR<input name="sector" placeholder="Sector" /></label>
+            <label>PUBLIC SIGNAL<textarea name="publicSignal" placeholder="Observed public friction or signal" /></label>
+            <label>SOURCE<input name="source" placeholder="Public source or manual observation" /></label>
+            <button type="submit" disabled={running === 'client_finder'}>{running === 'client_finder' ? 'ANALYZING' : 'RUN CLIENT FINDER'}</button>
+          </form>
+          {finder?.ifnorm ? (
+            <div className="finder-result">
+              <strong>{finder.ifnorm.entity_name || 'UNNAMED ENTITY'}</strong>
+              <p>{finder.ifnorm.detected_pain}</p>
+              <dl>
+                <div><dt>OFFER</dt><dd>{finder.ifnorm.recommended_offer}</dd></div>
+                <div><dt>ACTION</dt><dd>{finder.ifnorm.recommended_action}</dd></div>
+                <div><dt>P RESPONSE</dt><dd>{Number(finder.ifnorm.p_response ?? 0).toFixed(2)}</dd></div>
+                <div><dt>P MEETING</dt><dd>{Number(finder.ifnorm.p_meeting ?? 0).toFixed(2)}</dd></div>
+                <div><dt>P PAID DIAGNOSTIC</dt><dd>{Number(finder.ifnorm.p_paid_diagnostic ?? 0).toFixed(2)}</dd></div>
+              </dl>
+            </div>
+          ) : null}
+        </article>
+
+        <article className="commercial-panel">
+          <header><span>02</span><h2>REGISTER CLIENT</h2></header>
+          <form onSubmit={(event) => {
+            event.preventDefault();
+            const form = new FormData(event.currentTarget);
+            void mutate('create_client', Object.fromEntries(form.entries()));
+          }}>
+            <label>NAME<input name="name" required defaultValue={finder?.ifnorm?.entity_name ?? ''} /></label>
+            <label>SECTOR<input name="sector" defaultValue={finder?.ifnorm?.sector ?? ''} /></label>
+            <label>WEBSITE<input name="website" type="url" /></label>
+            <label>CONTACT NAME<input name="contactName" /></label>
+            <label>CONTACT ROLE<input name="contactRole" defaultValue={finder?.ifnorm?.person_or_role ?? ''} /></label>
+            <label>CONTACT EMAIL<input name="contactEmail" type="email" /></label>
+            <input name="source" type="hidden" value={finder ? 'client_finder' : 'manual'} />
+            <label>NOTES<textarea name="notes" defaultValue={finder?.ifnorm?.detected_pain ?? ''} /></label>
+            <button type="submit" disabled={running === 'create_client'}>CREATE CLIENT</button>
+          </form>
+        </article>
+
+        <article className="commercial-panel">
+          <header><span>03</span><h2>CREATE OPPORTUNITY</h2></header>
+          <form onSubmit={(event) => {
+            event.preventDefault();
+            const form = new FormData(event.currentTarget);
+            void mutate('create_opportunity', Object.fromEntries(form.entries()));
+          }}>
+            <label>CLIENT<select name="clientId" required defaultValue=""><option value="" disabled>SELECT</option>{workspace.clients.map((client) => <option key={value(client, 'id')} value={value(client, 'id')}>{value(client, 'name')}</option>)}</select></label>
+            <label>TITLE<input name="title" required placeholder="Paid diagnostic / pilot / engagement" /></label>
+            <label>PROBLEM STATEMENT<textarea name="problemStatement" required defaultValue={finder?.ifnorm?.detected_pain ?? ''} /></label>
+            <label>RECOMMENDED OFFER<input name="recommendedOffer" defaultValue={finder?.ifnorm?.recommended_offer ?? ''} /></label>
+            <label>ESTIMATED VALUE<input name="estimatedValue" type="number" min="0" step="1" /></label>
+            <label>CURRENCY<select name="currency" defaultValue="MXN"><option>MXN</option><option>USD</option><option>EUR</option></select></label>
+            <label>PROBABILITY<input name="probability" type="number" min="0" max="1" step="0.01" defaultValue={finder?.ifnorm?.p_paid_diagnostic ?? 0} /></label>
+            <label>SOURCE ACTION PROPOSAL<select name="sourceActionProposalId" defaultValue=""><option value="">NONE</option>{workspace.sourceProposals.map((proposal) => <option key={value(proposal, 'id')} value={value(proposal, 'id')}>{value(proposal, 'title') || value(proposal, 'proposal_type') || value(proposal, 'id')}</option>)}</select></label>
+            <label>NEXT ACTION<input name="nextAction" defaultValue={finder?.ifnorm?.recommended_action ?? ''} /></label>
+            <button type="submit" disabled={running === 'create_opportunity'}>CREATE OPPORTUNITY</button>
+          </form>
+        </article>
+
+        <article className="commercial-panel proposal-builder">
+          <header><span>04</span><h2>BUILD COMMERCIAL PROPOSAL</h2></header>
+          <form onSubmit={(event) => {
+            event.preventDefault();
+            const form = new FormData(event.currentTarget);
+            void mutate('create_proposal', Object.fromEntries(form.entries()));
+          }}>
+            <label>OPPORTUNITY<select name="opportunityId" required defaultValue=""><option value="" disabled>SELECT</option>{workspace.opportunities.filter((opportunity) => !['won', 'lost', 'archived'].includes(value(opportunity, 'stage'))).map((opportunity) => <option key={value(opportunity, 'id')} value={value(opportunity, 'id')}>{clientsById.get(value(opportunity, 'client_id'))} · {value(opportunity, 'title')}</option>)}</select></label>
+            <label>TITLE<input name="title" required /></label>
+            <label>DIAGNOSIS<textarea name="diagnosis" required /></label>
+            <label>SERVICE SCOPE<textarea name="serviceScope" required /></label>
+            <label>DELIVERABLES<textarea name="deliverables" placeholder="One deliverable per line" /></label>
+            <label>DURATION DAYS<input name="durationDays" type="number" min="1" /></label>
+            <label>PRICE<input name="priceAmount" type="number" min="0" /></label>
+            <label>CURRENCY<select name="currency" defaultValue="MXN"><option>MXN</option><option>USD</option><option>EUR</option></select></label>
+            <label>CONFIDENCE<input name="confidence" type="number" min="0" max="1" step="0.01" defaultValue="0.5" /></label>
+            <label>VALID UNTIL<input name="validUntil" type="date" /></label>
+            <label>ASSUMPTIONS<textarea name="assumptions" placeholder="One assumption per line" /></label>
+            <label>EXCLUSIONS<textarea name="exclusions" placeholder="One exclusion per line" /></label>
+            <label>EVIDENCE IDS<textarea name="evidenceIds" placeholder="UUIDs, one per line" /></label>
+            <label>SOURCE ACTION PROPOSAL IDS<textarea name="sourceActionProposalIds" placeholder="UUIDs, one per line" /></label>
+            <button type="submit" disabled={running === 'create_proposal'}>CREATE VERSION 1</button>
+          </form>
+        </article>
+      </section>
+
+      <section className="commercial-register">
+        <header><span>05</span><h2>COMMERCIAL REGISTER</h2></header>
+        <div className="commercial-table-wrap">
+          <table>
+            <thead><tr><th>PROPOSAL</th><th>CLIENT</th><th>OPPORTUNITY</th><th>STATUS</th><th>VALUE</th><th>CONF.</th><th>VALID</th><th>ACTIONS</th></tr></thead>
+            <tbody>
+              {workspace.proposals.map((proposal) => {
+                const opportunity = opportunitiesById.get(value(proposal, 'opportunity_id'));
+                const status = value(proposal, 'status');
+                const transitions = TRANSITIONS[status] ?? [];
+                return (
+                  <tr key={value(proposal, 'id')}>
+                    <td><strong>{value(proposal, 'proposal_number')}</strong><span>{value(proposal, 'title')}</span></td>
+                    <td>{clientsById.get(value(proposal, 'client_id')) ?? value(proposal, 'client_id')}</td>
+                    <td>{opportunity ? value(opportunity, 'title') : value(proposal, 'opportunity_id')}</td>
+                    <td><code>{status}</code></td>
+                    <td>{money(proposal.price_amount, proposal.currency)}</td>
+                    <td>{numberValue(proposal, 'confidence').toFixed(2)}</td>
+                    <td>{shortDate(proposal.valid_until)}</td>
+                    <td><div className="transition-actions">{transitions.map((next) => <button type="button" key={next} onClick={() => void mutate('transition_proposal', { proposalId: value(proposal, 'id'), status: next })}>{next.replaceAll('_', ' ')}</button>)}</div></td>
+                  </tr>
+                );
+              })}
+              {workspace.proposals.length === 0 ? <tr><td colSpan={8}>NO COMMERCIAL PROPOSALS RECORDED</td></tr> : null}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <footer className="commercial-footer">
+        <span>INTERNAL ACTION PROPOSAL ≠ COMMERCIAL PROPOSAL</span>
+        <span>No external outreach or document delivery is executed by this surface.</span>
+      </footer>
+    </main>
+  );
+}

--- a/src/components/root/commercial/root-commercial.css
+++ b/src/components/root/commercial/root-commercial.css
@@ -1,0 +1,329 @@
+:root {
+  --commercial-bg: #070706;
+  --commercial-panel: #0d0d0b;
+  --commercial-line: rgba(202, 170, 82, 0.22);
+  --commercial-gold: #caaa52;
+  --commercial-muted: #77766e;
+  --commercial-text: #d8d5ca;
+  --commercial-red: #b85b5b;
+  --commercial-green: #5c9b71;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--commercial-bg);
+  color: var(--commercial-text);
+}
+
+.commercial-shell {
+  min-height: 100vh;
+  background:
+    linear-gradient(rgba(202, 170, 82, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(202, 170, 82, 0.025) 1px, transparent 1px),
+    var(--commercial-bg);
+  background-size: 34px 34px;
+  padding: 18px;
+  font-family: "IBM Plex Mono", "JetBrains Mono", monospace;
+}
+
+.commercial-topbar,
+.commercial-panel,
+.commercial-register,
+.commercial-warning,
+.commercial-message,
+.commercial-metrics article {
+  border: 1px solid var(--commercial-line);
+  background: rgba(13, 13, 11, 0.94);
+}
+
+.commercial-topbar {
+  min-height: 88px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 16px 20px;
+}
+
+.commercial-topbar span,
+.commercial-panel header span,
+.commercial-register header span {
+  color: var(--commercial-gold);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+}
+
+.commercial-topbar h1,
+.commercial-panel h2,
+.commercial-register h2 {
+  margin: 5px 0 0;
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+}
+
+.commercial-topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+}
+
+.commercial-topbar-actions button,
+.commercial-topbar-actions a,
+.commercial-panel button,
+.transition-actions button {
+  border: 1px solid var(--commercial-line);
+  background: transparent;
+  color: var(--commercial-gold);
+  font: inherit;
+  font-size: 10px;
+  padding: 8px 11px;
+  text-decoration: none;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+.commercial-topbar-actions button:hover,
+.commercial-topbar-actions a:hover,
+.commercial-panel button:hover,
+.transition-actions button:hover {
+  background: rgba(202, 170, 82, 0.1);
+}
+
+.commercial-topbar-actions .ready { color: var(--commercial-green); }
+.commercial-topbar-actions .blocked { color: var(--commercial-red); }
+
+.commercial-metrics {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+  margin: 10px 0;
+}
+
+.commercial-metrics article {
+  padding: 12px;
+}
+
+.commercial-metrics span {
+  display: block;
+  color: var(--commercial-muted);
+  font-size: 9px;
+}
+
+.commercial-metrics strong {
+  display: block;
+  margin-top: 7px;
+  color: var(--commercial-gold);
+  font-size: 22px;
+  font-weight: 400;
+}
+
+.commercial-warning,
+.commercial-message {
+  margin: 10px 0;
+  padding: 12px 14px;
+  font-size: 11px;
+}
+
+.commercial-warning {
+  border-color: rgba(184, 91, 91, 0.45);
+}
+
+.commercial-warning strong,
+.commercial-warning code,
+.commercial-warning p {
+  display: block;
+  margin: 4px 0;
+}
+
+.commercial-warning strong { color: var(--commercial-red); }
+.commercial-warning code { color: #d0a0a0; }
+
+.commercial-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.commercial-panel {
+  padding: 14px;
+}
+
+.commercial-panel header,
+.commercial-register header {
+  display: flex;
+  align-items: baseline;
+  gap: 11px;
+  border-bottom: 1px solid var(--commercial-line);
+  padding-bottom: 11px;
+  margin-bottom: 13px;
+}
+
+.commercial-panel form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.commercial-panel label {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  color: var(--commercial-muted);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+}
+
+.commercial-panel label:has(textarea),
+.proposal-builder label:has(textarea) {
+  grid-column: 1 / -1;
+}
+
+.commercial-panel input,
+.commercial-panel textarea,
+.commercial-panel select {
+  width: 100%;
+  border: 1px solid rgba(202, 170, 82, 0.18);
+  background: #090908;
+  color: var(--commercial-text);
+  font: inherit;
+  font-size: 11px;
+  padding: 8px;
+  outline: none;
+}
+
+.commercial-panel input:focus,
+.commercial-panel textarea:focus,
+.commercial-panel select:focus {
+  border-color: var(--commercial-gold);
+}
+
+.commercial-panel textarea {
+  min-height: 74px;
+  resize: vertical;
+}
+
+.commercial-panel form > button {
+  grid-column: 1 / -1;
+  justify-self: start;
+}
+
+.finder-result {
+  margin-top: 12px;
+  border-left: 2px solid var(--commercial-gold);
+  padding: 10px 12px;
+  background: #090908;
+}
+
+.finder-result p {
+  color: #aaa79e;
+  font-size: 11px;
+  line-height: 1.55;
+}
+
+.finder-result dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0;
+  gap: 6px;
+}
+
+.finder-result dl div {
+  border-top: 1px solid rgba(202, 170, 82, 0.12);
+  padding-top: 6px;
+}
+
+.finder-result dt {
+  color: var(--commercial-muted);
+  font-size: 8px;
+}
+
+.finder-result dd {
+  margin: 3px 0 0;
+  color: var(--commercial-gold);
+  font-size: 10px;
+}
+
+.commercial-register {
+  margin-top: 10px;
+  padding: 14px;
+}
+
+.commercial-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.commercial-register table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 1080px;
+  font-size: 10px;
+}
+
+.commercial-register th,
+.commercial-register td {
+  border-bottom: 1px solid rgba(202, 170, 82, 0.11);
+  padding: 9px;
+  vertical-align: top;
+  text-align: left;
+}
+
+.commercial-register th {
+  color: var(--commercial-muted);
+  font-size: 8px;
+  font-weight: 400;
+  letter-spacing: 0.08em;
+}
+
+.commercial-register td strong,
+.commercial-register td span {
+  display: block;
+}
+
+.commercial-register td strong { color: var(--commercial-gold); }
+.commercial-register td span { margin-top: 4px; color: #8f8d84; }
+.commercial-register code { color: #d2b873; }
+
+.transition-actions {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+
+.transition-actions button {
+  padding: 5px 7px;
+  font-size: 8px;
+}
+
+.commercial-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--commercial-muted);
+  font-size: 9px;
+  padding: 15px 2px 3px;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+@media (max-width: 980px) {
+  .commercial-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .commercial-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 640px) {
+  .commercial-shell { padding: 8px; }
+  .commercial-topbar { align-items: flex-start; flex-direction: column; }
+  .commercial-metrics { grid-template-columns: 1fr; }
+  .commercial-panel form { grid-template-columns: 1fr; }
+  .commercial-panel label:has(textarea),
+  .proposal-builder label:has(textarea) { grid-column: auto; }
+  .commercial-footer { flex-direction: column; }
+}

--- a/src/components/root/sovereign/RootModuleRail.tsx
+++ b/src/components/root/sovereign/RootModuleRail.tsx
@@ -4,7 +4,6 @@ type InternalModule = {
   id: RootViewId;
   label: string;
   key: string;
-  href?: never;
 };
 
 type ExternalModule = {

--- a/src/components/root/sovereign/RootModuleRail.tsx
+++ b/src/components/root/sovereign/RootModuleRail.tsx
@@ -1,6 +1,20 @@
 import type { RootViewId } from './sovereignTypes';
 
-const MODULES: Array<{ id: RootViewId; label: string; key: string }> = [
+type InternalModule = {
+  id: RootViewId;
+  label: string;
+  key: string;
+  href?: never;
+};
+
+type ExternalModule = {
+  id: 'commercial';
+  label: string;
+  key: string;
+  href: string;
+};
+
+const MODULES: Array<InternalModule | ExternalModule> = [
   { id: 'overview', label: 'OVERVIEW', key: '01' },
   { id: 'cognitive-runtime', label: 'COGNITIVE RUNTIME', key: '02' },
   { id: 'governance', label: 'GOVERNANCE', key: '03' },
@@ -9,9 +23,34 @@ const MODULES: Array<{ id: RootViewId; label: string; key: string }> = [
   { id: 'amv', label: 'AMV', key: '06' },
   { id: 'evidence', label: 'EVIDENCE / ATLAS', key: '07' },
   { id: 'execution', label: 'EXECUTION', key: '08' },
-  { id: 'telemetry', label: 'TELEMETRY', key: '09' },
+  { id: 'commercial', label: 'CLIENT PROPOSALS', key: '09', href: '/root/commercial' },
+  { id: 'telemetry', label: 'TELEMETRY', key: '10' },
 ];
 
 export function RootModuleRail({ active, onChange }: { active: RootViewId; onChange: (view: RootViewId) => void }) {
-  return <nav className="rs-rail" aria-label="ROOT modules">{MODULES.map((module) => <button key={module.id} type="button" className={active === module.id ? 'active' : ''} aria-current={active === module.id ? 'page' : undefined} onClick={() => onChange(module.id)}><span>{module.key}</span><strong>{module.label}</strong></button>)}</nav>;
+  return (
+    <nav className="rs-rail" aria-label="ROOT modules">
+      {MODULES.map((module) => {
+        const isActive = module.id === active;
+        return (
+          <button
+            key={module.id}
+            type="button"
+            className={isActive ? 'active' : ''}
+            aria-current={isActive ? 'page' : undefined}
+            onClick={() => {
+              if ('href' in module) {
+                window.location.href = module.href;
+                return;
+              }
+              onChange(module.id);
+            }}
+          >
+            <span>{module.key}</span>
+            <strong>{module.label}</strong>
+          </button>
+        );
+      })}
+    </nav>
+  );
 }

--- a/src/lib/commercial/commercialService.ts
+++ b/src/lib/commercial/commercialService.ts
@@ -1,0 +1,349 @@
+import 'server-only';
+
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+export const COMMERCIAL_STATUSES = [
+  'draft',
+  'internal_review',
+  'approved',
+  'sent',
+  'viewed',
+  'negotiation',
+  'accepted',
+  'rejected',
+  'expired',
+  'converted',
+] as const;
+
+export type CommercialProposalStatus = typeof COMMERCIAL_STATUSES[number];
+
+type ServiceResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string; details?: string };
+
+type JsonRecord = Record<string, unknown>;
+
+function text(value: unknown, fallback = '') {
+  return typeof value === 'string' ? value.trim() : fallback;
+}
+
+function optionalText(value: unknown) {
+  const valueText = text(value);
+  return valueText.length > 0 ? valueText : null;
+}
+
+function optionalNumber(value: unknown) {
+  if (value === null || value === undefined || value === '') return null;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function bounded01(value: unknown) {
+  const parsed = optionalNumber(value);
+  return parsed === null ? 0 : Math.min(1, Math.max(0, parsed));
+}
+
+function stringList(value: unknown) {
+  if (Array.isArray(value)) return value.map((item) => text(item)).filter(Boolean);
+  return text(value).split(/\r?\n|,/).map((item) => item.trim()).filter(Boolean);
+}
+
+function uuidList(value: unknown) {
+  return stringList(value).filter((item) => /^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(item));
+}
+
+function proposalNumber() {
+  const date = new Date().toISOString().slice(0, 10).replaceAll('-', '');
+  const suffix = crypto.randomUUID().slice(0, 8).toUpperCase();
+  return `SFI-CP-${date}-${suffix}`;
+}
+
+async function recordEvent(input: {
+  eventType: string;
+  actorId: string;
+  clientId?: string | null;
+  opportunityId?: string | null;
+  proposalId?: string | null;
+  payload?: JsonRecord;
+}) {
+  const service = createServiceSupabaseClient();
+  return service.from('commercial_proposal_events').insert({
+    event_type: input.eventType,
+    actor_id: input.actorId,
+    client_id: input.clientId ?? null,
+    opportunity_id: input.opportunityId ?? null,
+    proposal_id: input.proposalId ?? null,
+    payload: input.payload ?? {},
+  });
+}
+
+export async function readCommercialWorkspace() {
+  const service = createServiceSupabaseClient();
+  const [clients, opportunities, proposals, sourceProposals] = await Promise.all([
+    service.from('commercial_clients').select('*').order('updated_at', { ascending: false }).limit(200),
+    service.from('commercial_opportunities').select('*').order('updated_at', { ascending: false }).limit(200),
+    service.from('commercial_proposals').select('*').order('updated_at', { ascending: false }).limit(200),
+    service
+      .from('action_proposals')
+      .select('id,title,status,risk_level,approval_required,objective,proposal_type,created_at,expected_field_delta')
+      .order('created_at', { ascending: false })
+      .limit(40),
+  ]);
+
+  const warnings = [
+    clients.error ? `commercial_clients:${clients.error.message}` : '',
+    opportunities.error ? `commercial_opportunities:${opportunities.error.message}` : '',
+    proposals.error ? `commercial_proposals:${proposals.error.message}` : '',
+    sourceProposals.error ? `action_proposals:${sourceProposals.error.message}` : '',
+  ].filter(Boolean);
+
+  const clientRows = clients.error ? [] : clients.data ?? [];
+  const opportunityRows = opportunities.error ? [] : opportunities.data ?? [];
+  const proposalRows = proposals.error ? [] : proposals.data ?? [];
+
+  return {
+    schemaReady: !clients.error && !opportunities.error && !proposals.error,
+    warnings,
+    clients: clientRows,
+    opportunities: opportunityRows,
+    proposals: proposalRows,
+    sourceProposals: sourceProposals.error ? [] : sourceProposals.data ?? [],
+    counts: {
+      clients: clientRows.length,
+      openOpportunities: opportunityRows.filter((row) => !['won', 'lost', 'archived'].includes(String(row.stage))).length,
+      draftProposals: proposalRows.filter((row) => ['draft', 'internal_review'].includes(String(row.status))).length,
+      activeProposals: proposalRows.filter((row) => ['approved', 'sent', 'viewed', 'negotiation'].includes(String(row.status))).length,
+      acceptedProposals: proposalRows.filter((row) => ['accepted', 'converted'].includes(String(row.status))).length,
+    },
+  };
+}
+
+export async function createCommercialClient(input: JsonRecord, actorId: string): Promise<ServiceResult<unknown>> {
+  const name = text(input.name);
+  if (!name) return { ok: false, error: 'client_name_required' };
+
+  const service = createServiceSupabaseClient();
+  const inserted = await service.from('commercial_clients').insert({
+    name,
+    legal_name: optionalText(input.legalName),
+    status: 'prospect',
+    sector: optionalText(input.sector),
+    website: optionalText(input.website),
+    primary_contact: {
+      name: optionalText(input.contactName),
+      role: optionalText(input.contactRole),
+      email: optionalText(input.contactEmail),
+      phone: optionalText(input.contactPhone),
+    },
+    source: optionalText(input.source) ?? 'manual',
+    notes: optionalText(input.notes),
+    created_by: actorId,
+    updated_at: new Date().toISOString(),
+  }).select('*').single();
+
+  if (inserted.error) return { ok: false, error: 'commercial_client_insert_failed', details: inserted.error.message };
+
+  const event = await recordEvent({
+    eventType: 'client.created',
+    actorId,
+    clientId: inserted.data.id,
+    payload: { source: inserted.data.source },
+  });
+  if (event.error) return { ok: false, error: 'commercial_client_event_failed', details: event.error.message };
+
+  return { ok: true, data: inserted.data };
+}
+
+export async function createCommercialOpportunity(input: JsonRecord, actorId: string): Promise<ServiceResult<unknown>> {
+  const clientId = text(input.clientId);
+  const title = text(input.title);
+  const problemStatement = text(input.problemStatement);
+  if (!clientId) return { ok: false, error: 'opportunity_client_required' };
+  if (!title) return { ok: false, error: 'opportunity_title_required' };
+  if (!problemStatement) return { ok: false, error: 'opportunity_problem_required' };
+
+  const service = createServiceSupabaseClient();
+  const inserted = await service.from('commercial_opportunities').insert({
+    client_id: clientId,
+    title,
+    problem_statement: problemStatement,
+    recommended_offer: optionalText(input.recommendedOffer),
+    stage: 'identified',
+    estimated_value: optionalNumber(input.estimatedValue),
+    currency: optionalText(input.currency) ?? 'MXN',
+    probability: bounded01(input.probability),
+    source_action_proposal_id: optionalText(input.sourceActionProposalId),
+    source_evidence_ids: uuidList(input.sourceEvidenceIds),
+    owner_id: actorId,
+    next_action: optionalText(input.nextAction),
+    next_action_at: optionalText(input.nextActionAt),
+    created_by: actorId,
+    updated_at: new Date().toISOString(),
+  }).select('*').single();
+
+  if (inserted.error) return { ok: false, error: 'commercial_opportunity_insert_failed', details: inserted.error.message };
+
+  const event = await recordEvent({
+    eventType: 'opportunity.created',
+    actorId,
+    clientId,
+    opportunityId: inserted.data.id,
+    payload: {
+      sourceActionProposalId: inserted.data.source_action_proposal_id,
+      recommendedOffer: inserted.data.recommended_offer,
+    },
+  });
+  if (event.error) return { ok: false, error: 'commercial_opportunity_event_failed', details: event.error.message };
+
+  return { ok: true, data: inserted.data };
+}
+
+export async function createCommercialProposal(input: JsonRecord, actorId: string): Promise<ServiceResult<unknown>> {
+  const opportunityId = text(input.opportunityId);
+  const title = text(input.title);
+  const diagnosis = text(input.diagnosis);
+  const serviceScope = text(input.serviceScope);
+  if (!opportunityId) return { ok: false, error: 'proposal_opportunity_required' };
+  if (!title) return { ok: false, error: 'proposal_title_required' };
+  if (!diagnosis) return { ok: false, error: 'proposal_diagnosis_required' };
+  if (!serviceScope) return { ok: false, error: 'proposal_scope_required' };
+
+  const service = createServiceSupabaseClient();
+  const opportunity = await service
+    .from('commercial_opportunities')
+    .select('id,client_id,stage')
+    .eq('id', opportunityId)
+    .maybeSingle();
+
+  if (opportunity.error) return { ok: false, error: 'proposal_opportunity_lookup_failed', details: opportunity.error.message };
+  if (!opportunity.data) return { ok: false, error: 'proposal_opportunity_not_found' };
+
+  const payload = {
+    proposal_number: proposalNumber(),
+    client_id: opportunity.data.client_id,
+    opportunity_id: opportunityId,
+    status: 'draft',
+    title,
+    diagnosis,
+    service_scope: serviceScope,
+    deliverables: stringList(input.deliverables),
+    duration_days: optionalNumber(input.durationDays),
+    price_amount: optionalNumber(input.priceAmount),
+    currency: optionalText(input.currency) ?? 'MXN',
+    assumptions: stringList(input.assumptions),
+    exclusions: stringList(input.exclusions),
+    confidence: bounded01(input.confidence),
+    evidence_ids: uuidList(input.evidenceIds),
+    source_action_proposal_ids: uuidList(input.sourceActionProposalIds),
+    valid_until: optionalText(input.validUntil),
+    created_by: actorId,
+    updated_at: new Date().toISOString(),
+  };
+
+  const inserted = await service.from('commercial_proposals').insert(payload).select('*').single();
+  if (inserted.error) return { ok: false, error: 'commercial_proposal_insert_failed', details: inserted.error.message };
+
+  const version = await service.from('commercial_proposal_versions').insert({
+    proposal_id: inserted.data.id,
+    version: 1,
+    snapshot: inserted.data,
+    created_by: actorId,
+  });
+
+  if (version.error) {
+    await service.from('commercial_proposals').delete().eq('id', inserted.data.id);
+    return { ok: false, error: 'commercial_proposal_version_failed', details: version.error.message };
+  }
+
+  const opportunityUpdate = await service.from('commercial_opportunities').update({
+    stage: 'proposal',
+    updated_at: new Date().toISOString(),
+  }).eq('id', opportunityId);
+
+  if (opportunityUpdate.error) {
+    return { ok: false, error: 'commercial_opportunity_stage_failed', details: opportunityUpdate.error.message };
+  }
+
+  const event = await recordEvent({
+    eventType: 'proposal.created',
+    actorId,
+    clientId: inserted.data.client_id,
+    opportunityId,
+    proposalId: inserted.data.id,
+    payload: { proposalNumber: inserted.data.proposal_number, version: 1 },
+  });
+  if (event.error) return { ok: false, error: 'commercial_proposal_event_failed', details: event.error.message };
+
+  return { ok: true, data: inserted.data };
+}
+
+const ALLOWED_TRANSITIONS: Record<CommercialProposalStatus, CommercialProposalStatus[]> = {
+  draft: ['internal_review'],
+  internal_review: ['draft', 'approved'],
+  approved: ['sent'],
+  sent: ['viewed', 'negotiation', 'accepted', 'rejected', 'expired'],
+  viewed: ['negotiation', 'accepted', 'rejected', 'expired'],
+  negotiation: ['accepted', 'rejected', 'expired'],
+  accepted: ['converted'],
+  rejected: [],
+  expired: [],
+  converted: [],
+};
+
+export async function transitionCommercialProposal(input: JsonRecord, actorId: string): Promise<ServiceResult<unknown>> {
+  const proposalId = text(input.proposalId);
+  const nextStatus = text(input.status) as CommercialProposalStatus;
+  if (!proposalId) return { ok: false, error: 'proposal_id_required' };
+  if (!COMMERCIAL_STATUSES.includes(nextStatus)) return { ok: false, error: 'proposal_status_invalid' };
+
+  const service = createServiceSupabaseClient();
+  const current = await service.from('commercial_proposals').select('*').eq('id', proposalId).maybeSingle();
+  if (current.error) return { ok: false, error: 'commercial_proposal_lookup_failed', details: current.error.message };
+  if (!current.data) return { ok: false, error: 'commercial_proposal_not_found' };
+
+  const currentStatus = String(current.data.status) as CommercialProposalStatus;
+  if (!ALLOWED_TRANSITIONS[currentStatus]?.includes(nextStatus)) {
+    return { ok: false, error: 'commercial_transition_not_allowed', details: `${currentStatus}->${nextStatus}` };
+  }
+
+  const now = new Date().toISOString();
+  const patch: JsonRecord = { status: nextStatus, updated_at: now };
+  if (nextStatus === 'approved') {
+    patch.approved_by = actorId;
+    patch.approved_at = now;
+  }
+  if (nextStatus === 'sent') patch.sent_at = now;
+  if (nextStatus === 'accepted') patch.accepted_at = now;
+
+  const updated = await service.from('commercial_proposals').update(patch).eq('id', proposalId).select('*').single();
+  if (updated.error) return { ok: false, error: 'commercial_proposal_transition_failed', details: updated.error.message };
+
+  const opportunityStage =
+    nextStatus === 'negotiation' ? 'negotiation'
+      : nextStatus === 'accepted' || nextStatus === 'converted' ? 'won'
+        : nextStatus === 'rejected' || nextStatus === 'expired' ? 'lost'
+          : nextStatus === 'approved' || nextStatus === 'sent' || nextStatus === 'viewed' ? 'proposal'
+            : null;
+
+  if (opportunityStage) {
+    const opportunityUpdate = await service.from('commercial_opportunities').update({
+      stage: opportunityStage,
+      updated_at: now,
+    }).eq('id', updated.data.opportunity_id);
+    if (opportunityUpdate.error) {
+      return { ok: false, error: 'commercial_opportunity_transition_failed', details: opportunityUpdate.error.message };
+    }
+  }
+
+  const event = await recordEvent({
+    eventType: 'proposal.status_changed',
+    actorId,
+    clientId: updated.data.client_id,
+    opportunityId: updated.data.opportunity_id,
+    proposalId,
+    payload: { from: currentStatus, to: nextStatus },
+  });
+  if (event.error) return { ok: false, error: 'commercial_transition_event_failed', details: event.error.message };
+
+  return { ok: true, data: updated.data };
+}

--- a/supabase/migrations/20260802144500_root_commercial_proposals.sql
+++ b/supabase/migrations/20260802144500_root_commercial_proposals.sql
@@ -1,0 +1,134 @@
+-- SFI Commercial Conversion Layer
+-- Separates internal action proposals from client-facing commercial proposals.
+-- All access is server-side through service_role and ROOT authorization.
+
+create table if not exists public.commercial_clients (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  legal_name text,
+  status text not null default 'prospect' check (status in ('prospect','active','inactive','archived')),
+  sector text,
+  website text,
+  primary_contact jsonb not null default '{}'::jsonb,
+  source text not null default 'manual',
+  notes text,
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.commercial_opportunities (
+  id uuid primary key default gen_random_uuid(),
+  client_id uuid not null references public.commercial_clients(id) on delete cascade,
+  title text not null,
+  problem_statement text not null,
+  recommended_offer text,
+  stage text not null default 'identified' check (stage in (
+    'identified','qualified','scoping','proposal','negotiation','won','lost','archived'
+  )),
+  estimated_value numeric,
+  currency text not null default 'MXN',
+  probability numeric not null default 0 check (probability >= 0 and probability <= 1),
+  source_action_proposal_id uuid references public.action_proposals(id) on delete set null,
+  source_evidence_ids uuid[] not null default '{}'::uuid[],
+  owner_id uuid,
+  next_action text,
+  next_action_at timestamptz,
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.commercial_proposals (
+  id uuid primary key default gen_random_uuid(),
+  proposal_number text not null unique,
+  client_id uuid not null references public.commercial_clients(id) on delete restrict,
+  opportunity_id uuid not null references public.commercial_opportunities(id) on delete cascade,
+  status text not null default 'draft' check (status in (
+    'draft','internal_review','approved','sent','viewed','negotiation',
+    'accepted','rejected','expired','converted'
+  )),
+  title text not null,
+  diagnosis text not null,
+  service_scope text not null,
+  deliverables jsonb not null default '[]'::jsonb,
+  duration_days integer check (duration_days is null or duration_days > 0),
+  price_amount numeric check (price_amount is null or price_amount >= 0),
+  currency text not null default 'MXN',
+  assumptions jsonb not null default '[]'::jsonb,
+  exclusions jsonb not null default '[]'::jsonb,
+  confidence numeric not null default 0 check (confidence >= 0 and confidence <= 1),
+  evidence_ids uuid[] not null default '{}'::uuid[],
+  source_action_proposal_ids uuid[] not null default '{}'::uuid[],
+  valid_until date,
+  approved_by uuid,
+  approved_at timestamptz,
+  sent_at timestamptz,
+  accepted_at timestamptz,
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.commercial_proposal_versions (
+  id uuid primary key default gen_random_uuid(),
+  proposal_id uuid not null references public.commercial_proposals(id) on delete cascade,
+  version integer not null,
+  snapshot jsonb not null,
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  unique (proposal_id, version)
+);
+
+create table if not exists public.commercial_proposal_events (
+  id uuid primary key default gen_random_uuid(),
+  proposal_id uuid references public.commercial_proposals(id) on delete cascade,
+  opportunity_id uuid references public.commercial_opportunities(id) on delete cascade,
+  client_id uuid references public.commercial_clients(id) on delete cascade,
+  event_type text not null,
+  payload jsonb not null default '{}'::jsonb,
+  actor_id uuid,
+  occurred_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create unique index if not exists commercial_clients_name_lower_idx
+  on public.commercial_clients (lower(name));
+create index if not exists commercial_clients_status_idx
+  on public.commercial_clients (status, updated_at desc);
+create index if not exists commercial_opportunities_stage_idx
+  on public.commercial_opportunities (stage, updated_at desc);
+create index if not exists commercial_opportunities_client_idx
+  on public.commercial_opportunities (client_id, updated_at desc);
+create index if not exists commercial_proposals_status_idx
+  on public.commercial_proposals (status, updated_at desc);
+create index if not exists commercial_proposals_client_idx
+  on public.commercial_proposals (client_id, updated_at desc);
+create index if not exists commercial_proposal_events_proposal_idx
+  on public.commercial_proposal_events (proposal_id, occurred_at desc);
+
+alter table public.commercial_clients enable row level security;
+alter table public.commercial_opportunities enable row level security;
+alter table public.commercial_proposals enable row level security;
+alter table public.commercial_proposal_versions enable row level security;
+alter table public.commercial_proposal_events enable row level security;
+
+drop policy if exists commercial_clients_service_all on public.commercial_clients;
+create policy commercial_clients_service_all on public.commercial_clients
+  for all to service_role using (true) with check (true);
+
+drop policy if exists commercial_opportunities_service_all on public.commercial_opportunities;
+create policy commercial_opportunities_service_all on public.commercial_opportunities
+  for all to service_role using (true) with check (true);
+
+drop policy if exists commercial_proposals_service_all on public.commercial_proposals;
+create policy commercial_proposals_service_all on public.commercial_proposals
+  for all to service_role using (true) with check (true);
+
+drop policy if exists commercial_proposal_versions_service_all on public.commercial_proposal_versions;
+create policy commercial_proposal_versions_service_all on public.commercial_proposal_versions
+  for all to service_role using (true) with check (true);
+
+drop policy if exists commercial_proposal_events_service_all on public.commercial_proposal_events;
+create policy commercial_proposal_events_service_all on public.commercial_proposal_events
+  for all to service_role using (true) with check (true);


### PR DESCRIPTION
## Implemented

- ROOT-only `/root/commercial` workspace.
- Existing Client Finder / IFNORM integration.
- Persistent clients, opportunities, proposals, versions, and lifecycle events.
- ROOT-authenticated `/api/root/commercial` reads and mutations.
- Commercial proposal states from draft through converted.
- `CLIENT PROPOSALS` entry in the ROOT module rail.
- Canonical architecture documentation.

## Separation of concerns

`action_proposals` remains an internal governance/runtime artifact. Commercial proposals now have explicit scope, price, validity, confidence, evidence links, versions, and client lifecycle.

## Safety

No external outreach, email, publication, or document delivery is executed. The `sent` state only records a human-confirmed send.

## Database

The schema migration was merged separately in PR #126: `supabase/migrations/20260802144500_root_commercial_proposals.sql`.

## Validation

- Domain boundary check: passed.
- Full TypeScript typecheck: passed.
- Production build: passed.

External preview status at integration time: Vercel pending; two legacy Netlify preview contexts failing independently of the primary SFI verification workflow.