### PR TITLE
Constitute the 15-document SFI canonical corpus

### DIFF
--- a/.github/workflows/mihm-contract-validation.yml
+++ b/.github/workflows/mihm-contract-validation.yml
@@ -13,6 +13,7 @@ on:
       - 'src/app/ledger/**'
       - 'src/app/atlas/**'
       - 'docs/MIHM_PHI_CANON.md'
+      - 'docs/canon/**'
       - '.github/workflows/mihm-contract-validation.yml'
   workflow_dispatch:
 
@@ -39,5 +40,5 @@ jobs:
       - name: TypeScript
         run: npm run typecheck
 
-      - name: MIHM formula and contract tests
-        run: node --import tsx --test src/core/formulas/canonicalFormulas.test.ts src/lib/mihm/phiContract.test.ts
+      - name: MIHM formula, Phi and variable registry tests
+        run: node --import tsx --test src/core/formulas/canonicalFormulas.test.ts src/lib/mihm/phiContract.test.ts src/lib/mihm/canonicalVariableRegistry.test.ts

--- a/docs/canon/01_SFI_CONSTITUTION.md
+++ b/docs/canon/01_SFI_CONSTITUTION.md
@@ -1,0 +1,18 @@
+# 01 · SFI Constitution
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.constitution.v1
+
+System Friction Institute observes systems before concluding about them. Its institutional sequence is:
+
+`observe → preserve → relate → hypothesize → test reversibly → record return → learn → govern promotion`
+
+SFI distinguishes reality, records, derivations, simulations and decisions. It does not convert absence into plausible data, simulation into observation, or model output into institutional fact.
+
+MIHM is the meta-methodological framework. Methods are instruments inside MIHM; they do not become interchangeable merely because they share variables or normalized scales.
+
+ROOT/ACP is the sovereign promotion authority. Agents and models may extract, propose, calculate, compare and explain. They may not approve their own outputs, modify formulas silently, fabricate sources or promote experimental state into canonical state.
+
+Every canonical object must have identity, scope, time, provenance, epistemic status and version. Every mutation must be attributable and reversible or explicitly declared irreversible.
+
+Unknown or conflicting information remains unknown or conflicted. This is not a system error; it is a valid institutional state.

--- a/docs/canon/02_EPISTEMIC_CLASSES.md
+++ b/docs/canon/02_EPISTEMIC_CLASSES.md
@@ -1,0 +1,24 @@
+# 02 · Epistemic Classes
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.epistemic.v1
+
+Every assertion, variable instance and result must declare one class:
+
+- `OBSERVED`: directly supported by an identified source or measurement.
+- `DECLARED`: stated by an identified actor but not independently verified.
+- `IMPORTED`: copied from an external system with source identity preserved.
+- `EXTRACTED`: obtained from source material without adding meaning beyond the source.
+- `DERIVED`: deterministically calculated from identified inputs.
+- `INFERRED`: interpretation whose premises and uncertainty are explicit.
+- `SIMULATED`: produced inside a declared model or scenario.
+- `PROPOSED`: candidate awaiting evidence or governance.
+- `MISSING`: required information is absent.
+- `DEGRADED`: information exists but fails a quality requirement.
+- `CONFLICTED`: two or more qualified sources or contracts disagree.
+- `REJECTED`: evaluated and not admitted.
+- `CANONICAL`: promoted by the authorized governance process.
+
+Confidence never changes class. A high-confidence inference remains inferred. A realistic simulation remains simulated. A declared statement remains declared until evidence changes its status.
+
+Interfaces may simplify labels for users, but stored state must retain the canonical class.

