### PR TITLE
Add institutional observer access for 30-day SFI experiment

### DIFF
--- a/src/app/api/root/console/route.ts
+++ b/src/app/api/root/console/route.ts
@@ -1,12 +1,16 @@
 import { NextResponse } from 'next/server';
-import { requireRootActor } from '@/lib/root/server';
+import { requireRootViewer } from '@/lib/root/server';
 import { readRootSovereignState } from '@/lib/root/sovereign/rootSovereignAdapter';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET() {
-  const gate = await requireRootActor('root.console.read');
+  const gate = await requireRootViewer('root.console.read');
   if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
-  return NextResponse.json({ ok: true, state: await readRootSovereignState() }, { headers: { 'Cache-Control': 'no-store' } });
+  return NextResponse.json({
+    ok: true,
+    state: await readRootSovereignState(),
+    accessMode: gate.ctx.isRoot ? 'sovereign' : 'observer',
+  }, { headers: { 'Cache-Control': 'no-store' } });
 }

--- a/src/app/api/root/evidence/route.ts
+++ b/src/app/api/root/evidence/route.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { buildMutationLogbookRow, createActionProposal, sha256, stringValue } from '@/lib/operational/common';
 import { appendEpistemicEvent } from '@/lib/events/eventStore';
-import { auditRootAction, asRecord, requireRootActor } from '@/lib/root/server';
+import { auditRootAction, asRecord, requireRootContributor } from '@/lib/root/server';
 import { ingestRootEvidenceIntoCognitiveTwin } from '@/lib/cognitive-twin/evidenceIngestion';
 
 export const dynamic = 'force-dynamic';
