### PR TITLE
Fix ROOT agent inventory and define layer data contracts

### DIFF
--- a/docs/ROOT_INFORMATION_CONTRACT.md
+++ b/docs/ROOT_INFORMATION_CONTRACT.md
@@ -1,0 +1,53 @@
+# ROOT Information Consumption Contract
+
+ROOT is the founder-only governance console of System Friction Institute. It does not own domain data and must not manufacture a second copy of FIELD, STUDIO, WorldSpect, AMV or prediction state. ROOT consumes canonical persisted state and exposes governed actions.
+
+## Layer contracts
+
+### Signals
+Consumes: `worldspect_snapshots`, `world_vector_observations`, canonical system-state observations and current instrument warnings.
+Shows: observed signal, time, source, confidence, persistence and contradictory evidence.
+Must not show: narrative drafts as observations, fallback metrics or decorative signals.
+
+### Evidence
+Consumes: `root_evidence_entries`, `sfi_evidence_ledger`, `epistemic_events`, canonical graph nodes and edges.
+Shows: provenance, lineage, epistemic class, verification state and relationships.
+Must not infer a relationship when no persisted edge exists.
+
+### Hypotheses and predictions
+Consumes: `sfi_predictive_models`, `sfi_predictive_runs`, evidence requests, outcomes and learning events.
+Shows: hypothesis, horizon, expected observations, contradictory observations, confidence, outcome and calibration.
+Must not treat an open prediction as a verified fact.
+
+### Memory
+Consumes: `sfi_amv_memory` and canonical institutional-memory events.
+Shows: recurrence, source events, validation state and retrieval context.
+Must not equate ingestion with verification.
+
+### Attractors and ejectors
+Consumes: persisted AMV attractors/ejectors, phenomenon evidence and longitudinal returns.
+Shows: direction, persistence, supporting observations, contradiction and affected variables.
+Must not create visual attractors only to fill the field.
+
+### Agents
+Consumes: `SFI_COGNITIVE_AGENT_REGISTRY`, real agentic capabilities, runtime execution traces and provider state.
+Shows: every registered agent, its purpose, layer, authority, availability, missing capability, last execution and provider when observed.
+Must not use subsystem rows as a substitute for the agent inventory.
+
+### History
+Consumes: audit events, governed proposals, mutations, execution events, prediction outcomes and learning events.
+Shows: chronological institutional changes and their audit references.
+Must not mix unpersisted UI actions into institutional history.
+
+### Governance
+Consumes: action proposals, mutation queue, evidence requirements, risk declarations, approvals and audit events.
+Shows only decisions that genuinely require founder authorization.
+Observation, calibration and ordinary institutional learning do not require recurring founder validation.
+
+## Canonical distinction
+
+- **Subsystem**: World Vector, evidence graph, AMV, predictive engine, telemetry and cognitive runtime.
+- **Agent**: a registered cognitive or agentic capability that observes, reconstructs, simulates, projects, decides, reports or learns.
+- **Execution**: a trace of an agent or governed capability running.
+
+These three concepts must never share the same counter.

