### PR TITLE
Remove synthetic FIELD graph and connect real MOP-H interpretation

### DIFF
--- a/src/app/api/interface/observatory/interpret/route.ts
+++ b/src/app/api/interface/observatory/interpret/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { AccessDeniedError, requireAuthenticatedUser } from '@/lib/system/access/server';
+import { runMophAgent } from '@/lib/agents/sfiAgents';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+function text(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+    const caseId = text(body.caseId);
+    const selectedTitle = text(body.selectedTitle);
+    const selectedSummary = text(body.selectedSummary);
+    if (!caseId) return NextResponse.json({ ok: false, error: 'case_required' }, { status: 400 });
+
+    const service = createServiceSupabaseClient();
+    const [{ data: fieldCase }, { data: attractor }, { data: recentEvidence }] = await Promise.all([
+      service.from('field_cases').select('id,title,description,status').eq('id', caseId).eq('owner_id', user.id).is('deleted_at', null).single(),
+      service.from('sfi_user_attractors').select('label,summary,objective,direction,confidence,perturbation').eq('case_id', caseId).eq('owner_id', user.id).eq('status', 'DECLARED').maybeSingle(),
+      service.from('field_case_evidence').select('label,source,reliability,payload,observed_at').eq('case_id', caseId).eq('owner_id', user.id).order('observed_at', { ascending: false }).limit(8),
+    ]);
+
+    if (!fieldCase || !attractor) return NextResponse.json({ ok: false, error: 'case_context_unavailable' }, { status: 404 });
+
+    const evidence = (recentEvidence ?? []).map((item) => {
+      const payload = item.payload && typeof item.payload === 'object' ? item.payload as Record<string, unknown> : {};
+      return [item.label, item.source, payload.note, item.observed_at].filter(Boolean).join(' · ');
+    }).join('\n');
+
+    const result = await runMophAgent({
+      stuckSystem: [fieldCase.title, fieldCase.description, attractor.summary, selectedTitle, selectedSummary].filter(Boolean).join('\n'),
+      objective: attractor.objective,
+      attempts: `Dirección observada: ${attractor.direction}`,
+      evidence,
+      consequence: 'La interpretación se utilizará para elegir una microejecución reversible dentro del observatorio personal.',
+      accountId: user.id,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      reading: result.user_friendly_explanation,
+      frictionReading: result.friction_reading,
+      conversionBreak: result.conversion_break,
+      proposedMicroExecution: result.minimal_perturbation,
+      nextAction: result.next_action,
+      confidence: result.confidence,
+      risk: result.risk,
+      provider: result.provider,
+      warnings: result.warnings,
+      persisted: false,
+    });
+  } catch (error) {
+    if (error instanceof AccessDeniedError) {
+      return NextResponse.json({ ok: false, error: error.code }, { status: error.status });
+    }
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'field_interpretation_failed' }, { status: 500 });
+  }
+}

--- a/src/components/interface/UserAttractorFieldExperience.tsx
+++ b/src/components/interface/UserAttractorFieldExperience.tsx
@@ -2,19 +2,7 @@
 
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
-import {
-  Activity,
-  ArrowRight,
-  CheckCircle2,
-  FileUp,
-  Gauge,
-  Loader2,
-  LockKeyhole,
-  Orbit,
-  Route,
-  Sparkles,
-  Target,
-} from 'lucide-react';
+import { ArrowRight, FileUp, Loader2, Orbit, Sparkles, Target } from 'lucide-react';
 
 type PersistedNodeType = 'attractor' | 'mark' | 'event' | 'evidence' | 'intervention' | 'return' | 'learning';
 
@@ -77,46 +65,21 @@ type Props = {
   nextReturnAt: string | null;
 };
 
-type VisualNodeType = PersistedNodeType | 'objective' | 'direction' | 'world' | 'origin';
-
-type VisualNode = {
-  id: string;
-  type: VisualNodeType;
-  label: string;
-  summary: string;
-  weight: number;
-  central?: boolean;
-  persisted?: boolean;
+type UploadState = { note: string; source: string; reliability: number; file: File | null };
+type AgentResult = {
+  reading: string;
+  frictionReading: string;
+  conversionBreak: string;
+  proposedMicroExecution: string;
+  nextAction: string;
+  confidence: number;
+  risk: string;
+  provider: string;
+  warnings: string[];
 };
 
-type VisualEdge = {
-  id: string;
-  source: string;
-  target: string;
-  strength: number;
-  curvature: number;
-  direction: string;
-  persisted?: boolean;
-};
-
-type Point = { x: number; y: number; radius: number };
-
-type UploadState = {
-  note: string;
-  source: string;
-  reliability: number;
-  file: File | null;
-};
-
-const FIELD_WIDTH = 1200;
-const FIELD_HEIGHT = 760;
-const CENTER_X = FIELD_WIDTH / 2;
-const CENTER_Y = FIELD_HEIGHT / 2;
-
-function clamp01(value: number | null | undefined, fallback: number) {
-  const parsed = typeof value === 'number' && Number.isFinite(value) ? value : fallback;
-  return Math.max(0, Math.min(1, parsed));
-}
+const WIDTH = 1000;
+const HEIGHT = 620;
 
 function hash(value: string) {
   let result = 2166136261;
@@ -128,252 +91,77 @@ function hash(value: string) {
 }
 
 function formatDate(value: string | null) {
-  if (!value) return 'Sin retorno programado';
-  return new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value));
+  if (!value) return 'Todavía no hay una fecha programada';
+  const date = new Date(value);
+  return Number.isNaN(date.valueOf()) ? value : new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(date);
 }
 