--- a/docs/canon/03_OBSERVATION_OBJECT_IDENTITY.md
+++ b/docs/canon/03_OBSERVATION_OBJECT_IDENTITY.md
@@ -1,0 +1,21 @@
+# 03 · Observation Object Identity
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.object-identity.v1
+
+No metric exists without an observed object. Each reading must identify:
+
+- `object_id`;
+- `object_type`;
+- owner or institutional scope;
+- temporal scope;
+- method and instrument;
+- source lineage.
+
+Canonical object types include person, session, bounded system, artifact, signal, phenomenon, case, organization, world context and SFI institution.
+
+A reading cannot be reassigned to another object merely because the variables have the same names. IHG, NTI or LDI measured for an artifact do not become institutional indicators. A personal session cannot stand in for a global human state. A world-context vector cannot stand in for SFI health.
+
+When legacy data lacks sufficient object identity, the record is `DEGRADED` and cannot be promoted until context is recovered. The correct repair is contextual migration, not a blind rename.
+
+Object identity precedes formula selection. If the object is unknown, the method selection result must be `AMBIGUOUS` or `BLOCKED`.

--- a/docs/canon/04_CANONICAL_VARIABLE_REGISTRY.md
+++ b/docs/canon/04_CANONICAL_VARIABLE_REGISTRY.md
@@ -1,0 +1,28 @@
+# 04 · Canonical Variable Registry
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.variables.v1
+
+A variable may be used canonically only when its registry entry declares:
+
+- canonical identifier and display symbol;
+- meaning and observed dimension;
+- permitted object types and methods;
+- data type, unit and valid range;
+- origin classes allowed;
+- missing-value policy;
+- formula authority and version when derived;
+- aliases and migration conditions.
+
+Variable names are classified as:
+
+- `CANONICAL`: valid for new records.
+- `ALIAS_UNAMBIGUOUS`: automatically resolvable to one canonical identifier.
+- `ALIAS_CONTEXTUAL`: resolvable only after method/object context is supplied.
+- `DEPRECATED`: readable for history but invalid for new writes.
+- `PROHIBITED`: must fail validation.
+- `UNKNOWN`: not in the registry; must not be invented or silently accepted.
+
+A redirect is safe only for an unambiguous alias. `PHI_SYSTEMIC → PHI_S` is safe. `PHI_SF` is contextual because historical records use it for both bounded systems and SFI. It must resolve from object context or remain conflicted.
+
+The laboratory may propose variables, but proposed variables remain namespaced `LAB_*` until approved and registered. Production writers must reject unregistered identifiers.

--- a/docs/canon/05_MIHM_METHOD_SELECTION.md
+++ b/docs/canon/05_MIHM_METHOD_SELECTION.md
@@ -1,0 +1,20 @@
+# 05 · MIHM Method Selection
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.method-selection.v2
+
+MIHM selects a method from the object, temporal scope, evidence modality and analytical purpose. It does not select a method from the variable name alone.
+
+Canonical primary methods:
+
+- `MOP_H`: identified person within an identified session.
+- `SCOREFRICTION`: bounded object, artifact, signal or system.
+- `PPOI`: longitudinal phenomenon with accumulated observations.
+- `WORLD_VECTOR`: current world-context synthesis.
+- `SFI_INSTITUTIONAL`: System Friction Institute as the observed institution.
+
+Supporting methods may add context but cannot overwrite the primary method's reading. World Vector may contextualize ScoreFriction; it cannot replace it. MOP-H may describe human impact; it cannot calculate institutional state.
+
+Selection outcomes are `READY`, `AMBIGUOUS` or `BLOCKED`. Required identifiers must be present before execution. A requested method that conflicts with object type must be rejected or sent to governance review.
+
+Every method execution records method version, object ID, temporal window, inputs, formula or model version, output class and warnings.

--- a/docs/canon/06_MIHM_PHI_FAMILY.md
+++ b/docs/canon/06_MIHM_PHI_FAMILY.md
@@ -1,0 +1,19 @@
+# 06 · MIHM Phi Family
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.phi-family.v1  
+**Primary authority:** `docs/MIHM_PHI_CANON.md`
+
+The canonical family is:
+
+- `PHI_H / Φ_H`: human session state through MOP-H.
+- `PHI_S / Φ_S`: bounded system or object state through ScoreFriction.
+- `PHI_F / Φ_F`: normalized phenomenon persistence through PPOI.
+- `PHI_W / Φ_W`: world-context state; WSI alias in the current version.
+- `PHI_SFI / Φ_SFI`: institutional state of System Friction Institute.
+
+All outputs use scale `0–1`. Shared scale is a transport and presentation convention, not proof of semantic equivalence. Cross-method averaging, substitution and ranking are prohibited unless a separately approved comparison method defines them.
+
+Every Phi reading must include object, method, dimension, formula version, timestamp, epistemic class, confidence and provenance.
+
+Legacy identifiers are migration inputs, not valid new outputs. `PHI_SF` requires object context and cannot be globally redirected.

