### PR TITLE
Read persisted WORLD data through authenticated service path

### DIFF
--- a/src/app/api/field/map/world/route.ts
+++ b/src/app/api/field/map/world/route.ts
@@ -1,28 +1,58 @@
 import { NextResponse } from 'next/server';
-import { createServerSupabaseClient } from '@/runtime/supabase/server';
+import {
+  createServerSupabaseClient,
+  createServiceSupabaseClient,
+} from '@/runtime/supabase/server';
 import { bootstrapWorldObservatory } from './bootstrap';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
-function isMissingWorldSchema(message: string) {
-  const normalized = message.toLowerCase();
-  return normalized.includes('schema cache')
-    || normalized.includes('world_source_observations')
-    || normalized.includes('world_friction_readings')
-    || normalized.includes('world_hypotheses')
-    || normalized.includes('world_hypothesis_outcomes')
-    || normalized.includes('world_learning_events');
+function isMissingWorldSchema(error: { code?: string | null; message?: string | null }) {
+  const code = String(error.code ?? '').toUpperCase();
+  const message = String(error.message ?? '').toLowerCase();
+  return code === 'PGRST205'
+    || code === '42P01'
+    || message.includes('could not find the table')
+    || message.includes('relation "public.world_');
+}
+
+function pendingSchemaResponse(error: { code?: string | null; message?: string | null }) {
+  return NextResponse.json({
+    ok: true,
+    generatedAt: new Date().toISOString(),
+    sourceState: 'WORLD_SCHEMA_PENDING',
+    nodes: [],
+    hypotheses: [],
+    outcomes: [],
+    learning: [],
+    sourceFamilies: [],
+    diagnostic: {
+      code: error.code ?? null,
+      message: error.message ?? null,
+      readPath: 'service_role_after_authenticated_user_gate',
+    },
+    limits: [
+      'The active production database still reports the WORLD relation as missing.',
+      'No fallback observations, provider scores or simulated nodes are generated.',
+    ],
+  });
 }
 
 export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const { data: auth } = await supabase.auth.getUser();
-  if (!auth.user) return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  const authClient = await createServerSupabaseClient();
+  const { data: auth, error: authError } = await authClient.auth.getUser();
+  if (authError || !auth.user) {
+    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+  }
 
-  const since = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
-  let observationsQuery = await supabase
+  // Authentication is enforced with the user's session. All WORLD reads then use
+  // the server-only service client so RLS/grant drift cannot hide persisted data.
+  const db = createServiceSupabaseClient();
+  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+
+  let observationsQuery = await db
     .from('world_source_observations')
     .select('*')
     .gte('observed_at', since)
@@ -30,35 +60,21 @@ export async function GET() {
     .limit(500);
 
   if (observationsQuery.error) {
-    if (isMissingWorldSchema(observationsQuery.error.message)) {
-      return NextResponse.json({
-        ok: true,
-        generatedAt: new Date().toISOString(),
-        sourceState: 'WORLD_SCHEMA_PENDING',
-        nodes: [],
-        hypotheses: [],
-        outcomes: [],
-        learning: [],
-        sourceFamilies: [],
-        setupRequired: {
-          migration: 'supabase/migrations/20260802214000_world_observatory_learning.sql',
-          reason: 'Supabase/PostgREST still reports the WORLD schema as unavailable.',
-        },
-        limits: [
-          'The WORLD schema is pending in the active Supabase schema cache.',
-          'No fallback observations, provider scores or simulated nodes are generated.',
-          "If the migration was just applied, run: NOTIFY pgrst, 'reload schema';",
-        ],
-      });
+    if (isMissingWorldSchema(observationsQuery.error)) {
+      return pendingSchemaResponse(observationsQuery.error);
     }
-
-    return NextResponse.json({ ok: false, error: 'world_observations_query_failed', details: observationsQuery.error.message }, { status: 503 });
+    return NextResponse.json({
+      ok: false,
+      error: 'world_observations_query_failed',
+      code: observationsQuery.error.code ?? null,
+      details: observationsQuery.error.message,
+    }, { status: 503 });
   }
 
   let bootstrap: Awaited<ReturnType<typeof bootstrapWorldObservatory>> | null = null;
   if ((observationsQuery.data ?? []).length === 0) {
     bootstrap = await bootstrapWorldObservatory();
-    observationsQuery = await supabase
+    observationsQuery = await db
       .from('world_source_observations')
       .select('*')
       .gte('observed_at', since)
@@ -66,67 +82,73 @@ export async function GET() {
       .limit(500);
   }
 
-  const [{ data: readings, error: readingsError }, { data: hypotheses, error: hypothesesError }, { data: outcomes, error: outcomesError }, { data: learning, error: learningError }] = await Promise.all([
-    supabase.from('world_friction_readings').select('*').order('created_at', { ascending: false }).limit(500),
-    supabase.from('world_hypotheses').select('*').order('created_at', { ascending: false }).limit(100),
-    supabase.from('world_hypothesis_outcomes').select('*').order('evaluated_at', { ascending: false }).limit(100),
-    supabase.from('world_learning_events').select('*').order('created_at', { ascending: false }).limit(100),
+  const [readingsQuery, hypothesesQuery, outcomesQuery, learningQuery] = await Promise.all([
+    db.from('world_friction_readings').select('*').order('created_at', { ascending: false }).limit(500),
+    db.from('world_hypotheses').select('*').order('created_at', { ascending: false }).limit(100),
+    db.from('world_hypothesis_outcomes').select('*').order('evaluated_at', { ascending: false }).limit(100),
+    db.from('world_learning_events').select('*').order('created_at', { ascending: false }).limit(100),
   ]);
 
-  const secondaryError = observationsQuery.error ?? readingsError ?? hypothesesError ?? outcomesError ?? learningError;
-  if (secondaryError) {
-    if (isMissingWorldSchema(secondaryError.message)) {
-      return NextResponse.json({
-        ok: true,
-        generatedAt: new Date().toISOString(),
-        sourceState: 'WORLD_SCHEMA_PARTIAL',
-        nodes: [],
-        hypotheses: [],
-        outcomes: [],
-        learning: [],
-        sourceFamilies: [],
-        bootstrap,
-        setupRequired: {
-          migration: 'supabase/migrations/20260802214000_world_observatory_learning.sql',
-          reason: 'The WORLD observatory schema is only partially available to PostgREST.',
-        },
-        limits: [
-          'The WORLD schema is partial; no incomplete analytical state is presented as valid.',
-          'No fallback observations, provider scores or simulated nodes are generated.',
-        ],
-      });
-    }
+  const secondaryError = observationsQuery.error
+    ?? readingsQuery.error
+    ?? hypothesesQuery.error
+    ?? outcomesQuery.error
+    ?? learningQuery.error;
 
-    return NextResponse.json({ ok: false, error: 'world_observatory_query_failed', details: secondaryError.message, bootstrap }, { status: 503 });
+  if (secondaryError) {
+    if (isMissingWorldSchema(secondaryError)) return pendingSchemaResponse(secondaryError);
+    return NextResponse.json({
+      ok: false,
+      error: 'world_observatory_query_failed',
+      code: secondaryError.code ?? null,
+      details: secondaryError.message,
+      bootstrap,
+    }, { status: 503 });
   }
 
-  const readingByObservation = new Map((readings ?? []).map((item) => [item.observation_id, item]));
+  const readings = readingsQuery.data ?? [];
+  const hypotheses = hypothesesQuery.data ?? [];
+  const outcomes = outcomesQuery.data ?? [];
+  const learning = learningQuery.data ?? [];
+  const readingByObservation = new Map(readings.map((item) => [item.observation_id, item]));
+
   const nodes = (observationsQuery.data ?? []).map((item) => ({
     id: item.id,
-    kind: 'observed',
+    kind: 'observed' as const,
     sourceFamily: item.source_family,
     publisher: item.publisher,
     title: item.title,
     summary: item.summary,
     observedAt: item.observed_at,
-    lat: item.latitude,
-    lng: item.longitude,
-    affectedSystems: item.affected_systems,
-    actors: item.actors,
+    lat: item.latitude === null ? null : Number(item.latitude),
+    lng: item.longitude === null ? null : Number(item.longitude),
+    affectedSystems: Array.isArray(item.affected_systems) ? item.affected_systems : [],
+    actors: Array.isArray(item.actors) ? item.actors : [],
     confidence: Number(item.confidence ?? 0),
     reading: readingByObservation.get(item.id) ?? null,
   }));
+
+  const locatedCount = nodes.filter((node) => Number.isFinite(node.lat) && Number.isFinite(node.lng)).length;
 
   return NextResponse.json({
     ok: true,
     generatedAt: new Date().toISOString(),
     sourceState: nodes.length ? 'OBSERVED_WORLD' : 'NO_WORLD_OBSERVATIONS',
     nodes,
-    hypotheses: hypotheses ?? [],
-    outcomes: outcomes ?? [],
-    learning: learning ?? [],
+    hypotheses,
+    outcomes,
+    learning,
     sourceFamilies: [...new Set(nodes.map((node) => node.sourceFamily))],
     bootstrap,
+    diagnostic: {
+      readPath: 'service_role_after_authenticated_user_gate',
+      observations: nodes.length,
+      located: locatedCount,
+      readings: readings.length,
+      hypotheses: hypotheses.length,
+      outcomes: outcomes.length,
+      learning: learning.length,
+    },
     limits: [
       'External source scores are not imported.',
       'Every node is a real observation with publisher and time.',


### PR DESCRIPTION
## Failure

WORLD ingestion succeeded with 128 observations and 80 hypotheses, but `/field/map` still rendered `WORLD_SCHEMA_PENDING` and zero nodes.

The read route authenticated the user and then queried WORLD tables with the session/anon client. A grant or RLS error mentioning `world_source_observations` was incorrectly classified as a missing schema because the detector matched table names broadly.

## Fix

- keep the authenticated user gate
- use the server-only service client for WORLD reads after authentication
- detect missing schema only by PostgREST/Postgres relation-missing codes and messages
- expose exact diagnostics
- normalize latitude/longitude to numbers
- expand the observation window to 30 days

No public unauthenticated access is introduced and no simulated data is generated.

## Validation

- domain boundaries
- strict TypeScript
- production build