-function colorFor(type: VisualNodeType) {
-  const colors: Record<VisualNodeType, string> = {
+function statusText(value: string) {
+  const labels: Record<string, string> = {
+    ACCEPTED: 'La evidencia aporta a la trayectoria',
+    PARTIAL: 'La evidencia aporta sólo una parte',
+    OBSERVED_NOT_INTEGRATED: 'La evidencia fue observada, pero aún no cambia la lectura',
+    REJECTED: 'La evidencia no sostiene esta lectura',
+  };
+  return labels[value] ?? value;
+}
+
+function nodeColor(type: PersistedNodeType) {
+  const colors: Record<PersistedNodeType, string> = {
     attractor: '#e1bd58',
-    mark: '#b8ad98',
-    event: '#c77d59',
-    evidence: '#79b9c7',
-    intervention: '#e29255',
-    return: '#8dbb78',
-    learning: '#b18bc7',
-    objective: '#e7d6a0',
-    direction: '#bd9d57',
-    world: '#6e95a0',
-    origin: '#716b60',
+    mark: '#c6b89c',
+    event: '#c97d5c',
+    evidence: '#75b9c7',
+    intervention: '#df9458',
+    return: '#8fbd79',
+    learning: '#b28bc8',
   };
   return colors[type];
 }
 
-function radiusFor(node: VisualNode) {
-  if (node.central) return 56;
-  const base: Record<VisualNodeType, number> = {
-    attractor: 56,
-    mark: 8,
-    event: 11,
-    evidence: 14,
-    intervention: 16,
-    return: 14,
-    learning: 12,
-    objective: 14,
-    direction: 12,
-    world: 13,
-    origin: 10,
-  };
-  return base[node.type] + Math.round(clamp01(node.weight, 0.5) * 7);
-}
-
-function structuralNodes(props: Props): VisualNode[] {
-  const now = props.caseData.createdAt;
-  return [
-    {
-      id: `attractor:${props.attractor.id}`,
-      type: 'attractor',
-      label: props.attractor.label,
-      summary: props.attractor.summary,
-      weight: props.attractor.confidence,
-      central: true,
-      persisted: true,
-    },
-    {
-      id: 'structure:objective',
-      type: 'objective',
-      label: 'Objetivo',
-      summary: props.attractor.objective,
-      weight: 0.82,
-    },
-    {
-      id: 'structure:direction',
-      type: 'direction',
-      label: 'Dirección',
-      summary: props.attractor.direction,
-      weight: 0.76,
-    },
-    {
-      id: 'structure:perturbation',
-      type: 'intervention',
-      label: props.attractor.perturbation.title || 'Perturbación mínima',
-      summary: props.attractor.perturbation.instruction || 'Aún no existe una perturbación declarada.',
-      weight: props.attractor.perturbation.instruction ? 0.72 : 0.28,
-    },
-    {
-      id: 'structure:return',
-      type: 'return',
-      label: 'Retorno',
-      summary: formatDate(props.nextReturnAt),
-      weight: props.nextReturnAt ? 0.64 : 0.25,
-    },
-    {
-      id: 'structure:world',
-      type: 'world',
-      label: props.world.regime || 'Campo mundial',
-      summary: `Tensión ${Math.round(clamp01(props.world.tension, 0.35) * 100)} · fricción ${Math.round(clamp01(props.world.friction, 0.45) * 100)}`,
-      weight: clamp01(props.world.confidence, 0.4),
-    },
-    {
-      id: 'structure:origin',
-      type: 'origin',
-      label: 'Origen observado',
-      summary: `${props.caseData.title} · ${new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium' }).format(new Date(now))}`,
-      weight: 0.46,
-    },
-  ];
-}
-
-function buildVisualModel(props: Props) {
-  const base = structuralNodes(props);
-  const centralId = base[0].id;
-  const persistedPeripheral = props.graph.nodes
-    .filter((node) => !node.is_central && node.node_type !== 'attractor')
-    .slice(-42)
-    .map<VisualNode>((node) => ({
-      id: `persisted:${node.id}`,
-      type: node.node_type,
-      label: node.label,
-      summary: node.summary || 'Evento registrado en la trayectoria.',
-      weight: node.weight,
-      persisted: true,
-    }));
-
-  const evidenceNodes = props.evidence.slice(0, 8).map<VisualNode>((item) => ({
-    id: `assessment:${item.id}`,
-    type: item.status === 'ACCEPTED' ? 'learning' : 'evidence',
-    label: item.status,
-    summary: item.reason,
-    weight: item.confidence,
-    persisted: true,
-  }));
-
-  const nodes = [...base, ...persistedPeripheral, ...evidenceNodes];
-  const persistedIdMap = new Map(props.graph.nodes.map((node) => [node.id, node.is_central || node.node_type === 'attractor' ? centralId : `persisted:${node.id}`]));
-
-  const edges: VisualEdge[] = [
-    { id: 'struct:objective', source: 'structure:origin', target: 'structure:objective', strength: 0.54, curvature: -0.12, direction: 'toward_objective' },
-    { id: 'struct:objective-center', source: 'structure:objective', target: centralId, strength: 0.92, curvature: 0.08, direction: 'toward_attractor' },
-    { id: 'struct:direction', source: 'structure:direction', target: centralId, strength: 0.86, curvature: -0.08, direction: 'toward_attractor' },
-    { id: 'struct:perturbation', source: 'structure:perturbation', target: centralId, strength: 0.74, curvature: 0.14, direction: 'tests_attractor' },
-    { id: 'struct:return', source: 'structure:return', target: centralId, strength: props.nextReturnAt ? 0.68 : 0.28, curvature: -0.16, direction: 'validates_attractor' },
-    { id: 'struct:world', source: 'structure:world', target: centralId, strength: clamp01(props.world.confidence, 0.4), curvature: 0.22, direction: 'modulates_field' },
-    { id: 'struct:origin-center', source: 'structure:origin', target: centralId, strength: 0.48, curvature: 0.26, direction: 'originates_trajectory' },
-  ];
-
-  props.graph.edges.slice(-80).forEach((edge) => {
-    const source = persistedIdMap.get(edge.source_node_id);
-    const target = persistedIdMap.get(edge.target_node_id);
-    if (!source || !target || source === target) return;
-    edges.push({
-      id: `persisted-edge:${edge.id}`,
-      source,
-      target,
-      strength: edge.strength,
-      curvature: edge.curvature,
-      direction: edge.direction,
-      persisted: true,
-    });
-  });
-
-  persistedPeripheral.forEach((node, index) => {
-    if (edges.some((edge) => edge.source === node.id || edge.target === node.id)) return;
-    edges.push({
-      id: `fallback:${node.id}`,
-      source: node.id,
-      target: centralId,
-      strength: 0.42 + clamp01(node.weight, 0.5) * 0.42,
-      curvature: ((index % 5) - 2) * 0.08,
-      direction: 'toward_attractor',
-      persisted: true,
-    });
-  });
-
-  evidenceNodes.forEach((node, index) => {
-    edges.push({
-      id: `assessment-edge:${node.id}`,
-      source: node.id,
-      target: centralId,
-      strength: 0.45 + node.weight * 0.45,
-      curvature: ((index % 4) - 1.5) * 0.1,
-      direction: node.type === 'learning' ? 'updates_attractor' : 'observes_attractor',
-      persisted: true,
-    });
-  });
-
-  return { nodes, edges, centralId };
-}
-
-function buildPositions(nodes: VisualNode[], centralId: string) {
-  const points = new Map<string, Point>();
-  points.set(centralId, { x: CENTER_X, y: CENTER_Y, radius: 56 });
-
-  const fixed: Record<string, [number, number]> = {
-    'structure:objective': [930, 170],
-    'structure:direction': [965, 470],
-    'structure:perturbation': [840, 650],
-    'structure:return': [360, 650],
-    'structure:world': [245, 205],
-    'structure:origin': [210, 480],
-  };
-
-  nodes.forEach((node) => {
-    if (node.id === centralId) return;
-    const fixedPoint = fixed[node.id];
-    if (fixedPoint) {
-      points.set(node.id, { x: fixedPoint[0], y: fixedPoint[1], radius: radiusFor(node) });
-      return;
-    }
+function positions(nodes: GraphNode[]) {
+  const result = new Map<string, { x: number; y: number }>();
+  const central = nodes.find((node) => node.is_central || node.node_type === 'attractor');
+  if (central) result.set(central.id, { x: WIDTH / 2, y: HEIGHT / 2 });
+  const peripheral = nodes.filter((node) => node.id !== central?.id);
+  peripheral.forEach((node, index) => {
     const seed = hash(node.id);
-    const ringIndex = seed % 3;
-    const ringRadiusX = [235, 330, 435][ringIndex];
-    const ringRadiusY = [150, 225, 305][ringIndex];
-    const angle = ((seed % 360) * Math.PI) / 180;
-    const jitterX = ((seed >> 8) % 45) - 22;
-    const jitterY = ((seed >> 16) % 35) - 17;
-    points.set(node.id, {
-      x: Math.max(70, Math.min(FIELD_WIDTH - 70, CENTER_X + Math.cos(angle) * ringRadiusX + jitterX)),
-      y: Math.max(65, Math.min(FIELD_HEIGHT - 65, CENTER_Y + Math.sin(angle) * ringRadiusY + jitterY)),
-      radius: radiusFor(node),
+    const ring = 150 + (seed % 3) * 70;
+    const angle = peripheral.length ? (index / peripheral.length) * Math.PI * 2 + ((seed % 31) / 100) : 0;
+    result.set(node.id, {
+      x: Math.max(70, Math.min(WIDTH - 70, WIDTH / 2 + Math.cos(angle) * ring)),
+      y: Math.max(65, Math.min(HEIGHT - 65, HEIGHT / 2 + Math.sin(angle) * ring * 0.72)),
     });
   });
-  return points;
+  return result;
 }
 
-function edgePath(source: Point, target: Point, curvature: number) {
-  const midpointX = (source.x + target.x) / 2;
-  const midpointY = (source.y + target.y) / 2;
+function path(source: { x: number; y: number }, target: { x: number; y: number }, curvature: number) {
+  const middleX = (source.x + target.x) / 2;
+  const middleY = (source.y + target.y) / 2;
   const dx = target.x - source.x;
   const dy = target.y - source.y;
   const length = Math.max(1, Math.hypot(dx, dy));
-  const normalX = -dy / length;
-  const normalY = dx / length;
-  const bend = curvature * 180;
-  return `M ${source.x} ${source.y} Q ${midpointX + normalX * bend} ${midpointY + normalY * bend} ${target.x} ${target.y}`;
+  const bend = Math.max(-1, Math.min(1, curvature)) * 110;
+  return `M ${source.x} ${source.y} Q ${middleX + (-dy / length) * bend} ${middleY + (dx / length) * bend} ${target.x} ${target.y}`;
 }
 
 export default function UserAttractorFieldExperience(props: Props) {
-  const { entitlement, caseData, attractor, world, evidence, nextReturnAt, userEmail } = props;
-  const model = useMemo(() => buildVisualModel(props), [props]);
-  const positions = useMemo(() => buildPositions(model.nodes, model.centralId), [model]);
-  const [selectedNodeId, setSelectedNodeId] = useState(model.centralId);
+  const { entitlement, caseData, attractor, graph, evidence, world, nextReturnAt, userEmail } = props;
+  const [selectedId, setSelectedId] = useState<string | null>(graph.nodes.find((node) => node.is_central)?.id ?? graph.nodes[0]?.id ?? null);
   const [upload, setUpload] = useState<UploadState>({ note: '', source: 'observación directa', reliability: 0.7, file: null });
-  const [status, setStatus] = useState<'idle' | 'uploading' | 'checkout' | 'error'>('idle');
-  const [error, setError] = useState<string | null>(null);
-  const [assessment, setAssessment] = useState<null | { status: string; reason: string; nextAction: string; confidence: number }>(null);
-
-  const selectedNode = model.nodes.find((node) => node.id === selectedNodeId) || model.nodes[0];
-  const tension = clamp01(world.tension, 0.35);
-  const friction = clamp01(world.friction, 0.45);
-  const confidence = clamp01(attractor.confidence, 0.5);
-  const fieldHue = 36 + Math.round(tension * 15);
-  const activeNodeCount = model.nodes.filter((node) => node.persisted).length;
+  const [status, setStatus] = useState<'idle' | 'uploading' | 'interpreting' | 'error'>('idle');
+  const [message, setMessage] = useState<string | null>(null);
+  const [agent, setAgent] = useState<AgentResult | null>(null);
+  const pointMap = useMemo(() => positions(graph.nodes), [graph.nodes]);
+  const nodeMap = useMemo(() => new Map(graph.nodes.map((node) => [node.id, node])), [graph.nodes]);
+  const selected = selectedId ? nodeMap.get(selectedId) ?? null : null;
+  const realEdges = graph.edges.filter((edge) => pointMap.has(edge.source_node_id) && pointMap.has(edge.target_node_id));
 
   async function submitEvidence() {
     if (!entitlement.active || (!upload.note.trim() && !upload.file)) return;
     setStatus('uploading');
-    setError(null);
-    setAssessment(null);
+    setMessage(null);
     try {
       const form = new FormData();
       form.set('caseId', caseData.id);
@@ -383,271 +171,128 @@ export default function UserAttractorFieldExperience(props: Props) {
       if (upload.file) form.set('file', upload.file);
       const response = await fetch('/api/interface/observatory/evidence', { method: 'POST', body: form });
       const body = await response.json();
-      if (!response.ok || !body.ok) throw new Error(body.error || 'evidence_upload_failed');
-      setAssessment(body.assessment);
+      if (!response.ok || !body.ok) throw new Error(body.error || 'No fue posible guardar la evidencia.');
       setUpload({ note: '', source: 'observación directa', reliability: 0.7, file: null });
-      setStatus('idle');
+      setMessage(`${statusText(body.assessment.status)}. ${body.assessment.reason}`);
       window.setTimeout(() => window.location.reload(), 900);
-    } catch (nextError) {
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'No fue posible guardar la evidencia.');
       setStatus('error');
-      setError(nextError instanceof Error ? nextError.message : 'evidence_upload_failed');
+      return;
     }
+    setStatus('idle');
   }
 
-  async function startCheckout() {
-    setStatus('checkout');
-    setError(null);
+  async function interpret() {
+    setStatus('interpreting');
+    setMessage(null);
+    setAgent(null);
     try {
-      const response = await fetch('/api/interface/checkout', { method: 'POST' });
+      const response = await fetch('/api/interface/observatory/interpret', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          caseId: caseData.id,
+          selectedTitle: selected?.label ?? attractor.label,
+          selectedSummary: selected?.summary ?? attractor.summary,
+        }),
+      });
       const body = await response.json();
-      if (!response.ok || !body.url) throw new Error(body.error || 'checkout_failed');
-      window.location.assign(body.url);
-    } catch (nextError) {
+      if (!response.ok || !body.ok) throw new Error(body.error || 'No fue posible generar la lectura.');
+      setAgent(body as AgentResult);
+      setStatus('idle');
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'No fue posible generar la lectura.');
       setStatus('error');
-      setError(nextError instanceof Error ? nextError.message : 'checkout_failed');
     }
   }
 
   return (
-    <main className="min-h-screen overflow-x-hidden bg-[#030302] text-[#d8d0be]">
-      <style jsx global>{`
-        @keyframes sfi-attractor-breathe {
-          0%, 100% { transform: scale(0.96); opacity: 0.72; }
-          50% { transform: scale(1.06); opacity: 1; }
-        }
-        @keyframes sfi-field-drift {
-          0% { transform: translate3d(-1.5%, -1%, 0) rotate(-0.4deg); }
-          50% { transform: translate3d(1.4%, 1.1%, 0) rotate(0.5deg); }
-          100% { transform: translate3d(-1.5%, -1%, 0) rotate(-0.4deg); }
-        }
-        @keyframes sfi-orbit {
-          from { transform: rotate(0deg); }
-          to { transform: rotate(360deg); }
-        }
-        .sfi-attractor-ring { transform-box: fill-box; transform-origin: center; animation: sfi-attractor-breathe 4.8s ease-in-out infinite; }
-        .sfi-field-drift { animation: sfi-field-drift 18s ease-in-out infinite; }
-        .sfi-orbit-ring { transform-box: fill-box; transform-origin: center; animation: sfi-orbit 36s linear infinite; }
-      `}</style>
-
-      <header className="border-b border-[#2d281d] bg-[#040403e8] px-5 py-5 backdrop-blur-xl md:px-8">
-        <div className="mx-auto flex max-w-[1800px] flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-          <div>
-            <div className="font-mono text-[10px] uppercase tracking-[0.34em] text-[#d5b45b]">SFI / Personal Attractor Field</div>
-            <h1 className="mt-3 text-3xl font-semibold tracking-[-0.045em] text-[#f5eedb] md:text-5xl">El campo ya está ocurriendo.</h1>
-            <p className="mt-3 max-w-3xl text-sm leading-7 text-[#8f8778]">El nodo dorado es el atractor declarado. Todo evento, evidencia, perturbación y retorno modifica su relación con esa dirección central.</p>
+    <main className="min-h-screen bg-[#050504] text-[#d9d1bf]">
+      <header className="border-b border-[#302a1f] px-5 py-6 md:px-10">
+        <div className="mx-auto flex max-w-[1500px] flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+          <div className="max-w-4xl">
+            <div className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#c8a951]">SFI · observatorio personal</div>
+            <h1 className="mt-3 text-3xl text-[#f4ecd9] md:text-5xl">Tu trayectoria, construida con evidencia real.</h1>
+            <p className="mt-4 max-w-3xl text-sm leading-7 text-[#958d7d]">Este espacio no completa vacíos con datos de ejemplo. Sólo muestra hechos, relaciones, intervenciones y aprendizajes que ya fueron registrados en tu caso.</p>
           </div>
-          <div className="flex flex-wrap gap-2 font-mono text-[9px] uppercase tracking-[0.14em]">
-            <span className="border border-[#302b20] bg-[#070706] px-3 py-2 text-[#7f786b]">{userEmail}</span>
-            <span className="border border-[#65542a] bg-[#0c0a05] px-3 py-2 text-[#d5b45b]">{entitlement.active ? entitlement.tier : 'observación limitada'}</span>
-            <span className="border border-[#2d3435] bg-[#06090a] px-3 py-2 text-[#7799a1]">{world.regime}</span>
+          <div className="flex flex-wrap gap-2 font-mono text-[9px] uppercase tracking-[0.13em]">
+            <span className="border border-[#302a1f] px-3 py-2 text-[#8c8476]">{userEmail ?? 'Cuenta privada'}</span>
+            <Link href="/interface?new=1" className="border border-[#574927] px-3 py-2 text-[#c8a951]">Iniciar otra trayectoria</Link>
           </div>
         </div>
       </header>
 
-      <section className="mx-auto grid max-w-[1800px] gap-5 px-4 py-5 md:px-8 2xl:grid-cols-[minmax(0,1fr)_390px]">
-        <div className="min-w-0 space-y-5">
-          <section className="relative min-h-[720px] overflow-hidden border border-[#3a321f] bg-[#050504] shadow-[0_40px_120px_rgba(0,0,0,0.55)] md:min-h-[790px]">
-            <div
-              className="sfi-field-drift absolute -inset-[8%] opacity-90"
-              style={{
-                backgroundImage: `
-                  linear-gradient(hsla(${fieldHue}, 46%, 58%, ${0.055 + tension * 0.085}) 1px, transparent 1px),
-                  linear-gradient(90deg, hsla(${fieldHue}, 46%, 58%, ${0.055 + tension * 0.085}) 1px, transparent 1px),
-                  radial-gradient(circle at 50% 50%, rgba(222,184,78,${0.13 + confidence * 0.11}), transparent 20%),
-                  radial-gradient(ellipse at 18% 24%, rgba(62,104,118,${0.10 + tension * 0.15}), transparent 34%),
-                  radial-gradient(ellipse at 82% 76%, rgba(117,58,43,${0.09 + friction * 0.16}), transparent 36%),
-                  radial-gradient(ellipse at 74% 18%, rgba(88,69,113,${0.04 + tension * 0.08}), transparent 26%)
-                `,
-                backgroundSize: '42px 42px, 42px 42px, auto, auto, auto, auto',
-                filter: `blur(${Math.round(friction * 1.8)}px)`,
-              }}
-            />
-
-            <div className="absolute left-4 top-4 z-20 flex flex-wrap gap-2 font-mono text-[9px] uppercase tracking-[0.14em]">
-              <span className="border border-[#3b3425] bg-[#070706d9] px-3 py-2 text-[#a69b83] backdrop-blur">nodos activos {activeNodeCount}</span>
-              <span className="border border-[#3b3425] bg-[#070706d9] px-3 py-2 text-[#a69b83] backdrop-blur">tensión {Math.round(tension * 100)}</span>
-              <span className="border border-[#3b3425] bg-[#070706d9] px-3 py-2 text-[#a69b83] backdrop-blur">viscosidad {Math.round(friction * 100)}</span>
-            </div>
-
-            <svg
-              className="absolute inset-0 h-full w-full"
-              viewBox={`0 0 ${FIELD_WIDTH} ${FIELD_HEIGHT}`}
-              preserveAspectRatio="xMidYMid meet"
-              role="img"
-              aria-label="Grafo vivo de trayectoria hacia el atractor"
-            >
-              <defs>
-                <filter id="fieldNoise" x="-20%" y="-20%" width="140%" height="140%">
-                  <feTurbulence type="fractalNoise" baseFrequency="0.008 0.016" numOctaves="2" seed="17" result="noise" />
-                  <feDisplacementMap in="SourceGraphic" in2="noise" scale={8 + friction * 22} xChannelSelector="R" yChannelSelector="B" />
-                </filter>
-                <filter id="goldGlow" x="-250%" y="-250%" width="600%" height="600%">
-                  <feGaussianBlur stdDeviation="10" result="blur10" />
-                  <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur3" />
-                  <feMerge><feMergeNode in="blur10" /><feMergeNode in="blur3" /><feMergeNode in="SourceGraphic" /></feMerge>
-                </filter>
-                <filter id="nodeGlow" x="-150%" y="-150%" width="400%" height="400%">
-                  <feGaussianBlur stdDeviation="2.4" result="blur" />
-                  <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
-                </filter>
-                <radialGradient id="goldCore" cx="38%" cy="32%" r="68%">
-                  <stop offset="0%" stopColor="#fff1b0" />
-                  <stop offset="28%" stopColor="#e4bd54" />
-                  <stop offset="72%" stopColor="#9d7227" />
-                  <stop offset="100%" stopColor="#4c3010" />
-                </radialGradient>
-                <linearGradient id="goldLine" x1="0" y1="0" x2="1" y2="1">
-                  <stop offset="0%" stopColor="#4d4128" stopOpacity="0.15" />
-                  <stop offset="45%" stopColor="#d6b35a" stopOpacity="0.88" />
-                  <stop offset="100%" stopColor="#7d6d48" stopOpacity="0.18" />
-                </linearGradient>
-              </defs>
-
-              <g opacity={0.17 + tension * 0.18} filter="url(#fieldNoise)">
-                {[150, 245, 350, 470].map((radius, index) => (
-                  <ellipse key={radius} cx={CENTER_X} cy={CENTER_Y} rx={radius} ry={radius * 0.63} fill="none" stroke={index % 2 ? '#705b32' : '#4c5b5f'} strokeWidth="1" strokeDasharray={`${8 + index * 3} ${13 + index * 5}`} />
-                ))}
-              </g>
-
-              <g>
-                {model.edges.map((edge, index) => {
-                  const source = positions.get(edge.source);
-                  const target = positions.get(edge.target);
-                  if (!source || !target) return null;
-                  const d = edgePath(source, target, edge.curvature);
-                  const toward = edge.target === model.centralId || edge.direction.includes('attractor');
-                  return (
-                    <g key={edge.id}>
-                      <path d={d} fill="none" stroke={toward ? 'url(#goldLine)' : '#665f50'} strokeWidth={0.8 + edge.strength * 2.2} strokeOpacity={0.2 + edge.strength * 0.58} strokeLinecap="round" />
-                      <path d={d} fill="none" stroke={toward ? '#e4bf5d' : '#8d8779'} strokeWidth="0.55" strokeOpacity={0.16 + edge.strength * 0.32} strokeDasharray={edge.persisted ? '2 10' : '1 14'}>
-                        <animate attributeName="stroke-dashoffset" from="24" to="0" dur={`${4.6 + (index % 5)}s`} repeatCount="indefinite" />
-                      </path>
-                      {toward && edge.strength > 0.38 ? (
-                        <circle r={1.7 + edge.strength * 1.6} fill="#f0cc69" opacity="0.85" filter="url(#nodeGlow)">
-                          <animateMotion dur={`${5.2 + (index % 4) * 1.1}s`} repeatCount="indefinite" path={d} />
-                        </circle>
-                      ) : null}
-                    </g>
-                  );
-                })}
-              </g>
-
-              <g>
-                {model.nodes.filter((node) => !node.central).map((node) => {
-                  const point = positions.get(node.id);
-                  if (!point) return null;
-                  const selected = selectedNode?.id === node.id;
-                  return (
-                    <g key={node.id} onClick={() => setSelectedNodeId(node.id)} className="cursor-pointer" role="button" aria-label={node.label}>
-                      <circle cx={point.x} cy={point.y} r={point.radius * 2.15} fill={colorFor(node.type)} opacity={selected ? 0.12 : 0.045} filter="url(#nodeGlow)" />
-                      <circle cx={point.x} cy={point.y} r={point.radius} fill={colorFor(node.type)} fillOpacity={node.persisted ? 0.9 : 0.5} stroke={selected ? '#fff0b0' : '#17140f'} strokeWidth={selected ? 3 : 1.5} filter={selected ? 'url(#nodeGlow)' : undefined} />
-                      <circle cx={point.x} cy={point.y} r={Math.max(2.2, point.radius * 0.22)} fill="#fff6d7" fillOpacity={0.45 + node.weight * 0.42} />
-                      {(selected || node.type === 'objective' || node.type === 'intervention') ? (
-                        <g pointerEvents="none">
-                          <rect x={point.x - 76} y={point.y + point.radius + 11} width="152" height="25" rx="2" fill="#050504" fillOpacity="0.88" stroke="#3b3425" />
-                          <text x={point.x} y={point.y + point.radius + 28} textAnchor="middle" fill="#d7cfbc" fontSize="10" fontFamily="monospace" letterSpacing="1.2">{node.label.slice(0, 24).toUpperCase()}</text>
-                        </g>
-                      ) : null}
-                    </g>
-                  );
-                })}
-              </g>
-
-              <g onClick={() => setSelectedNodeId(model.centralId)} className="cursor-pointer" role="button" aria-label={attractor.label}>
-                <ellipse className="sfi-orbit-ring" cx={CENTER_X} cy={CENTER_Y} rx={118} ry={86} fill="none" stroke="#d8b657" strokeWidth="1.1" strokeOpacity="0.24" strokeDasharray="3 13" />
-                <ellipse cx={CENTER_X} cy={CENTER_Y} rx={92} ry={66} fill="none" stroke="#d8b657" strokeWidth="1.4" strokeOpacity="0.37" strokeDasharray="2 8">
-                  <animate attributeName="stroke-dashoffset" from="20" to="0" dur="8s" repeatCount="indefinite" />
-                </ellipse>
-                <circle className="sfi-attractor-ring" cx={CENTER_X} cy={CENTER_Y} r={78} fill="#d9b551" fillOpacity="0.055" stroke="#d9b551" strokeWidth="1.3" strokeOpacity="0.52" filter="url(#goldGlow)" />
-                <circle cx={CENTER_X} cy={CENTER_Y} r={58} fill="url(#goldCore)" stroke="#f2d47e" strokeWidth="2.4" filter="url(#goldGlow)" />
-                <circle cx={CENTER_X - 15} cy={CENTER_Y - 17} r={11} fill="#fff4bc" fillOpacity="0.86" />
-                <circle cx={CENTER_X} cy={CENTER_Y} r={16} fill="#201506" fillOpacity="0.34" stroke="#f7dfa0" strokeWidth="1.2" />
-                <circle cx={CENTER_X} cy={CENTER_Y} r={5.2} fill="#fff3b5" />
-                <text x={CENTER_X} y={CENTER_Y + 112} textAnchor="middle" fill="#d9bd71" fontSize="11" fontFamily="monospace" letterSpacing="2.8">ATRACTOR CENTRAL</text>
-                <text x={CENTER_X} y={CENTER_Y + 134} textAnchor="middle" fill="#82765f" fontSize="9" fontFamily="monospace" letterSpacing="1.3">DIRECCIÓN · TRAYECTORIA · OBJETIVO</text>
-              </g>
-            </svg>
-
-            <div className="absolute bottom-4 left-4 z-20 max-w-md border border-[#3a3221] bg-[#060604e8] p-4 backdrop-blur-xl">
-              <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.16em] text-[#d5b45b]"><Route className="h-4 w-4" /> Trayectoria activa</div>
-              <p className="mt-2 text-sm leading-6 text-[#b8ae9a]">{attractor.direction}</p>
-            </div>
-
-            <div className="absolute bottom-4 right-4 z-20 hidden border border-[#3a3221] bg-[#060604e8] px-4 py-3 font-mono text-[9px] uppercase tracking-[0.14em] text-[#938974] backdrop-blur-xl md:block">
-              persisted {props.graph.nodes.length} · edges {props.graph.edges.length} · field {model.nodes.length}
+      <section className="mx-auto grid max-w-[1500px] gap-6 px-5 py-7 md:px-10 xl:grid-cols-[minmax(0,1fr)_390px]">
+        <div className="space-y-6">
+          <section className="border border-[#302a1f] bg-[#090908] p-5 md:p-7">
+            <div className="grid gap-5 md:grid-cols-3">
+              <div><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#91866d]">Objetivo declarado</span><p className="mt-3 text-lg leading-7 text-[#eee3c9]">{attractor.objective || 'Todavía no se registró un objetivo.'}</p></div>
+              <div><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#91866d]">Dirección observada</span><p className="mt-3 text-lg leading-7 text-[#eee3c9]">{attractor.direction || 'Todavía no se ha determinado una dirección.'}</p></div>
+              <div><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#91866d]">Próximo retorno</span><p className="mt-3 text-lg leading-7 text-[#eee3c9]">{formatDate(nextReturnAt)}</p></div>
             </div>
           </section>
 
-          <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-            <div className="border border-[#302a1e] bg-[#080706] p-4"><div className="font-mono text-[9px] uppercase tracking-[0.15em] text-[#756d60]">Atractor</div><div className="mt-2 text-lg text-[#f0e5ca]">{attractor.label}</div></div>
-            <div className="border border-[#302a1e] bg-[#080706] p-4"><div className="font-mono text-[9px] uppercase tracking-[0.15em] text-[#756d60]">Confianza</div><div className="mt-2 text-lg text-[#f0e5ca]">{Math.round(confidence * 100)}%</div></div>
-            <div className="border border-[#302a1e] bg-[#080706] p-4"><div className="font-mono text-[9px] uppercase tracking-[0.15em] text-[#756d60]">Tensión</div><div className="mt-2 text-lg text-[#f0e5ca]">{Math.round(tension * 100)}%</div></div>
-            <div className="border border-[#302a1e] bg-[#080706] p-4"><div className="font-mono text-[9px] uppercase tracking-[0.15em] text-[#756d60]">Retorno</div><div className="mt-2 text-sm text-[#f0e5ca]">{formatDate(nextReturnAt)}</div></div>
+          <section className="overflow-hidden border border-[#302a1f] bg-[#080807]">
+            <div className="flex flex-col gap-3 border-b border-[#302a1f] p-5 md:flex-row md:items-end md:justify-between">
+              <div><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">Mapa de trayectoria</span><h2 className="mt-2 text-2xl text-[#f3ead6]">Lo que ya está conectado en tu caso</h2></div>
+              <div className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#827867]">{graph.nodes.length} puntos · {realEdges.length} relaciones persistidas</div>
+            </div>
+            {graph.nodes.length ? (
+              <svg viewBox={`0 0 ${WIDTH} ${HEIGHT}`} className="h-[560px] w-full bg-[radial-gradient(circle_at_center,rgba(95,36,70,.13),transparent_46%)]" role="img" aria-label="Trayectoria basada en nodos y relaciones persistidos">
+                {realEdges.map((edge) => {
+                  const source = pointMap.get(edge.source_node_id);
+                  const target = pointMap.get(edge.target_node_id);
+                  if (!source || !target) return null;
+                  return <path key={edge.id} d={path(source, target, edge.curvature)} fill="none" stroke="#947944" strokeOpacity={Math.max(.16, Math.min(.75, edge.strength))} strokeWidth={1 + Math.max(0, edge.strength) * 2} />;
+                })}
+                {graph.nodes.map((node) => {
+                  const point = pointMap.get(node.id);
+                  if (!point) return null;
+                  const radius = node.is_central ? 24 : 8 + Math.max(0, Math.min(1, node.weight)) * 8;
+                  return <g key={node.id} role="button" tabIndex={0} onClick={() => setSelectedId(node.id)} onKeyDown={(event) => { if (event.key === 'Enter') setSelectedId(node.id); }} className="cursor-pointer outline-none">
+                    <circle cx={point.x} cy={point.y} r={radius * 2.1} fill={nodeColor(node.node_type)} opacity={selectedId === node.id ? .24 : .09} />
+                    <circle cx={point.x} cy={point.y} r={radius} fill={nodeColor(node.node_type)} stroke={selectedId === node.id ? '#fff0b6' : '#17130b'} strokeWidth={selectedId === node.id ? 3 : 1} />
+                    {(node.is_central || selectedId === node.id) ? <text x={point.x + radius + 8} y={point.y + 4} fill="#e7d6aa" fontSize="13">{node.label.slice(0, 42)}</text> : null}
+                  </g>;
+                })}
+              </svg>
+            ) : (
+              <div className="grid min-h-[430px] place-items-center p-8 text-center"><div><Orbit className="mx-auto h-8 w-8 text-[#c8a951]" /><h3 className="mt-4 text-xl text-[#f0e5cc]">Todavía no existe un mapa persistido.</h3><p className="mx-auto mt-3 max-w-lg text-sm leading-7 text-[#908777]">Carga evidencia o registra una microejecución. El mapa aparecerá cuando existan nodos y relaciones reales.</p></div></div>
+            )}
           </section>
         </div>
 
         <aside className="space-y-5">
-          <section className="border border-[#40351e] bg-[#0a0804] p-5 shadow-[0_20px_60px_rgba(0,0,0,0.4)]">
-            <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.17em] text-[#d5b45b]"><Target className="h-4 w-4" /> Nodo seleccionado</div>
-            <div className="mt-5 flex items-center gap-4">
-              <div className="h-12 w-12 shrink-0 rounded-full border border-[#e1bd58]" style={{ background: `radial-gradient(circle at 35% 30%, #fff0ae, ${colorFor(selectedNode.type)} 48%, #1d1407)` }} />
-              <div>
-                <h2 className="text-xl text-[#f2e8d0]">{selectedNode.label}</h2>
-                <div className="mt-1 font-mono text-[9px] uppercase tracking-[0.14em] text-[#776e5e]">{selectedNode.type} · {selectedNode.persisted ? 'persistido' : 'estructura del campo'}</div>
-              </div>
-            </div>
-            <p className="mt-4 text-sm leading-7 text-[#a59b88]">{selectedNode.summary}</p>
+          <section className="border border-[#302a1f] bg-[#090908] p-5">
+            <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">Punto seleccionado</div>
+            {selected ? <><h2 className="mt-3 text-2xl text-[#f1e5ca]">{selected.label}</h2><p className="mt-3 text-sm leading-7 text-[#9b927f]">{selected.summary || 'Este punto todavía no tiene una explicación registrada.'}</p><dl className="mt-5 space-y-3 text-sm"><div><dt className="text-[#766d5d]">Tipo</dt><dd className="text-[#d8cbaa]">{selected.node_type}</dd></div><div><dt className="text-[#766d5d]">Observado</dt><dd className="text-[#d8cbaa]">{formatDate(selected.observed_at)}</dd></div></dl></> : <p className="mt-3 text-sm leading-7 text-[#908777]">Selecciona un punto del mapa para revisar su significado.</p>}
+            <button type="button" onClick={() => void interpret()} disabled={status === 'interpreting'} className="mt-5 inline-flex w-full items-center justify-center gap-2 bg-[#c8a951] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.16em] text-[#050504] disabled:opacity-40">{status === 'interpreting' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />} Pedir lectura al agente SFI</button>
           </section>
 
-          <section className="border border-[#40351e] bg-[#090805] p-5">
-            <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.16em] text-[#d5b45b]"><Sparkles className="h-4 w-4" /> Perturbación mínima</div>
-            <p className="mt-4 text-sm leading-7 text-[#a59b88]">{attractor.perturbation.instruction || 'El campo aún no tiene una perturbación declarada.'}</p>
-            {entitlement.active ? (
-              <Link href={`/field?case=${encodeURIComponent(caseData.id)}`} className="mt-5 inline-flex items-center gap-2 border border-[#6d592b] px-4 py-3 font-mono text-[9px] uppercase tracking-[0.16em] text-[#d5b45b]">Abrir ciclo de campo <ArrowRight className="h-4 w-4" /></Link>
-            ) : (
-              <button type="button" onClick={() => void startCheckout()} disabled={status === 'checkout'} className="mt-5 inline-flex w-full items-center justify-center gap-2 bg-[#d5b45b] px-4 py-3 font-mono text-[9px] uppercase tracking-[0.16em] text-[#050403] disabled:opacity-50">
-                {status === 'checkout' ? <Loader2 className="h-4 w-4 animate-spin" /> : <LockKeyhole className="h-4 w-4" />} Desbloquear campo
-              </button>
-            )}
+          {agent ? <section className="border border-[#645327] bg-[#0d0c08] p-5"><div className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">Lectura del agente MOP-H</div><p className="mt-4 whitespace-pre-wrap text-sm leading-7 text-[#d8cdb5]">{agent.reading}</p><div className="mt-5 border-t border-[#302a1f] pt-4"><span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#9d8c68]">Microejecución propuesta</span><p className="mt-2 text-sm leading-7 text-[#f0dfb8]">{agent.proposedMicroExecution}</p></div><p className="mt-4 text-xs leading-6 text-[#827867]">Confianza del agente: {Math.round(agent.confidence * 100)}%. Esta lectura no se persiste ni se ejecuta automáticamente.</p></section> : null}
+
+          <section className="border border-[#302a1f] bg-[#090908] p-5">
+            <div className="flex items-center gap-2"><FileUp className="h-4 w-4 text-[#c8a951]" /><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">Agregar evidencia</span></div>
+            <p className="mt-3 text-xs leading-6 text-[#8d8474]">Añade algo que observaste o un archivo que ayude a confirmar, matizar o contradecir la trayectoria.</p>
+            <textarea value={upload.note} onChange={(event) => setUpload((current) => ({ ...current, note: event.target.value }))} rows={4} placeholder="Describe qué ocurrió y por qué puede ser relevante." className="mt-4 w-full resize-y border border-[#302a1f] bg-[#050504] px-3 py-3 text-sm text-[#eee4cb] outline-none focus:border-[#c8a951]" />
+            <input type="text" value={upload.source} onChange={(event) => setUpload((current) => ({ ...current, source: event.target.value }))} aria-label="Origen de la evidencia" className="mt-3 w-full border border-[#302a1f] bg-[#050504] px-3 py-3 text-sm text-[#eee4cb] outline-none focus:border-[#c8a951]" />
+            <input type="file" onChange={(event) => setUpload((current) => ({ ...current, file: event.target.files?.[0] ?? null }))} className="mt-3 block w-full text-xs text-[#918979]" />
+            <label className="mt-4 grid gap-2 text-xs text-[#918979]"><span>Qué tan confiable consideras la fuente: {Math.round(upload.reliability * 100)}%</span><input type="range" min={0} max={1} step={0.05} value={upload.reliability} onChange={(event) => setUpload((current) => ({ ...current, reliability: Number(event.target.value) }))} /></label>
+            <button type="button" onClick={() => void submitEvidence()} disabled={!entitlement.active || status === 'uploading' || (!upload.note.trim() && !upload.file)} className="mt-5 inline-flex w-full items-center justify-center gap-2 border border-[#66552c] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951] disabled:opacity-35">{status === 'uploading' ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />} Guardar y evaluar</button>
           </section>
 
-          <section className="border border-[#3b3424] bg-[#080706] p-5">
-            <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.16em] text-[#d5b45b]"><FileUp className="h-4 w-4" /> Cargar evidencia</div>
-            <p className="mt-3 text-xs leading-6 text-[#887f70]">La evidencia entra como nodo periférico. MIHM decide si observa, integra o modifica la trayectoria.</p>
-            {!entitlement.active ? (
-              <div className="mt-4 border border-[#393226] p-3 text-xs leading-5 text-[#7f776a]">La carga se habilita con acceso de campo.</div>
-            ) : (
-              <div className="mt-4 space-y-4">
-                <label className="grid gap-2"><span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#777063]">Qué ocurrió</span><textarea value={upload.note} onChange={(event) => setUpload((current) => ({ ...current, note: event.target.value }))} rows={4} className="border border-[#302b20] bg-[#040403] p-3 text-sm text-[#eee6d4] outline-none focus:border-[#c8a951]" /></label>
-                <label className="grid gap-2"><span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#777063]">Fuente</span><input value={upload.source} onChange={(event) => setUpload((current) => ({ ...current, source: event.target.value }))} className="border border-[#302b20] bg-[#040403] p-3 text-sm text-[#eee6d4] outline-none focus:border-[#c8a951]" /></label>
-                <label className="grid gap-2"><span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#777063]">Archivo opcional · 8 MB</span><input type="file" onChange={(event) => setUpload((current) => ({ ...current, file: event.target.files?.[0] || null }))} className="text-xs text-[#8e8576]" /></label>
-                <label className="grid gap-2"><span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#777063]">Confiabilidad · {Math.round(upload.reliability * 100)}%</span><input type="range" min={0.1} max={1} step={0.1} value={upload.reliability} onChange={(event) => setUpload((current) => ({ ...current, reliability: Number(event.target.value) }))} /></label>
-                <button type="button" onClick={() => void submitEvidence()} disabled={status === 'uploading' || (!upload.note.trim() && !upload.file)} className="inline-flex w-full items-center justify-center gap-2 bg-[#d5b45b] px-4 py-3 font-mono text-[9px] uppercase tracking-[0.16em] text-[#050403] disabled:opacity-40">
-                  {status === 'uploading' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Activity className="h-4 w-4" />} Aplicar MIHM
-                </button>
-              </div>
-            )}
-            {error ? <div className="mt-4 border border-[#6b352a] bg-[#160d0a] p-3 text-xs text-[#d89685]">{error}</div> : null}
-            {assessment ? (
-              <div className="mt-4 border border-[#4f5d3e] bg-[#0b1208] p-4">
-                <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.14em] text-[#a8c58c]"><CheckCircle2 className="h-4 w-4" /> {assessment.status}</div>
-                <p className="mt-2 text-xs leading-6 text-[#a6ad98]">{assessment.reason}</p>
-                <p className="mt-2 text-xs leading-6 text-[#c7d1b6]">{assessment.nextAction}</p>
-              </div>
-            ) : null}
+          {message ? <section className="border border-[#5a4926] bg-[#0d0b07] p-4 text-sm leading-6 text-[#d2bd8b]">{message}</section> : null}
+
+          <section className="border border-[#302a1f] bg-[#090908] p-5">
+            <div className="flex items-center gap-2"><Target className="h-4 w-4 text-[#c8a951]" /><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">Lectura disponible</span></div>
+            <p className="mt-3 text-sm leading-7 text-[#968d7d]">{attractor.summary || 'Todavía no existe una lectura consolidada.'}</p>
+            {attractor.perturbation.instruction ? <div className="mt-4 border-l-2 border-[#c8a951] pl-4"><span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#9d8c68]">Microejecución registrada</span><p className="mt-2 text-sm leading-7 text-[#e7d6ae]">{attractor.perturbation.instruction}</p></div> : null}
           </section>
 
-          <section className="border border-[#302a1e] bg-[#080706] p-5">
-            <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.16em] text-[#d5b45b]"><Gauge className="h-4 w-4" /> Aprendizaje reciente</div>
-            <div className="mt-4 space-y-3">
-              {evidence.length ? evidence.slice(0, 5).map((item) => (
-                <article key={item.id} className="border border-[#2d291f] p-3">
-                  <div className="flex items-center justify-between font-mono text-[9px] uppercase tracking-[0.12em]"><span className="text-[#9fbd83]">{item.status}</span><span className="text-[#6f685d]">{Math.round(item.confidence * 100)}%</span></div>
-                  <p className="mt-2 text-xs leading-5 text-[#918979]">{item.reason}</p>
-                </article>
-              )) : <p className="text-xs leading-5 text-[#81796c]">El campo ya contiene estructura; los nodos de aprendizaje aparecerán con evidencia validada.</p>}
-            </div>
-          </section>
+          {(world.friction !== null || world.tension !== null || world.confidence !== null) ? <section className="border border-[#302a1f] bg-[#090908] p-5"><div className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">Contexto general</div><p className="mt-3 text-xs leading-6 text-[#8d8474]">Esta información describe el entorno observado por SFI; no define tu caso.</p><dl className="mt-4 space-y-2 text-sm"><div><dt className="text-[#766d5d]">Régimen</dt><dd className="text-[#d8cbaa]">{world.regime === 'MISSING' ? 'Sin lectura disponible' : world.regime}</dd></div>{world.friction !== null ? <div><dt className="text-[#766d5d]">Fricción observada</dt><dd className="text-[#d8cbaa]">{Math.round(world.friction * 100)}%</dd></div> : null}{world.tension !== null ? <div><dt className="text-[#766d5d]">Tensión observada</dt><dd className="text-[#d8cbaa]">{Math.round(world.tension * 100)}%</dd></div> : null}</dl></section> : null}
+
+          {evidence.length ? <section className="border border-[#302a1f] bg-[#090908] p-5"><div className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">Evaluaciones recientes</div><div className="mt-4 space-y-3">{evidence.slice(0, 5).map((item) => <div key={item.id} className="border border-[#272219] p-3"><strong className="text-sm text-[#e7d8b8]">{statusText(item.status)}</strong><p className="mt-2 text-xs leading-6 text-[#8f8676]">{item.reason}</p></div>)}</div></section> : null}
         </aside>
       </section>
     </main>


### PR DESCRIPTION
## Purpose
Make the personal FIELD observatory trustworthy and understandable for a normal user.

## Removed
- Synthetic structural nodes for objective, direction, world, origin and return.
- Fallback edges that implied relationships not stored in the database.
- Fixed synthetic graph weights and default world metrics presented as readings.
- Engineering-oriented graph explanations.

## Real data only
- The trajectory map now renders only persisted `sfi_user_graph_nodes` and `sfi_user_graph_edges`.
- Evidence continues through the existing authenticated evidence writer and assessment pipeline.
- Missing graph or context is shown explicitly instead of filled with decorative information.

## Real agent interaction
- Adds `/api/interface/observatory/interpret`.
- The endpoint authenticates the user, reads their own case, declared attractor and recent evidence, then invokes the existing MOP-H agent.
- The UI clearly labels the response as an agent reading and states that it is not persisted or executed automatically.

## User-facing language
- Objective, direction, return, evidence and proposed micro-execution are expressed in plain Spanish.
- Database identifiers, payloads, formulas and internal route names are not exposed in the primary experience.

## Files
- `src/app/api/interface/observatory/interpret/route.ts`
- `src/components/interface/UserAttractorFieldExperience.tsx`