### PR TITLE
Allow institutional observers through ROOT proxy gate

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -47,6 +47,17 @@ function hasEnabledModule(moduleAccess: ModuleAccess, ...keys: string[]) {
   return keys.some((key) => moduleAccess[key] === true)
 }
 
+function canEnterRootRoute(
+  userId?: string | null,
+  role?: string | null,
+  email?: string | null,
+  moduleAccess?: ModuleAccess,
+) {
+  if (isRootRouteUser(userId, role, email)) return true
+  if (role === 'observer') return true
+  return hasEnabledModule(moduleAccess, 'root', 'root_observe')
+}
+
 function isStudioRouteUser(
   userId?: string | null,
   role?: string | null,
@@ -151,7 +162,10 @@ export async function proxy(request: NextRequest) {
     .eq('user_id', user.id)
     .maybeSingle()
 
-  if (pathname.startsWith('/root') && !isRootRouteUser(user.id, profile?.role, user.email)) {
+  if (
+    pathname.startsWith('/root') &&
+    !canEnterRootRoute(user.id, profile?.role, user.email, profile?.module_access as ModuleAccess)
+  ) {
     return NextResponse.redirect(new URL('/unauthorized', request.url))
   }
 


### PR DESCRIPTION
Fixes the actual Edwin ROOT access blocker in `src/proxy.ts`.

Root cause: the proxy intercepted `/root` before the page-level `requireRootObserverPage()` gate and only allowed founder/root/system identities. Edwin's Supabase identity and profile were correct (`role=observer`, `module_access.root=true`, `root_observe=true`) but the proxy ignored those observer entitlements and redirected him to `/unauthorized`.

Changes:
- adds `canEnterRootRoute()` to distinguish route visibility from sovereign ROOT authority;
- allows authenticated `observer` profiles to enter `/root`;
- honors explicit `module_access.root` / `root_observe` for route visibility;
- preserves `isRootRouteUser()` for sovereign/founder behavior;
- does not grant execution, governance, canonical promotion, or sovereign actions. Those remain guarded downstream by `requireRootActor()` and the existing observer read-only UI.

Scope is intentionally limited to the proxy gate.