### PR TITLE
Implement SFI Continuity Runtime

### DIFF
--- a/src/app/api/cron/continuity-heartbeat/route.ts
+++ b/src/app/api/cron/continuity-heartbeat/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { runContinuityHeartbeat } from '@/lib/continuity/runtime';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function bearer(request: NextRequest) {
+  const match = (request.headers.get('authorization') ?? '').match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() ?? '';
+}
+
+function authorize(request: NextRequest) {
+  const secret = process.env.SFI_CONTINUITY_CRON_SECRET || process.env.CRON_SECRET || '';
+  if (!secret && process.env.NODE_ENV !== 'production') return true;
+  return Boolean(secret) && bearer(request) === secret;
+}
+
+export async function GET(request: NextRequest) {
+  if (!authorize(request)) return NextResponse.json({ ok: false, error: 'unauthorized_continuity_cron' }, { status: 401 });
+  try {
+    const result = await runContinuityHeartbeat('vercel_cron');
+    return NextResponse.json({ ok: result.status !== 'FAILED', ...result });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: 'continuity_heartbeat_failed', details: error instanceof Error ? error.message : String(error) }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return GET(request);
+}

--- a/src/app/api/cron/continuity-report/route.ts
+++ b/src/app/api/cron/continuity-report/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createDailyContinuityReport } from '@/lib/continuity/runtime';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function bearer(request: NextRequest) {
+  const match = (request.headers.get('authorization') ?? '').match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() ?? '';
+}
+
+export async function GET(request: NextRequest) {
+  const secret = process.env.SFI_CONTINUITY_CRON_SECRET || process.env.CRON_SECRET || '';
+  if ((process.env.NODE_ENV === 'production' && !secret) || (secret && bearer(request) !== secret)) {
+    return NextResponse.json({ ok: false, error: 'unauthorized_continuity_report' }, { status: 401 });
+  }
+  try {
+    const report = await createDailyContinuityReport();
+    return NextResponse.json({ ok: true, report });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: 'continuity_report_failed', details: error instanceof Error ? error.message : String(error) }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return GET(request);
+}

--- a/src/app/api/root/continuity/route.ts
+++ b/src/app/api/root/continuity/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { readContinuityDashboard, runContinuityHeartbeat } from '@/lib/continuity/runtime';
+import type { ContinuityMode } from '@/lib/continuity/contracts';
+import { auditRootAction, requireRootActor } from '@/lib/root/server';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const modeSchema = z.object({
+  action: z.enum(['set_mode', 'heartbeat', 'emergency_halt']),
+  mode: z.enum(['NORMAL','FOUNDER_ABSENT_PREP','FOUNDER_ABSENT_ACTIVE','DEGRADED_SAFE','EMERGENCY_HALT','RECOVERY']).optional(),
+  reason: z.string().trim().min(1).max(1000).optional(),
+  expectedReturnAt: z.string().datetime().optional(),
+});
+
+const ALLOWED_TRANSITIONS: Record<ContinuityMode, ContinuityMode[]> = {
+  NORMAL: ['FOUNDER_ABSENT_PREP', 'EMERGENCY_HALT'],
+  FOUNDER_ABSENT_PREP: ['FOUNDER_ABSENT_ACTIVE', 'NORMAL', 'EMERGENCY_HALT'],
+  FOUNDER_ABSENT_ACTIVE: ['DEGRADED_SAFE', 'RECOVERY', 'EMERGENCY_HALT'],
+  DEGRADED_SAFE: ['FOUNDER_ABSENT_ACTIVE', 'RECOVERY', 'EMERGENCY_HALT'],
+  EMERGENCY_HALT: ['RECOVERY'],
+  RECOVERY: ['NORMAL', 'FOUNDER_ABSENT_PREP', 'EMERGENCY_HALT'],
+};
+
+export async function GET() {
+  const gate = await requireRootActor('continuity.state.read');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+  try {
+    return NextResponse.json({ ok: true, ...(await readContinuityDashboard()) });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: 'continuity_state_failed', details: error instanceof Error ? error.message : String(error) }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const gate = await requireRootActor('continuity.mutate');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+  const parsed = modeSchema.safeParse(await request.json().catch(() => ({})));
+  if (!parsed.success) return NextResponse.json({ ok: false, error: 'invalid_continuity_request', details: parsed.error.flatten() }, { status: 400 });
+
+  if (parsed.data.action === 'heartbeat') {
+    const result = await runContinuityHeartbeat('founder_manual');
+    await auditRootAction({ actorId: gate.ctx.user.id, action: 'continuity.heartbeat.execute', target: result.runId, request, payload: { status: result.status } });
+    return NextResponse.json({ ok: true, result });
+  }
+
+  const db = createServiceSupabaseClient();
+  const { data: current, error } = await db.from('sfi_continuity_state').select('*').eq('id', 'institution').single();
+  if (error || !current) return NextResponse.json({ ok: false, error: 'continuity_state_unavailable', details: error?.message }, { status: 503 });
+
+  const nextMode: ContinuityMode = parsed.data.action === 'emergency_halt' ? 'EMERGENCY_HALT' : (parsed.data.mode as ContinuityMode);
+  if (!nextMode) return NextResponse.json({ ok: false, error: 'mode_required' }, { status: 400 });
+  const allowed = ALLOWED_TRANSITIONS[current.mode as ContinuityMode] ?? [];
+  if (!allowed.includes(nextMode)) {
+    return NextResponse.json({ ok: false, error: 'invalid_continuity_transition', from: current.mode, to: nextMode, allowed }, { status: 409 });
+  }
+
+  const now = new Date().toISOString();
+  const patch = {
+    mode: nextMode,
+    founder_available: nextMode === 'NORMAL' || nextMode === 'FOUNDER_ABSENT_PREP' || nextMode === 'RECOVERY',
+    activated_at: ['FOUNDER_ABSENT_ACTIVE','EMERGENCY_HALT'].includes(nextMode) ? now : current.activated_at,
+    expected_return_at: parsed.data.expectedReturnAt ?? current.expected_return_at,
+    halt_reason: nextMode === 'EMERGENCY_HALT' ? (parsed.data.reason ?? 'Founder emergency halt') : null,
+    updated_at: now,
+  };
+  const update = await db.from('sfi_continuity_state').update(patch).eq('id', 'institution').select('*').single();
+  if (update.error) return NextResponse.json({ ok: false, error: 'continuity_transition_failed', details: update.error.message }, { status: 500 });
+
+  await auditRootAction({
+    actorId: gate.ctx.user.id,
+    action: 'continuity.mode.change',
+    target: 'institution',
+    request,
+    payload: { from: current.mode, to: nextMode, reason: parsed.data.reason ?? null, expectedReturnAt: parsed.data.expectedReturnAt ?? null },
+  });
+  return NextResponse.json({ ok: true, state: update.data });
+}

