### PR TITLE
Make Edwin's institutional observer workspace ROOT

### DIFF
--- a/src/app/member/page.tsx
+++ b/src/app/member/page.tsx
@@ -10,6 +10,10 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false, nocache: true },
 };
 
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
 export default async function MemberPage() {
   const { user, profile, member, supabase } = await requireSfiMemberPage('/member');
 
@@ -20,6 +24,8 @@ export default async function MemberPage() {
   ]);
 
   const displayName = member?.displayName ?? profile.alias ?? user.email ?? 'Miembro SFI';
+  const access = record(profile.module_access);
+  const canObserveRoot = profile.role === 'observer' || access.root === true || access.root_observe === true;
 
   return (
     <main className="min-h-screen bg-[#050504] px-5 py-8 text-[#d8d1c0] md:px-10">
@@ -28,9 +34,8 @@ export default async function MemberPage() {
           <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-[#c8a951]">SYSTEM FRICTION INSTITUTE · MIEMBRO</p>
           <h1 className="mt-4 font-serif text-4xl text-[#f2e8d2]">Bienvenido, {displayName}.</h1>
           <p className="mt-4 max-w-3xl text-sm leading-7 text-[#999080]">
-            Este es tu espacio institucional dentro de SFI. Aquí puedes construir una trayectoria en FIELD,
-            trabajar objetos en STUDIO y consultar el campo mundial y el observatorio público. ROOT permanece
-            reservado para la gobernanza del instituto.
+            Este es tu espacio institucional dentro de SFI. FIELD y STUDIO conservan tus trayectorias y objetos.
+            {canObserveRoot ? ' Tu rol incluye observación institucional en ROOT sin autoridad soberana.' : ' ROOT permanece reservado a los roles autorizados.'}
           </p>
           <div className="mt-5 flex flex-wrap gap-2 font-mono text-[9px] uppercase tracking-[0.13em]">
             <span className="border border-[#332c20] px-3 py-2 text-[#a69a83]">{user.email}</span>
@@ -40,44 +45,17 @@ export default async function MemberPage() {
         </header>
 
         <section className="mt-6 grid gap-4 md:grid-cols-3">
-          <article className="border border-[#332c20] bg-[#090908] p-5">
-            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#98896b]">Trayectorias propias</span>
-            <strong className="mt-3 block text-3xl font-normal text-[#e4c377]">{cases.count ?? 0}</strong>
-            <p className="mt-3 text-xs leading-6 text-[#8e8575]">Procesos longitudinales que has abierto en FIELD.</p>
-          </article>
-          <article className="border border-[#332c20] bg-[#090908] p-5">
-            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#98896b]">Objetos propios</span>
-            <strong className="mt-3 block text-3xl font-normal text-[#e4c377]">{objects.count ?? 0}</strong>
-            <p className="mt-3 text-xs leading-6 text-[#8e8575]">Objetos que has trasladado o cargado en STUDIO.</p>
-          </article>
-          <article className="border border-[#332c20] bg-[#090908] p-5">
-            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#98896b]">Retornos pendientes</span>
-            <strong className="mt-3 block text-3xl font-normal text-[#e4c377]">{returns.count ?? 0}</strong>
-            <p className="mt-3 text-xs leading-6 text-[#8e8575]">Puntos de revisión que todavía necesitan observación posterior.</p>
-          </article>
+          <article className="border border-[#332c20] bg-[#090908] p-5"><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#98896b]">Trayectorias propias</span><strong className="mt-3 block text-3xl font-normal text-[#e4c377]">{cases.count ?? 0}</strong><p className="mt-3 text-xs leading-6 text-[#8e8575]">Procesos longitudinales que has abierto en FIELD.</p></article>
+          <article className="border border-[#332c20] bg-[#090908] p-5"><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#98896b]">Objetos propios</span><strong className="mt-3 block text-3xl font-normal text-[#e4c377]">{objects.count ?? 0}</strong><p className="mt-3 text-xs leading-6 text-[#8e8575]">Objetos que has trasladado o cargado en STUDIO.</p></article>
+          <article className="border border-[#332c20] bg-[#090908] p-5"><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#98896b]">Retornos pendientes</span><strong className="mt-3 block text-3xl font-normal text-[#e4c377]">{returns.count ?? 0}</strong><p className="mt-3 text-xs leading-6 text-[#8e8575]">Puntos de revisión que todavía necesitan observación posterior.</p></article>
         </section>
 
         <section className="mt-6 grid gap-4 md:grid-cols-2">
-          <Link href="/interface" className="group border border-[#5b4b28] bg-[#0b0a08] p-6 no-underline hover:border-[#c8a951]">
-            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">FIELD</span>
-            <h2 className="mt-3 text-2xl text-[#f0e4c9]">Observar y construir una trayectoria</h2>
-            <p className="mt-3 text-sm leading-7 text-[#908777]">Conserva apariciones, organiza evidencia y prueba microejecuciones reversibles sin concluir demasiado pronto.</p>
-          </Link>
-          <Link href="/studio" className="group border border-[#5b4b28] bg-[#0b0a08] p-6 no-underline hover:border-[#c8a951]">
-            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">STUDIO</span>
-            <h2 className="mt-3 text-2xl text-[#f0e4c9]">Analizar o transformar un objeto</h2>
-            <p className="mt-3 text-sm leading-7 text-[#908777]">Trabaja sobre objetos propios y prepara resultados que puedan volver a FIELD como evidencia o retorno.</p>
-          </Link>
-          <Link href="/field/map" className="group border border-[#332c20] bg-[#090908] p-6 no-underline hover:border-[#c8a951]">
-            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">CAMPO MUNDIAL</span>
-            <h2 className="mt-3 text-2xl text-[#f0e4c9]">Explorar señales localizadas</h2>
-            <p className="mt-3 text-sm leading-7 text-[#908777]">Observa eventos y tensiones geográficas sin asumir causalidad por su ubicación.</p>
-          </Link>
-          <Link href="/observatory" className="group border border-[#332c20] bg-[#090908] p-6 no-underline hover:border-[#c8a951]">
-            <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">OBSERVATORIO PÚBLICO</span>
-            <h2 className="mt-3 text-2xl text-[#f0e4c9]">Consultar la lectura agregada</h2>
-            <p className="mt-3 text-sm leading-7 text-[#908777]">Revisa el estado longitudinal publicado por SFI y sus límites metodológicos.</p>
-          </Link>
+          {canObserveRoot ? <Link href="/root" className="group border border-[#c8a951] bg-[#0b0a08] p-6 no-underline hover:border-[#e4c377]"><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">ROOT · OBSERVER</span><h2 className="mt-3 text-2xl text-[#f0e4c9]">Observar el estado institucional</h2><p className="mt-3 text-sm leading-7 text-[#908777]">Revisa evidencia, runtime, reportes, trayectoria e institucionalización sin ejecutar acciones soberanas.</p></Link> : null}
+          <Link href="/interface" className="group border border-[#5b4b28] bg-[#0b0a08] p-6 no-underline hover:border-[#c8a951]"><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">FIELD</span><h2 className="mt-3 text-2xl text-[#f0e4c9]">Observar y construir una trayectoria</h2><p className="mt-3 text-sm leading-7 text-[#908777]">Conserva apariciones, organiza evidencia y prueba microejecuciones reversibles sin concluir demasiado pronto.</p></Link>
+          <Link href="/studio" className="group border border-[#5b4b28] bg-[#0b0a08] p-6 no-underline hover:border-[#c8a951]"><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">STUDIO</span><h2 className="mt-3 text-2xl text-[#f0e4c9]">Analizar o transformar un objeto</h2><p className="mt-3 text-sm leading-7 text-[#908777]">Trabaja sobre objetos propios y prepara resultados que puedan volver a FIELD como evidencia o retorno.</p></Link>
+          <Link href="/field/map" className="group border border-[#332c20] bg-[#090908] p-6 no-underline hover:border-[#c8a951]"><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">CAMPO MUNDIAL</span><h2 className="mt-3 text-2xl text-[#f0e4c9]">Explorar señales localizadas</h2><p className="mt-3 text-sm leading-7 text-[#908777]">Observa eventos y tensiones geográficas sin asumir causalidad por su ubicación.</p></Link>
+          <Link href="/observatory" className="group border border-[#332c20] bg-[#090908] p-6 no-underline hover:border-[#c8a951]"><span className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c8a951]">OBSERVATORIO PÚBLICO</span><h2 className="mt-3 text-2xl text-[#f0e4c9]">Consultar la lectura agregada</h2><p className="mt-3 text-sm leading-7 text-[#908777]">Revisa el estado longitudinal publicado por SFI y sus límites metodológicos.</p></Link>
         </section>
       </div>
     </main>

--- a/src/lib/auth/actions.ts
+++ b/src/lib/auth/actions.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from 'next/navigation'
 import { checkRateLimit, rateLimitKey } from '@/lib/auth/rateLimit'
-import { createServerSupabaseClient } from '@/runtime/supabase/server'
+import { createServerSupabaseClient, createServiceSupabaseClient } from '@/runtime/supabase/server'
 import { authSchema } from '@/lib/validation/schemas'
 
 function formValue(formData: FormData, key: string) {
@@ -15,6 +15,24 @@ function safeInternalRedirect(value: string) {
   if (value.startsWith('//')) return '/field'
   if (value.startsWith('/login') || value.startsWith('/signup') || value.startsWith('/verify')) return '/field'
   return value
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+async function resolvePostLoginPath(userId: string, requestedNext: string) {
+  if (requestedNext !== '/field') return requestedNext
+  const service = createServiceSupabaseClient()
+  const { data: profile } = await service
+    .from('profiles')
+    .select('role,module_access')
+    .eq('user_id', userId)
+    .maybeSingle()
+  const role = typeof profile?.role === 'string' ? profile.role : null
+  const access = record(profile?.module_access)
+  if (role === 'observer' && (access.root === true || access.root_observe === true)) return '/root'
+  return requestedNext
 }
 
 export async function registerAction(formData: FormData) {
@@ -47,10 +65,10 @@ export async function loginAction(formData: FormData) {
 
   const supabase = await createServerSupabaseClient()
   if (!supabase) redirect(`/login?error=supabase_no_configurado&next=${encodeURIComponent(next)}`)
-  const { error } = await supabase.auth.signInWithPassword(parsed.data)
-  if (error) redirect(`/login?error=${encodeURIComponent(error.message)}&next=${encodeURIComponent(next)}`)
+  const { data, error } = await supabase.auth.signInWithPassword(parsed.data)
+  if (error || !data.user) redirect(`/login?error=${encodeURIComponent(error?.message ?? 'auth_user_missing')}&next=${encodeURIComponent(next)}`)
 
-  redirect(next)
+  redirect(await resolvePostLoginPath(data.user.id, next))
 }
 
 export async function forgotPasswordAction(formData: FormData) {

--- a/src/lib/system/access/institutionalMembers.ts
+++ b/src/lib/system/access/institutionalMembers.ts
@@ -1,14 +1,14 @@
 export type SfiInstitutionalMember = {
   email: string;
   displayName: string;
-  role: 'operator' | 'controller';
-  workspace: '/member';
+  role: 'operator' | 'controller' | 'observer';
+  workspace: '/member' | '/root';
   modules: {
     field: boolean;
     studio: boolean;
     observatory: boolean;
     worldField: boolean;
-    root: false;
+    root: boolean;
   };
 };
 
@@ -16,14 +16,14 @@ const MEMBERS: SfiInstitutionalMember[] = [
   {
     email: 'edwin.tzolkin@gmail.com',
     displayName: 'Edwin',
-    role: 'operator',
-    workspace: '/member',
+    role: 'observer',
+    workspace: '/root',
     modules: {
       field: true,
       studio: true,
       observatory: true,
       worldField: true,
-      root: false,
+      root: true,
     },
   },
 ];

--- a/src/lib/system/access/server.ts
+++ b/src/lib/system/access/server.ts
@@ -71,7 +71,8 @@ async function readOrProvisionInstitutionalProfile(user: { id: string; email?: s
         field: member.modules.field,
         studio: member.modules.studio,
         world_field: member.modules.worldField,
-        root: false,
+        root: member.modules.root,
+        root_observe: member.modules.root,
       },
       last_seen_at: new Date().toISOString(),
     })
@@ -85,7 +86,7 @@ async function readOrProvisionInstitutionalProfile(user: { id: string; email?: s
 export async function requireSfiMember() {
   const context = await requireAuthenticatedUser();
   const resolved = await readOrProvisionInstitutionalProfile(context.user);
-  const allowedRoles = new Set(['operator', 'controller', 'root', 'system']);
+  const allowedRoles = new Set(['operator', 'controller', 'observer', 'root', 'system']);
   if (!resolved.profile || (!allowedRoles.has(String(resolved.profile.role)) && !resolved.member)) {
     throw new AccessDeniedError(403, 'SFI_MEMBER_REQUIRED', 'An active SFI institutional membership is required.');
   }


### PR DESCRIPTION
Removes the last contradictory access definitions for the institutional observer.

Changes:
- institutional member registry now identifies Edwin as `observer`, workspace `/root`, `root=true`;
- profile provisioning preserves `root` and `root_observe` from institutional membership instead of forcing `root:false`;
- `observer` is an accepted institutional member role;
- post-login routing reads the persisted profile through the service client and sends an observer with `root/root_observe=true` to `/root` when no more specific destination was requested;
- `/member` no longer tells an authorized observer that ROOT is categorically reserved and exposes a visible `ROOT · OBSERVER` entry point.

Authority boundary remains unchanged: observer access is read/contributor access only; `requireRootActor()` still protects sovereign execution.