@@ -79,7 +79,7 @@ async function parseEvidenceRequest(request: Request): Promise<ParsedEvidence> {
 }
 
 export async function POST(req: Request) {
-  const gate = await requireRootActor('evidence.write');
+  const gate = await requireRootContributor('evidence.write');
   if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
 
   const input = await parseEvidenceRequest(req);
@@ -91,7 +91,8 @@ export async function POST(req: Request) {
   const title = input.title ?? input.file?.name ?? 'root.evidence';
   const evidenceType = input.evidenceType ?? 'root_evidence';
   const targetNodeId = input.targetNodeId;
-  const proposalType = input.proposalType;
+  const proposalType = gate.ctx.isRoot ? input.proposalType : null;
+  const actorRole = typeof gate.ctx.profile?.role === 'string' ? gate.ctx.profile.role : 'unknown';
   const service = gate.ctx.service;
 
   let attachment: Record<string, unknown> | null = null;
@@ -113,8 +114,13 @@ export async function POST(req: Request) {
     evidenceType,
     targetNodeId,
     relationType: input.relationType,
-    source: input.source ?? 'root_console',
-    metadata: { ...input.metadata, ...(attachment ? { attachment } : {}) },
+    source: input.source ?? (gate.ctx.isRoot ? 'root_console' : 'institutional_observer'),
+    metadata: {
+      ...input.metadata,
+      actorRole,
+      observerContribution: !gate.ctx.isRoot,
+      ...(attachment ? { attachment } : {}),
+    },
   };
   const evidenceHash = sha256(payload);
 
@@ -122,7 +128,7 @@ export async function POST(req: Request) {
   if (existing.error) return NextResponse.json({ ok: false, error: 'root_evidence_lookup_failed', details: existing.error.message }, { status: 400 });
   if (existing.data) {
     const [audit, cognitiveTwin] = await Promise.all([
-      auditRootAction({ actorId: gate.ctx.user.id, action: 'evidence.duplicate_seen', target: 'root_evidence_entries', payload: { evidenceHash, evidenceId: existing.data.id }, request: req }),
+      auditRootAction({ actorId: gate.ctx.user.id, action: 'evidence.duplicate_seen', target: 'root_evidence_entries', payload: { evidenceHash, evidenceId: existing.data.id, actorRole }, request: req }),
       ingestRootEvidenceIntoCognitiveTwin(existing.data),
     ]);
     if (!audit.ok) return NextResponse.json(audit, { status: 500 });
@@ -157,7 +163,7 @@ export async function POST(req: Request) {
       claimBoundary: 'OBSERVED applies to capture/provenance. Claims inside the submitted content are not automatically verified.',
     },
     occurredAt: new Date().toISOString(),
-    source: { sourceId: gate.ctx.user.id, sourceType: 'root_evidence_capture' },
+    source: { sourceId: gate.ctx.user.id, sourceType: gate.ctx.isRoot ? 'root_evidence_capture' : 'institutional_observer_evidence_capture' },
     logbookId: 'BR',
     lineage: [],
   });
@@ -187,7 +193,7 @@ export async function POST(req: Request) {
     label: title,
     ontology_type: 'evidence',
     lineage: [String(event.data.event_id ?? event.data.id)],
-    attributes: { evidenceHash, evidenceType, rootEvidenceId: evidenceInsert.data.id, targetNodeId, attachment, epistemicClass: 'OBSERVED', observedObject: 'evidence_record' },
+    attributes: { evidenceHash, evidenceType, rootEvidenceId: evidenceInsert.data.id, targetNodeId, attachment, epistemicClass: 'OBSERVED', observedObject: 'evidence_record', actorRole },
     updated_at: new Date().toISOString(),
   }, { onConflict: 'node_id' }).select('*').single();
 
@@ -246,7 +252,7 @@ export async function POST(req: Request) {
   if (mutation.error) return NextResponse.json({ ok: false, error: 'logbook_evidence_insert_failed', details: mutation.error.message }, { status: 400 });
 
   const [audit, cognitiveTwin] = await Promise.all([
-    auditRootAction({ actorId: gate.ctx.user.id, action: 'evidence.write', target: 'root_evidence_entries', payload: { evidenceHash, evidenceId: evidenceInsert.data.id, eventId: event.data.id, proposalId: proposal?.ok ? proposal.data.id : null, attachment, relationType: input.relationType }, request: req }),
+    auditRootAction({ actorId: gate.ctx.user.id, action: 'evidence.write', target: 'root_evidence_entries', payload: { evidenceHash, evidenceId: evidenceInsert.data.id, eventId: event.data.id, proposalId: proposal?.ok ? proposal.data.id : null, attachment, relationType: input.relationType, actorRole }, request: req }),
     ingestRootEvidenceIntoCognitiveTwin(evidenceInsert.data),
   ]);
   if (!audit.ok) return NextResponse.json(audit, { status: 500 });
@@ -263,6 +269,7 @@ export async function POST(req: Request) {
       proposal,
       cognitiveTwin,
       audit,
+      accessMode: gate.ctx.isRoot ? 'sovereign' : 'observer',
     },
   }, { status: 201 });
 }

--- a/src/app/root/evidence/intake/page.tsx
+++ b/src/app/root/evidence/intake/page.tsx
@@ -1,10 +1,10 @@
-import { requireFounderPage } from '@/lib/root/server';
+import { requireRootObserverPage } from '@/lib/root/server';
 import { SimpleEvidenceIntake } from '@/components/root/evidence/SimpleEvidenceIntake';
 
 export const dynamic = 'force-dynamic';
 export const metadata = { robots: { index: false, follow: false, nocache: true } };
 
 export default async function RootEvidenceIntakePage() {
-  await requireFounderPage('/root/evidence/intake');
+  await requireRootObserverPage('/root/evidence/intake');
   return <SimpleEvidenceIntake />;
 }

--- a/src/app/root/page.tsx
+++ b/src/app/root/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { RootSovereignConsole } from '@/components/root/sovereign/RootSovereignConsole';
-import { requireFounderPage } from '@/lib/root/server';
+import { requireRootObserverPage } from '@/lib/root/server';
 import { readRootSovereignState } from '@/lib/root/sovereign/rootSovereignAdapter';
 
 export const dynamic = 'force-dynamic';