--- a/src/lib/root/sovereign/readers/readRootAgents.ts
+++ b/src/lib/root/sovereign/readers/readRootAgents.ts
@@ -15,60 +15,13 @@ type AgenticCapability = {
 };
 
 const AGENTIC_CAPABILITIES: AgenticCapability[] = [
-  {
-    id: 'world_vector_agent',
-    name: 'World Vector Agent',
-    purpose: 'Integra observación mundial, oportunidades y estado operativo para producir una lectura trazable.',
-    layer: 'observe',
-    route: '/api/root/agentic/world-vector',
-  },
-  {
-    id: 'moph_agent',
-    name: 'MOP-H Agent',
-    purpose: 'Interpreta una fricción observada y propone una perturbación mínima reversible sustentada por evidencia.',
-    layer: 'reconstruct',
-    route: '/api/interface/observatory/interpret',
-    providerAware: true,
-  },
-  {
-    id: 'neural_graph_agent',
-    name: 'Neural Graph Agent',
-    purpose: 'Recupera relaciones y evidencia del grafo persistido sin crear conexiones de respaldo.',
-    layer: 'relate',
-    route: '/api/root/agentic/neural-graph',
-  },
-  {
-    id: 'amv_agent',
-    name: 'AMV Agent',
-    purpose: 'Recupera memoria operativa, recurrencias y asociaciones institucionales persistidas.',
-    layer: 'remember',
-    route: '/api/root/agentic/amv',
-  },
-  {
-    id: 'prediction_agent',
-    name: 'Prediction Agent',
-    purpose: 'Formula predicciones y probabilidades con base explícita de evidencia e incertidumbre.',
-    layer: 'project',
-    route: '/api/root/agentic/prediction',
-  },
-  {
-    id: 'client_finder_agent',
-    name: 'Client Finder Agent',
-    purpose: 'Detecta oportunidades comerciales, ejecuta IFNORM y prepara una propuesta para revisión humana.',
-    layer: 'decide',
-    route: '/api/root/agentic/client-finder',
-    providerAware: true,
-    approvalRequired: true,
-  },
-  {
-    id: 'report_agent',
-    name: 'Report Agent',
-    purpose: 'Genera lecturas institucionales, calibraciones, borradores y reportes sustentados por evidencia.',
-    layer: 'report',
-    route: '/api/root/agentic/report',
-    providerAware: true,
-    approvalRequired: true,
-  },
+  { id: 'world_vector_agent', name: 'World Vector Agent', purpose: 'Integra observación mundial, oportunidades y estado operativo para producir una lectura trazable.', layer: 'observar', route: '/api/root/agentic/world-vector' },
+  { id: 'moph_agent', name: 'MOP-H Agent', purpose: 'Interpreta una fricción observada y propone una perturbación mínima reversible sustentada por evidencia.', layer: 'reconstruir', route: '/api/interface/observatory/interpret', providerAware: true },
+  { id: 'neural_graph_agent', name: 'Neural Graph Agent', purpose: 'Recupera relaciones y evidencia del grafo persistido sin crear conexiones de respaldo.', layer: 'relacionar', route: '/api/root/agentic/neural-graph' },
+  { id: 'amv_agent', name: 'AMV Agent', purpose: 'Recupera memoria operativa, recurrencias y asociaciones institucionales persistidas.', layer: 'recordar', route: '/api/root/agentic/amv' },
+  { id: 'prediction_agent', name: 'Prediction Agent', purpose: 'Formula predicciones y probabilidades con base explícita de evidencia e incertidumbre.', layer: 'proyectar', route: '/api/root/agentic/prediction' },
+  { id: 'client_finder_agent', name: 'Client Finder Agent', purpose: 'Detecta oportunidades comerciales, ejecuta IFNORM y prepara una propuesta para revisión humana.', layer: 'proponer', route: '/api/root/agentic/client-finder', providerAware: true, approvalRequired: true },
+  { id: 'report_agent', name: 'Report Agent', purpose: 'Genera lecturas institucionales, calibraciones, borradores y reportes sustentados por evidencia.', layer: 'reportar', route: '/api/root/agentic/report', providerAware: true, approvalRequired: true },
 ];
 
 function registryAgent(entry: (typeof SFI_COGNITIVE_AGENT_REGISTRY)[number]): RootAgent {
@@ -76,58 +29,59 @@ function registryAgent(entry: (typeof SFI_COGNITIVE_AGENT_REGISTRY)[number]): Ro
   const gated = entry.humanApprovalRequired === true;
   const status: RootDataStatus = missingCapability ? 'missing' : gated ? 'gated' : 'observed';
   const availability = missingCapability
-    ? 'capability_missing'
+    ? 'capacidad faltante'
     : entry.operationalMode
-      ? 'operational'
+      ? 'operativo'
       : gated
-        ? 'registered_gated'
-        : 'registered';
+        ? 'registrado · requiere autorización'
+        : 'registrado';
 
   return {
     id: entry.id,
-    role: `${entry.name} · ${entry.layer} · ${entry.purpose}`,
+    role: entry.name,
     state: {
       value: availability,
       status,
-      source: 'SFI_COGNITIVE_AGENT_REGISTRY',
+      source: 'Registro cognitivo canónico de SFI',
       observedAt: null,
       confidence: null,
       evidenceIds: [],
       explanation: missingCapability
-        ? 'El agente está registrado, pero declara una capacidad faltante y no debe presentarse como operativo.'
+        ? `Capa ${entry.layer}. El agente está registrado, pero declara una capacidad faltante.`
         : entry.operationalMode
-          ? 'El agente está registrado y declarado en modo operativo por el runtime cognitivo.'
-          : 'El agente existe en el registro canónico. Su ausencia de ejecución reciente no significa que no exista.',
-      warning: missingCapability ? 'Capacidad declarada como faltante.' : gated ? 'Requiere aprobación humana para acciones gobernadas.' : null,
+          ? `Capa ${entry.layer}. El runtime lo declara en modo operativo.`
+          : `Capa ${entry.layer}. El agente existe en el registro canónico; no tener una ejecución reciente no significa que no exista.`,
+      warning: missingCapability ? 'Capacidad declarada como faltante.' : gated ? 'Requiere autorización humana para acciones gobernadas.' : null,
     },
     provider: null,
     model: null,
     lastRun: null,
-    lastResult: null,
+    lastResult: entry.purpose,
     availability,
-    error: missingCapability ? 'missing_capability' : null,
+    error: missingCapability ? 'Capacidad faltante' : null,
   };
 }
 
 function capabilityAgent(entry: AgenticCapability): RootAgent {
+  const availability = entry.approvalRequired ? 'disponible · requiere autorización' : 'disponible';
   return {
     id: entry.id,
-    role: `${entry.name} · ${entry.layer} · ${entry.purpose}`,
+    role: entry.name,
     state: {
-      value: entry.approvalRequired ? 'available_gated' : 'available',
+      value: availability,
       status: entry.approvalRequired ? 'gated' : 'observed',
-      source: 'src/lib/agents + authenticated API route',
+      source: 'Capacidad agentic implementada y ruta autenticada',
       observedAt: null,
       confidence: null,
       evidenceIds: [],
-      explanation: 'Capacidad agentic implementada en código y expuesta mediante una ruta autenticada. La ejecución y el proveedor se observan por traza, no se inventan en este inventario.',
-      warning: entry.approvalRequired ? 'La salida puede requerir revisión humana antes de publicación, contacto o mutación.' : null,
+      explanation: `Capa ${entry.layer}. La capacidad está implementada. La última ejecución y el proveedor sólo deben mostrarse cuando exista una traza real.`,
+      warning: entry.approvalRequired ? 'La salida requiere revisión antes de publicación, contacto o mutación.' : null,
     },
-    provider: entry.providerAware ? 'resolved_at_runtime' : null,
-    model: entry.providerAware ? 'resolved_at_runtime' : null,
+    provider: entry.providerAware ? 'Se resuelve durante la ejecución' : null,
+    model: entry.providerAware ? 'Se resuelve durante la ejecución' : null,
     lastRun: null,
-    lastResult: null,
-    availability: entry.approvalRequired ? 'available_gated' : 'available',
+    lastResult: entry.purpose,
+    availability,
     error: null,
   };
 }
