### PR TITLE
Make FIELD emergence-first and longitudinal

### DIFF
--- a/src/components/field/ParticipantWindowConsole.tsx
+++ b/src/components/field/ParticipantWindowConsole.tsx
@@ -2,28 +2,22 @@
 
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowRight, Check, Clock3, MapPin, Orbit, Plus, UserRound } from 'lucide-react';
+import { ArrowRight, ChevronDown, Clock3, Orbit, Plus } from 'lucide-react';
 
 type ParticipantWindow = {
   id: string;
-  case_id: string | null;
-  attractor_id: string | null;
   status: 'ACTIVE' | 'CLOSED';
   watched_thoughts: string[];
   started_at: string;
-  expected_close_at: string;
-  closed_at: string | null;
   mark_count: number;
 };
 
 type ParticipantMark = {
   id: string;
-  day_number: number;
   moment_at: string;
   trigger_text: string | null;
   activity: string | null;
   location_context: string | null;
-  social_context: string | null;
   thought_after: string | null;
   feeling_after: string | null;
   action_after: string | null;
@@ -40,13 +34,12 @@ type WindowState = {
 
 type MarkForm = {
   triggerText: string;
+  intensity: number;
   activity: string;
   locationContext: string;
-  socialContext: string;
   thoughtAfter: string;
   feelingAfter: string;
   actionAfter: string;
-  intensity: number;
   note: string;
 };
 
@@ -59,57 +52,28 @@ type ReflectionForm = {
   neededToday: string;
 };
 
-const EMPTY_MARK: MarkForm = {
-  triggerText: '',
-  activity: '',
-  locationContext: '',
-  socialContext: '',
-  thoughtAfter: '',
-  feelingAfter: '',
-  actionAfter: '',
-  intensity: 3,
-  note: '',
-};
-
-const EMPTY_REFLECTION: ReflectionForm = {
-  whatChanged: '',
-  whatNoticed: '',
-  whatAvoided: '',
-  whatWasMine: '',
-  whatWasNotMine: '',
-  neededToday: '',
-};
-
-const inputClass = 'w-full border border-[#312b1d] bg-[#050504] px-4 py-3 text-sm text-[#eee4cb] outline-none placeholder:text-[#5d574a] focus:border-[#c9aa54]';
+const EMPTY_MARK: MarkForm = { triggerText: '', intensity: 3, activity: '', locationContext: '', thoughtAfter: '', feelingAfter: '', actionAfter: '', note: '' };
+const EMPTY_REFLECTION: ReflectionForm = { whatChanged: '', whatNoticed: '', whatAvoided: '', whatWasMine: '', whatWasNotMine: '', neededToday: '' };
+const inputClass = 'w-full border border-[#312b1d] bg-[#050504] px-4 py-3 text-sm leading-6 text-[#eee4cb] outline-none placeholder:text-[#5d574a] focus:border-[#c9aa54]';
 const labelClass = 'font-mono text-[9px] uppercase tracking-[0.18em] text-[#a49572]';
 const buttonClass = 'inline-flex items-center justify-center gap-2 border border-[#c8a95166] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951] disabled:cursor-not-allowed disabled:opacity-35';
 
 function dayFromStart(startedAt: string) {
-  const elapsedHours = (Date.now() - new Date(startedAt).getTime()) / 3_600_000;
-  if (elapsedHours < 24) return 1;
-  if (elapsedHours < 48) return 2;
-  return 3;
+  const hours = (Date.now() - new Date(startedAt).getTime()) / 3_600_000;
+  return hours < 24 ? 1 : hours < 48 ? 2 : 3;
 }
 
-function TextArea({ label, value, onChange, placeholder, rows = 2 }: {
-  label: string;
-  value: string;
-  onChange: (value: string) => void;
-  placeholder?: string;
-  rows?: number;
-}) {
-  return (
-    <label className="grid gap-2">
-      <span className={labelClass}>{label}</span>
-      <textarea
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        placeholder={placeholder}
-        rows={rows}
-        className={`${inputClass} resize-y`}
-      />
-    </label>
-  );
+function readableError(value: string) {
+  const dictionary: Record<string, string> = {
+    TRIGGER_TEXT_REQUIRED: 'Describe brevemente qué apareció.',
+    CALIBRATION_WINDOW_NOT_COMPLETE: 'La ventana de observación todavía no ha concluido.',
+    PARTICIPANT_WINDOW_NOT_ACTIVE: 'Esta ventana ya no está activa.',
+  };
+  return dictionary[value] ?? 'No fue posible guardar el registro. Inténtalo de nuevo.';
+}
+
+function ContextField({ label, value, onChange, placeholder }: { label: string; value: string; onChange: (value: string) => void; placeholder: string }) {
+  return <label className="grid gap-2"><span className={labelClass}>{label}</span><textarea rows={2} value={value} onChange={(event) => onChange(event.target.value)} placeholder={placeholder} className={`${inputClass} resize-y`} /></label>;
 }
 
 export function ParticipantWindowConsole({ authenticated }: { authenticated: boolean }) {
@@ -118,6 +82,7 @@ export function ParticipantWindowConsole({ authenticated }: { authenticated: boo
   const [activeState, setActiveState] = useState<WindowState | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [showContext, setShowContext] = useState(false);
   const [mark, setMark] = useState<MarkForm>(EMPTY_MARK);
   const [reflection, setReflection] = useState<ReflectionForm>(EMPTY_REFLECTION);
 
@@ -143,7 +108,7 @@ export function ParticipantWindowConsole({ authenticated }: { authenticated: boo
         const active = items.find((item) => item.status === 'ACTIVE');
         if (active) await refreshActive(active.id);
       } catch (nextError) {
-        if (!cancelled) setError(nextError instanceof Error ? nextError.message : 'NETWORK_ERROR');
+        if (!cancelled) setError(readableError(nextError instanceof Error ? nextError.message : 'NETWORK_ERROR'));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -154,35 +119,26 @@ export function ParticipantWindowConsole({ authenticated }: { authenticated: boo
   const remaining = useMemo(() => {
     if (!activeState || activeState.hoursRemaining === null) return null;
     const totalMinutes = Math.max(0, Math.ceil(activeState.hoursRemaining * 60));
-    return {
-      hours: Math.floor(totalMinutes / 60),
-      minutes: totalMinutes % 60,
-      progress: Math.max(0, Math.min(100, ((72 - activeState.hoursRemaining) / 72) * 100)),
-    };
+    return { hours: Math.floor(totalMinutes / 60), minutes: totalMinutes % 60, progress: Math.max(0, Math.min(100, ((72 - activeState.hoursRemaining) / 72) * 100)) };
   }, [activeState]);
 
-  const markComplete = mark.triggerText.trim()
-    && mark.activity.trim()
-    && mark.locationContext.trim()
-    && mark.thoughtAfter.trim()
-    && mark.feelingAfter.trim();
-
   async function addMark() {
-    if (!activeState || !markComplete) return;
+    if (!activeState || !mark.triggerText.trim()) return;
     setSubmitting(true);
     setError(null);
     try {
       const response = await fetch(`/api/field/participant/windows/${activeState.window.id}/marks`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...mark, dayNumber: dayFromStart(activeState.window.started_at) }),
+        body: JSON.stringify({ ...mark, socialContext: null, dayNumber: dayFromStart(activeState.window.started_at) }),
       });
       const body = await response.json();
       if (!response.ok || !body.ok) throw new Error(body.details || body.error || 'MARK_CREATE_FAILED');
       setMark(EMPTY_MARK);
+      setShowContext(false);
       await refreshActive(activeState.window.id);
     } catch (nextError) {
-      setError(nextError instanceof Error ? nextError.message : 'MARK_CREATE_FAILED');
+      setError(readableError(nextError instanceof Error ? nextError.message : 'MARK_CREATE_FAILED'));
     } finally {
       setSubmitting(false);
     }
@@ -195,155 +151,54 @@ export function ParticipantWindowConsole({ authenticated }: { authenticated: boo
     setSubmitting(true);
     setError(null);
     try {
-      const response = await fetch(`/api/field/participant/windows/${activeState.window.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(reflection),
-      });
+      const response = await fetch(`/api/field/participant/windows/${activeState.window.id}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(reflection) });
       const body = await response.json();
       if (!response.ok || !body.ok) throw new Error(body.details || body.error || 'WINDOW_CLOSE_FAILED');
       window.location.assign(body.nextPath || '/interface/observatory');
     } catch (nextError) {
-      setError(nextError instanceof Error ? nextError.message : 'WINDOW_CLOSE_FAILED');
+      setError(readableError(nextError instanceof Error ? nextError.message : 'WINDOW_CLOSE_FAILED'));
     } finally {
       setSubmitting(false);
     }
   }
 
-  return (
-    <main className="min-h-screen bg-[#050504] px-5 py-8 text-[#d8d2c2] md:px-10">
-      <div className="mx-auto max-w-6xl space-y-6">
-        <header className="border border-[#302b20] bg-[#0a0a08] p-6 md:p-8">
-          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
-            <div className="max-w-3xl">
-              <p className="font-mono text-[10px] uppercase tracking-[0.3em] text-[#c8a951]">SFI / calibración inicial</p>
-              <h1 className="mt-4 text-3xl font-semibold leading-tight text-[#f5eedc] md:text-5xl">Observa durante 72 horas. No corrijas todavía.</h1>
-              <p className="mt-4 text-sm leading-7 text-[#9f9788]">
-                Cada vez que aparezca el pensamiento, impulso o tensión central, registra una marca. La marca no interpreta: fija el contexto necesario para declarar después la dirección real del atractor.
-              </p>
-            </div>
-            <Link href="/interface" className={buttonClass}>Volver a interfaz</Link>
+  return <main className="min-h-screen bg-[#050504] px-5 py-8 text-[#d8d2c2] md:px-10">
+    <div className="mx-auto max-w-6xl space-y-6">
+      <header className="border border-[#302b20] bg-[#0a0a08] p-6 md:p-8">
+        <p className="font-mono text-[10px] uppercase tracking-[0.3em] text-[#c8a951]">SFI · campo de observación</p>
+        <h1 className="mt-4 max-w-4xl text-3xl font-semibold leading-tight text-[#f5eedc] md:text-5xl">Deja que las cosas aparezcan antes de decidir qué significan.</h1>
+        <p className="mt-4 max-w-3xl text-sm leading-7 text-[#9f9788]">Registra una marca cuando algo se repita, cambie la dirección o aumente la tensión. Una marca no es un diagnóstico: conserva el momento para que la trayectoria pueda observarse después.</p>
+      </header>
+
+      {!authenticated ? <section className="border border-[#302b20] bg-[#0a0a08] p-6"><p>Esta observación es privada y requiere una cuenta.</p><Link href="/login?next=%2Ffield%2Fparticipant" className={`mt-4 ${buttonClass}`}>Iniciar sesión <ArrowRight className="h-4 w-4" /></Link></section> : null}
+      {authenticated && loading ? <section className="border border-[#302b20] bg-[#0a0a08] p-6 text-[#9f9788]">Recuperando tu ventana de observación…</section> : null}
+      {error ? <section className="border border-[#6b352a] bg-[#160d0a] p-4 text-sm text-[#d89685]">{error}</section> : null}
+
+      {authenticated && !loading && !activeState ? <section className="border border-[#302b20] bg-[#0a0a08] p-8 text-center"><Orbit className="mx-auto h-8 w-8 text-[#c8a951]" /><h2 className="mt-4 text-2xl text-[#f5eedc]">No hay una observación activa.</h2><p className="mx-auto mt-3 max-w-xl text-sm leading-7 text-[#918979]">Inicia una trayectoria o abre tu observatorio si ya existe un recorrido.</p><div className="mt-6 flex justify-center gap-3"><Link href="/interface" className={buttonClass}>Iniciar trayectoria</Link>{windows.some((item) => item.status === 'CLOSED') ? <Link href="/interface/observatory" className={buttonClass}>Mi observatorio</Link> : null}</div></section> : null}
+
+      {activeState ? <>
+        <section className="border border-[#302b20] bg-[#0a0a08] p-5 md:p-7">
+          <div className="flex flex-wrap items-center justify-between gap-4"><div><div className={labelClass}>Ventana activa</div><div className="mt-2 text-3xl text-[#f5eedc]">{activeState.window.mark_count} apariciones conservadas</div></div><div className="flex items-center gap-2 border border-[#493d22] bg-[#100e08] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951]"><Clock3 className="h-4 w-4" />{remaining ? `${remaining.hours}h ${remaining.minutes}m para el primer corte` : 'Tiempo no disponible'}</div></div>
+          <div className="mt-5 h-1 overflow-hidden bg-[#211d14]"><div className="h-full bg-[#c8a951]" style={{ width: `${remaining?.progress ?? 0}%` }} /></div>
+          <div className="mt-5 grid gap-2 md:grid-cols-3">{activeState.window.watched_thoughts.map((prompt) => <div key={prompt} className="border border-[#282319] bg-[#070706] p-3 text-xs leading-5 text-[#9f9788]">{prompt}</div>)}</div>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+          <div className="border border-[#302b20] bg-[#0a0a08] p-5 md:p-7">
+            <div className="flex items-center gap-3"><Plus className="h-5 w-5 text-[#c8a951]" /><div><div className={labelClass}>Nueva marca</div><h2 className="mt-2 text-2xl text-[#f5eedc]">¿Qué apareció?</h2></div></div>
+            <p className="mt-3 max-w-2xl text-sm leading-7 text-[#918979]">Puede ser un pensamiento, un evento, una sensación, una conversación o un cambio de dirección. Descríbelo sin explicarlo todavía.</p>
+            <textarea rows={5} value={mark.triggerText} onChange={(event) => setMark((current) => ({ ...current, triggerText: event.target.value }))} placeholder="Ejemplo: volvió la misma duda justo antes de enviar la propuesta." className={`mt-5 ${inputClass} resize-y`} />
+            <label className="mt-5 grid gap-2"><span className={labelClass}>Intensidad percibida · {mark.intensity}/5</span><input type="range" min={1} max={5} value={mark.intensity} onChange={(event) => setMark((current) => ({ ...current, intensity: Number(event.target.value) }))} /></label>
+            <button type="button" onClick={() => setShowContext((value) => !value)} className={`mt-5 ${buttonClass}`}>Agregar contexto opcional <ChevronDown className={`h-4 w-4 transition-transform ${showContext ? 'rotate-180' : ''}`} /></button>
+            {showContext ? <div className="mt-5 grid gap-5 md:grid-cols-2"><ContextField label="Qué estabas haciendo" value={mark.activity} onChange={(value) => setMark((current) => ({ ...current, activity: value }))} placeholder="Actividad concreta." /><ContextField label="Dónde ocurrió" value={mark.locationContext} onChange={(value) => setMark((current) => ({ ...current, locationContext: value }))} placeholder="Lugar o entorno." /><ContextField label="Qué pensaste después" value={mark.thoughtAfter} onChange={(value) => setMark((current) => ({ ...current, thoughtAfter: value }))} placeholder="Sólo si lo recuerdas." /><ContextField label="Qué sentiste después" value={mark.feelingAfter} onChange={(value) => setMark((current) => ({ ...current, feelingAfter: value }))} placeholder="Sólo si fue claro." /><ContextField label="Qué hiciste después" value={mark.actionAfter} onChange={(value) => setMark((current) => ({ ...current, actionAfter: value }))} placeholder="Respuesta observable." /><ContextField label="Nota adicional" value={mark.note} onChange={(value) => setMark((current) => ({ ...current, note: value }))} placeholder="Cualquier dato útil." /></div> : null}
+            <button type="button" onClick={() => void addMark()} disabled={submitting || !mark.triggerText.trim()} className={`mt-6 bg-[#c8a951] text-[#050504] ${buttonClass}`}>{submitting ? 'Guardando…' : 'Conservar esta aparición'}</button>
           </div>
-        </header>
 
-        {!authenticated ? (
-          <section className="border border-[#302b20] bg-[#0a0a08] p-6 text-sm leading-7 text-[#9f9788]">
-            Esta ventana es privada y requiere cuenta.
-            <Link href="/login?next=%2Ffield%2Fparticipant" className={`mt-4 ${buttonClass}`}>Iniciar sesión <ArrowRight className="h-4 w-4" /></Link>
-          </section>
-        ) : null}
+          <aside className="border border-[#302b20] bg-[#0a0a08] p-5"><div className={labelClass}>Trayectoria hasta ahora</div><div className="mt-4 space-y-3">{activeState.marks.length ? activeState.marks.slice().reverse().map((item) => <article key={item.id} className="border border-[#282319] bg-[#070706] p-4"><time className="font-mono text-[8px] uppercase tracking-[0.12em] text-[#7d7465]">{new Date(item.moment_at).toLocaleString('es-MX')}</time><p className="mt-2 text-sm leading-6 text-[#d4cbb7]">{item.trigger_text}</p><div className="mt-2 text-xs text-[#8e8576]">Intensidad {item.intensity ?? 'sin medida'}/5</div></article>) : <p className="text-sm leading-7 text-[#918979]">La trayectoria comenzará con la primera aparición conservada.</p>}</div></aside>
+        </section>
 
-        {authenticated && loading ? <section className="border border-[#302b20] bg-[#0a0a08] p-6 text-sm text-[#9f9788]">Cargando calibración…</section> : null}
-
-        {error ? <section className="border border-[#6b352a] bg-[#160d0a] p-4 font-mono text-[10px] uppercase tracking-[0.14em] text-[#d89685]">{error}</section> : null}
-
-        {authenticated && !loading && !activeState ? (
-          <section className="border border-[#302b20] bg-[#0a0a08] p-8 text-center">
-            <Orbit className="mx-auto h-8 w-8 text-[#c8a951]" />
-            <h2 className="mt-4 text-2xl text-[#f5eedc]">No hay una calibración activa.</h2>
-            <p className="mx-auto mt-3 max-w-xl text-sm leading-7 text-[#918979]">La primera ventana se abre automáticamente al concluir el Mini MOP-H.</p>
-            <div className="mt-6 flex justify-center gap-3">
-              <Link href="/interface" className={buttonClass}>Abrir Mini MOP-H</Link>
-              {windows.some((item) => item.status === 'CLOSED') ? <Link href="/interface/observatory" className={buttonClass}>Mi observatorio</Link> : null}
-            </div>
-          </section>
-        ) : null}
-
-        {activeState ? (
-          <>
-            <section className="border border-[#302b20] bg-[#0a0a08] p-5 md:p-7">
-              <div className="flex flex-wrap items-center justify-between gap-4">
-                <div>
-                  <div className={labelClass}>Ventana activa</div>
-                  <div className="mt-2 text-3xl text-[#f5eedc]">{activeState.window.mark_count} marcas</div>
-                </div>
-                <div className="flex items-center gap-2 border border-[#493d22] bg-[#100e08] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951]">
-                  <Clock3 className="h-4 w-4" />
-                  {remaining ? `${remaining.hours}h ${remaining.minutes}m restantes` : 'Tiempo no disponible'}
-                </div>
-              </div>
-              <div className="mt-5 h-1 overflow-hidden bg-[#211d14]">
-                <div className="h-full bg-[#c8a951] transition-all" style={{ width: `${remaining?.progress ?? 0}%` }} />
-              </div>
-              <div className="mt-5 grid gap-2 md:grid-cols-3">
-                {activeState.window.watched_thoughts.map((prompt) => (
-                  <div key={prompt} className="border border-[#282319] bg-[#070706] p-3 text-xs leading-5 text-[#9f9788]">{prompt}</div>
-                ))}
-              </div>
-            </section>
-
-            <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
-              <div className="border border-[#302b20] bg-[#0a0a08] p-5 md:p-7">
-                <div className="flex items-center gap-3">
-                  <Plus className="h-5 w-5 text-[#c8a951]" />
-                  <div>
-                    <div className={labelClass}>Nueva marca</div>
-                    <h2 className="mt-2 text-2xl text-[#f5eedc]">¿Qué ocurrió alrededor del pensamiento?</h2>
-                  </div>
-                </div>
-                <div className="mt-6 grid gap-5 md:grid-cols-2">
-                  <TextArea label="Qué apareció" value={mark.triggerText} onChange={(value) => setMark((current) => ({ ...current, triggerText: value }))} placeholder="Pensamiento, impulso, recuerdo, evento o tensión." rows={3} />
-                  <TextArea label="Qué estabas haciendo" value={mark.activity} onChange={(value) => setMark((current) => ({ ...current, activity: value }))} placeholder="Actividad concreta en ese momento." rows={3} />
-                  <TextArea label="Dónde estabas" value={mark.locationContext} onChange={(value) => setMark((current) => ({ ...current, locationContext: value }))} placeholder="Lugar o entorno." />
-                  <TextArea label="Con quién / solo" value={mark.socialContext} onChange={(value) => setMark((current) => ({ ...current, socialContext: value }))} placeholder="Contexto social opcional." />
-                  <TextArea label="Qué pensaste después" value={mark.thoughtAfter} onChange={(value) => setMark((current) => ({ ...current, thoughtAfter: value }))} />
-                  <TextArea label="Qué sentiste después" value={mark.feelingAfter} onChange={(value) => setMark((current) => ({ ...current, feelingAfter: value }))} />
-                  <TextArea label="Qué hiciste después" value={mark.actionAfter} onChange={(value) => setMark((current) => ({ ...current, actionAfter: value }))} placeholder="Opcional, pero útil." />
-                  <TextArea label="Nota adicional" value={mark.note} onChange={(value) => setMark((current) => ({ ...current, note: value }))} placeholder="Dato que no encaje en los campos anteriores." />
-                </div>
-                <label className="mt-5 grid gap-2">
-                  <span className={labelClass}>Intensidad: {mark.intensity}/5</span>
-                  <input type="range" min={1} max={5} value={mark.intensity} onChange={(event) => setMark((current) => ({ ...current, intensity: Number(event.target.value) }))} />
-                </label>
-                <button type="button" onClick={() => void addMark()} disabled={submitting || !markComplete} className={`mt-6 bg-[#c8a951] text-[#050504] ${buttonClass}`}>
-                  {submitting ? 'Registrando…' : `Registrar marca · día ${dayFromStart(activeState.window.started_at)}`}
-                </button>
-              </div>
-
-              <aside className="border border-[#302b20] bg-[#0a0a08] p-5">
-                <div className={labelClass}>Marcas registradas</div>
-                <div className="mt-4 space-y-3">
-                  {activeState.marks.length ? activeState.marks.slice().reverse().map((item) => (
-                    <article key={item.id} className="border border-[#282319] bg-[#070706] p-3">
-                      <div className="flex items-center justify-between font-mono text-[9px] uppercase tracking-[0.12em] text-[#716a5e]">
-                        <span>Día {item.day_number}</span><span>{item.intensity ?? 0}/5</span>
-                      </div>
-                      <p className="mt-2 text-sm leading-6 text-[#d5cdbd]">{item.trigger_text || item.note}</p>
-                      <div className="mt-3 space-y-1 text-[11px] text-[#81796b]">
-                        <div className="flex gap-2"><MapPin className="mt-0.5 h-3 w-3" />{item.location_context}</div>
-                        {item.social_context ? <div className="flex gap-2"><UserRound className="mt-0.5 h-3 w-3" />{item.social_context}</div> : null}
-                      </div>
-                    </article>
-                  )) : <p className="text-sm leading-6 text-[#81796b]">Aún no existen marcas. Registra sólo cuando el patrón aparezca.</p>}
-                </div>
-              </aside>
-            </section>
-
-            <section className={`border p-5 md:p-7 ${activeState.canClose ? 'border-[#5e6d42] bg-[#0b1208]' : 'border-[#302b20] bg-[#0a0a08]'}`}>
-              <div className="flex items-center gap-3">
-                {activeState.canClose ? <Check className="h-5 w-5 text-[#9cb57d]" /> : <Clock3 className="h-5 w-5 text-[#766b50]" />}
-                <div>
-                  <div className={labelClass}>Cierre de calibración</div>
-                  <h2 className="mt-2 text-2xl text-[#f5eedc]">{activeState.canClose ? 'La ventana terminó. Declara qué observaste.' : 'El retorno se habilita al cumplir 72 horas.'}</h2>
-                </div>
-              </div>
-              {activeState.canClose ? (
-                <div className="mt-6 grid gap-4 md:grid-cols-2">
-                  <TextArea label="Qué piensas ahora" value={reflection.whatChanged} onChange={(value) => setReflection((current) => ({ ...current, whatChanged: value }))} />
-                  <TextArea label="Qué sentiste durante estos días" value={reflection.whatNoticed} onChange={(value) => setReflection((current) => ({ ...current, whatNoticed: value }))} />
-                  <TextArea label="Qué evitaste ver o hacer" value={reflection.whatAvoided} onChange={(value) => setReflection((current) => ({ ...current, whatAvoided: value }))} />
-                  <TextArea label="Qué parte fue tuya" value={reflection.whatWasMine} onChange={(value) => setReflection((current) => ({ ...current, whatWasMine: value }))} />
-                  <TextArea label="Qué parte no fue tuya" value={reflection.whatWasNotMine} onChange={(value) => setReflection((current) => ({ ...current, whatWasNotMine: value }))} />
-                  <TextArea label="Qué necesitas ahora" value={reflection.neededToday} onChange={(value) => setReflection((current) => ({ ...current, neededToday: value }))} />
-                </div>
-              ) : null}
-              <button type="button" onClick={() => void closeWindow()} disabled={submitting || !activeState.canClose || !reflectionComplete} className={`mt-6 ${buttonClass}`}>
-                Declarar atractor y abrir observatorio <ArrowRight className="h-4 w-4" />
-              </button>
-            </section>
-          </>
-        ) : null}
-      </div>
-    </main>
-  );
+        {activeState.canClose ? <section className="border border-[#4b4025] bg-[#0d0c08] p-6"><div className={labelClass}>Primer corte longitudinal</div><h2 className="mt-3 text-2xl text-[#f5eedc]">Observa el conjunto, no una marca aislada.</h2><p className="mt-3 text-sm leading-7 text-[#918979]">Estas preguntas no buscan una respuesta correcta. Ayudan a separar repetición, contexto, agencia y condiciones externas antes de proponer una perturbación mínima.</p><div className="mt-6 grid gap-5 md:grid-cols-2"><ContextField label="Qué cambió" value={reflection.whatChanged} onChange={(value) => setReflection((current) => ({ ...current, whatChanged: value }))} placeholder="Cambio observable." /><ContextField label="Qué comenzó a repetirse" value={reflection.whatNoticed} onChange={(value) => setReflection((current) => ({ ...current, whatNoticed: value }))} placeholder="Señales persistentes." /><ContextField label="Qué evitaste o postergaste" value={reflection.whatAvoided} onChange={(value) => setReflection((current) => ({ ...current, whatAvoided: value }))} placeholder="Sólo si ocurrió." /><ContextField label="Qué dependía de ti" value={reflection.whatWasMine} onChange={(value) => setReflection((current) => ({ ...current, whatWasMine: value }))} placeholder="Parte propia del campo." /><ContextField label="Qué no dependía de ti" value={reflection.whatWasNotMine} onChange={(value) => setReflection((current) => ({ ...current, whatWasNotMine: value }))} placeholder="Condiciones externas." /><ContextField label="Qué condición mínima necesitas ahora" value={reflection.neededToday} onChange={(value) => setReflection((current) => ({ ...current, neededToday: value }))} placeholder="No una solución completa." /></div><button type="button" onClick={() => void closeWindow()} disabled={submitting || !reflectionComplete} className={`mt-6 bg-[#c8a951] text-[#050504] ${buttonClass}`}>Cerrar el primer corte y abrir observatorio</button></section> : null}
+      </> : null}
+    </div>
+  </main>;
 }

--- a/src/lib/field/participantCapture.ts
+++ b/src/lib/field/participantCapture.ts
@@ -15,11 +15,11 @@ export type CreateParticipantWindowInput = {
 export type AddParticipantMarkInput = {
   dayNumber: number;
   triggerText: string;
-  activity: string;
-  locationContext: string;
+  activity?: string | null;
+  locationContext?: string | null;
   socialContext?: string | null;
-  thoughtAfter: string;
-  feelingAfter: string;
+  thoughtAfter?: string | null;
+  feelingAfter?: string | null;
   actionAfter?: string | null;
   intensity: number;
   note?: string | null;
@@ -46,19 +46,19 @@ function record(value: unknown): Row {
   return value && typeof value === 'object' && !Array.isArray(value) ? (value as Row) : {};
 }
 
-function requireText(value: string | undefined | null, field: string, max = 4000) {
+function required(value: string | undefined | null, field: string, max = 4000) {
   const trimmed = typeof value === 'string' ? value.trim() : '';
   if (!trimmed) throw new Error(`${field}_REQUIRED`);
   return trimmed.slice(0, max);
 }
 
+function optional(value: string | undefined | null, max: number) {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed ? trimmed.slice(0, max) : null;
+}
+
 async function loadOwnedWindow(client: ServiceClient, ownerId: string, windowId: string) {
-  const { data, error } = await client
-    .from(TABLE_WINDOWS)
-    .select('*')
-    .eq('id', windowId)
-    .eq('owner_id', ownerId)
-    .maybeSingle();
+  const { data, error } = await client.from(TABLE_WINDOWS).select('*').eq('id', windowId).eq('owner_id', ownerId).maybeSingle();
   if (error) throw new Error(`PARTICIPANT_WINDOW_READ_FAILED: ${error.message}`);
   if (!data) throw new Error('PARTICIPANT_WINDOW_NOT_FOUND');
   return record(data);
@@ -67,53 +67,33 @@ async function loadOwnedWindow(client: ServiceClient, ownerId: string, windowId:
 export async function createParticipantWindow(ownerId: string, input: CreateParticipantWindowInput) {
   const client = createServiceSupabaseClient();
   const watchedThoughts = Array.isArray(input.watchedThoughts)
-    ? input.watchedThoughts
-        .map((item) => (typeof item === 'string' ? item.trim() : ''))
-        .filter(Boolean)
-        .slice(0, 5)
+    ? input.watchedThoughts.map((item) => (typeof item === 'string' ? item.trim() : '')).filter(Boolean).slice(0, 5)
     : [];
-  if (watchedThoughts.length === 0) throw new Error('WATCHED_THOUGHTS_REQUIRED');
+  if (!watchedThoughts.length) throw new Error('WATCHED_THOUGHTS_REQUIRED');
 
-  const { data: activeWindow, error: activeError } = await client
-    .from(TABLE_WINDOWS)
-    .select('*')
-    .eq('owner_id', ownerId)
-    .eq('status', 'ACTIVE')
-    .order('started_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
+  const { data: activeWindow, error: activeError } = await client.from(TABLE_WINDOWS).select('*').eq('owner_id', ownerId).eq('status', 'ACTIVE').order('started_at', { ascending: false }).limit(1).maybeSingle();
   if (activeError) throw new Error(`PARTICIPANT_WINDOW_READ_FAILED: ${activeError.message}`);
   if (activeWindow) return record(activeWindow);
 
   const startedAt = new Date();
   const expectedCloseAt = new Date(startedAt.getTime() + WINDOW_HOURS * 60 * 60 * 1000);
-
-  const { data, error } = await client
-    .from(TABLE_WINDOWS)
-    .insert({
-      owner_id: ownerId,
-      case_id: input.caseId || null,
-      attractor_id: input.attractorId || null,
-      calibration_kind: input.calibrationKind || 'INITIAL_ATTRACTOR',
-      watched_thoughts: watchedThoughts,
-      status: 'ACTIVE',
-      started_at: startedAt.toISOString(),
-      expected_close_at: expectedCloseAt.toISOString(),
-    })
-    .select('*')
-    .single();
-
+  const { data, error } = await client.from(TABLE_WINDOWS).insert({
+    owner_id: ownerId,
+    case_id: input.caseId || null,
+    attractor_id: input.attractorId || null,
+    calibration_kind: input.calibrationKind || 'INITIAL_ATTRACTOR',
+    watched_thoughts: watchedThoughts,
+    status: 'ACTIVE',
+    started_at: startedAt.toISOString(),
+    expected_close_at: expectedCloseAt.toISOString(),
+  }).select('*').single();
   if (error) throw new Error(`PARTICIPANT_WINDOW_CREATE_FAILED: ${error.message}`);
   return record(data);
 }
 
 export async function listParticipantWindows(ownerId: string) {
   const client = createServiceSupabaseClient();
-  const { data, error } = await client
-    .from(TABLE_WINDOWS)
-    .select('*')
-    .eq('owner_id', ownerId)
-    .order('started_at', { ascending: false });
+  const { data, error } = await client.from(TABLE_WINDOWS).select('*').eq('owner_id', ownerId).order('started_at', { ascending: false });
   if (error) throw new Error(`PARTICIPANT_WINDOWS_LIST_FAILED: ${error.message}`);
   return Array.isArray(data) ? data.map(record) : [];
 }
@@ -121,27 +101,15 @@ export async function listParticipantWindows(ownerId: string) {
 export async function getParticipantWindowState(ownerId: string, windowId: string) {
   const client = createServiceSupabaseClient();
   const windowRow = await loadOwnedWindow(client, ownerId, windowId);
-
-  const { data: marks, error } = await client
-    .from(TABLE_MARKS)
-    .select('*')
-    .eq('window_id', windowId)
-    .eq('owner_id', ownerId)
-    .order('moment_at', { ascending: true });
+  const { data: marks, error } = await client.from(TABLE_MARKS).select('*').eq('window_id', windowId).eq('owner_id', ownerId).order('moment_at', { ascending: true });
   if (error) throw new Error(`PARTICIPANT_MARKS_READ_FAILED: ${error.message}`);
-
   const now = Date.now();
-  const expectedCloseAt = typeof windowRow.expected_close_at === 'string'
-    ? new Date(windowRow.expected_close_at).getTime()
-    : Number.NaN;
-
+  const expectedCloseAt = typeof windowRow.expected_close_at === 'string' ? new Date(windowRow.expected_close_at).getTime() : Number.NaN;
   return {
     window: windowRow,
     marks: Array.isArray(marks) ? marks.map(record) : [],
     canClose: windowRow.status === 'ACTIVE' && Number.isFinite(expectedCloseAt) && now >= expectedCloseAt,
-    hoursRemaining: Number.isFinite(expectedCloseAt)
-      ? Math.max(0, (expectedCloseAt - now) / (60 * 60 * 1000))
-      : null,
+    hoursRemaining: Number.isFinite(expectedCloseAt) ? Math.max(0, (expectedCloseAt - now) / 3_600_000) : null,
   };
 }
 
@@ -149,95 +117,58 @@ export async function addParticipantMark(ownerId: string, windowId: string, inpu
   const client = createServiceSupabaseClient();
   const windowRow = await loadOwnedWindow(client, ownerId, windowId);
   if (windowRow.status !== 'ACTIVE') throw new Error('PARTICIPANT_WINDOW_NOT_ACTIVE');
-
   const dayNumber = [1, 2, 3].includes(input.dayNumber) ? input.dayNumber : null;
   if (!dayNumber) throw new Error('DAY_NUMBER_INVALID');
-
   const momentAt = input.observedAt ? new Date(input.observedAt) : new Date();
   if (Number.isNaN(momentAt.getTime())) throw new Error('OBSERVED_AT_INVALID');
   const intensity = Math.round(Number(input.intensity));
   if (intensity < 1 || intensity > 5) throw new Error('INTENSITY_INVALID');
 
-  const triggerText = requireText(input.triggerText, 'TRIGGER_TEXT', 1200);
-  const activity = requireText(input.activity, 'ACTIVITY', 800);
-  const locationContext = requireText(input.locationContext, 'LOCATION_CONTEXT', 500);
-  const thoughtAfter = requireText(input.thoughtAfter, 'THOUGHT_AFTER', 1200);
-  const feelingAfter = requireText(input.feelingAfter, 'FEELING_AFTER', 800);
-
-  const { data, error } = await client
-    .from(TABLE_MARKS)
-    .insert({
-      window_id: windowId,
-      owner_id: ownerId,
-      day_number: dayNumber,
-      moment_at: momentAt.toISOString(),
-      trigger_text: triggerText,
-      activity,
-      location_context: locationContext,
-      social_context: typeof input.socialContext === 'string' ? input.socialContext.trim().slice(0, 500) || null : null,
-      thought_after: thoughtAfter,
-      feeling_after: feelingAfter,
-      action_after: typeof input.actionAfter === 'string' ? input.actionAfter.trim().slice(0, 1000) || null : null,
-      intensity,
-      note: typeof input.note === 'string' ? input.note.trim().slice(0, 2000) || null : null,
-      payload: { captureVersion: 'SFI-CALIBRATION-MARK-V1' },
-    })
-    .select('*')
-    .single();
+  const { data, error } = await client.from(TABLE_MARKS).insert({
+    window_id: windowId,
+    owner_id: ownerId,
+    day_number: dayNumber,
+    moment_at: momentAt.toISOString(),
+    trigger_text: required(input.triggerText, 'TRIGGER_TEXT', 1200),
+    activity: optional(input.activity, 800),
+    location_context: optional(input.locationContext, 500),
+    social_context: optional(input.socialContext, 500),
+    thought_after: optional(input.thoughtAfter, 1200),
+    feeling_after: optional(input.feelingAfter, 800),
+    action_after: optional(input.actionAfter, 1000),
+    intensity,
+    note: optional(input.note, 2000),
+    payload: { captureVersion: 'SFI-FIELD-MARK-V2', epistemicState: 'OBSERVED_NOT_INTERPRETED' },
+  }).select('*').single();
   if (error) throw new Error(`PARTICIPANT_MARK_CREATE_FAILED: ${error.message}`);
 
   const currentCount = typeof windowRow.mark_count === 'number' ? windowRow.mark_count : 0;
-  const { error: updateError } = await client
-    .from(TABLE_WINDOWS)
-    .update({ mark_count: currentCount + 1, updated_at: new Date().toISOString() })
-    .eq('id', windowId)
-    .eq('owner_id', ownerId);
+  const { error: updateError } = await client.from(TABLE_WINDOWS).update({ mark_count: currentCount + 1, updated_at: new Date().toISOString() }).eq('id', windowId).eq('owner_id', ownerId);
   if (updateError) throw new Error(`PARTICIPANT_WINDOW_COUNT_FAILED: ${updateError.message}`);
-
   return record(data);
 }
 
-export async function closeParticipantWindow(
-  ownerId: string,
-  windowId: string,
-  input: CloseParticipantWindowInput,
-) {
+export async function closeParticipantWindow(ownerId: string, windowId: string, input: CloseParticipantWindowInput) {
   const client = createServiceSupabaseClient();
   const windowRow = await loadOwnedWindow(client, ownerId, windowId);
   if (windowRow.status !== 'ACTIVE') throw new Error('PARTICIPANT_WINDOW_NOT_ACTIVE');
-
-  const expectedCloseAt = typeof windowRow.expected_close_at === 'string'
-    ? new Date(windowRow.expected_close_at).getTime()
-    : Number.NaN;
+  const expectedCloseAt = typeof windowRow.expected_close_at === 'string' ? new Date(windowRow.expected_close_at).getTime() : Number.NaN;
   const allowEarly = process.env.SFI_ALLOW_EARLY_CALIBRATION_CLOSE === 'true';
-  if (!allowEarly && (!Number.isFinite(expectedCloseAt) || Date.now() < expectedCloseAt)) {
-    throw new Error('CALIBRATION_WINDOW_NOT_COMPLETE');
-  }
+  if (!allowEarly && (!Number.isFinite(expectedCloseAt) || Date.now() < expectedCloseAt)) throw new Error('CALIBRATION_WINDOW_NOT_COMPLETE');
 
   const payload = {
     status: 'CLOSED' as const,
     closed_at: new Date().toISOString(),
-    reflection_what_changed: requireText(input.whatChanged, 'WHAT_CHANGED'),
-    reflection_what_noticed: requireText(input.whatNoticed, 'WHAT_NOTICED'),
-    reflection_what_avoided: requireText(input.whatAvoided, 'WHAT_AVOIDED'),
-    reflection_what_was_mine: requireText(input.whatWasMine, 'WHAT_WAS_MINE'),
-    reflection_what_was_not_mine: requireText(input.whatWasNotMine, 'WHAT_WAS_NOT_MINE'),
-    reflection_needed_today: requireText(input.neededToday, 'NEEDED_TODAY'),
+    reflection_what_changed: required(input.whatChanged, 'WHAT_CHANGED'),
+    reflection_what_noticed: required(input.whatNoticed, 'WHAT_NOTICED'),
+    reflection_what_avoided: required(input.whatAvoided, 'WHAT_AVOIDED'),
+    reflection_what_was_mine: required(input.whatWasMine, 'WHAT_WAS_MINE'),
+    reflection_what_was_not_mine: required(input.whatWasNotMine, 'WHAT_WAS_NOT_MINE'),
+    reflection_needed_today: required(input.neededToday, 'NEEDED_TODAY'),
     updated_at: new Date().toISOString(),
   };
-
-  const { data, error } = await client
-    .from(TABLE_WINDOWS)
-    .update(payload)
-    .eq('id', windowId)
-    .eq('owner_id', ownerId)
-    .select('*')
-    .single();
+  const { data, error } = await client.from(TABLE_WINDOWS).update(payload).eq('id', windowId).eq('owner_id', ownerId).select('*').single();
   if (error) throw new Error(`PARTICIPANT_WINDOW_CLOSE_FAILED: ${error.message}`);
-
-  const attractor = windowRow.attractor_id
-    ? await finalizeAttractorFromWindow(ownerId, windowId)
-    : null;
-
+  const attractor = windowRow.attractor_id ? await finalizeAttractorFromWindow(ownerId, windowId) : null;
   return { window: record(data), attractor };
 }


### PR DESCRIPTION
## Purpose
Align FIELD with the core SFI proposition: preserve emergence before judgment, observe longitudinally, and only then identify persistent signals, phenomena, phenotype candidates and minimum perturbation conditions.

## Capture changes
- A mark now requires only the observed appearance and perceived intensity.
- Activity, location, thought, feeling, response and notes are optional context.
- Missing context remains null in persistence; the UI does not duplicate or invent values to satisfy the writer.
- Persisted marks use `SFI-FIELD-MARK-V2` with epistemic state `OBSERVED_NOT_INTERPRETED`.

## User experience
- Reframes the 72-hour window as a field of observation rather than a calibration test.
- Uses plain Spanish for a normal user.
- Explains that a mark is not a diagnosis and should not be interpreted immediately.
- Shows the actual longitudinal sequence of persisted marks.
- The first closure asks about change, recurrence, agency, external conditions and the minimum condition needed now.

## Integrity
- Reuses the existing participant window, mark, closure and attractor finalization writers.
- No mock data, synthetic context or duplicated fields.
- No new database schema or parallel process.

## Files
- `src/lib/field/participantCapture.ts`
- `src/components/field/ParticipantWindowConsole.tsx`