--- a/docs/canon/07_EVIDENCE_AND_PROVENANCE.md
+++ b/docs/canon/07_EVIDENCE_AND_PROVENANCE.md
@@ -1,0 +1,16 @@
+# 07 · Evidence and Provenance
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.evidence.v1
+
+Evidence is an identified record capable of supporting or challenging a claim. Each evidence item must preserve source, acquisition method, observed time, ingestion time, owner or scope, content hash when available, and lineage.
+
+Evidence strength is separate from epistemic class. A declared statement may be weak or strong as testimony but remains `DECLARED`. A deterministic calculation may be exact but remains `DERIVED`.
+
+No interface, agent or migration may fabricate evidence IDs, dates, sources or relationships. Missing evidence is represented as a request or blocker.
+
+Derived and inferred outputs must list the evidence and variable instances used. Simulations must list their source dataset, scenario assumptions, seed and model version.
+
+A source may be superseded but not erased from lineage. Corrections append a new version and relation to the corrected record.
+
+Public views expose only authorized summaries. Private evidence remains accessible according to ownership, RLS and governance rules. Redaction must preserve the existence and identity of the evidence relationship without leaking protected content.

--- a/docs/canon/08_HYPOTHESES_PROPOSITIONS_PREDICTIONS.md
+++ b/docs/canon/08_HYPOTHESES_PROPOSITIONS_PREDICTIONS.md
@@ -1,0 +1,16 @@
+# 08 · Hypotheses, Propositions and Predictions
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.propositions.v1
+
+A hypothesis is an explanatory candidate. A proposition is a structured conditional statement. A prediction is a proposition registered before its evaluation window or perturbation.
+
+Each item must declare subject, antecedents, expected consequence, temporal horizon, assumptions, confidence, supporting and opposing evidence, falsification condition and creator.
+
+A retrospective explanation is not predictive evidence. A prediction recorded after the observed outcome is classified as retrospective.
+
+Model-generated statements are `PROPOSED` or `INFERRED` until evaluated. Confidence does not promote them.
+
+Contradictory hypotheses may coexist. The system must preserve rival explanations rather than selecting one by narrative fluency.
+
+Outcomes update calibration and evidence state; they do not rewrite the original prediction. Failed hypotheses remain in the ledger with their failure reason and any refinement.

--- a/docs/canon/09_METHOD_LAB_AND_SIMULATION.md
+++ b/docs/canon/09_METHOD_LAB_AND_SIMULATION.md
@@ -1,0 +1,16 @@
+# 09 · Method Lab and Simulation
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.method-lab.v1
+
+Method Lab is an isolated experimental context. It may read authorized canonical state and produce candidate variables, methods, propositions, simulations, calibration results and promotion requests. It may not mutate canonical state directly.
+
+Laboratory identifiers use the `LAB_*` namespace until promoted. A candidate variable is not available to production methods merely because a model extracted it from narrative.
+
+Canonical simulation families are deterministic rules, historical replay, Monte Carlo, controlled perturbation, graph propagation, system dynamics, agent-based and counterfactual. Each run records method version, dataset hash, parameters, seed, code commit, provider/model when used, timestamps and result hash.
+
+Simulation output is always `SIMULATED`. It may validate internal consistency or estimate sensitivity; it does not become observed evidence.
+
+Validation levels are structural, logical, simulation, retrospective and prospective. The interface must state the achieved level and never imply that simulation validation equals reality validation.
+
+Promotion from the lab requires a complete contract, reproducible run, evaluation evidence and ROOT/ACP decision.