@@ -135,19 +89,14 @@ function capabilityAgent(entry: AgenticCapability): RootAgent {
 export async function readRootAgents() {
   const byId = new Map<string, RootAgent>();
 
-  for (const entry of SFI_COGNITIVE_AGENT_REGISTRY) {
-    byId.set(entry.id, registryAgent(entry));
-  }
-
-  for (const entry of AGENTIC_CAPABILITIES) {
-    if (!byId.has(entry.id)) byId.set(entry.id, capabilityAgent(entry));
-  }
+  for (const entry of SFI_COGNITIVE_AGENT_REGISTRY) byId.set(entry.id, registryAgent(entry));
+  for (const entry of AGENTIC_CAPABILITIES) if (!byId.has(entry.id)) byId.set(entry.id, capabilityAgent(entry));
 
   const agents = [...byId.values()].sort((a, b) => a.role.localeCompare(b.role, 'es'));
 
   return source(
     { agents },
-    'canonical cognitive registry + implemented agentic capabilities',
+    'Registro cognitivo canónico + capacidades agentic implementadas',
     [],
     null,
     false,

--- a/src/lib/root/sovereign/readers/readRootAgents.ts
+++ b/src/lib/root/sovereign/readers/readRootAgents.ts
@@ -1,131 +1,155 @@
 import 'server-only';
-import type { RootAgent, RootDataStatus, RootRow } from '../rootSovereignState';
-import { dateValue, selectRows, source, text } from './readerSupport';
 
-type AgentInput = {
+import { SFI_COGNITIVE_AGENT_REGISTRY } from '@/lib/sfi/cognitive-runtime/registry';
+import type { RootAgent, RootDataStatus } from '../rootSovereignState';
+import { source } from './readerSupport';
+
+type AgenticCapability = {
   id: string;
-  role: string;
-  sourceName: string;
-  row: RootRow | null;
-  error: string | null;
-  observedAt: string | null;
-  stateValue: string | null;
-  lastResult: string | null;
+  name: string;
+  purpose: string;
+  layer: string;
+  route: string;
+  providerAware?: boolean;
+  approvalRequired?: boolean;
 };
 
-function agent(input: AgentInput): RootAgent {
-  const status: RootDataStatus = input.error ? 'degraded' : input.row ? 'observed' : 'missing';
-  const stateValue = input.error ? 'degraded' : input.stateValue ?? (input.row ? 'observed' : 'empty');
+const AGENTIC_CAPABILITIES: AgenticCapability[] = [
+  {
+    id: 'world_vector_agent',
+    name: 'World Vector Agent',
+    purpose: 'Integra observación mundial, oportunidades y estado operativo para producir una lectura trazable.',
+    layer: 'observe',
+    route: '/api/root/agentic/world-vector',
+  },
+  {
+    id: 'moph_agent',
+    name: 'MOP-H Agent',
+    purpose: 'Interpreta una fricción observada y propone una perturbación mínima reversible sustentada por evidencia.',
+    layer: 'reconstruct',
+    route: '/api/interface/observatory/interpret',
+    providerAware: true,
+  },
+  {
+    id: 'neural_graph_agent',
+    name: 'Neural Graph Agent',
+    purpose: 'Recupera relaciones y evidencia del grafo persistido sin crear conexiones de respaldo.',
+    layer: 'relate',
+    route: '/api/root/agentic/neural-graph',
+  },
+  {
+    id: 'amv_agent',
+    name: 'AMV Agent',
+    purpose: 'Recupera memoria operativa, recurrencias y asociaciones institucionales persistidas.',
+    layer: 'remember',
+    route: '/api/root/agentic/amv',
+  },
+  {
+    id: 'prediction_agent',
+    name: 'Prediction Agent',
+    purpose: 'Formula predicciones y probabilidades con base explícita de evidencia e incertidumbre.',
+    layer: 'project',
+    route: '/api/root/agentic/prediction',
+  },
+  {
+    id: 'client_finder_agent',
+    name: 'Client Finder Agent',
+    purpose: 'Detecta oportunidades comerciales, ejecuta IFNORM y prepara una propuesta para revisión humana.',
+    layer: 'decide',
+    route: '/api/root/agentic/client-finder',
+    providerAware: true,
+    approvalRequired: true,
+  },
+  {
+    id: 'report_agent',
+    name: 'Report Agent',
+    purpose: 'Genera lecturas institucionales, calibraciones, borradores y reportes sustentados por evidencia.',
+    layer: 'report',
+    route: '/api/root/agentic/report',
+    providerAware: true,
+    approvalRequired: true,
+  },
+];
+
+function registryAgent(entry: (typeof SFI_COGNITIVE_AGENT_REGISTRY)[number]): RootAgent {
+  const missingCapability = entry.missingCapability === true;
+  const gated = entry.humanApprovalRequired === true;
+  const status: RootDataStatus = missingCapability ? 'missing' : gated ? 'gated' : 'observed';
+  const availability = missingCapability
+    ? 'capability_missing'
+    : entry.operationalMode
+      ? 'operational'
+      : gated
+        ? 'registered_gated'
+        : 'registered';
+
   return {
-    id: input.id,
-    role: input.role,
+    id: entry.id,
+    role: `${entry.name} · ${entry.layer} · ${entry.purpose}`,
     state: {
-      value: stateValue,
+      value: availability,
       status,
-      source: input.sourceName,
-      observedAt: input.observedAt,
+      source: 'SFI_COGNITIVE_AGENT_REGISTRY',
+      observedAt: null,
       confidence: null,
       evidenceIds: [],
-      explanation: 'Estado derivado de la última fila persistida del subsistema; no es un health score.',
-      warning: input.error,
+      explanation: missingCapability
+        ? 'El agente está registrado, pero declara una capacidad faltante y no debe presentarse como operativo.'
+        : entry.operationalMode
+          ? 'El agente está registrado y declarado en modo operativo por el runtime cognitivo.'
+          : 'El agente existe en el registro canónico. Su ausencia de ejecución reciente no significa que no exista.',
+      warning: missingCapability ? 'Capacidad declarada como faltante.' : gated ? 'Requiere aprobación humana para acciones gobernadas.' : null,
     },
     provider: null,
     model: null,
-    lastRun: input.observedAt,
-    lastResult: input.lastResult,
-    availability: input.error ? 'degraded' : input.row ? 'available' : 'empty',
-    error: input.error,
+    lastRun: null,
+    lastResult: null,
+    availability,
+    error: missingCapability ? 'missing_capability' : null,
+  };
+}
+
+function capabilityAgent(entry: AgenticCapability): RootAgent {
+  return {
+    id: entry.id,
+    role: `${entry.name} · ${entry.layer} · ${entry.purpose}`,
+    state: {
+      value: entry.approvalRequired ? 'available_gated' : 'available',
+      status: entry.approvalRequired ? 'gated' : 'observed',
+      source: 'src/lib/agents + authenticated API route',
+      observedAt: null,
+      confidence: null,
+      evidenceIds: [],
+      explanation: 'Capacidad agentic implementada en código y expuesta mediante una ruta autenticada. La ejecución y el proveedor se observan por traza, no se inventan en este inventario.',
+      warning: entry.approvalRequired ? 'La salida puede requerir revisión humana antes de publicación, contacto o mutación.' : null,
+    },
+    provider: entry.providerAware ? 'resolved_at_runtime' : null,
+    model: entry.providerAware ? 'resolved_at_runtime' : null,
+    lastRun: null,
+    lastResult: null,
+    availability: entry.approvalRequired ? 'available_gated' : 'available',
+    error: null,
   };
 }
 
 export async function readRootAgents() {
-  const [world, sfiGraph, canonicalGraph, amv, prediction] = await Promise.all([
-    selectRows({
-      table: 'world_vector_observations',
-      select: 'id,status,confidence,dominant_signal,warnings,observed_at,created_at',
-      order: 'observed_at',
-      limit: 1,
-    }),
-    selectRows({
-      table: 'sfi_graph_nodes',
-      select: 'id,node_key,status,updated_at,created_at',
-      order: 'updated_at',
-      limit: 1,
-    }),
-    selectRows({
-      table: 'graph_nodes',
-      select: 'id,node_key,node_type,epistemic_class,updated_at,created_at',
-      order: 'updated_at',
-      limit: 1,
-    }),
-    selectRows({
-      table: 'sfi_amv_memory',
-      select: 'id,module,evaluation,requires_human_validation,created_at',
-      order: 'created_at',
-      limit: 1,
-    }),
-    selectRows({
-      table: 'sfi_predictive_runs',
-      select: 'id,status,calibration_status,subject_type,subject_id,updated_at,created_at',
-      order: 'updated_at',
-      limit: 1,
-    }),
-  ]);
+  const byId = new Map<string, RootAgent>();
 
-  const worldRow = world.rows[0] ?? null;
-  const graphRow = sfiGraph.rows[0] ?? canonicalGraph.rows[0] ?? null;
-  const graphError = [sfiGraph.error, canonicalGraph.error].filter(Boolean).join(' | ') || null;
-  const amvRow = amv.rows[0] ?? null;
-  const predictionRow = prediction.rows[0] ?? null;
+  for (const entry of SFI_COGNITIVE_AGENT_REGISTRY) {
+    byId.set(entry.id, registryAgent(entry));
+  }
 
-  const agents: RootAgent[] = [
-    agent({
-      id: 'WORLD-VECTOR',
-      role: 'World Vector observation',
-      sourceName: 'world_vector_observations',
-      row: worldRow,
-      error: world.error,
-      observedAt: dateValue(worldRow?.observed_at ?? worldRow?.created_at),
-      stateValue: text(worldRow?.status, '') || null,
-      lastResult: text(worldRow?.dominant_signal, '') || null,
-    }),
-    agent({
-      id: 'NEURAL-GRAPH',
-      role: 'Persistent evidence graph',
-      sourceName: 'sfi_graph_nodes + graph_nodes',
-      row: graphRow,
-      error: graphError,
-      observedAt: dateValue(graphRow?.updated_at ?? graphRow?.created_at),
-      stateValue: text(graphRow?.status ?? graphRow?.epistemic_class, '') || null,
-      lastResult: graphRow ? text(graphRow.node_key ?? graphRow.id, 'node persisted') : null,
-    }),
-    agent({
-      id: 'AMV',
-      role: 'Operational memory',
-      sourceName: 'sfi_amv_memory',
-      row: amvRow,
-      error: amv.error,
-      observedAt: dateValue(amvRow?.created_at),
-      stateValue: amvRow ? 'persisted' : null,
-      lastResult: amvRow ? text(amvRow.module, 'memory persisted') : null,
-    }),
-    agent({
-      id: 'PREDICTION',
-      role: 'Predictive learning engine',
-      sourceName: 'sfi_predictive_runs',
-      row: predictionRow,
-      error: prediction.error,
-      observedAt: dateValue(predictionRow?.updated_at ?? predictionRow?.created_at),
-      stateValue: text(predictionRow?.status, '') || null,
-      lastResult: predictionRow ? [predictionRow.subject_type, predictionRow.subject_id].filter(Boolean).map(String).join(' · ') || null : null,
-    }),
-  ];
+  for (const entry of AGENTIC_CAPABILITIES) {
+    if (!byId.has(entry.id)) byId.set(entry.id, capabilityAgent(entry));
+  }
+
+  const agents = [...byId.values()].sort((a, b) => a.role.localeCompare(b.role, 'es'));
 
   return source(
     { agents },
-    'persisted subsystem status',
-    [world.error, graphError, amv.error, prediction.error],
-    agents.map((item) => item.lastRun).find(Boolean) ?? null,
+    'canonical cognitive registry + implemented agentic capabilities',
+    [],
+    null,
     false,
   );
 }


### PR DESCRIPTION
## Root cause
`readRootAgents()` did not read the SFI agent inventory. It manually created exactly four entries from World Vector, graph, AMV and prediction subsystem rows. Those were subsystem status proxies, not agents, so ROOT always displayed 4.

## Fix
- Replaces the fixed four-item array with `SFI_COGNITIVE_AGENT_REGISTRY`.
- Adds implemented agentic capabilities that are not represented as subsystem rows: World Vector Agent, MOP-H Agent, Neural Graph Agent, AMV Agent, Prediction Agent, Client Finder Agent and Report Agent.
- Deduplicates by canonical agent ID.
- Distinguishes registered, operational, gated and missing-capability states.
- Does not invent last-run time, provider or model. Those remain absent unless observed in a real execution trace.
- Presents readable names and purposes instead of subsystem/table terminology.

## ROOT information contract
Adds `docs/ROOT_INFORMATION_CONTRACT.md` defining exactly what each ROOT layer consumes and must not manufacture:
- Signals
- Evidence
- Hypotheses and predictions
- Memory
- Attractors/ejectors
- Agents
- History
- Governance

The contract also separates subsystem, agent and execution counters.

## Integrity
- No mock agents or fabricated executions.
- No database schema changes.
- No duplicate agent implementations.
- Existing canonical registry and authenticated agentic routes remain the source of truth.