### PR TITLE
Register Edwing as SFI member with dedicated workspace

### DIFF
--- a/src/app/member/page.tsx
+++ b/src/app/member/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { requireSfiMemberPage } from '@/lib/system/access/server';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Espacio de miembro · System Friction Institute',
+  description: 'Espacio institucional para miembros de SFI.',
+  robots: { index: false, follow: false, nocache: true },
+};
+
+export default async function MemberPage() {
+  const { user, profile, member, supabase } = await requireSfiMemberPage('/member');
+
+  const [cases, objects, returns] = await Promise.all([
+    supabase.from('field_cases').select('id', { count: 'exact', head: true }).eq('owner_id', user.id).is('deleted_at', null),
+    supabase.from('studio_objects').select('id', { count: 'exact', head: true }).eq('owner_id', user.id),
+    supabase.from('field_returns').select('id', { count: 'exact', head: true }).eq('owner_id', user.id).is('returned_at', null),
+  ]);
+
+  const displayName = member?.displayName ?? profile.alias ?? user.email ?? 'Miembro SFI';
+
+  return (
+    <main className="min-h-screen bg-[#050504] px-5 py-8 text-[#d8d1c0] md:px-10">
+      <div className="mx-auto max-w-6xl">
+        <header className="border border-[#332c20] bg-[#090908] p-6 md:p-9">
+          <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[#c8a951]">SYSTEM FRICTION INSTITUTE · MIEMBRO</p>
+          <h1 className="mt-4 font-serif text-4xl text-[#f2e8d2]">Bienvenido, {displayName}.</h1>
+          <p className="mt-4 max-w-3xl text-sm leading-7 text-[#999080]">
+            Este es tu espacio institucional dentro de SFI. Aquí puedes construir una trayectoria en FIELD,
+            trabajar objetos en STUDIO y consultar el campo mundial y el observatorio público. ROOT permanece
+            reservado para la gobernanza del instituto.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-2 font-mono text-[9px] uppercase tracking-[0.13em]">
+            <span className="border border-[#332c20] px-3 py-2 text-[#a69a83]">{user.email}</span>
+            <span className="border border-[#5b4b28] px-3 py-2 text-[#c8a951]">Rol: {String(profile.role)}</span>
+            <span className="border border-[#332c20] px-3 py-2 text-[#a69a83]">Membresía SFI activa</span>
+          </div>
+        </header>
+
+        <section className="mt-6 grid gap-4 md:grid-cols-3">
+          <article className="border border-[#332c20] bg-[#090908] p-5">
+            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#98896b]">Trayectorias propias</span>
+            <strong className="mt-3 block text-3xl font-normal text-[#e4c377]">{cases.count ?? 0}</strong>
+            <p className="mt-3 text-xs leading-6 text-[#8e8575]">Procesos longitudinales que has abierto en FIELD.</p>
+          </article>
+          <article className="border border-[#332c20] bg-[#090908] p-5">
+            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#98896b]">Objetos propios</span>
+            <strong className="mt-3 block text-3xl font-normal text-[#e4c377]">{objects.count ?? 0}</strong>
+            <p className="mt-3 text-xs leading-6 text-[#8e8575]">Objetos que has trasladado o cargado en STUDIO.</p>
+          </article>
+          <article className="border border-[#332c20] bg-[#090908] p-5">
+            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#98896b]">Retornos pendientes</span>
+            <strong className="mt-3 block text-3xl font-normal text-[#e4c377]">{returns.count ?? 0}</strong>
+            <p className="mt-3 text-xs leading-6 text-[#8e8575]">Puntos de revisión que todavía necesitan observación posterior.</p>
+          </article>
+        </section>
+
+        <section className="mt-6 grid gap-4 md:grid-cols-2">
+          <Link href="/interface" className="group border border-[#5b4b28] bg-[#0b0a08] p-6 no-underline hover:border-[#c8a951]">
+            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">FIELD</span>
+            <h2 className="mt-3 text-2xl text-[#f0e4c9]">Observar y construir una trayectoria</h2>
+            <p className="mt-3 text-sm leading-7 text-[#908777]">Conserva apariciones, organiza evidencia y prueba microejecuciones reversibles sin concluir demasiado pronto.</p>
+          </Link>
+          <Link href="/studio" className="group border border-[#5b4b28] bg-[#0b0a08] p-6 no-underline hover:border-[#c8a951]">
+            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">STUDIO</span>
+            <h2 className="mt-3 text-2xl text-[#f0e4c9]">Analizar o transformar un objeto</h2>
+            <p className="mt-3 text-sm leading-7 text-[#908777]">Trabaja sobre objetos propios y prepara resultados que puedan volver a FIELD como evidencia o retorno.</p>
+          </Link>
+          <Link href="/field/map" className="group border border-[#332c20] bg-[#090908] p-6 no-underline hover:border-[#c8a951]">
+            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">CAMPO MUNDIAL</span>
+            <h2 className="mt-3 text-2xl text-[#f0e4c9]">Explorar señales localizadas</h2>
+            <p className="mt-3 text-sm leading-7 text-[#908777]">Observa eventos y tensiones geográficas sin asumir causalidad por su ubicación.</p>
+          </Link>
+          <Link href="/observatory" className="group border border-[#332c20] bg-[#090908] p-6 no-underline hover:border-[#c8a951]">
+            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">OBSERVATORIO PÚBLICO</span>
+            <h2 className="mt-3 text-2xl text-[#f0e4c9]">Consultar la lectura agregada</h2>
+            <p className="mt-3 text-sm leading-7 text-[#908777]">Revisa el estado longitudinal publicado por SFI y sus límites metodológicos.</p>
+          </Link>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/unauthorized/page.tsx
+++ b/src/app/unauthorized/page.tsx
@@ -1,15 +1,28 @@
-// src/app/unauthorized/page.tsx
-export default function UnauthorizedPage() {
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { findInstitutionalMember } from '@/lib/system/access/institutionalMembers';
+import { createServerSupabaseClient } from '@/runtime/supabase/server';
+
+export const dynamic = 'force-dynamic';
+
+export default async function UnauthorizedPage() {
+  const supabase = await createServerSupabaseClient();
+  const { data } = await supabase.auth.getUser();
+  if (findInstitutionalMember(data.user?.email)) redirect('/member');
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-void text-paper">
-      <div className="terminal-panel max-w-md p-8 text-center">
-        <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-gold">Umbral ROOT</p>
-        <h1 className="mt-3 font-display text-2xl text-red-500">Acceso bloqueado</h1>
-        <p className="mt-4 text-sm text-paper/80">Acceso bloqueado porque esta sesion no tiene permiso raiz.</p>
-        <p className="mt-3 text-xs text-paper/55">
-          Accion siguiente: volver al umbral, iniciar sesion con permiso raiz o revisar si la sesion expiro.
+    <div className="flex min-h-screen items-center justify-center bg-void px-5 text-paper">
+      <div className="terminal-panel max-w-lg p-8 text-center">
+        <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-gold">Acceso institucional SFI</p>
+        <h1 className="mt-3 font-display text-2xl text-red-500">Esta superficie no corresponde a tu cuenta</h1>
+        <p className="mt-4 text-sm text-paper/80">
+          ROOT está reservado para la gobernanza del instituto. Una cuenta autenticada puede seguir utilizando las superficies que tenga asignadas.
         </p>
-        <a href="/" className="mt-6 inline-block text-gold underline">Volver al umbral</a>
+        <div className="mt-6 flex flex-wrap justify-center gap-3">
+          <Link href="/member" className="border border-gold/50 px-4 py-2 text-gold">Ir a mi espacio</Link>
+          <Link href="/interface" className="border border-paper/20 px-4 py-2 text-paper/75">Ir a FIELD</Link>
+          <Link href="/" className="border border-paper/20 px-4 py-2 text-paper/75">Inicio</Link>
+        </div>
       </div>
     </div>
   );

--- a/src/lib/system/access/institutionalMembers.ts
+++ b/src/lib/system/access/institutionalMembers.ts
@@ -1,0 +1,40 @@
+export type SfiInstitutionalMember = {
+  email: string;
+  displayName: string;
+  role: 'operator' | 'controller';
+  workspace: '/member';
+  modules: {
+    field: boolean;
+    studio: boolean;
+    observatory: boolean;
+    worldField: boolean;
+    root: false;
+  };
+};
+
+const MEMBERS: SfiInstitutionalMember[] = [
+  {
+    email: 'edwing.tzolkin@gmail.com',
+    displayName: 'Edwing',
+    role: 'operator',
+    workspace: '/member',
+    modules: {
+      field: true,
+      studio: true,
+      observatory: true,
+      worldField: true,
+      root: false,
+    },
+  },
+];
+
+export function normalizeMemberEmail(value: string | null | undefined) {
+  return value?.trim().toLowerCase() ?? '';
+}
+
+export function findInstitutionalMember(email: string | null | undefined) {
+  const normalized = normalizeMemberEmail(email);
+  return MEMBERS.find((member) => member.email === normalized) ?? null;
+}
+
+export const SFI_INSTITUTIONAL_MEMBERS = MEMBERS;

--- a/src/lib/system/access/server.ts
+++ b/src/lib/system/access/server.ts
@@ -2,11 +2,12 @@ import 'server-only';
 
 import { redirect } from 'next/navigation';
 import { createServerSupabaseClient, createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { findInstitutionalMember } from './institutionalMembers';
 
 export class AccessDeniedError extends Error {
   constructor(
     public readonly status: 401 | 403 | 404,
-    public readonly code: 'AUTH_REQUIRED' | 'FOUNDER_REQUIRED' | 'FIELD_USER_REQUIRED' | 'OWNER_REQUIRED' | 'NOT_FOUND',
+    public readonly code: 'AUTH_REQUIRED' | 'FOUNDER_REQUIRED' | 'FIELD_USER_REQUIRED' | 'SFI_MEMBER_REQUIRED' | 'OWNER_REQUIRED' | 'NOT_FOUND',
     message: string,
   ) {
     super(message);
@@ -40,19 +41,75 @@ export async function requireAuthenticatedUser() {
   return { supabase, user: data.user };
 }
 
-export async function requireFieldUser() {
-  const context = await requireAuthenticatedUser();
-  const { data: profile } = await context.supabase
+async function readOrProvisionInstitutionalProfile(user: { id: string; email?: string | null }) {
+  const member = findInstitutionalMember(user.email);
+  const service = createServiceSupabaseClient();
+  const existing = await service
     .from('profiles')
-    .select('role')
-    .eq('user_id', context.user.id)
+    .select('user_id,alias,email,role,module_access,subscription_tier')
+    .eq('user_id', user.id)
     .maybeSingle();
 
-  if (!profile) {
+  if (existing.error) throw existing.error;
+  if (existing.data) return { profile: existing.data, member };
+  if (!member) return { profile: null, member: null };
+
+  const inserted = await service
+    .from('profiles')
+    .insert({
+      user_id: user.id,
+      alias: member.displayName,
+      email: member.email,
+      role: member.role,
+      subscription_tier: 'enterprise',
+      module_access: {
+        observatory: member.modules.observatory,
+        planner: member.modules.field,
+        simulator: member.modules.studio,
+        executor: false,
+        social: member.modules.worldField,
+        field: member.modules.field,
+        studio: member.modules.studio,
+        world_field: member.modules.worldField,
+        root: false,
+      },
+      last_seen_at: new Date().toISOString(),
+    })
+    .select('user_id,alias,email,role,module_access,subscription_tier')
+    .single();
+
+  if (inserted.error || !inserted.data) throw inserted.error ?? new Error('SFI member profile could not be created.');
+  return { profile: inserted.data, member };
+}
+
+export async function requireSfiMember() {
+  const context = await requireAuthenticatedUser();
+  const resolved = await readOrProvisionInstitutionalProfile(context.user);
+  const allowedRoles = new Set(['operator', 'controller', 'root', 'system']);
+  if (!resolved.profile || (!allowedRoles.has(String(resolved.profile.role)) && !resolved.member)) {
+    throw new AccessDeniedError(403, 'SFI_MEMBER_REQUIRED', 'An active SFI institutional membership is required.');
+  }
+  return { ...context, profile: resolved.profile, member: resolved.member };
+}
+
+export async function requireSfiMemberPage(nextPath = '/member') {
+  try {
+    return await requireSfiMember();
+  } catch (error) {
+    if (error instanceof AccessDeniedError && error.status === 401) {
+      redirect(`/login?next=${encodeURIComponent(nextPath)}`);
+    }
+    redirect('/unauthorized');
+  }
+}
+
+export async function requireFieldUser() {
+  const context = await requireAuthenticatedUser();
+  const resolved = await readOrProvisionInstitutionalProfile(context.user);
+  if (!resolved.profile) {
     throw new AccessDeniedError(403, 'FIELD_USER_REQUIRED', 'A FIELD profile is required.');
   }
-
-  return { ...context, profile };
+  return { ...context, profile: resolved.profile };
 }
 
 export async function requireFounder() {

--- a/supabase/migrations/20260803201500_register_edwing_sfi_member.sql
+++ b/supabase/migrations/20260803201500_register_edwing_sfi_member.sql
@@ -1,0 +1,41 @@
+-- Register the existing Supabase account as an SFI institutional operator.
+-- This does not grant ROOT/founder authority.
+insert into public.profiles (
+  user_id,
+  alias,
+  email,
+  role,
+  subscription_tier,
+  module_access,
+  created_at,
+  updated_at
+)
+select
+  users.id,
+  'Edwing',
+  lower(users.email),
+  'operator',
+  'enterprise',
+  jsonb_build_object(
+    'observatory', true,
+    'planner', true,
+    'simulator', true,
+    'executor', false,
+    'social', true,
+    'field', true,
+    'studio', true,
+    'world_field', true,
+    'root', false
+  ),
+  now(),
+  now()
+from auth.users as users
+where lower(users.email) = 'edwing.tzolkin@gmail.com'
+on conflict (user_id) do update
+set
+  alias = case when public.profiles.alias is null or btrim(public.profiles.alias) = '' then excluded.alias else public.profiles.alias end,
+  email = excluded.email,
+  role = case when public.profiles.role in ('root', 'controller') then public.profiles.role else 'operator' end,
+  subscription_tier = 'enterprise',
+  module_access = coalesce(public.profiles.module_access, '{}'::jsonb) || excluded.module_access,
+  updated_at = now();


### PR DESCRIPTION
## Problem
The Supabase account `edwing.tzolkin@gmail.com` exists, but application access requires a `profiles` row. Authentication alone therefore produced repeated access-denied responses.

## Fix
- Registers Edwing as an SFI institutional `operator`.
- Adds `/member` as his dedicated institutional workspace.
- Provides FIELD, STUDIO, World Field and Public Observatory access.
- Explicitly keeps ROOT/founder governance unavailable.
- Adds self-healing server provisioning when the known member signs in without a profile row.
- Adds a database migration that links the existing `auth.users` account by normalized email.
- Redirects this member from the generic ROOT denial page to `/member`.

## Security boundary
- Exact normalized email match.
- No ROOT authorization.
- No publication or external-execution authority.
- Existing ownership and RLS boundaries remain in effect.
- Member sees only their own FIELD and STUDIO records.

## Files
- `src/lib/system/access/institutionalMembers.ts`
- `src/lib/system/access/server.ts`
- `src/app/member/page.tsx`
- `src/app/unauthorized/page.tsx`
- `supabase/migrations/20260803201500_register_edwing_sfi_member.sql`