--- a/docs/canon/10_THRESHOLDS_AND_CALIBRATION.md
+++ b/docs/canon/10_THRESHOLDS_AND_CALIBRATION.md
@@ -1,0 +1,16 @@
+# 10 · Thresholds and Calibration
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.calibration.v1
+
+A threshold is part of a versioned method contract. It is not an arbitrary UI constant and must not be changed silently by a model or developer.
+
+Each threshold declares variable, method, object scope, value or range, unit, decision effect, calibration mode, evidence window, error costs and version.
+
+Calibration modes are expert-seeded, supervised empirical, unsupervised exploratory and longitudinal. Expert-seeded thresholds remain `THIN` until evaluated. Exploratory thresholds remain laboratory-only.
+
+Evaluation must consider false positives, false negatives, precision, sensitivity, temporal stability, sensitivity to perturbation and institutional error cost. The selected threshold and rejected alternatives remain reproducible.
+
+When a threshold changes, existing readings retain the version used at calculation time. Recalculation creates a new reading; it does not overwrite history.
+
+Missing calibration does not authorize a plausible default unless the method contract explicitly permits a named default and marks the result `THIN` with a warning.

--- a/docs/canon/11_EVENTS_AND_STATE_TRANSITIONS.md
+++ b/docs/canon/11_EVENTS_AND_STATE_TRANSITIONS.md
@@ -1,0 +1,16 @@
+# 11 · Events and State Transitions
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.events.v1
+
+Institutional continuity is event-driven. Events record what happened; state is a projection derived from ordered events and persisted records.
+
+Every event declares event name, schema version, actor or source, object identity, occurrence time, ingestion time, epistemic class, confidence, payload, lineage and authorization.
+
+Canonical lifecycle transitions must be explicit and validated. Examples include evidence admission, hypothesis creation, prediction registration, simulation completion, calibration completion, promotion request, approval, rejection and reversion.
+
+An event cannot claim a transition that the current state does not allow. Duplicate events must be idempotent or rejected. Failed persistence must be visible and retryable; it must not be represented as successful execution.
+
+State labels are not inferred from interface text. Writers and reducers use declared contracts. Historical events are immutable except for append-only correction or invalidation events.
+
+Schedulers and agents may request transitions. Governed transitions require the authority declared by the relevant contract.

--- a/docs/canon/12_SURFACES_AND_DATA_BOUNDARIES.md
+++ b/docs/canon/12_SURFACES_AND_DATA_BOUNDARIES.md
@@ -1,0 +1,20 @@
+# 12 · Surfaces and Data Boundaries
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.surfaces.v1
+
+SFI surfaces are bounded contexts, not interchangeable screens.
+
+- `FIELD`: captures appearances, evidence, trajectory and return.
+- `STUDIO`: analyzes or transforms an identified object and prepares an observable return.
+- `OBSERVATORY`: presents aggregated, authorized longitudinal state.
+- `WORLD/FIELD MAP`: localizes public world-context signals.
+- `METHOD LAB`: experiments without writing canonical state.
+- `ATLAS`: represents promoted methods, results and confirmed trajectories.
+- `ROOT`: founder-only governance, institutional observation and promotion authority.
+
+A surface may consume another surface's authorized contract but must not read private tables ad hoc or duplicate writers. Transfers preserve object identity and provenance.
+
+Missing information remains missing. Interfaces must not manufacture fallback nodes, relationships, metrics or institutional states for visual completeness.
+
+Public surfaces never expose ROOT controls, private evidence or private identity. Normal users do not enter ROOT. Authorization is enforced by server contracts and data policy, not only by hidden navigation.

--- a/docs/canon/13_COGNITIVE_TWIN_AND_AGENT_AUTHORITY.md
+++ b/docs/canon/13_COGNITIVE_TWIN_AND_AGENT_AUTHORITY.md
@@ -1,0 +1,22 @@
+# 13 · Cognitive Twin and Agent Authority
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.cognitive-authority.v1
+
+The Cognitive Twin is a versioned representation of declared identity, observed history, evidence, hypotheses, constraints, preferences, trajectories and unresolved contradictions. It is not the person, institution or world itself.
+
+Agents operate under explicit capabilities. They may observe authorized sources, extract structured candidates, calculate approved formulas, produce hypotheses, request evidence, simulate scenarios and draft actions.
+
+Agents may not:
+
+- fabricate observations or sources;
+- silently create canonical variables;
+- promote their own conclusions;
+- alter formulas, thresholds or governance rules;
+- execute external or irreversible actions without declared authority;
+- convert model memory into evidence;
+- hide contradictory or negative results.
+
+Every execution records agent ID, capability, provider/model when applicable, inputs, outputs, evidence lineage, confidence, duration, errors and authorization.
+
+An agent registry entry is not proof of operational execution. Registered, available, operational, gated, degraded and failed states remain distinct. ROOT reports real executions rather than deriving activity from subsystem presence.

