### PR TITLE
Restore global Tailwind styling pipeline

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,7 @@
+/** @type {import('postcss-load-config').Config} */
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
## Failure

The application loaded `globals.css`, but Tailwind directives were not processed because the repository had no PostCSS configuration. As a result, utility classes rendered as unstyled HTML across `/field`, `/field/map`, `/repository`, ROOT and other surfaces.

## Fix

Adds canonical Tailwind 3 PostCSS configuration:

```js
module.exports = {
  plugins: {
    tailwindcss: {},
    autoprefixer: {},
  },
};
```

## Expected result

- `@tailwind base/components/utilities` are compiled globally.
- Existing component class names regain layout, spacing, typography, borders and responsive behavior.
- No route-specific redesign or mock styling is introduced.

## Validation requested

- Domain boundaries
- TypeScript
- Production build
- CSS asset generation