### PR TITLE
Connect real FIELD trajectory points to STUDIO

### DIFF
--- a/src/app/api/interface/observatory/send-to-studio/route.ts
+++ b/src/app/api/interface/observatory/send-to-studio/route.ts
@@ -1,0 +1,156 @@
+import { NextResponse } from 'next/server';
+import { AccessDeniedError, requireAuthenticatedUser } from '@/lib/system/access/server';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+type Body = {
+  caseId?: unknown;
+  nodeId?: unknown;
+};
+
+function clean(value: unknown, max = 240) {
+  return typeof value === 'string' && value.trim() ? value.trim().slice(0, max) : '';
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const body = await request.json().catch(() => null) as Body | null;
+    const caseId = clean(body?.caseId);
+    const nodeId = clean(body?.nodeId);
+    if (!caseId || !nodeId) {
+      return NextResponse.json({ ok: false, error: 'Selecciona un punto real de la trayectoria.' }, { status: 400 });
+    }
+
+    const service = createServiceSupabaseClient();
+    const [{ data: fieldCase, error: caseError }, { data: node, error: nodeError }] = await Promise.all([
+      service
+        .from('field_cases')
+        .select('id,title,status,created_at')
+        .eq('id', caseId)
+        .eq('owner_id', user.id)
+        .is('deleted_at', null)
+        .maybeSingle(),
+      service
+        .from('sfi_user_graph_nodes')
+        .select('id,case_id,node_type,label,summary,weight,is_central,source_type,source_id,metadata,observed_at')
+        .eq('id', nodeId)
+        .eq('case_id', caseId)
+        .eq('owner_id', user.id)
+        .maybeSingle(),
+    ]);
+
+    if (caseError || !fieldCase) {
+      return NextResponse.json({ ok: false, error: 'No fue posible encontrar esta trayectoria.' }, { status: 404 });
+    }
+    if (nodeError || !node) {
+      return NextResponse.json({ ok: false, error: 'El punto seleccionado no pertenece a esta trayectoria.' }, { status: 404 });
+    }
+
+    const title = clean(node.label, 240) || `Objeto observado en ${fieldCase.title}`;
+    const summary = clean(node.summary, 4000);
+    const observedAt = clean(node.observed_at, 100) || null;
+    const nodeMetadata = record(node.metadata);
+    const transferredAt = new Date().toISOString();
+
+    const session = await service
+      .from('studio_sessions')
+      .insert({
+        owner_id: user.id,
+        title: `${title} · estudio`,
+        status: 'active',
+        metadata: {
+          source: 'field_trajectory_transfer_v1',
+          fieldCaseId: fieldCase.id,
+          fieldNodeId: node.id,
+          transferredAt,
+        },
+      })
+      .select('id')
+      .single();
+    if (session.error || !session.data) {
+      return NextResponse.json({ ok: false, error: 'No fue posible abrir una sesión de análisis.' }, { status: 503 });
+    }
+
+    const sourceText = [
+      `Título observado: ${title}`,
+      summary ? `Descripción registrada: ${summary}` : null,
+      `Estado de origen: ${clean(node.node_type, 80) || 'observado'}`,
+      observedAt ? `Observado: ${observedAt}` : null,
+      `Trayectoria: ${fieldCase.title}`,
+    ].filter(Boolean).join('\n\n');
+
+    const object = await service
+      .from('studio_objects')
+      .insert({
+        session_id: session.data.id,
+        owner_id: user.id,
+        title,
+        object_type: 'text',
+        source_uri: `field://${fieldCase.id}/nodes/${node.id}`,
+        mime_type: 'text/plain',
+        status: 'draft',
+        metadata: {
+          declaration: {
+            context: summary || null,
+            notes: sourceText,
+            authorityConsent: true,
+            provenance: {
+              source: 'field_trajectory_transfer_v1',
+              ownerId: user.id,
+              fieldCaseId: fieldCase.id,
+              fieldNodeId: node.id,
+              sourceType: node.source_type ?? null,
+              sourceId: node.source_id ?? null,
+              observedAt,
+              transferredAt,
+            },
+          },
+          epistemicState: clean(node.node_type, 80) || 'observed',
+          fieldNodeMetadata: nodeMetadata,
+          fieldWeight: typeof node.weight === 'number' ? node.weight : null,
+          fieldCentral: node.is_central === true,
+        },
+      })
+      .select('id,session_id')
+      .single();
+
+    if (object.error || !object.data) {
+      await service.from('studio_sessions').delete().eq('id', session.data.id).eq('owner_id', user.id);
+      return NextResponse.json({ ok: false, error: 'No fue posible preparar el objeto para STUDIO.' }, { status: 503 });
+    }
+
+    await service.from('studio_evidence_traces').insert({
+      object_id: object.data.id,
+      evidence_kind: 'field_trajectory_node',
+      source_uri: `field://${fieldCase.id}/nodes/${node.id}`,
+      summary: summary || title,
+      confidence: typeof node.weight === 'number' ? Math.max(0, Math.min(1, node.weight)) : null,
+      metadata: {
+        fieldCaseId: fieldCase.id,
+        fieldNodeId: node.id,
+        nodeType: node.node_type,
+        observedAt,
+        transferredAt,
+      },
+    });
+
+    return NextResponse.json({
+      ok: true,
+      objectId: object.data.id,
+      nextPath: `/studio?objectId=${encodeURIComponent(object.data.id)}`,
+      explanation: 'El punto fue preparado como objeto de STUDIO conservando su procedencia. Todavía no ha sido interpretado ni transformado.',
+    }, { status: 201 });
+  } catch (error) {
+    if (error instanceof AccessDeniedError) {
+      return NextResponse.json({ ok: false, error: error.code }, { status: error.status });
+    }
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : 'No fue posible enviar el punto a STUDIO.' }, { status: 500 });
+  }
+}

