### PR TITLE
Implement WORLD friction observatory and automatic calibration

### DIFF
--- a/src/app/api/cron/world-observatory/route.ts
+++ b/src/app/api/cron/world-observatory/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { runWorldCalibrationCycle, runWorldObservationCycle } from '@/lib/world-observatory/worldCycle';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function secret() {
+  return process.env.SFI_CRON_SECRET || process.env.CRON_SECRET || '';
+}
+
+function authorized(request: NextRequest) {
+  const configured = secret();
+  if (!configured && process.env.NODE_ENV !== 'production') return true;
+  return request.headers.get('authorization') === `Bearer ${configured}`;
+}
+
+export async function POST(request: NextRequest) {
+  if (!authorized(request)) return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  const observation = await runWorldObservationCycle();
+  const calibration = await runWorldCalibrationCycle();
+  return NextResponse.json({ ok: observation.ok && calibration.ok, observation, calibration });
+}
+
+export async function GET(request: NextRequest) {
+  return POST(request);
+}

--- a/src/app/api/cron/world-observatory/route.ts
+++ b/src/app/api/cron/world-observatory/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { runWorldCalibrationCycle, runWorldObservationCycle } from '@/lib/world-observatory/worldCycle';
+import { runWorldHypothesisCycle } from '@/lib/world-observatory/hypothesisCycle';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -17,8 +18,9 @@ function authorized(request: NextRequest) {
 export async function POST(request: NextRequest) {
   if (!authorized(request)) return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
   const observation = await runWorldObservationCycle();
+  const hypothesis = await runWorldHypothesisCycle();
   const calibration = await runWorldCalibrationCycle();
-  return NextResponse.json({ ok: observation.ok && calibration.ok, observation, calibration });
+  return NextResponse.json({ ok: observation.ok && hypothesis.ok && calibration.ok, observation, hypothesis, calibration });
 }
 
 export async function GET(request: NextRequest) {

--- a/src/app/api/field/map/world/route.ts
+++ b/src/app/api/field/map/world/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { createServerSupabaseClient } from '@/runtime/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const supabase = await createServerSupabaseClient();
+  const { data: auth } = await supabase.auth.getUser();
+  if (!auth.user) return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+
+  const since = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+  const [{ data: observations, error: observationsError }, { data: readings }, { data: hypotheses }, { data: outcomes }, { data: learning }] = await Promise.all([
+    supabase.from('world_source_observations').select('*').gte('observed_at', since).order('observed_at', { ascending: false }).limit(500),
+    supabase.from('world_friction_readings').select('*').order('created_at', { ascending: false }).limit(500),
+    supabase.from('world_hypotheses').select('*').order('created_at', { ascending: false }).limit(100),
+    supabase.from('world_hypothesis_outcomes').select('*').order('evaluated_at', { ascending: false }).limit(100),
+    supabase.from('world_learning_events').select('*').order('created_at', { ascending: false }).limit(100),
+  ]);
+
+  if (observationsError) return NextResponse.json({ ok: false, error: 'world_schema_unavailable', details: observationsError.message }, { status: 503 });
+  const readingByObservation = new Map((readings ?? []).map((item) => [item.observation_id, item]));
+  const nodes = (observations ?? []).map((item) => ({
+    id: item.id,
+    kind: 'observed',
+    sourceFamily: item.source_family,
+    publisher: item.publisher,
+    title: item.title,
+    summary: item.summary,
+    observedAt: item.observed_at,
+    lat: item.latitude,
+    lng: item.longitude,
+    affectedSystems: item.affected_systems,
+    actors: item.actors,
+    confidence: Number(item.confidence ?? 0),
+    reading: readingByObservation.get(item.id) ?? null,
+  }));
+
+  return NextResponse.json({
+    ok: true,
+    generatedAt: new Date().toISOString(),
+    sourceState: nodes.length ? 'OBSERVED_WORLD' : 'NO_WORLD_OBSERVATIONS',
+    nodes,
+    hypotheses: hypotheses ?? [],
+    outcomes: outcomes ?? [],
+    learning: learning ?? [],
+    sourceFamilies: [...new Set(nodes.map((node) => node.sourceFamily))],
+    limits: [
+      'External source scores are not imported.',
+      'Every node is a real observation with publisher and time.',
+      'Missing or failed sources remain missing; no simulated values are generated.',
+      'SFI readings use the canonical Φ and F_s implementation.',
+    ],
+  });
+}

--- a/src/app/field/map/page.tsx
+++ b/src/app/field/map/page.tsx
@@ -1,14 +1,14 @@
 import type { Metadata } from 'next';
-import { FieldMapConsole } from '@/components/field/map/FieldMapConsole';
+import { WorldFieldObservatory } from '@/components/field/map/WorldFieldObservatory';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'FIELD Map · System Friction Institute',
-  description: 'Authenticated geographic field of persisted SFI FIELD observations. No simulated nodes or inferred coordinates.',
+  title: 'WORLD Field Observatory · System Friction Institute',
+  description: 'Authenticated WORLD observatory for real observations, systemic-friction readings, hypotheses, automatic calibration and learning.',
   robots: { index: false, follow: false },
 };
 
 export default function FieldMapPage() {
-  return <FieldMapConsole />;
+  return <WorldFieldObservatory />;
 }