--- a/docs/canon/14_GOVERNANCE_AND_PROMOTION.md
+++ b/docs/canon/14_GOVERNANCE_AND_PROMOTION.md
@@ -1,0 +1,16 @@
+# 14 · Governance and Promotion
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.governance.v1
+
+Canonical state changes only through an attributable promotion decision. ROOT/ACP evaluates proposals for variables, methods, formulas, thresholds, evidence classes, agent capabilities and public representations.
+
+A promotion request must include objective, proposed identifier and version, scope, contract, evidence, tests, reproducibility data, risks, migration plan, rollback plan and unresolved limitations.
+
+Decisions are `ACCEPTED`, `REJECTED`, `NEEDS_EVIDENCE`, `FROZEN` or `SUPERSEDED`. Approval does not erase prior versions. Reversion creates a new governance event and restores an identified prior contract.
+
+Models and submitting agents cannot approve their own proposals. High-impact, public, irreversible, privacy-sensitive or external-execution changes require explicit human authorization.
+
+A document alone does not make a runtime behavior canonical. A runtime implementation alone does not make an undocumented concept canonical. Promotion requires agreement among documentation, executable contract, persistence semantics and validation.
+
+Conflicts discovered after promotion are marked `CONFLICTED` and routed back to governance; they are not silently patched through aliases.

--- a/docs/canon/15_COMPATIBILITY_DEPRECATION_MIGRATION.md
+++ b/docs/canon/15_COMPATIBILITY_DEPRECATION_MIGRATION.md
@@ -1,0 +1,23 @@
+# 15 · Compatibility, Deprecation and Migration
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.migration.v1
+
+Compatibility exists to preserve history, not to perpetuate ambiguity.
+
+Migration classes:
+
+- `DIRECT_ALIAS`: one legacy identifier maps to exactly one canonical identifier.
+- `CONTEXTUAL_ALIAS`: resolution requires method, object type or storage context.
+- `TRANSFORM_REQUIRED`: scale, unit or formula conversion is required.
+- `HISTORICAL_ONLY`: readable but cannot generate new records.
+- `UNRESOLVED`: insufficient information; no automatic migration.
+- `PROHIBITED`: invalid concept or identifier.
+
+Automatic redirection is permitted only for `DIRECT_ALIAS`. Contextual aliases must use an explicit resolver. Transformations must preserve raw values, conversion formula and versions. Unresolved records remain degraded instead of being guessed.
+
+`PHI_SYSTEMIC → PHI_S` is direct. `PHI_SF` is contextual: bounded assets map to `PHI_S`; institutional snapshots map to `PHI_SFI`. PPOI composite `0–5 → PHI_F 0–1` requires transformation and retention of the raw composite.
+
+Deprecated fields remain available for historical reads during a declared compatibility window. New writers use canonical identifiers only. Removal requires usage audit, migration verification, rollback plan and governance approval.
+
+The repository must fail validation when production code introduces an unknown canonical-looking variable without registry admission.