--- a/src/app/interface/observatory/page.tsx
+++ b/src/app/interface/observatory/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import UserAttractorFieldExperience from '@/components/interface/UserAttractorFieldExperience';
+import { FieldStudioTransfer } from '@/components/interface/FieldStudioTransfer';
 import { SfiSurfaceGuide } from '@/components/sfi/SfiSurfaceGuide';
 import { readPublicObservatoryState } from '@/lib/observatory/public/readPublicObservatoryState';
 import { createServerSupabaseClient } from '@/runtime/supabase/server';
@@ -51,15 +51,7 @@ export default async function UserObservatoryPage() {
     .maybeSingle();
   if (!attractor) redirect('/interface');
 
-  const [
-    caseQuery,
-    entitlementQuery,
-    nodesQuery,
-    edgesQuery,
-    assessmentsQuery,
-    nextReturnQuery,
-    worldState,
-  ] = await Promise.all([
+  const [caseQuery, entitlementQuery, nodesQuery, edgesQuery, assessmentsQuery, nextReturnQuery, worldState] = await Promise.all([
     supabase.from('field_cases').select('id,title,status,created_at').eq('id', attractor.case_id).eq('owner_id', user.id).single(),
     supabase.from('sfi_user_entitlements').select('tier,status,valid_until').eq('user_id', user.id).maybeSingle(),
     supabase.from('sfi_user_graph_nodes').select('id,node_type,label,summary,weight,is_central,metadata,observed_at').eq('owner_id', user.id).eq('case_id', attractor.case_id).order('observed_at', { ascending: true }).limit(120),
@@ -105,18 +97,19 @@ export default async function UserObservatoryPage() {
         eyebrow="SFI · observación longitudinal privada"
         title="Tu trayectoria se construye con evidencia, retornos y cambios observados."
         description="Este observatorio personal muestra únicamente relaciones persistidas. Una señal aislada no se convierte en diagnóstico. Las interpretaciones y microejecuciones aparecen como propuestas revisables y nunca se ejecutan por sí solas."
-      >
-        <Link href="/studio">TRABAJAR UN OBJETO EN STUDIO</Link>
-      </SfiSurfaceGuide>
+      />
+      <div className="bg-[#050504] px-5 pt-6 md:px-10">
+        <div className="mx-auto max-w-[1500px]">
+          <FieldStudioTransfer
+            caseId={caseQuery.data.id}
+            nodes={nodes.map((node) => ({ id: node.id, label: node.label, nodeType: node.node_type, observedAt: node.observed_at }))}
+          />
+        </div>
+      </div>
       <UserAttractorFieldExperience
         userEmail={user.email ?? null}
         entitlement={entitlement}
-        caseData={{
-          id: caseQuery.data.id,
-          title: caseQuery.data.title,
-          status: caseQuery.data.status,
-          createdAt: caseQuery.data.created_at,
-        }}
+        caseData={{ id: caseQuery.data.id, title: caseQuery.data.title, status: caseQuery.data.status, createdAt: caseQuery.data.created_at }}
         attractor={{
           id: attractor.id,
           code: attractor.code,

--- a/src/app/studio/page.tsx
+++ b/src/app/studio/page.tsx
@@ -18,17 +18,40 @@ export default async function StudioPage({ searchParams }: { searchParams?: Prom
     includeLegacy = false;
   }
   const state = await readStudioProductionState({ ownerId: user.id, includeLegacy, objectId });
+  const cameFromField = state.activeObject.sourceUri?.startsWith('field://') === true;
 
   return (
     <main className="min-h-screen bg-[#050504]">
       <SfiSurfaceGuide
         current="studio"
         eyebrow="SFI · análisis y transformación"
-        title="Trabaja sobre un objeto sin perder su origen ni su retorno."
-        description="STUDIO recibe un objeto o señal ya observado, muestra qué información lo sostiene y permite analizar, modelar o probar una transformación. Una salida de STUDIO sólo adquiere valor cuando puede regresar a FIELD como condición observable, intervención reversible o resultado verificable."
+        title={cameFromField ? 'Este objeto llegó desde una trayectoria de FIELD.' : 'Trabaja sobre un objeto sin perder su origen ni su retorno.'}
+        description={cameFromField
+          ? 'STUDIO conserva el punto observado y su procedencia. Todavía no lo considera una conclusión: aquí puede analizarse, relacionarse o convertirse en una prueba reversible que después regrese a FIELD.'
+          : 'STUDIO recibe un objeto o señal ya observado, muestra qué información lo sostiene y permite analizar, modelar o probar una transformación. Una salida sólo adquiere valor cuando puede regresar a FIELD como condición observable, intervención reversible o resultado verificable.'}
       >
         <Link href="/interface/observatory">VOLVER A MI TRAYECTORIA</Link>
       </SfiSurfaceGuide>
+
+      {cameFromField ? (
+        <section className="border-b border-[#302a1f] bg-[#080807] px-5 py-5 text-[#d8d1c0] md:px-10">
+          <div className="mx-auto grid max-w-[1500px] gap-4 md:grid-cols-3">
+            <div>
+              <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">Objeto recibido</span>
+              <p className="mt-2 text-lg text-[#f0e5cc]">{state.activeObject.title}</p>
+            </div>
+            <div>
+              <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">Estado actual</span>
+              <p className="mt-2 text-sm leading-6 text-[#9a907e]">Conservado como objeto de análisis. No se ha convertido automáticamente en hipótesis, diagnóstico ni intervención.</p>
+            </div>
+            <div>
+              <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">Retorno esperado</span>
+              <p className="mt-2 text-sm leading-6 text-[#9a907e]">Una condición observable, una transformación verificable o una microejecución reversible que pueda registrarse de nuevo en FIELD.</p>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
       <StudioProductionConsole state={state} />
     </main>
   );

--- a/src/components/interface/FieldStudioTransfer.tsx
+++ b/src/components/interface/FieldStudioTransfer.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState } from 'react';
+import { ArrowRight, Loader2 } from 'lucide-react';
+
+type TransferNode = {
+  id: string;
+  label: string;
+  nodeType: string;
+  observedAt: string;
+};
+
+function typeLabel(value: string) {
+  const labels: Record<string, string> = {
+    attractor: 'dirección persistente',
+    mark: 'aparición observada',
+    event: 'evento',
+    evidence: 'evidencia',
+    intervention: 'microejecución',
+    return: 'retorno',
+    learning: 'aprendizaje',
+  };
+  return labels[value] ?? 'punto observado';
+}
+
+export function FieldStudioTransfer({ caseId, nodes }: { caseId: string; nodes: TransferNode[] }) {
+  const [nodeId, setNodeId] = useState(nodes[0]?.id ?? '');
+  const [status, setStatus] = useState<'idle' | 'sending' | 'error'>('idle');
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function send() {
+    if (!nodeId || status === 'sending') return;
+    setStatus('sending');
+    setMessage(null);
+    try {
+      const response = await fetch('/api/interface/observatory/send-to-studio', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ caseId, nodeId }),
+      });
+      const body = await response.json();
+      if (!response.ok || !body.ok) throw new Error(body.error || 'No fue posible preparar este punto para STUDIO.');
+      window.location.assign(body.nextPath);
+    } catch (error) {
+      setStatus('error');
+      setMessage(error instanceof Error ? error.message : 'No fue posible preparar este punto para STUDIO.');
+    }
+  }
+
+  return (
+    <section className="border border-[#302a1f] bg-[#090908] p-5">
+      <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">Continuar en STUDIO</div>
+      <h2 className="mt-3 text-xl text-[#f1e5ca]">Trabajar un punto sin perder su procedencia</h2>
+      <p className="mt-3 text-xs leading-6 text-[#8d8474]">Elige una observación real de tu trayectoria. STUDIO la recibirá como objeto de análisis con su fecha, tipo y vínculo al caso. El traslado no cambia su significado ni ejecuta una intervención.</p>
+
+      {nodes.length ? (
+        <>
+          <label className="mt-5 grid gap-2">
+            <span className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#91866d]">Punto de la trayectoria</span>
+            <select value={nodeId} onChange={(event) => setNodeId(event.target.value)} className="border border-[#302a1f] bg-[#050504] px-3 py-3 text-sm text-[#eee4cb] outline-none focus:border-[#c8a951]">
+              {nodes.map((node) => (
+                <option key={node.id} value={node.id}>{node.label} · {typeLabel(node.nodeType)}</option>
+              ))}
+            </select>
+          </label>
+          <button type="button" onClick={() => void send()} disabled={!nodeId || status === 'sending'} className="mt-4 inline-flex w-full items-center justify-center gap-2 border border-[#66552c] px-4 py-3 font-mono text-[10px] uppercase tracking-[0.16em] text-[#c8a951] disabled:opacity-35">
+            {status === 'sending' ? <Loader2 className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
+            {status === 'sending' ? 'Preparando objeto' : 'Abrir este punto en STUDIO'}
+          </button>
+        </>
+      ) : (
+        <p className="mt-4 text-sm leading-6 text-[#918979]">Todavía no existe un punto persistido que pueda enviarse. Conserva una aparición, carga evidencia o registra un retorno primero.</p>
+      )}
+
+      {message ? <p className="mt-4 border border-[#6b352a] bg-[#160d0a] p-3 text-xs leading-6 text-[#d89685]">{message}</p> : null}
+    </section>
+  );
+}


### PR DESCRIPTION
## Purpose
Implement the first operational transit between SFI user surfaces without creating parallel data or synthetic objects.

## FIELD → STUDIO
- Adds an authenticated transfer endpoint for an owned, persisted trajectory node.
- Verifies the FIELD case and graph node belong to the current user.
- Creates a real `studio_sessions` row and a real text `studio_objects` row.
- Preserves provenance through a `field://` source URI, case ID, node ID, source type, source ID, observed time and transfer time.
- Adds a Studio evidence trace for the transferred node.

## User experience
- The personal observatory lists only actual persisted trajectory nodes as transferable objects.
- The user chooses a point and opens it directly in STUDIO.
- The UI explains that transfer preserves the object but does not interpret, diagnose, transform or execute it.
- STUDIO recognizes FIELD-origin objects and states the expected return: an observable condition, verifiable transformation or reversible micro-execution.

## Integrity
- No mock object, fallback node, fabricated metric or new schema.
- Uses existing `studio_sessions`, `studio_objects` and `studio_evidence_traces` contracts.
- Uses existing `objectId` selection in the STUDIO adapter.
- ROOT remains absent from normal-user navigation.

## Files
- `src/app/api/interface/observatory/send-to-studio/route.ts`
- `src/components/interface/FieldStudioTransfer.tsx`
- `src/app/interface/observatory/page.tsx`
- `src/app/studio/page.tsx`