--- a/src/app/root/continuity/page.tsx
+++ b/src/app/root/continuity/page.tsx
@@ -14,7 +14,11 @@ export default async function RootContinuityPage() {
   await requireFounderPage('/root/continuity');
   let dashboard;
   try {
-    dashboard = await readContinuityDashboard();
+    const observed = await readContinuityDashboard();
+    dashboard = {
+      ...observed,
+      errors: observed.errors.filter((item): item is string => typeof item === 'string'),
+    };
   } catch (error) {
     dashboard = {
       state: { mode: 'UNAVAILABLE' }, runs: [], checks: [], incidents: [], decisions: [], reports: [],

--- a/src/app/root/continuity/page.tsx
+++ b/src/app/root/continuity/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import { ContinuityConsole } from '@/components/root/continuity/ContinuityConsole';
+import { readContinuityDashboard } from '@/lib/continuity/runtime';
+import { requireFounderPage } from '@/lib/root/server';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'SFI Continuity Runtime',
+  robots: { index: false, follow: false, nocache: true },
+};
+
+export default async function RootContinuityPage() {
+  await requireFounderPage('/root/continuity');
+  let dashboard;
+  try {
+    dashboard = await readContinuityDashboard();
+  } catch (error) {
+    dashboard = {
+      state: { mode: 'UNAVAILABLE' }, runs: [], checks: [], incidents: [], decisions: [], reports: [],
+      errors: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+  return <ContinuityConsole initial={dashboard} />;
+}

--- a/src/components/root/continuity/ContinuityConsole.tsx
+++ b/src/components/root/continuity/ContinuityConsole.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type Dashboard = {
+  state: any;
+  runs: any[];
+  checks: any[];
+  incidents: any[];
+  decisions: any[];
+  reports: any[];
+  errors: string[];
+};
+
+export function ContinuityConsole({ initial }: { initial: Dashboard }) {
+  const [data, setData] = useState(initial);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
+
+  async function refresh() {
+    const response = await fetch('/api/root/continuity', { cache: 'no-store' });
+    const payload = await response.json();
+    if (payload.ok) setData(payload);
+  }
+
+  useEffect(() => {
+    const id = window.setInterval(() => void refresh(), 30000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  async function command(body: Record<string, unknown>) {
+    setBusy(true);
+    setMessage('');
+    try {
+      const response = await fetch('/api/root/continuity', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload.error ?? 'continuity_command_failed');
+      setMessage('Comando ejecutado y auditado.');
+      await refresh();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const latestByCapability = useMemo(() => {
+    const map = new Map<string, any>();
+    for (const check of data.checks) if (!map.has(check.capability_id)) map.set(check.capability_id, check);
+    return [...map.values()];
+  }, [data.checks]);
+
+  const latestRun = data.runs[0];
+  const mode = data.state?.mode ?? 'UNAVAILABLE';
+
+  return (
+    <main className="continuity-shell">
+      <header className="continuity-header">
+        <div><span>SYSTEM FRICTION INSTITUTE</span><h1>CONTINUITY RUNTIME</h1><p>Autonomía limitada, trazable y reversible.</p></div>
+        <div className="continuity-mode"><small>MODE</small><strong>{mode}</strong><em>{data.state?.last_heartbeat_at ?? 'SIN HEARTBEAT'}</em></div>
+      </header>
+
+      <section className="continuity-actions">
+        <button disabled={busy} onClick={() => command({ action: 'heartbeat' })}>EJECUTAR HEARTBEAT</button>
+        {mode === 'NORMAL' && <button disabled={busy} onClick={() => command({ action: 'set_mode', mode: 'FOUNDER_ABSENT_PREP', reason: 'Preparar prueba de autonomía' })}>PREPARAR AUSENCIA</button>}
+        {mode === 'FOUNDER_ABSENT_PREP' && <button disabled={busy} onClick={() => command({ action: 'set_mode', mode: 'FOUNDER_ABSENT_ACTIVE', reason: 'Iniciar prueba controlada' })}>ACTIVAR AUSENCIA</button>}
+        {['FOUNDER_ABSENT_ACTIVE','DEGRADED_SAFE'].includes(mode) && <button disabled={busy} onClick={() => command({ action: 'set_mode', mode: 'RECOVERY', reason: 'Iniciar recuperación supervisada' })}>INICIAR RECUPERACIÓN</button>}
+        {mode === 'RECOVERY' && <button disabled={busy} onClick={() => command({ action: 'set_mode', mode: 'NORMAL', reason: 'Recuperación verificada' })}>VOLVER A NORMAL</button>}
+        {mode !== 'EMERGENCY_HALT' && <button className="danger" disabled={busy} onClick={() => command({ action: 'emergency_halt', reason: 'Paro manual desde ROOT' })}>EMERGENCY HALT</button>}
+        {message && <output>{message}</output>}
+      </section>
+
+      <section className="continuity-grid summary">
+        <article><small>ÚLTIMO CICLO</small><strong>{latestRun?.status ?? 'SIN CICLOS'}</strong><span>{latestRun?.started_at ?? '—'}</span></article>
+        <article><small>CAPACIDADES SANAS</small><strong>{latestRun?.healthy_count ?? 0}/{latestRun?.capability_count ?? 0}</strong><span>fallidas {latestRun?.failed_count ?? 0}</span></article>
+        <article><small>INCIDENTES ABIERTOS</small><strong>{data.incidents.length}</strong><span>requieren contención</span></article>
+        <article><small>DECISIONES RESERVADAS</small><strong>{data.decisions.length}</strong><span>esperan autoridad</span></article>
+      </section>
+
+      <section className="continuity-panel">
+        <h2>CAPABILITY PROBES</h2>
+        <div className="continuity-table">
+          <div className="row head"><span>CAPACIDAD</span><span>NIVEL</span><span>ESTADO</span><span>LATENCIA</span><span>EVIDENCIA</span></div>
+          {latestByCapability.map((check) => <div className="row" key={check.capability_id}><span>{check.capability_id}</span><span>{check.autonomy_level}</span><span data-status={check.status}>{check.status}</span><span>{check.latency_ms ?? '—'} ms</span><span>{check.error_code ?? check.checked_at}</span></div>)}
+          {!latestByCapability.length && <p>Sin probes registrados. Ejecute el primer heartbeat después de aplicar la migración.</p>}
+        </div>
+      </section>
+
+      <section className="continuity-grid detail">
+        <article><h2>INCIDENTES</h2>{data.incidents.length ? data.incidents.map((item) => <p key={item.id}><b>{item.severity}</b> · {item.title}<small>{item.error_code ?? item.status}</small></p>) : <p>Sin incidentes abiertos.</p>}</article>
+        <article><h2>DECISION QUEUE</h2>{data.decisions.length ? data.decisions.map((item) => <p key={item.id}><b>{item.category}</b> · {item.title}<small>{item.safe_default ?? item.status}</small></p>) : <p>Sin decisiones reservadas.</p>}</article>
+        <article><h2>REPORTES</h2>{data.reports.length ? data.reports.map((item) => <pre key={item.id}>{item.content}</pre>) : <p>Sin reportes diarios.</p>}</article>
+      </section>
+
+      <style jsx>{`
+        .continuity-shell{min-height:100vh;background:#070706;color:#eee7d7;padding:28px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}.continuity-header{display:flex;justify-content:space-between;gap:24px;border-bottom:1px solid #6c5a2d;padding-bottom:20px}.continuity-header span,.continuity-header small{color:#bba365;font-size:11px;letter-spacing:.15em}.continuity-header h1{font-size:28px;margin:5px 0}.continuity-header p{color:#8f8878;margin:0}.continuity-mode{border:1px solid #6c5a2d;padding:14px 18px;min-width:260px;display:grid;gap:6px}.continuity-mode strong{font-size:17px}.continuity-mode em{font-size:10px;color:#8f8878}.continuity-actions{display:flex;flex-wrap:wrap;gap:8px;padding:18px 0}.continuity-actions button{background:#15130e;color:#d8c488;border:1px solid #6c5a2d;padding:10px 13px;font:inherit;font-size:11px}.continuity-actions button:disabled{opacity:.45}.continuity-actions .danger{border-color:#7f2f2f;color:#e89b9b}.continuity-actions output{width:100%;color:#bba365}.continuity-grid{display:grid;gap:12px}.summary{grid-template-columns:repeat(4,minmax(0,1fr))}.continuity-grid article,.continuity-panel{border:1px solid #29251b;background:#0d0c09;padding:16px}.summary article{display:grid;gap:8px}.summary small{color:#8f8878}.summary strong{font-size:24px;color:#d8c488}.summary span{font-size:11px;color:#777064}.continuity-panel{margin-top:12px}.continuity-panel h2,.detail h2{font-size:12px;letter-spacing:.15em;color:#bba365}.continuity-table .row{display:grid;grid-template-columns:1.4fr .5fr .8fr .6fr 1.8fr;gap:10px;padding:9px 0;border-top:1px solid #211e17;font-size:11px}.continuity-table .head{color:#777064}.row [data-status=OPERATIONAL]{color:#84b58c}.row [data-status=FAILED]{color:#df7474}.row [data-status=DEGRADED],.row [data-status=BLOCKED]{color:#d8b768}.detail{grid-template-columns:1fr 1fr 1fr;margin-top:12px}.detail p{display:grid;gap:5px;border-top:1px solid #211e17;padding-top:9px;font-size:11px}.detail small{color:#777064}.detail pre{white-space:pre-wrap;font-size:10px;border-top:1px solid #211e17;padding-top:9px;color:#a8a08f}@media(max-width:900px){.summary,.detail{grid-template-columns:1fr}.continuity-header{display:grid}.continuity-table{overflow:auto}.continuity-table .row{min-width:760px}}
+      `}</style>
+    </main>
+  );
+}

--- a/src/components/root/sovereign/RootTopBar.tsx
+++ b/src/components/root/sovereign/RootTopBar.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { RootSovereignState } from '@/lib/root/sovereign/rootSovereignState';
 
 export function RootTopBar({ state, refreshing, onRefresh }: { state: RootSovereignState; refreshing: boolean; onRefresh: () => void }) {
@@ -6,7 +7,7 @@ export function RootTopBar({ state, refreshing, onRefresh }: { state: RootSovere
     <header className="rs-topbar">
       <div className="rs-identity"><span>SFI</span><strong>ROOT</strong><em>SOVEREIGN CONSOLE</em></div>
       <div className="rs-system-state"><span>SYSTEM STATE</span><strong data-status={governance?.state.status}>{governance?.state.value ?? 'SIN DATO'}</strong><small>ACP · {governance?.state.observedAt ?? 'NO MEDIDO'}</small></div>
-      <div className="rs-topbar-actions"><time>{new Date(state.generatedAt).toISOString().replace('T', ' ').slice(0, 19)} UTC</time><button type="button" onClick={onRefresh} disabled={refreshing}>{refreshing ? 'REFRESHING' : 'REFRESH'}</button></div>
+      <div className="rs-topbar-actions"><Link href="/root/continuity" style={{ color: '#d8c488', fontSize: 11, textDecoration: 'none', border: '1px solid #6c5a2d', padding: '7px 9px' }}>CONTINUITY</Link><time>{new Date(state.generatedAt).toISOString().replace('T', ' ').slice(0, 19)} UTC</time><button type="button" onClick={onRefresh} disabled={refreshing}>{refreshing ? 'REFRESHING' : 'REFRESH'}</button></div>
     </header>
   );
 }

--- a/src/lib/continuity/contracts.test.ts
+++ b/src/lib/continuity/contracts.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { CONTINUITY_CAPABILITIES, SAFE_ABSENCE_RULES } from './contracts';
+
+test('continuity capability identifiers are unique', () => {
+  const ids = CONTINUITY_CAPABILITIES.map((capability) => capability.id);
+  assert.equal(new Set(ids).size, ids.length);
+});
+
+test('founder absence blocks reserved authority', () => {
+  assert.equal(SAFE_ABSENCE_RULES.mayPublish, false);
+  assert.equal(SAFE_ABSENCE_RULES.mayChangeCanon, false);
+  assert.equal(SAFE_ABSENCE_RULES.mayChangeFormula, false);
+  assert.equal(SAFE_ABSENCE_RULES.mayGrantRootAccess, false);
+  assert.equal(SAFE_ABSENCE_RULES.mayExecuteIrreversibleExternalAction, false);
+});
+
+test('all A3 capabilities are blocked in founder absence', () => {
+  for (const capability of CONTINUITY_CAPABILITIES.filter((item) => item.autonomyLevel === 'A3')) {
+    assert.equal(capability.allowedInFounderAbsence, false, capability.id);
+  }
+});
+
+test('critical observational capabilities remain available', () => {
+  const required = ['world_vector', 'scorefriction', 'mihm', 'evidence'];
+  for (const id of required) {
+    const capability = CONTINUITY_CAPABILITIES.find((item) => item.id === id);
+    assert.ok(capability, id);
+    assert.equal(capability.allowedInFounderAbsence, true, id);
+  }
+});

--- a/src/lib/continuity/contracts.ts
+++ b/src/lib/continuity/contracts.ts
@@ -1,0 +1,42 @@
+export type ContinuityMode =
+  | 'NORMAL'
+  | 'FOUNDER_ABSENT_PREP'
+  | 'FOUNDER_ABSENT_ACTIVE'
+  | 'DEGRADED_SAFE'
+  | 'EMERGENCY_HALT'
+  | 'RECOVERY';
+
+export type AutonomyLevel = 'A0' | 'A1' | 'A2' | 'A3';
+export type CapabilityHealth = 'OPERATIONAL' | 'DEGRADED' | 'FAILED' | 'BLOCKED';
+
+export type ContinuityCapability = {
+  id: string;
+  name: string;
+  autonomyLevel: AutonomyLevel;
+  probePath: string;
+  timeoutMs: number;
+  critical: boolean;
+  allowedInFounderAbsence: boolean;
+};
+
+export const CONTINUITY_CAPABILITIES: ContinuityCapability[] = [
+  { id: 'world_vector', name: 'World Vector', autonomyLevel: 'A0', probePath: '/api/worldspect/state', timeoutMs: 8000, critical: true, allowedInFounderAbsence: true },
+  { id: 'scorefriction', name: 'ScoreFriction', autonomyLevel: 'A0', probePath: '/api/scorefriction/state', timeoutMs: 8000, critical: true, allowedInFounderAbsence: true },
+  { id: 'mihm', name: 'MIHM', autonomyLevel: 'A0', probePath: '/api/mihm', timeoutMs: 8000, critical: true, allowedInFounderAbsence: true },
+  { id: 'cognitive_runtime', name: 'Cognitive Runtime', autonomyLevel: 'A1', probePath: '/api/root/cognitive-runtime', timeoutMs: 10000, critical: true, allowedInFounderAbsence: true },
+  { id: 'evidence', name: 'Evidence Ledger', autonomyLevel: 'A1', probePath: '/api/root/evidence', timeoutMs: 8000, critical: true, allowedInFounderAbsence: true },
+  { id: 'observatory', name: 'Public Observatory', autonomyLevel: 'A1', probePath: '/api/observatory/state', timeoutMs: 8000, critical: false, allowedInFounderAbsence: true },
+  { id: 'governance', name: 'Governance', autonomyLevel: 'A3', probePath: '/api/governance/acp', timeoutMs: 8000, critical: true, allowedInFounderAbsence: false },
+  { id: 'publication', name: 'Institutional Publication', autonomyLevel: 'A3', probePath: '/api/publisher/draft', timeoutMs: 8000, critical: false, allowedInFounderAbsence: false },
+];
+
+export const SAFE_ABSENCE_RULES = {
+  mayObserve: true,
+  mayPrepareDrafts: true,
+  mayRunReversibleJobs: true,
+  mayPublish: false,
+  mayChangeCanon: false,
+  mayChangeFormula: false,
+  mayGrantRootAccess: false,
+  mayExecuteIrreversibleExternalAction: false,
+} as const;

--- a/src/lib/continuity/runtime.ts
+++ b/src/lib/continuity/runtime.ts
@@ -1,0 +1,185 @@
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import {
+  CONTINUITY_CAPABILITIES,
+  type CapabilityHealth,
+  type ContinuityCapability,
+  type ContinuityMode,
+} from './contracts';
+
+function siteOrigin() {
+  const explicit = process.env.SFI_SITE_URL || process.env.NEXT_PUBLIC_SITE_URL;
+  if (explicit) return explicit.replace(/\/$/, '');
+  const vercel = process.env.VERCEL_URL;
+  if (vercel) return `https://${vercel}`;
+  return 'http://localhost:3000';
+}
+
+async function probeCapability(capability: ContinuityCapability, mode: ContinuityMode) {
+  if (mode === 'EMERGENCY_HALT') {
+    return { capability, status: 'BLOCKED' as CapabilityHealth, latencyMs: 0, errorCode: 'continuity_emergency_halt' };
+  }
+  if (mode === 'FOUNDER_ABSENT_ACTIVE' && !capability.allowedInFounderAbsence) {
+    return { capability, status: 'BLOCKED' as CapabilityHealth, latencyMs: 0, errorCode: 'founder_authority_required' };
+  }
+
+  const started = Date.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), capability.timeoutMs);
+  try {
+    const response = await fetch(`${siteOrigin()}${capability.probePath}`, {
+      method: 'GET',
+      cache: 'no-store',
+      signal: controller.signal,
+      headers: { 'x-sfi-continuity-probe': '1' },
+    });
+    const latencyMs = Date.now() - started;
+    if (response.ok) return { capability, status: 'OPERATIONAL' as CapabilityHealth, latencyMs };
+    if (response.status === 401 || response.status === 403) {
+      return {
+        capability,
+        status: capability.allowedInFounderAbsence ? 'DEGRADED' as CapabilityHealth : 'BLOCKED' as CapabilityHealth,
+        latencyMs,
+        errorCode: `http_${response.status}_gated`,
+      };
+    }
+    return { capability, status: 'FAILED' as CapabilityHealth, latencyMs, errorCode: `http_${response.status}` };
+  } catch (error) {
+    return {
+      capability,
+      status: 'FAILED' as CapabilityHealth,
+      latencyMs: Date.now() - started,
+      errorCode: error instanceof Error && error.name === 'AbortError' ? 'probe_timeout' : 'probe_transport_error',
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function runContinuityHeartbeat(trigger = 'scheduled') {
+  const db = createServiceSupabaseClient();
+  const { data: stateRow, error: stateError } = await db
+    .from('sfi_continuity_state')
+    .select('*')
+    .eq('id', 'institution')
+    .single();
+  if (stateError) throw new Error(`continuity_state_unavailable:${stateError.message}`);
+
+  const mode = stateRow.mode as ContinuityMode;
+  const { data: run, error: runError } = await db
+    .from('sfi_continuity_runs')
+    .insert({ trigger, mode, status: 'RUNNING' })
+    .select('id')
+    .single();
+  if (runError || !run) throw new Error(`continuity_run_create_failed:${runError?.message ?? 'unknown'}`);
+
+  const results = await Promise.all(CONTINUITY_CAPABILITIES.map((capability) => probeCapability(capability, mode)));
+  const checks = results.map((result) => ({
+    run_id: run.id,
+    capability_id: result.capability.id,
+    autonomy_level: result.capability.autonomyLevel,
+    status: result.status,
+    latency_ms: result.latencyMs,
+    error_code: result.errorCode ?? null,
+    details: {
+      name: result.capability.name,
+      probePath: result.capability.probePath,
+      critical: result.capability.critical,
+      allowedInFounderAbsence: result.capability.allowedInFounderAbsence,
+    },
+  }));
+  const { error: checksError } = await db.from('sfi_capability_health_checks').insert(checks);
+  if (checksError) throw new Error(`continuity_checks_persist_failed:${checksError.message}`);
+
+  const healthy = results.filter((item) => item.status === 'OPERATIONAL').length;
+  const degraded = results.filter((item) => item.status === 'DEGRADED' || item.status === 'BLOCKED').length;
+  const failed = results.filter((item) => item.status === 'FAILED').length;
+  const criticalFailures = results.filter((item) => item.status === 'FAILED' && item.capability.critical);
+  const finalStatus = mode === 'EMERGENCY_HALT' ? 'HALTED' : criticalFailures.length ? 'DEGRADED' : failed ? 'DEGRADED' : 'COMPLETED';
+
+  if (criticalFailures.length) {
+    await db.from('sfi_institutional_incidents').insert(
+      criticalFailures.map((item) => ({
+        severity: 'P1',
+        capability_id: item.capability.id,
+        title: `${item.capability.name} failed its continuity probe`,
+        error_code: item.errorCode ?? 'continuity_probe_failed',
+        evidence: [{ runId: run.id, latencyMs: item.latencyMs, probePath: item.capability.probePath }],
+        requires_founder: false,
+      })),
+    );
+  }
+
+  await db.from('sfi_continuity_runs').update({
+    status: finalStatus,
+    completed_at: new Date().toISOString(),
+    capability_count: results.length,
+    healthy_count: healthy,
+    degraded_count: degraded,
+    failed_count: failed,
+    evidence: results.map((item) => ({ capabilityId: item.capability.id, status: item.status, latencyMs: item.latencyMs })),
+    errors: results.filter((item) => item.errorCode).map((item) => ({ capabilityId: item.capability.id, code: item.errorCode })),
+  }).eq('id', run.id);
+
+  await db.from('sfi_continuity_state').update({
+    last_heartbeat_at: new Date().toISOString(),
+    last_successful_run_at: criticalFailures.length ? stateRow.last_successful_run_at : new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }).eq('id', 'institution');
+
+  return { runId: run.id, mode, status: finalStatus, healthy, degraded, failed, results };
+}
+
+export async function readContinuityDashboard() {
+  const db = createServiceSupabaseClient();
+  const [state, runs, checks, incidents, decisions, reports] = await Promise.all([
+    db.from('sfi_continuity_state').select('*').eq('id', 'institution').single(),
+    db.from('sfi_continuity_runs').select('*').order('started_at', { ascending: false }).limit(20),
+    db.from('sfi_capability_health_checks').select('*').order('checked_at', { ascending: false }).limit(80),
+    db.from('sfi_institutional_incidents').select('*').neq('status', 'RESOLVED').order('opened_at', { ascending: false }).limit(50),
+    db.from('sfi_founder_decision_queue').select('*').in('status', ['PENDING', 'DEFERRED']).order('created_at', { ascending: false }).limit(50),
+    db.from('sfi_continuity_reports').select('*').order('created_at', { ascending: false }).limit(7),
+  ]);
+  return {
+    state: state.data,
+    runs: runs.data ?? [],
+    checks: checks.data ?? [],
+    incidents: incidents.data ?? [],
+    decisions: decisions.data ?? [],
+    reports: reports.data ?? [],
+    errors: [state.error, runs.error, checks.error, incidents.error, decisions.error, reports.error].filter(Boolean).map((error) => error?.message),
+  };
+}
+
+export async function createDailyContinuityReport() {
+  const db = createServiceSupabaseClient();
+  const dashboard = await readContinuityDashboard();
+  const periodEnd = new Date();
+  const periodStart = new Date(periodEnd.getTime() - 24 * 60 * 60 * 1000);
+  const recentRuns = dashboard.runs.filter((run: any) => new Date(run.started_at) >= periodStart);
+  const summary = {
+    mode: dashboard.state?.mode ?? 'UNKNOWN',
+    runs: recentRuns.length,
+    successfulRuns: recentRuns.filter((run: any) => run.status === 'COMPLETED').length,
+    degradedRuns: recentRuns.filter((run: any) => run.status === 'DEGRADED').length,
+    openIncidents: dashboard.incidents.length,
+    pendingFounderDecisions: dashboard.decisions.length,
+  };
+  const content = [
+    `SFI CONTINUITY DAILY REPORT`,
+    `Period: ${periodStart.toISOString()} — ${periodEnd.toISOString()}`,
+    `Mode: ${summary.mode}`,
+    `Runs: ${summary.runs}; completed: ${summary.successfulRuns}; degraded: ${summary.degradedRuns}`,
+    `Open incidents: ${summary.openIncidents}`,
+    `Founder decisions pending: ${summary.pendingFounderDecisions}`,
+  ].join('\n');
+  const { data, error } = await db.from('sfi_continuity_reports').insert({
+    period_start: periodStart.toISOString(),
+    period_end: periodEnd.toISOString(),
+    mode: summary.mode,
+    summary,
+    content,
+  }).select('*').single();
+  if (error) throw new Error(`continuity_report_failed:${error.message}`);
+  await db.from('sfi_continuity_state').update({ last_report_at: periodEnd.toISOString(), updated_at: periodEnd.toISOString() }).eq('id', 'institution');
+  return data;
+}

--- a/supabase/migrations/20260807003000_sfi_continuity_runtime.sql
+++ b/supabase/migrations/20260807003000_sfi_continuity_runtime.sql
@@ -1,0 +1,97 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.sfi_continuity_state (
+  id text primary key default 'institution',
+  mode text not null default 'NORMAL' check (mode in ('NORMAL','FOUNDER_ABSENT_PREP','FOUNDER_ABSENT_ACTIVE','DEGRADED_SAFE','EMERGENCY_HALT','RECOVERY')),
+  founder_available boolean not null default true,
+  activated_at timestamptz,
+  expected_return_at timestamptz,
+  last_heartbeat_at timestamptz,
+  last_successful_run_at timestamptz,
+  last_report_at timestamptz,
+  halt_reason text,
+  metadata jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now()
+);
+insert into public.sfi_continuity_state (id) values ('institution') on conflict (id) do nothing;
+
+create table if not exists public.sfi_continuity_runs (
+  id uuid primary key default gen_random_uuid(),
+  trigger text not null,
+  mode text not null,
+  status text not null check (status in ('RUNNING','COMPLETED','DEGRADED','FAILED','HALTED')),
+  started_at timestamptz not null default now(),
+  completed_at timestamptz,
+  capability_count integer not null default 0,
+  healthy_count integer not null default 0,
+  degraded_count integer not null default 0,
+  failed_count integer not null default 0,
+  evidence jsonb not null default '[]'::jsonb,
+  errors jsonb not null default '[]'::jsonb
+);
+
+create table if not exists public.sfi_capability_health_checks (
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid references public.sfi_continuity_runs(id) on delete cascade,
+  capability_id text not null,
+  autonomy_level text not null check (autonomy_level in ('A0','A1','A2','A3')),
+  status text not null check (status in ('OPERATIONAL','DEGRADED','FAILED','BLOCKED')),
+  checked_at timestamptz not null default now(),
+  latency_ms integer,
+  evidence_ref text,
+  error_code text,
+  details jsonb not null default '{}'::jsonb
+);
+create index if not exists sfi_capability_health_checks_capability_checked_idx on public.sfi_capability_health_checks(capability_id, checked_at desc);
+
+create table if not exists public.sfi_institutional_incidents (
+  id uuid primary key default gen_random_uuid(),
+  severity text not null check (severity in ('P0','P1','P2','P3')),
+  capability_id text,
+  status text not null default 'OPEN' check (status in ('OPEN','CONTAINED','RECOVERING','RESOLVED','ESCALATED')),
+  title text not null,
+  error_code text,
+  evidence jsonb not null default '[]'::jsonb,
+  opened_at timestamptz not null default now(),
+  resolved_at timestamptz,
+  requires_founder boolean not null default false
+);
+
+create table if not exists public.sfi_founder_decision_queue (
+  id uuid primary key default gen_random_uuid(),
+  status text not null default 'PENDING' check (status in ('PENDING','DEFERRED','RESOLVED','CANCELLED')),
+  category text not null,
+  title text not null,
+  rationale text not null,
+  options jsonb not null default '[]'::jsonb,
+  evidence jsonb not null default '[]'::jsonb,
+  safe_default text,
+  due_at timestamptz,
+  created_at timestamptz not null default now(),
+  resolved_at timestamptz,
+  resolution text
+);
+
+create table if not exists public.sfi_continuity_reports (
+  id uuid primary key default gen_random_uuid(),
+  period_start timestamptz not null,
+  period_end timestamptz not null,
+  mode text not null,
+  summary jsonb not null,
+  content text not null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.sfi_continuity_state enable row level security;
+alter table public.sfi_continuity_runs enable row level security;
+alter table public.sfi_capability_health_checks enable row level security;
+alter table public.sfi_institutional_incidents enable row level security;
+alter table public.sfi_founder_decision_queue enable row level security;
+alter table public.sfi_continuity_reports enable row level security;
+
+revoke all on public.sfi_continuity_state from anon, authenticated;
+revoke all on public.sfi_continuity_runs from anon, authenticated;
+revoke all on public.sfi_capability_health_checks from anon, authenticated;
+revoke all on public.sfi_institutional_incidents from anon, authenticated;
+revoke all on public.sfi_founder_decision_queue from anon, authenticated;
+revoke all on public.sfi_continuity_reports from anon, authenticated;

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,20 @@
 {
   "crons": [
     {
+      "path": "/api/cron/continuity-heartbeat",
+      "schedule": "15 * * * *"
+    },
+    {
       "path": "/api/cron/sfi-indicators",
       "schedule": "0 8 * * *"
     },
     {
       "path": "/api/cron/predictive-engine",
       "schedule": "30 8 * * *"
+    },
+    {
+      "path": "/api/cron/continuity-report",
+      "schedule": "45 8 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
Turn the institutional continuity promise into executable infrastructure instead of another static declaration.

## Implemented
- founder absence state machine: NORMAL, PREP, ACTIVE, DEGRADED_SAFE, EMERGENCY_HALT, RECOVERY;
- explicit autonomy levels A0–A3 and safe absence rules;
- persistent continuity runs and capability health checks;
- institutional incident ledger;
- founder decision queue;
- daily continuity reports;
- hourly Vercel heartbeat and daily report cron;
- governed ROOT API with audited state transitions;
- `/root/continuity` operational console;
- direct CONTINUITY entry from ROOT;
- tests that prevent A3 execution during founder absence.

## Safety boundary
Founder absence permits observation, drafting and reversible pre-authorized work. It blocks publication, canon/formula mutation, ROOT access grants and irreversible external execution.

## Required deployment configuration
- apply migration `20260807003000_sfi_continuity_runtime.sql`;
- configure `SFI_CONTINUITY_CRON_SECRET` or the shared `CRON_SECRET`;
- configure `SFI_SITE_URL`/`NEXT_PUBLIC_SITE_URL` when the deployment origin cannot be inferred.

## Validation requested
- TypeScript;
- domain-boundary verification;
- production build;
- continuity contract tests.