--- a/src/components/field/map/WorldFieldObservatory.tsx
+++ b/src/components/field/map/WorldFieldObservatory.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Activity, Aperture, CircleDot, RefreshCw, Route, ShieldCheck } from 'lucide-react';
+
+type Reading = {
+  systemic_friction: number;
+  interaction_density: number;
+  friction_gradient: number;
+  systemic_coherence: number;
+  tension: { question?: string; between?: string[] };
+  pain_map: { question?: string; affectedSystems?: string[]; actors?: string[] };
+  field_drivers: { question?: string; drivers?: string[] };
+  permissions: { question?: string; enabled?: string[]; constrained?: string[] };
+  trajectory: { question?: string; direction?: string; expectedSignal?: string; horizonHours?: number };
+  minimum_viable_perturbation: { question?: string; action?: string; returnWindowHours?: number };
+};
+
+type WorldNode = {
+  id: string;
+  kind: 'observed';
+  sourceFamily: string;
+  publisher: string;
+  title: string;
+  summary: string | null;
+  observedAt: string;
+  lat: number | null;
+  lng: number | null;
+  affectedSystems: string[];
+  actors: string[];
+  confidence: number;
+  reading: Reading | null;
+};
+
+type WorldResponse = {
+  ok: boolean;
+  generatedAt?: string;
+  sourceState?: string;
+  nodes?: WorldNode[];
+  hypotheses?: Array<Record<string, unknown>>;
+  outcomes?: Array<Record<string, unknown>>;
+  learning?: Array<Record<string, unknown>>;
+  sourceFamilies?: string[];
+  limits?: string[];
+  error?: string;
+  details?: string;
+};
+
+function point(lat: number, lng: number) {
+  return { left: `${((lng + 180) / 360) * 100}%`, top: `${((90 - lat) / 180) * 100}%` };
+}
+
+function pct(value: unknown) {
+  const numeric = Number(value ?? 0);
+  return `${Math.round(Math.max(0, Math.min(1, numeric)) * 100)}%`;
+}
+
+function date(value: string | null | undefined) {
+  if (!value) return 'sin fecha';
+  return new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value));
+}
+
+function nodeClass(family: string, selected: boolean) {
+  const base = selected ? 'h-9 w-9 border-[#ffe0a0]' : 'h-5 w-5';
+  if (family === 'aviation') return `${base} border-[#e7a66c] bg-[#bd643755] shadow-[0_0_28px_rgba(210,112,58,.72)]`;
+  if (family === 'natural_event') return `${base} border-[#80c6d0] bg-[#4b9eaa55] shadow-[0_0_28px_rgba(89,184,198,.72)]`;
+  if (family === 'gnss') return `${base} border-[#db7c67] bg-[#a83f3555] shadow-[0_0_28px_rgba(209,74,62,.75)]`;
+  return `${base} border-[#c7a65b] bg-[#a9813555] shadow-[0_0_28px_rgba(198,158,69,.66)]`;
+}
+
+export function WorldFieldObservatory() {
+  const [data, setData] = useState<WorldResponse | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true); setError(null);
+    try {
+      const response = await fetch('/api/field/map/world', { cache: 'no-store', credentials: 'include' });
+      const body = await response.json() as WorldResponse;
+      if (!response.ok || !body.ok) throw new Error(body.details ?? body.error ?? `HTTP ${response.status}`);
+      setData(body);
+      setSelectedId((current) => current ?? body.nodes?.[0]?.id ?? null);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'world_observatory_load_failed');
+    } finally { setLoading(false); }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const nodes = data?.nodes ?? [];
+  const located = useMemo(() => nodes.filter((node) => node.lat !== null && node.lng !== null), [nodes]);
+  const selected = nodes.find((node) => node.id === selectedId) ?? null;
+  const reading = selected?.reading ?? null;
+  const hypotheses = data?.hypotheses ?? [];
+  const outcomes = data?.outcomes ?? [];
+  const openHypotheses = hypotheses.filter((item) => ['OPEN', 'AWAITING_OUTCOME'].includes(String(item.status)));
+
+  return (
+    <main className="min-h-screen bg-[#020507] text-[#d9e2df]">
+      <header className="border-b border-[#26343b] bg-[#04080b] px-5 py-5 md:px-8">
+        <div className="mx-auto flex max-w-[1800px] flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#c29b54]">SFI · WORLD / FIELD OBSERVATORY</div>
+            <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-[#f1ead7] md:text-5xl">Navegación de tensión.</h1>
+            <p className="mt-3 max-w-4xl text-sm leading-7 text-[#87949a]">No clasifica países ni replica puntuaciones externas. Observa señales reales, pregunta qué tensión aparece, a quién le duele, qué mueve el campo, qué permanece permitido y hacia dónde se desplaza la trayectoria.</p>
+          </div>
+          <div className="flex gap-2">
+            <button onClick={() => void load()} disabled={loading} className="inline-flex items-center gap-2 border border-[#34505a] px-3 py-2 font-mono text-[9px] uppercase tracking-[0.15em] text-[#9bc3cc]"><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} /> Reobservar</button>
+            <Link href="/field" className="border border-[#68542f] px-3 py-2 font-mono text-[9px] uppercase tracking-[0.15em] text-[#d0aa61]">FIELD</Link>
+          </div>
+        </div>
+      </header>
+
+      <section className="relative min-h-[72vh] overflow-hidden border-b border-[#26343b] bg-[#020609]">
+        <div className="absolute inset-0 bg-[url('/field/sfi-field-world-skin.webp')] bg-cover bg-center opacity-90" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(195,154,77,.08),transparent_32%),linear-gradient(rgba(88,123,135,.07)_1px,transparent_1px),linear-gradient(90deg,rgba(88,123,135,.07)_1px,transparent_1px)] bg-[size:auto,5%_10%,5%_10%]" />
+        <svg className="pointer-events-none absolute inset-0 z-[4] h-full w-full" viewBox="0 0 100 100" preserveAspectRatio="none">
+          {located.slice(0, 120).map((node, index) => {
+            if (index === 0) return null;
+            const previous = located[index - 1];
+            if (previous.lat === null || previous.lng === null || node.lat === null || node.lng === null) return null;
+            const a = { x: ((previous.lng + 180) / 360) * 100, y: ((90 - previous.lat) / 180) * 100 };
+            const b = { x: ((node.lng + 180) / 360) * 100, y: ((90 - node.lat) / 180) * 100 };
+            const sameSystem = previous.affectedSystems.some((system) => node.affectedSystems.includes(system));
+            if (!sameSystem) return null;
+            return <path key={`${previous.id}:${node.id}`} d={`M ${a.x} ${a.y} Q ${(a.x + b.x) / 2} ${Math.min(a.y, b.y) - 4} ${b.x} ${b.y}`} fill="none" stroke="#b49450" strokeOpacity="0.18" strokeWidth="0.18" vectorEffect="non-scaling-stroke" />;
+          })}
+        </svg>
+
+        {located.map((node) => (
+          <button key={node.id} onClick={() => setSelectedId(node.id)} className="absolute z-10 -translate-x-1/2 -translate-y-1/2" style={point(node.lat as number, node.lng as number)} title={`${node.publisher} · ${node.title}`}>
+            <span className={`block rounded-full border transition-all ${nodeClass(node.sourceFamily, node.id === selectedId)}`} />
+          </button>
+        ))}
+
+        {!located.length ? <div className="absolute inset-0 z-20 grid place-items-center"><div className="max-w-lg border border-[#6a5530] bg-[#05090ce8] p-7 text-center"><Aperture className="mx-auto h-8 w-8 text-[#c9a35c]" /><strong className="mt-4 block text-xl text-[#efe4ca]">SIN OBSERVACIONES WORLD PERSISTIDAS</strong><p className="mt-3 text-sm leading-7 text-[#829097]">No se inventan nodos. La primera ejecución del ciclo de ingesta debe persistir observaciones reales.</p></div></div> : null}
+
+        <div className="absolute left-4 top-4 z-20 border border-[#304149] bg-[#03080bdc] px-3 py-2 font-mono text-[9px] uppercase tracking-[0.14em] text-[#8da1a9]">observadas {nodes.length} · localizadas {located.length} · hipótesis abiertas {openHypotheses.length}</div>
+        <div className="absolute bottom-4 left-4 z-20 border border-[#304149] bg-[#03080bdc] px-3 py-2 font-mono text-[9px] uppercase tracking-[0.14em] text-[#8da1a9]">{data?.sourceFamilies?.join(' · ') || 'NO SOURCE FAMILIES'} · {date(data?.generatedAt)}</div>
+      </section>
+
+      <section className="mx-auto grid max-w-[1800px] gap-px bg-[#26343b] xl:grid-cols-[minmax(0,1.25fr)_minmax(360px,.75fr)]">
+        <article className="bg-[#05090c] p-5 md:p-7">
+          <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.17em] text-[#c49d55]"><CircleDot className="h-4 w-4" /> Observación seleccionada</div>
+          {selected ? <>
+            <div className="mt-4 flex flex-wrap items-center gap-2"><span className="border border-[#33464e] px-2 py-1 font-mono text-[9px] uppercase text-[#91a8b1]">{selected.publisher}</span><span className="border border-[#33464e] px-2 py-1 font-mono text-[9px] uppercase text-[#91a8b1]">{selected.sourceFamily}</span><span className="text-xs text-[#718087]">{date(selected.observedAt)}</span></div>
+            <h2 className="mt-4 text-2xl text-[#f0e5cd]">{selected.title}</h2>
+            <p className="mt-3 max-w-4xl text-sm leading-7 text-[#8d9a9f]">{selected.summary || 'Observación sin resumen editorial.'}</p>
+            {reading ? <div className="mt-6 grid gap-4 md:grid-cols-2">
+              {[
+                ['¿Qué tensión aparece?', reading.tension?.between?.join(' ↔ ')],
+                ['¿A quién le duele?', reading.pain_map?.affectedSystems?.join(' · ')],
+                ['¿Qué mueve el campo?', reading.field_drivers?.drivers?.join(' · ')],
+                ['¿Qué se permitirá?', `permite: ${reading.permissions?.enabled?.join(', ')} · restringe: ${reading.permissions?.constrained?.join(', ')}`],
+                ['¿Hacia dónde va?', `${reading.trajectory?.direction} · ${reading.trajectory?.expectedSignal}`],
+                ['¿Qué puede hacerse mínimamente?', reading.minimum_viable_perturbation?.action],
+              ].map(([question, answer]) => <div key={question} className="border border-[#273840] bg-[#071015] p-4"><div className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#c49d55]">{question}</div><p className="mt-3 text-sm leading-6 text-[#a0aaac]">{answer || 'MISSING'}</p></div>)}
+            </div> : <p className="mt-6 border border-[#604d2d] p-4 text-sm text-[#c5a66b]">La observación existe, pero aún no tiene lectura SFI persistida.</p>}
+          </> : <p className="mt-4 text-sm text-[#78868c]">Selecciona un nodo observado.</p>}
+        </article>
+
+        <aside className="bg-[#04080a] p-5 md:p-7">
+          <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.17em] text-[#c49d55]"><Activity className="h-4 w-4" /> Estado matemático</div>
+          {reading ? <div className="mt-4 grid grid-cols-2 gap-px bg-[#25343a]">
+            {[['F_s', reading.systemic_friction], ['D_i', reading.interaction_density], ['G_f', reading.friction_gradient], ['Φ', reading.systemic_coherence]].map(([label, value]) => <div key={String(label)} className="bg-[#071015] p-4"><div className="font-mono text-[9px] text-[#73878f]">{label}</div><div className="mt-2 text-2xl text-[#efe4cb]">{pct(value)}</div></div>)}
+          </div> : null}
+
+          <div className="mt-7 flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.17em] text-[#c49d55]"><Route className="h-4 w-4" /> Hipótesis y retorno</div>
+          <div className="mt-4 space-y-3">
+            {hypotheses.slice(0, 8).map((item) => <article key={String(item.id)} className="border border-[#283940] p-4"><div className="flex justify-between gap-3 font-mono text-[9px] uppercase"><span className="text-[#9eb1b8]">{String(item.status)}</span><span className="text-[#c9a35b]">{pct(item.current_confidence)}</span></div><p className="mt-3 text-xs leading-6 text-[#89969b]">{String(item.statement)}</p><div className="mt-2 text-[10px] text-[#65757c]">retorno · {date(String(item.validation_ends_at))}</div></article>)}
+            {!hypotheses.length ? <p className="text-xs leading-6 text-[#78868c]">Todavía no existe una hipótesis WORLD congelada.</p> : null}
+          </div>
+
+          <div className="mt-7 flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.17em] text-[#c49d55]"><ShieldCheck className="h-4 w-4" /> Contrato</div>
+          {(data?.limits ?? []).map((limit) => <p key={limit} className="mt-3 text-xs leading-6 text-[#78868c]">{limit}</p>)}
+          <p className="mt-3 text-xs leading-6 text-[#78868c]">Outcomes persistidos: {outcomes.length}. Aprendizajes persistidos: {data?.learning?.length ?? 0}.</p>
+          {error ? <div className="mt-5 border border-[#743e32] bg-[#170c09] p-4 text-xs text-[#d48d7c]">{error}</div> : null}
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/src/lib/world-observatory/hypothesisCycle.ts
+++ b/src/lib/world-observatory/hypothesisCycle.ts
@@ -1,0 +1,136 @@
+import 'server-only';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { clamp01 } from '@/lib/sfi/math';
+import { WORLD_METHODOLOGY_VERSION } from './worldCycle';
+
+type ReadingRow = {
+  id: string;
+  observation_id: string;
+  systemic_friction: number;
+  interaction_density: number;
+  friction_gradient: number;
+  systemic_coherence: number;
+  tension: Record<string, unknown>;
+  pain_map: Record<string, unknown>;
+  field_drivers: Record<string, unknown>;
+  permissions: Record<string, unknown>;
+  trajectory: Record<string, unknown>;
+  minimum_viable_perturbation: Record<string, unknown> | null;
+  created_at: string;
+};
+
+type ObservationRow = {
+  id: string;
+  source_id: string;
+  source_family: string;
+  publisher: string;
+  title: string;
+  summary: string | null;
+  observed_at: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  affected_systems: string[];
+  actors: string[];
+};
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.length > 0) : [];
+}
+
+export async function runWorldHypothesisCycle() {
+  const db = createServiceSupabaseClient();
+  const since = new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString();
+  const { data: readings, error } = await db
+    .from('world_friction_readings')
+    .select('*')
+    .gte('created_at', since)
+    .gte('systemic_friction', 0.48)
+    .order('systemic_friction', { ascending: false })
+    .limit(80);
+
+  if (error) return { ok: false, created: 0, error: error.message };
+  let created = 0;
+
+  for (const reading of (readings ?? []) as ReadingRow[]) {
+    const { data: observation } = await db
+      .from('world_source_observations')
+      .select('id,source_id,source_family,publisher,title,summary,observed_at,latitude,longitude,affected_systems,actors')
+      .eq('id', reading.observation_id)
+      .maybeSingle();
+    if (!observation) continue;
+
+    const source = observation as ObservationRow;
+    const phenomenonKey = `${source.source_family}:${source.id}`;
+    const { data: existing } = await db
+      .from('world_hypotheses')
+      .select('id')
+      .eq('phenomenon_key', phenomenonKey)
+      .in('status', ['OPEN', 'AWAITING_OUTCOME'])
+      .maybeSingle();
+    if (existing) continue;
+
+    const trajectory = reading.trajectory ?? {};
+    const direction = typeof trajectory.direction === 'string' ? trajectory.direction : 'displacement';
+    const expectedSignal = typeof trajectory.expectedSignal === 'string'
+      ? trajectory.expectedSignal
+      : `change in ${source.affected_systems.join(', ') || source.source_family}`;
+    const affected = source.affected_systems.length ? source.affected_systems : [source.source_family];
+    const horizonHours = Number(trajectory.horizonHours ?? 24);
+    const cutoff = new Date();
+    const validationStartsAt = new Date(cutoff.getTime() + 60 * 60 * 1000);
+    const validationEndsAt = new Date(cutoff.getTime() + Math.max(6, Math.min(168, horizonHours)) * 60 * 60 * 1000);
+    const expectedSignals = [...new Set([
+      ...affected,
+      direction,
+      ...strings((reading.field_drivers ?? {}).drivers),
+    ])].slice(0, 8);
+    const contradictionSignals = direction === 'fragmentation'
+      ? ['restored', 'reopened', 'normal operation', 'stabilized']
+      : direction === 'displacement'
+        ? ['unchanged', 'normal operation', 'no disruption']
+        : ['closure', 'escalation', 'disruption'];
+    const initialConfidence = clamp01(
+      Number(source.publisher ? 0.25 : 0.1)
+      + Number(reading.systemic_coherence ?? 0) * 0.35
+      + Number(reading.interaction_density ?? 0) * 0.2
+      + Number(reading.friction_gradient ?? 0) * 0.2,
+    );
+
+    const { error: insertError } = await db.from('world_hypotheses').insert({
+      phenomenon_key: phenomenonKey,
+      graph_snapshot: {
+        observationId: source.id,
+        readingId: reading.id,
+        sourceId: source.source_id,
+        sourceFamily: source.source_family,
+        publisher: source.publisher,
+        title: source.title,
+        observedAt: source.observed_at,
+        geography: source.latitude !== null && source.longitude !== null ? { lat: source.latitude, lng: source.longitude } : null,
+        affectedSystems: source.affected_systems,
+        actors: source.actors,
+        tension: reading.tension,
+        painMap: reading.pain_map,
+        fieldDrivers: reading.field_drivers,
+        permissions: reading.permissions,
+        minimumViablePerturbation: reading.minimum_viable_perturbation,
+      },
+      cutoff_at: cutoff.toISOString(),
+      statement: `Si la tensión observada en “${source.title}” persiste, el campo tenderá a ${direction} y deberá aparecer ${expectedSignal} dentro de la ventana de retorno.`,
+      predicted_trajectory: { direction, expectedSignal, affectedSystems: affected, horizonHours },
+      expected_signals: expectedSignals,
+      contradiction_signals: contradictionSignals,
+      validation_starts_at: validationStartsAt.toISOString(),
+      validation_ends_at: validationEndsAt.toISOString(),
+      initial_confidence: initialConfidence,
+      current_confidence: initialConfidence,
+      methodology_version: WORLD_METHODOLOGY_VERSION,
+      evidence_ids: [source.id],
+      status: 'AWAITING_OUTCOME',
+    });
+
+    if (!insertError) created += 1;
+  }
+
+  return { ok: true, created, considered: readings?.length ?? 0, generatedAt: new Date().toISOString() };
+}

--- a/src/lib/world-observatory/worldCycle.ts
+++ b/src/lib/world-observatory/worldCycle.ts
@@ -1,0 +1,229 @@
+import 'server-only';
+import { createHash } from 'crypto';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { calculateLdiFromAge, evaluateSfi, clamp01 } from '@/lib/sfi/math';
+
+export const WORLD_METHODOLOGY_VERSION = 'SFI-WORLD-2026.08.1';
+export const WORLD_COLLECTOR_VERSION = 'world-observatory-v1';
+
+type NormalizedObservation = {
+  sourceId: string;
+  sourceFamily: string;
+  publisher: string;
+  observationKind: string;
+  externalId: string;
+  title: string;
+  summary: string | null;
+  observedAt: string | null;
+  releasedAt: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  countryCodes: string[];
+  actors: string[];
+  affectedSystems: string[];
+  payload: Record<string, unknown>;
+  sourceUrl: string | null;
+  confidence: number;
+};
+
+type FrictionReading = {
+  ihg: number;
+  nti: number;
+  ldi: number;
+  phi: number;
+  fs: number;
+  regime: string;
+  tension: Record<string, unknown>;
+  painMap: Record<string, unknown>;
+  fieldDrivers: Record<string, unknown>;
+  permissions: Record<string, unknown>;
+  trajectory: Record<string, unknown>;
+  minimumViablePerturbation: Record<string, unknown>;
+};
+
+function hash(value: unknown) {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+function iso(value: unknown): string | null {
+  if (typeof value === 'number') return new Date(value).toISOString();
+  if (typeof value !== 'string' || !value) return null;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null;
+}
+
+function finite(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function json(url: string): Promise<unknown> {
+  const response = await fetch(url, { headers: { 'user-agent': 'SystemFrictionInstitute/1.0' }, cache: 'no-store', signal: AbortSignal.timeout(12000) });
+  if (!response.ok) throw new Error(`${response.status}:${url}`);
+  return response.json();
+}
+
+async function text(url: string): Promise<string> {
+  const response = await fetch(url, { headers: { 'user-agent': 'SystemFrictionInstitute/1.0' }, cache: 'no-store', signal: AbortSignal.timeout(12000) });
+  if (!response.ok) throw new Error(`${response.status}:${url}`);
+  return response.text();
+}
+
+async function collectUsgs(): Promise<NormalizedObservation[]> {
+  const payload = await json('https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_day.geojson') as { features?: Array<Record<string, unknown>> };
+  return (payload.features ?? []).slice(0, 120).flatMap((feature) => {
+    const properties = (feature.properties ?? {}) as Record<string, unknown>;
+    const geometry = (feature.geometry ?? {}) as { coordinates?: unknown[] };
+    const coordinates = geometry.coordinates ?? [];
+    const lat = finite(coordinates[1]);
+    const lng = finite(coordinates[0]);
+    if (lat === null || lng === null) return [];
+    const magnitude = finite(properties.mag) ?? 0;
+    return [{
+      sourceId: 'usgs-earthquakes', sourceFamily: 'natural_event', publisher: 'USGS', observationKind: 'measurement',
+      externalId: String(feature.id ?? hash(feature)), title: String(properties.title ?? 'Earthquake'), summary: String(properties.place ?? ''),
+      observedAt: iso(properties.time), releasedAt: iso(properties.updated), latitude: lat, longitude: lng, countryCodes: [], actors: [],
+      affectedSystems: ['population', 'infrastructure', 'logistics'], payload: { magnitude, depthKm: finite(coordinates[2]), tsunami: properties.tsunami },
+      sourceUrl: typeof properties.url === 'string' ? properties.url : null, confidence: 0.96,
+    }];
+  });
+}
+
+async function collectEonet(): Promise<NormalizedObservation[]> {
+  const payload = await json('https://eonet.gsfc.nasa.gov/api/v3/events?status=open&days=30&limit=100') as { events?: Array<Record<string, unknown>> };
+  return (payload.events ?? []).flatMap((event) => {
+    const geometries = Array.isArray(event.geometry) ? event.geometry as Array<Record<string, unknown>> : [];
+    const latest = geometries.at(-1);
+    const coordinates = Array.isArray(latest?.coordinates) ? latest?.coordinates as unknown[] : [];
+    const lng = finite(coordinates[0]); const lat = finite(coordinates[1]);
+    if (lat === null || lng === null) return [];
+    const categories = Array.isArray(event.categories) ? event.categories as Array<Record<string, unknown>> : [];
+    const category = String(categories[0]?.title ?? 'Natural event');
+    if (/earthquake/i.test(category)) return [];
+    return [{
+      sourceId: 'nasa-eonet', sourceFamily: 'natural_event', publisher: 'NASA EONET', observationKind: 'event', externalId: String(event.id ?? hash(event)),
+      title: String(event.title ?? category), summary: category, observedAt: iso(latest?.date), releasedAt: null, latitude: lat, longitude: lng,
+      countryCodes: [], actors: [], affectedSystems: ['population', 'environment', 'infrastructure'], payload: { category, closed: event.closed ?? null },
+      sourceUrl: typeof event.link === 'string' ? event.link : null, confidence: 0.88,
+    }];
+  });
+}
+
+function tag(xml: string, name: string): string | null {
+  const match = xml.match(new RegExp(`<${name}[^>]*>(?:<!\\[CDATA\\[)?([\\s\\S]*?)(?:\\]\\]>)?<\\/${name}>`, 'i'));
+  return match?.[1]?.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim() ?? null;
+}
+
+async function collectGdacs(): Promise<NormalizedObservation[]> {
+  const xml = await text('https://www.gdacs.org/xml/rss.xml');
+  return [...xml.matchAll(/<item>([\s\S]*?)<\/item>/gi)].slice(0, 100).flatMap((match) => {
+    const item = match[1]; const point = tag(item, 'georss:point')?.split(/\s+/).map(Number) ?? [];
+    const lat = finite(point[0]); const lng = finite(point[1]); const alert = tag(item, 'gdacs:alertlevel') ?? 'Unknown';
+    if (lat === null || lng === null || /^green$/i.test(alert)) return [];
+    return [{
+      sourceId: 'gdacs', sourceFamily: 'natural_event', publisher: 'GDACS', observationKind: 'event', externalId: tag(item, 'guid') ?? hash(item),
+      title: tag(item, 'title') ?? 'GDACS event', summary: tag(item, 'description'), observedAt: iso(tag(item, 'pubDate')), releasedAt: iso(tag(item, 'pubDate')),
+      latitude: lat, longitude: lng, countryCodes: [], actors: [], affectedSystems: ['population', 'infrastructure', 'humanitarian_response'],
+      payload: { alertLevel: alert, eventType: tag(item, 'gdacs:eventtype') }, sourceUrl: tag(item, 'link'), confidence: 0.92,
+    }];
+  });
+}
+
+async function collectFaa(): Promise<NormalizedObservation[]> {
+  const xml = await text('https://nasstatus.faa.gov/api/airport-status-information');
+  return [...xml.matchAll(/<(Airport|Delay|Ground_Stop|Ground_Delay|Closure)[^>]*>([\s\S]*?)<\/\1>/gi)].slice(0, 100).flatMap((match, index) => {
+    const body = match[2]; const name = tag(body, 'Name') ?? tag(body, 'ARPT') ?? tag(body, 'Airport');
+    if (!name) return [];
+    const lat = finite(tag(body, 'Latitude')); const lng = finite(tag(body, 'Longitude'));
+    return [{
+      sourceId: 'faa-asws', sourceFamily: 'aviation', publisher: 'FAA ASWS', observationKind: 'restriction', externalId: `${name}:${index}:${hash(body).slice(0, 12)}`,
+      title: `${match[1].replaceAll('_', ' ')} · ${name}`, summary: tag(body, 'Reason') ?? tag(body, 'Status'), observedAt: new Date().toISOString(), releasedAt: null,
+      latitude: lat, longitude: lng, countryCodes: ['US'], actors: ['airport_operator', 'air_navigation'], affectedSystems: ['aviation', 'logistics', 'passengers'],
+      payload: { type: match[1], delay: tag(body, 'Avg') ?? tag(body, 'Delay') }, sourceUrl: 'https://nasstatus.faa.gov/', confidence: 0.94,
+    }];
+  });
+}
+
+function deriveReading(observation: NormalizedObservation): FrictionReading {
+  const now = Date.now();
+  const observed = observation.observedAt ? new Date(observation.observedAt).getTime() : now;
+  const ageHours = Math.max(0, (now - observed) / 3600000);
+  const interactionDensity = clamp01((observation.affectedSystems.length + observation.actors.length) / 8);
+  const sourceTrust = clamp01(observation.confidence);
+  const recency = 1 - calculateLdiFromAge(ageHours, 168);
+  const impact = clamp01(Number(observation.payload.magnitude ?? 0) / 8 || interactionDensity);
+  const ihg = clamp01(0.35 + impact * 0.35 + sourceTrust * 0.3);
+  const nti = clamp01(interactionDensity * 0.55 + recency * 0.45);
+  const ldi = calculateLdiFromAge(ageHours, 168);
+  const metrics = evaluateSfi({ ihg, nti, ldi, xi: 0.03 });
+  const affected = observation.affectedSystems;
+  return {
+    ...metrics,
+    tension: { question: '¿Qué fuerzas incompatibles se acumulan?', between: [`continuidad de ${affected[0] ?? 'sistema'}`, `restricción observada: ${observation.title}`] },
+    painMap: { question: '¿A quién le duele?', affectedSystems: affected, actors: observation.actors, direct: affected.slice(0, 2), transferred: affected.slice(2) },
+    fieldDrivers: { question: '¿Qué mueve el campo?', drivers: [observation.observationKind, observation.sourceFamily, recency > 0.7 ? 'persistence_now' : 'residual_effect'] },
+    permissions: { question: '¿Qué se permitirá?', enabled: ['observe', 'reroute', 'verify_independently'], constrained: affected.map((item) => `normal_operation:${item}`) },
+    trajectory: { question: '¿Hacia dónde va?', direction: metrics.fs > 0.72 ? 'fragmentation' : metrics.fs > 0.48 ? 'displacement' : 'absorption', expectedSignal: `change in ${affected.join(', ') || 'field continuity'}`, horizonHours: 24 },
+    minimumViablePerturbation: { question: '¿Qué acción mínima y reversible puede probarse?', action: 'add an independent observation lane and compare the next ingestion cycle', reversible: true, returnWindowHours: 24 },
+  };
+}
+
+export async function runWorldObservationCycle() {
+  const collectors = [collectUsgs, collectEonet, collectGdacs, collectFaa];
+  const settled = await Promise.allSettled(collectors.map((collector) => collector()));
+  const observations = settled.flatMap((result) => result.status === 'fulfilled' ? result.value : []);
+  const failures = settled.flatMap((result, index) => result.status === 'rejected' ? [{ collector: collectors[index].name, error: String(result.reason) }] : []);
+  const db = createServiceSupabaseClient();
+  let inserted = 0;
+  for (const observation of observations) {
+    const rawHash = hash(observation.payload);
+    const { data, error } = await db.from('world_source_observations').upsert({
+      source_id: observation.sourceId, source_family: observation.sourceFamily, publisher: observation.publisher, observation_kind: observation.observationKind,
+      external_id: observation.externalId, title: observation.title, summary: observation.summary, observed_at: observation.observedAt, released_at: observation.releasedAt,
+      latitude: observation.latitude, longitude: observation.longitude, country_codes: observation.countryCodes, actors: observation.actors, affected_systems: observation.affectedSystems,
+      payload: observation.payload, raw_hash: rawHash, source_url: observation.sourceUrl, collector_version: WORLD_COLLECTOR_VERSION, confidence: observation.confidence,
+    }, { onConflict: 'source_id,external_id,raw_hash' }).select('id').single();
+    if (error || !data) continue;
+    const reading = deriveReading(observation);
+    await db.from('world_friction_readings').upsert({
+      observation_id: data.id, methodology_version: WORLD_METHODOLOGY_VERSION, systemic_friction: reading.fs, interaction_density: reading.nti,
+      friction_gradient: clamp01(reading.fs * (1 - reading.ldi)), systemic_coherence: reading.phi, tension: reading.tension, pain_map: reading.painMap,
+      field_drivers: reading.fieldDrivers, permissions: reading.permissions, trajectory: reading.trajectory, minimum_viable_perturbation: reading.minimumViablePerturbation,
+    }, { onConflict: 'observation_id,methodology_version' });
+    inserted += 1;
+  }
+  return { ok: failures.length < collectors.length, observed: observations.length, persisted: inserted, failures, generatedAt: new Date().toISOString() };
+}
+
+export async function runWorldCalibrationCycle() {
+  const db = createServiceSupabaseClient();
+  const now = new Date().toISOString();
+  const { data: hypotheses } = await db.from('world_hypotheses').select('*').in('status', ['OPEN', 'AWAITING_OUTCOME']).lte('validation_ends_at', now).limit(100);
+  let calibrated = 0;
+  for (const hypothesis of hypotheses ?? []) {
+    const expected = Array.isArray(hypothesis.expected_signals) ? hypothesis.expected_signals as string[] : [];
+    const contradictions = Array.isArray(hypothesis.contradiction_signals) ? hypothesis.contradiction_signals as string[] : [];
+    const { data: later } = await db.from('world_source_observations').select('id,title,summary,affected_systems,observed_at').gt('observed_at', hypothesis.cutoff_at).lte('observed_at', now).limit(500);
+    const corpus = JSON.stringify(later ?? []).toLowerCase();
+    const expectedHits = expected.filter((signal) => corpus.includes(signal.toLowerCase()));
+    const contradictionHits = contradictions.filter((signal) => corpus.includes(signal.toLowerCase()));
+    const coverage = expected.length ? expectedHits.length / expected.length : 0;
+    const classification = !later?.length ? 'INCONCLUSIVE' : contradictionHits.length > expectedHits.length ? 'CONTRADICTED' : coverage >= 0.75 ? 'VALIDATED' : coverage > 0 ? 'PARTIALLY_VALIDATED' : 'EXPIRED';
+    const outcomeScore = classification === 'VALIDATED' ? 1 : classification === 'PARTIALLY_VALIDATED' ? 0.6 : classification === 'CONTRADICTED' ? 0 : 0.35;
+    const before = Number(hypothesis.current_confidence ?? hypothesis.initial_confidence ?? 0.5);
+    const after = classification === 'INCONCLUSIVE' ? before : clamp01(before * 0.75 + outcomeScore * clamp01(coverage || 0.5) * 0.25);
+    const { data: outcome } = await db.from('world_hypothesis_outcomes').upsert({
+      hypothesis_id: hypothesis.id, classification, observed_outcome: `${expectedHits.length}/${expected.length} expected signals; ${contradictionHits.length} contradictions`,
+      directional_accuracy: outcomeScore, temporal_accuracy: later?.length ? 1 : null, actor_accuracy: null, mechanism_accuracy: coverage,
+      source_coverage: coverage, evidence_ids: (later ?? []).map((item) => item.id), evaluator_version: WORLD_METHODOLOGY_VERSION,
+    }, { onConflict: 'hypothesis_id' }).select('id').single();
+    if (!outcome) continue;
+    await db.from('world_learning_events').insert({
+      hypothesis_id: hypothesis.id, outcome_id: outcome.id, retained_assumptions: expectedHits, rejected_assumptions: contradictionHits,
+      missing_variables: expected.filter((signal) => !expectedHits.includes(signal)), graph_adjustments: [], confidence_before: before, confidence_after: after,
+    });
+    await db.from('world_hypotheses').update({ status: classification, current_confidence: after }).eq('id', hypothesis.id);
+    calibrated += 1;
+  }
+  return { ok: true, calibrated, generatedAt: now };
+}

--- a/supabase/migrations/20260802214000_world_observatory_learning.sql
+++ b/supabase/migrations/20260802214000_world_observatory_learning.sql
@@ -1,0 +1,108 @@
+create table if not exists public.world_source_observations (
+  id uuid primary key default gen_random_uuid(),
+  source_id text not null,
+  source_family text not null,
+  publisher text not null,
+  observation_kind text not null,
+  external_id text not null,
+  title text not null,
+  summary text,
+  observed_at timestamptz,
+  released_at timestamptz,
+  fetched_at timestamptz not null default now(),
+  latitude double precision,
+  longitude double precision,
+  country_codes text[] not null default '{}',
+  actors text[] not null default '{}',
+  affected_systems text[] not null default '{}',
+  payload jsonb not null default '{}'::jsonb,
+  raw_hash text not null,
+  source_url text,
+  collector_version text not null,
+  freshness text not null default 'fresh',
+  availability text not null default 'available',
+  confidence numeric,
+  unique(source_id, external_id, raw_hash)
+);
+
+create table if not exists public.world_friction_readings (
+  id uuid primary key default gen_random_uuid(),
+  observation_id uuid not null references public.world_source_observations(id) on delete cascade,
+  methodology_version text not null,
+  systemic_friction numeric not null,
+  interaction_density numeric not null,
+  friction_gradient numeric not null,
+  systemic_coherence numeric not null,
+  tension jsonb not null,
+  pain_map jsonb not null,
+  field_drivers jsonb not null,
+  permissions jsonb not null,
+  trajectory jsonb not null,
+  minimum_viable_perturbation jsonb,
+  created_at timestamptz not null default now(),
+  unique(observation_id, methodology_version)
+);
+
+create table if not exists public.world_hypotheses (
+  id uuid primary key default gen_random_uuid(),
+  phenomenon_key text not null,
+  graph_snapshot jsonb not null,
+  cutoff_at timestamptz not null,
+  statement text not null,
+  predicted_trajectory jsonb not null,
+  expected_signals jsonb not null,
+  contradiction_signals jsonb not null,
+  validation_starts_at timestamptz not null,
+  validation_ends_at timestamptz not null,
+  initial_confidence numeric not null,
+  current_confidence numeric not null,
+  methodology_version text not null,
+  evidence_ids uuid[] not null default '{}',
+  status text not null default 'OPEN',
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.world_hypothesis_outcomes (
+  id uuid primary key default gen_random_uuid(),
+  hypothesis_id uuid not null references public.world_hypotheses(id) on delete cascade,
+  classification text not null,
+  observed_outcome text not null,
+  directional_accuracy numeric,
+  temporal_accuracy numeric,
+  actor_accuracy numeric,
+  mechanism_accuracy numeric,
+  source_coverage numeric not null default 0,
+  evidence_ids uuid[] not null default '{}',
+  evaluator_version text not null,
+  evaluated_at timestamptz not null default now(),
+  unique(hypothesis_id)
+);
+
+create table if not exists public.world_learning_events (
+  id uuid primary key default gen_random_uuid(),
+  hypothesis_id uuid not null references public.world_hypotheses(id) on delete cascade,
+  outcome_id uuid not null references public.world_hypothesis_outcomes(id) on delete cascade,
+  retained_assumptions jsonb not null default '[]'::jsonb,
+  rejected_assumptions jsonb not null default '[]'::jsonb,
+  missing_variables jsonb not null default '[]'::jsonb,
+  graph_adjustments jsonb not null default '[]'::jsonb,
+  confidence_before numeric not null,
+  confidence_after numeric not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists world_observations_time_idx on public.world_source_observations(observed_at desc);
+create index if not exists world_observations_geo_idx on public.world_source_observations(latitude, longitude);
+create index if not exists world_hypotheses_status_window_idx on public.world_hypotheses(status, validation_ends_at);
+
+alter table public.world_source_observations enable row level security;
+alter table public.world_friction_readings enable row level security;
+alter table public.world_hypotheses enable row level security;
+alter table public.world_hypothesis_outcomes enable row level security;
+alter table public.world_learning_events enable row level security;
+
+create policy "world observations readable" on public.world_source_observations for select using (true);
+create policy "world readings readable" on public.world_friction_readings for select using (true);
+create policy "world hypotheses readable" on public.world_hypotheses for select using (true);
+create policy "world outcomes readable" on public.world_hypothesis_outcomes for select using (true);
+create policy "world learning readable" on public.world_learning_events for select using (true);


### PR DESCRIPTION
## Purpose

Replace the empty FIELD map behavior with a WORLD observatory that navigates systemic tension rather than reproducing external dashboards or risk scores.

## Real source lanes

Initial no-key collectors:

- USGS earthquakes M4.5+ daily GeoJSON
- NASA EONET open natural events
- GDACS non-green disaster alerts
- FAA ASWS operational restrictions

No probabilistic fallback, demo event, random node, or imported provider score is used.

## SFI processing

Every external item is persisted as an observation, then evaluated through the canonical SFI math implementation in `src/lib/sfi/math.ts`:

- Φ systemic coherence
- F_s systemic friction
- D_i interaction density
- G_f friction gradient

The reading persists the SFI questions:

- What tension appears?
- Who is hurt?
- What moves the field?
- What remains permitted or constrained?
- Where is the trajectory moving?
- What minimum reversible perturbation can be tested?

## Automatic learning cycle

The cron executes three independent stages:

1. real-world observation ingestion
2. prior hypothesis generation for material friction readings
3. automatic outcome calibration from later observations

Hypotheses freeze the graph snapshot, cutoff, statement, expected signals, contradiction signals, return window and initial confidence. Later observations produce VALIDATED, PARTIALLY_VALIDATED, CONTRADICTED, INCONCLUSIVE or EXPIRED outcomes and append immutable learning events with confidence before/after.

## Observatory

`/field/map` now renders the WORLD field observatory:

- real geolocated observation nodes
- source provenance and observation time
- SFI question-based reading
- canonical metrics
- open hypotheses and return windows
- persisted outcomes and learning counts

It is explicitly not a dashboard and does not rank countries.

## Deployment requirements

Apply migration:

`supabase/migrations/20260802214000_world_observatory_learning.sql`

Schedule:

`GET or POST /api/cron/world-observatory`

with the existing `SFI_CRON_SECRET` / `CRON_SECRET` bearer pattern.

## Validation

- domain boundaries
- strict TypeScript
- production build