--- a/docs/canon/README.md
+++ b/docs/canon/README.md
@@ -1,0 +1,31 @@
+# SFI Canonical Corpus
+
+**Status:** CANONICAL  
+**Version:** 2026-08-06.corpus.v1  
+**Authority:** System Friction Institute / ACP
+
+This directory is the ordered constitutional corpus for the runtime. The documents must be read in sequence. A later document may specialize an earlier one but may not silently contradict it.
+
+1. `01_SFI_CONSTITUTION.md`
+2. `02_EPISTEMIC_CLASSES.md`
+3. `03_OBSERVATION_OBJECT_IDENTITY.md`
+4. `04_CANONICAL_VARIABLE_REGISTRY.md`
+5. `05_MIHM_METHOD_SELECTION.md`
+6. `06_MIHM_PHI_FAMILY.md`
+7. `07_EVIDENCE_AND_PROVENANCE.md`
+8. `08_HYPOTHESES_PROPOSITIONS_PREDICTIONS.md`
+9. `09_METHOD_LAB_AND_SIMULATION.md`
+10. `10_THRESHOLDS_AND_CALIBRATION.md`
+11. `11_EVENTS_AND_STATE_TRANSITIONS.md`
+12. `12_SURFACES_AND_DATA_BOUNDARIES.md`
+13. `13_COGNITIVE_TWIN_AND_AGENT_AUTHORITY.md`
+14. `14_GOVERNANCE_AND_PROMOTION.md`
+15. `15_COMPATIBILITY_DEPRECATION_MIGRATION.md`
+
+## Enforcement rule
+
+A variable, metric, state, event or method is canonical only when it is declared in this corpus and represented by an executable contract or registry. Unknown identifiers must not be guessed, redirected by spelling similarity or persisted as canonical values.
+
+## Conflict rule
+
+When documentation and runtime disagree, the conflict must be surfaced as `CONFLICTED`. Neither side silently overrides the other. ROOT/ACP resolves the conflict through a versioned change.

--- a/src/lib/mihm/canonicalVariableRegistry.test.ts
+++ b/src/lib/mihm/canonicalVariableRegistry.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  assertCanonicalVariable,
+  resolveCanonicalVariable,
+} from './canonicalVariableRegistry';
+
+test('canonical variables resolve directly', () => {
+  assert.equal(assertCanonicalVariable('PHI_H'), 'PHI_H');
+  assert.equal(assertCanonicalVariable('wsi'), 'WSI');
+});
+
+test('unambiguous aliases redirect automatically', () => {
+  assert.equal(resolveCanonicalVariable('PHI_SYSTEMIC').canonicalId, 'PHI_S');
+  assert.equal(resolveCanonicalVariable('PHI_PERSONAL').canonicalId, 'PHI_H');
+});
+
+test('PHI_SF requires context', () => {
+  assert.equal(resolveCanonicalVariable('PHI_SF').canonicalId, null);
+  assert.equal(resolveCanonicalVariable('PHI_SF', { objectType: 'ARTIFACT' }).canonicalId, 'PHI_S');
+  assert.equal(resolveCanonicalVariable('PHI_SF', { objectType: 'SFI_INSTITUTION' }).canonicalId, 'PHI_SFI');
+});
+
+test('unknown and prohibited identifiers fail closed', () => {
+  assert.equal(resolveCanonicalVariable('invented_metric').aliasClass, 'UNKNOWN');
+  assert.equal(resolveCanonicalVariable('GLOBAL_PHI').aliasClass, 'PROHIBITED');
+  assert.throws(() => assertCanonicalVariable('invented_metric'), /mihm_variable_not_canonical/);
+});