@@ -14,11 +14,15 @@ export const metadata: Metadata = {
 };
 
 export default async function RootPage() {
-  await requireFounderPage('/root');
-
+  const ctx = await requireRootObserverPage('/root');
   const state = await readRootSovereignState();
+  const role = typeof ctx.profile?.role === 'string' ? ctx.profile.role : null;
 
   return (
-    <RootSovereignConsole initialState={state} />
+    <RootSovereignConsole
+      initialState={state}
+      accessMode={ctx.isRoot ? 'sovereign' : 'observer'}
+      actorLabel={ctx.profile?.alias || ctx.user?.email || role || 'observer'}
+    />
   );
 }

--- a/src/components/root/sovereign/RootSovereignConsole.tsx
+++ b/src/components/root/sovereign/RootSovereignConsole.tsx
@@ -17,7 +17,17 @@ function auditId(body: Record<string, unknown>) {
 }
 function abortReason(signal: AbortSignal) { return typeof signal.reason === 'string' ? signal.reason : null; }
 
-export function RootSovereignConsole({ initialState }: { initialState: RootSovereignState }) {
+type RootAccessMode = 'sovereign' | 'observer';
+
+export function RootSovereignConsole({
+  initialState,
+  accessMode = 'sovereign',
+  actorLabel = 'ROOT',
+}: {
+  initialState: RootSovereignState;
+  accessMode?: RootAccessMode;
+  actorLabel?: string;
+}) {
   const [state, setState] = useState(initialState);
   const [selection, setSelection] = useState<RootSelection | null>(null);
   const [viewMode, setViewMode] = useState<'topology' | 'legacy'>('topology');
@@ -29,6 +39,7 @@ export function RootSovereignConsole({ initialState }: { initialState: RootSover
   const [events, setEvents] = useState<RootSessionEvent[]>([]);
   const controller = useRef<AbortController | null>(null);
   const refreshSequence = useRef(0);
+  const readOnly = accessMode === 'observer';
 
   const refresh = useCallback(async () => {
     if (document.hidden) return;
@@ -63,10 +74,25 @@ export function RootSovereignConsole({ initialState }: { initialState: RootSover
     return () => { window.clearInterval(interval); document.removeEventListener('visibilitychange', visible); refreshSequence.current += 1; controller.current?.abort('unmount'); };
   }, [refresh]);
 
-  function requestAction(action: RootActionRequest) { setPending(action); setConfirmed(false); }
+  function requestAction(action: RootActionRequest) {
+    if (readOnly) {
+      const blocked: RootSessionEvent = {
+        id: `observer-block-${Date.now()}`,
+        at: new Date().toISOString(),
+        label: action.label,
+        status: 'blocked',
+        detail: 'Modo OBSERVER: puede observar ROOT y aportar evidencia, pero no ejecutar acciones soberanas.',
+        auditId: null,
+      };
+      setEvents((current) => [blocked, ...current].slice(0, 30));
+      return;
+    }
+    setPending(action);
+    setConfirmed(false);
+  }
 
   async function execute() {
-    if (!pending || !confirmed || running) return;
+    if (readOnly || !pending || !confirmed || running) return;
     const action = pending;
     setRunning(true);
     const started: RootSessionEvent = { id: `${action.id}-${Date.now()}`, at: new Date().toISOString(), label: action.label, status: 'running', detail: action.effect, auditId: null };
@@ -86,17 +112,25 @@ export function RootSovereignConsole({ initialState }: { initialState: RootSover
 
   return (
     <div className={`rs-console-host ${viewMode === 'legacy' ? 'is-legacy' : 'is-topology'} ${selection ? 'has-semantic-selection' : ''}`}>
+      {readOnly ? (
+        <div className="rs-observer-banner" role="status">
+          <strong>OBSERVER · {actorLabel}</strong>
+          <span>Observación institucional de 30 días · lectura ROOT habilitada · gobernanza y ejecución reservadas al founder.</span>
+          <a href="/root/evidence/intake">REGISTRAR EVIDENCIA</a>
+        </div>
+      ) : null}
+
       {viewMode === 'topology' ? (
         <><RootInstitutionalSelfPerception state={state} /><RootTopologyField state={state} refreshing={refreshing} warning={refreshWarning} onRefresh={() => void refresh()} onSelect={setSelection} onAction={requestAction} onLegacy={() => setViewMode('legacy')} /></>
       ) : (
         <><button type="button" className="rs-return-to-topologies" onClick={() => setViewMode('topology')}>VOLVER A TOPOLOGÍAS I–III</button><RootOperationalShell state={state} refreshing={refreshing} warning={refreshWarning} onRefresh={() => void refresh()} onSelect={setSelection} onAction={requestAction} /></>
       )}
       <RootSemanticInspector value={selection} onClose={() => setSelection(null)} />
-      <RootMethodologyWorkbench state={state} />
+      {!readOnly ? <RootMethodologyWorkbench state={state} /> : null}
 
       {events.length ? <div className="rs-root-events" aria-live="polite">{events.slice(0, 3).map((event) => <div key={event.id} data-status={event.status}><strong>{event.label}</strong><span>{event.detail}</span></div>)}</div> : null}
 
-      {pending ? (
+      {!readOnly && pending ? (
         <div className="rs-dialog-backdrop" role="presentation"><section className="rs-dialog" role="dialog" aria-modal="true" aria-labelledby="rs-dialog-title"><span>REVISAR ANTES DE EJECUTAR</span><h2 id="rs-dialog-title">{pending.label}</h2><dl><div><dt>QUÉ HARÁ</dt><dd>{pending.effect}</dd></div><div><dt>SOBRE QUÉ</dt><dd>{pending.target}</dd></div></dl><label className="rs-confirm"><input type="checkbox" checked={confirmed} onChange={(event) => setConfirmed(event.target.checked)} />Confirmo esta acción y comprendo su objetivo.</label><div className="rs-dialog-actions"><button type="button" onClick={() => { setPending(null); setConfirmed(false); }} disabled={running}>CANCELAR</button><button type="button" onClick={() => void execute()} disabled={!confirmed || running}>{running ? 'EJECUTANDO' : 'CONFIRMAR Y EJECUTAR'}</button></div></section></div>
       ) : null}
     </div>

--- a/src/lib/root/server.ts
+++ b/src/lib/root/server.ts
@@ -13,11 +13,35 @@ export function stringValue(value: unknown) {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
 }
 
+export async function requireRootViewer(action: string) {
+  const ctx = await getServerUserContext();
+  if (!ctx.user) return { ok: false as const, status: 401, body: { ok: false, error: 'Unauthorized' } };
+  if (!ctx.canObserveRoot) return { ok: false as const, status: 403, body: { ok: false, error: 'root_observer_access_required' } };
+  return { ok: true as const, ctx, action };
+}
+
+export async function requireRootContributor(action: string) {
+  const ctx = await getServerUserContext();
+  if (!ctx.user) return { ok: false as const, status: 401, body: { ok: false, error: 'Unauthorized' } };
+  const role = typeof ctx.profile?.role === 'string' ? ctx.profile.role : null;
+  if (!ctx.isRoot && role !== 'observer') {
+    return { ok: false as const, status: 403, body: { ok: false, error: 'root_evidence_contributor_required' } };
+  }
+  return { ok: true as const, ctx, action };
+}
+
 export async function requireRootActor(action: string) {
   const ctx = await getServerUserContext();
   if (!ctx.user) return { ok: false as const, status: 401, body: { ok: false, error: 'Unauthorized' } };
   if (!ctx.isRoot) return { ok: false as const, status: 403, body: { ok: false, error: 'root_required' } };
   return { ok: true as const, ctx, action };
+}
+
+export async function requireRootObserverPage(pathname: string) {
+  const ctx = await getServerUserContext();
+  if (!ctx.user) redirect(`/login?next=${encodeURIComponent(pathname)}`);
+  if (!ctx.canObserveRoot) redirect('/unauthorized');
+  return ctx;
 }
 
 export async function requireFounderPage(pathname: string) {
@@ -57,12 +81,6 @@ export async function auditRootAction(input: {
   request?: Request;
 }) {
   if (isReadOnlyAction(input.action)) {
-    // No se escribe root_audit_event ni epistemic_event por una lectura.
-    // DT-TRUTH-001 / R19 en espíritu: una lectura no es evidencia nueva, es
-    // solo consultar lo que ya existe. Se devuelve ok:true con skipped:true
-    // para que quien llama pueda seguir su flujo normal sin tratarlo como
-    // fallo, pero quede visible en logs de desarrollo que se omitió a
-    // propósito, no por error silencioso.
     return { ok: true as const, skipped: true as const, reason: 'read_only_action_not_audited' as const };
   }
 
@@ -107,7 +125,6 @@ export async function auditRootAction(input: {
 
   return { ok: true as const, skipped: false as const, audit: auditInsert.data, epistemicEvent: event.data };
 }
-
 
 export async function readTableHealth(table: string, limit = 5) {
   const service = createServiceSupabaseClient();

--- a/src/lib/server/productionBackend.ts
+++ b/src/lib/server/productionBackend.ts
@@ -21,6 +21,10 @@ export function isRootRole(role?: string | null) {
   return role === 'root' || role === 'system';
 }
 
+export function isInstitutionalObserverRole(role?: string | null) {
+  return role === 'observer';
+}
+
 export function isRootUser(
   role?: string | null,
   email?: string | null
@@ -35,6 +39,13 @@ export function isRootUser(
         email.toLowerCase() === rootEmail.toLowerCase()
     )
   );
+}
+
+export function canObserveRoot(
+  role?: string | null,
+  email?: string | null
+) {
+  return isRootUser(role, email) || isInstitutionalObserverRole(role);
 }
 
 export async function getServerUserContext() {
@@ -60,6 +71,7 @@ export async function getServerUserContext() {
       user: null,
       profile: null,
       isRoot: false,
+      canObserveRoot: false,
     };
   }
 
@@ -107,15 +119,18 @@ export async function getServerUserContext() {
     profile = createdProfile;
   }
 
+  const isRoot = isRootUser(
+    profile?.role,
+    user.email
+  );
+
   return {
     supabase,
     service,
     user,
     profile,
-    isRoot: isRootUser(
-      profile?.role,
-      user.email
-    ),
+    isRoot,
+    canObserveRoot: canObserveRoot(profile?.role, user.email),
   };
 }
 
@@ -154,30 +169,18 @@ export async function ensureOwnedNode(
     })
     .limit(1);
 
-  let node = nodes?.[0] || null;
-
-  if (!node && !nodeId) {
-    const { data } = await ctx.service
-      .from('nodes')
-      .insert({
-        user_id: ctx.user.id,
-        source: 'web',
-        current_ihg: 0.52,
-        current_nti: 0.48,
-        current_ldi: 1.12,
-      })
-      .select('*')
-      .single();
-
-    node = data;
-  }
+  const node = nodes?.[0] || null;
 
   if (!node) {
     return {
       ...ctx,
       node: null,
       error: NextResponse.json(
-        { error: 'node_not_found' },
+        {
+          error: 'node_not_found',
+          epistemicStatus: 'MISSING',
+          message: 'No persisted node exists for this actor. SFI will not synthesize IHG, NTI or LDI values.',
+        },
         { status: 404 }
       ),
     };
@@ -204,6 +207,11 @@ export async function ensureOwnedNode(
   };
 }
 
+function finiteMetric(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return value;
+}
+
 export function denseFragment(
   metrics: {
     ihg?: number;
@@ -213,14 +221,16 @@ export function denseFragment(
   },
   hint?: string
 ) {
-  const ihg = Number(metrics.ihg ?? 0.5);
-  const nti = Number(metrics.nti ?? 0.5);
-  const ldi = Number(metrics.ldi ?? 0.5);
+  const ihg = finiteMetric(metrics.ihg);
+  const nti = finiteMetric(metrics.nti);
+  const ldi = finiteMetric(metrics.ldi);
+  const explicitPhi = finiteMetric(metrics.phi);
 
-  const phi = Number(
-    metrics.phi ??
-      (ihg * nti) / (1 + ldi)
-  );
+  if (ihg === null || nti === null || ldi === null) {
+    return `MISSING · lectura insuficiente para interpretar IHG/NTI/LDI.${hint ? ` Vector declarado: ${hint}.` : ''}`;
+  }
+
+  const phi = explicitPhi ?? (ihg * nti) / (1 + ldi);
 
   const ldiMark =
     ldi > 1

--- a/src/lib/server/productionBackend.ts
+++ b/src/lib/server/productionBackend.ts
@@ -41,6 +41,35 @@ export function isRootUser(
   );
 }
 
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function isConfiguredRootEmail(email?: string | null) {
+  const rootEmail = process.env.SYSTEM_ROOT_EMAIL;
+  return Boolean(
+    rootEmail &&
+      email &&
+      email.toLowerCase() === rootEmail.toLowerCase()
+  );
+}
+
+function hasSovereignRootAuthority(
+  profile: Record<string, unknown> | null,
+  email?: string | null,
+) {
+  if (isConfiguredRootEmail(email)) return true;
+  if (!profile) return false;
+
+  const role = typeof profile.role === 'string' ? profile.role : null;
+  if (!isRootRole(role)) return false;
+
+  const moduleAccess = record(profile.module_access);
+  return moduleAccess.full_access === true;
+}
+
 export function canObserveRoot(
   role?: string | null,
   email?: string | null
@@ -82,13 +111,9 @@ export async function getServerUserContext() {
     .maybeSingle();
 
   if (!profile) {
-    const rootEmail = process.env.SYSTEM_ROOT_EMAIL;
-
-    const role =
-      rootEmail &&
-      user.email?.toLowerCase() === rootEmail.toLowerCase()
-        ? 'root'
-        : 'observer';
+    const role = isConfiguredRootEmail(user.email)
+      ? 'root'
+      : 'observer';
 
     const alias =
       user.email?.split('@')[0] || 'observador';
@@ -105,6 +130,7 @@ export async function getServerUserContext() {
           user.email ||
           `${user.id}@systemfriction.local`,
         role,
+        module_access: role === 'root' ? ROOT_ENTITLEMENTS : {},
       })
       .select('*')
       .single();
@@ -119,10 +145,10 @@ export async function getServerUserContext() {
     profile = createdProfile;
   }
 
-  const isRoot = isRootUser(
-    profile?.role,
-    user.email
-  );
+  const profileRecord = profile ? record(profile) : null;
+  const role = typeof profile?.role === 'string' ? profile.role : null;
+  const isRoot = hasSovereignRootAuthority(profileRecord, user.email);
+  const legacyRootWithoutAuthority = isRootRole(role) && !isRoot;
 
   return {
     supabase,
@@ -130,7 +156,10 @@ export async function getServerUserContext() {
     user,
     profile,
     isRoot,
-    canObserveRoot: canObserveRoot(profile?.role, user.email),
+    canObserveRoot:
+      isRoot ||
+      isInstitutionalObserverRole(role) ||
+      legacyRootWithoutAuthority,
   };
 }
 


### PR DESCRIPTION
Adds a non-sovereign ROOT observation mode for the 30-day institutional experiment. Observer accounts can read ROOT, refresh the console, and submit evidence; sovereign actions remain founder-only. Sovereign ROOT now requires explicit full_access entitlement (or configured root email), preventing legacy root labels without authority from inheriting founder powers. Also removes seeded node IHG/NTI/LDI values and default 0.5 metrics from productionBackend so missing measurements remain MISSING.