--- a/src/lib/mihm/canonicalVariableRegistry.ts
+++ b/src/lib/mihm/canonicalVariableRegistry.ts
@@ -1,0 +1,121 @@
+import type { MihmMethodId } from './methodSelectionContract';
+
+export type CanonicalVariableId =
+  | 'IHG'
+  | 'NTI'
+  | 'LDI'
+  | 'XI'
+  | 'PHI_H'
+  | 'PHI_S'
+  | 'PHI_F'
+  | 'PHI_W'
+  | 'PHI_SFI'
+  | 'F_S'
+  | 'C_FIELD'
+  | 'PPOI_COMPOSITE'
+  | 'WSI'
+  | 'REDUCED_KERNEL_CONTINUITY';
+
+export type VariableAliasClass =
+  | 'CANONICAL'
+  | 'DIRECT_ALIAS'
+  | 'CONTEXTUAL_ALIAS'
+  | 'HISTORICAL_ONLY'
+  | 'PROHIBITED'
+  | 'UNKNOWN';
+
+export type VariableContext = {
+  methodId?: MihmMethodId | null;
+  objectType?: 'PERSON' | 'SESSION' | 'BOUNDED_SYSTEM' | 'ARTIFACT' | 'SIGNAL' | 'PHENOMENON' | 'WORLD_CONTEXT' | 'SFI_INSTITUTION' | null;
+};
+
+export type CanonicalVariableDefinition = {
+  id: CanonicalVariableId;
+  scale: '0-1' | '0-5' | 'hours' | 'unitless';
+  methods: MihmMethodId[];
+  description: string;
+};
+
+export const CANONICAL_VARIABLE_REGISTRY: Record<CanonicalVariableId, CanonicalVariableDefinition> = {
+  IHG: { id: 'IHG', scale: '0-1', methods: ['MOP_H', 'SCOREFRICTION', 'SFI_INSTITUTIONAL'], description: 'Integrity or homeostatic integrity within the declared method and object.' },
+  NTI: { id: 'NTI', scale: '0-1', methods: ['MOP_H', 'SCOREFRICTION', 'WORLD_VECTOR', 'SFI_INSTITUTIONAL'], description: 'Declared intensity/traceability variable whose semantics remain method-scoped.' },
+  LDI: { id: 'LDI', scale: '0-1', methods: ['MOP_H', 'SCOREFRICTION', 'SFI_INSTITUTIONAL'], description: 'Normalized longitudinal dissipation within the declared method.' },
+  XI: { id: 'XI', scale: '0-1', methods: ['SCOREFRICTION', 'SFI_INSTITUTIONAL'], description: 'Residual/noise term used only by a versioned formula.' },
+  PHI_H: { id: 'PHI_H', scale: '0-1', methods: ['MOP_H'], description: 'Human-session Phi.' },
+  PHI_S: { id: 'PHI_S', scale: '0-1', methods: ['SCOREFRICTION'], description: 'Bounded-system or object Phi.' },
+  PHI_F: { id: 'PHI_F', scale: '0-1', methods: ['PPOI'], description: 'Normalized longitudinal phenomenon persistence.' },
+  PHI_W: { id: 'PHI_W', scale: '0-1', methods: ['WORLD_VECTOR'], description: 'Typed world-context Phi.' },
+  PHI_SFI: { id: 'PHI_SFI', scale: '0-1', methods: ['SFI_INSTITUTIONAL'], description: 'Institutional Phi reserved to System Friction Institute.' },
+  F_S: { id: 'F_S', scale: '0-1', methods: ['SCOREFRICTION', 'SFI_INSTITUTIONAL'], description: 'Friction complement of the method-scoped Phi.' },
+  C_FIELD: { id: 'C_FIELD', scale: '0-1', methods: ['SCOREFRICTION', 'SFI_INSTITUTIONAL'], description: 'Field continuity/capacity formula output.' },
+  PPOI_COMPOSITE: { id: 'PPOI_COMPOSITE', scale: '0-5', methods: ['PPOI'], description: 'Raw PPOI weighted composite retained before normalization.' },
+  WSI: { id: 'WSI', scale: '0-1', methods: ['WORLD_VECTOR'], description: 'World State Index; current source value for PHI_W.' },
+  REDUCED_KERNEL_CONTINUITY: { id: 'REDUCED_KERNEL_CONTINUITY', scale: '0-1', methods: ['SFI_INSTITUTIONAL'], description: 'Non-Phi operational continuity estimate from the reduced kernel.' },
+};
+
+const DIRECT_ALIASES: Record<string, CanonicalVariableId> = {
+  PHI_PERSONAL: 'PHI_H',
+  PHI_SYSTEMIC: 'PHI_S',
+  PHI_PHENOMENOLOGICAL: 'PHI_F',
+  PHI_WORLD: 'PHI_W',
+  PSI_MOPH: 'PHI_H',
+  XI_NOISE: 'XI',
+  NTI_OBS: 'NTI',
+  LDI_HOURS_NORMALIZED: 'LDI',
+};
+
+const HISTORICAL_ONLY = new Set(['PHI', 'PHI_GENERIC', 'PHI_SF_LEGACY']);
+const PROHIBITED = new Set(['GLOBAL_PHI', 'UNIVERSAL_PHI', 'AVERAGE_PHI']);
+
+function normalizeIdentifier(identifier: string): string {
+  return identifier.trim().toUpperCase().replace(/[\s-]+/g, '_');
+}
+
+export type VariableResolution = {
+  input: string;
+  normalizedInput: string;
+  aliasClass: VariableAliasClass;
+  canonicalId: CanonicalVariableId | null;
+  reason: string;
+};
+
+export function resolveCanonicalVariable(identifier: string, context: VariableContext = {}): VariableResolution {
+  const normalizedInput = normalizeIdentifier(identifier);
+
+  if (normalizedInput in CANONICAL_VARIABLE_REGISTRY) {
+    return { input: identifier, normalizedInput, aliasClass: 'CANONICAL', canonicalId: normalizedInput as CanonicalVariableId, reason: 'canonical_identifier' };
+  }
+
+  const direct = DIRECT_ALIASES[normalizedInput];
+  if (direct) {
+    return { input: identifier, normalizedInput, aliasClass: 'DIRECT_ALIAS', canonicalId: direct, reason: 'unambiguous_legacy_alias' };
+  }
+
+  if (normalizedInput === 'PHI_SF') {
+    if (context.methodId === 'SFI_INSTITUTIONAL' || context.objectType === 'SFI_INSTITUTION') {
+      return { input: identifier, normalizedInput, aliasClass: 'CONTEXTUAL_ALIAS', canonicalId: 'PHI_SFI', reason: 'institutional_context' };
+    }
+    if (context.methodId === 'SCOREFRICTION' || ['BOUNDED_SYSTEM', 'ARTIFACT', 'SIGNAL'].includes(context.objectType ?? '')) {
+      return { input: identifier, normalizedInput, aliasClass: 'CONTEXTUAL_ALIAS', canonicalId: 'PHI_S', reason: 'bounded_system_context' };
+    }
+    return { input: identifier, normalizedInput, aliasClass: 'CONTEXTUAL_ALIAS', canonicalId: null, reason: 'context_required_for_phi_sf' };
+  }
+
+  if (HISTORICAL_ONLY.has(normalizedInput)) {
+    return { input: identifier, normalizedInput, aliasClass: 'HISTORICAL_ONLY', canonicalId: null, reason: 'historical_identifier_requires_manual_migration' };
+  }
+
+  if (PROHIBITED.has(normalizedInput)) {
+    return { input: identifier, normalizedInput, aliasClass: 'PROHIBITED', canonicalId: null, reason: 'concept_prohibited_by_mihm_canon' };
+  }
+
+  return { input: identifier, normalizedInput, aliasClass: 'UNKNOWN', canonicalId: null, reason: 'identifier_not_registered' };
+}
+
+export function assertCanonicalVariable(identifier: string, context: VariableContext = {}): CanonicalVariableId {
+  const resolution = resolveCanonicalVariable(identifier, context);
+  if (!resolution.canonicalId) {
+    throw new Error(`mihm_variable_not_canonical:${resolution.normalizedInput}:${resolution.reason}`);
+  }
+  return resolution.canonicalId;
+}


### PR DESCRIPTION
## Purpose

Create the ordered final canonical corpus for System Friction Institute and prevent variables outside the canon from being accepted or redirected by guesswork.

## Canonical corpus

Adds 15 ordered documents covering:

1. constitution;
2. epistemic classes;
3. observation object identity;
4. canonical variable registry;
5. MIHM method selection;
6. MIHM Phi family;
7. evidence and provenance;
8. hypotheses, propositions and predictions;
9. Method Lab and simulation;
10. thresholds and calibration;
11. events and state transitions;
12. surfaces and data boundaries;
13. Cognitive Twin and agent authority;
14. governance and promotion;
15. compatibility, deprecation and migration.

## Executable enforcement

Adds `canonicalVariableRegistry.ts` and tests. Identifiers now resolve as canonical, direct alias, contextual alias, historical-only, prohibited or unknown.

- Direct aliases may redirect automatically.
- `PHI_SF` requires object/method context.
- Unknown and prohibited variables fail closed.
- Laboratory variables remain `LAB_*` until promotion.

## Validation

Extends MIHM CI to include the canonical corpus and variable-registry tests. The branch is based directly on current `main` and is not behind it.