### PR TITLE
Recover authorized observers from unauthorized route

### DIFF
--- a/src/app/unauthorized/page.tsx
+++ b/src/app/unauthorized/page.tsx
@@ -1,22 +1,23 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { findInstitutionalMember } from '@/lib/system/access/institutionalMembers';
-import { createServerSupabaseClient } from '@/runtime/supabase/server';
+import { getServerUserContext } from '@/lib/server/productionBackend';
 
 export const dynamic = 'force-dynamic';
 
 export default async function UnauthorizedPage() {
-  const supabase = await createServerSupabaseClient();
-  const { data } = await supabase.auth.getUser();
-  if (findInstitutionalMember(data.user?.email)) redirect('/member');
+  const ctx = await getServerUserContext();
+
+  if (ctx.user && ctx.canObserveRoot) {
+    redirect('/root');
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-void px-5 text-paper">
       <div className="terminal-panel max-w-lg p-8 text-center">
         <p className="font-mono text-[10px] uppercase tracking-[0.24em] text-gold">Acceso institucional SFI</p>
-        <h1 className="mt-3 font-display text-2xl text-red-500">Esta superficie no corresponde a tu cuenta</h1>
+        <h1 className="mt-3 font-display text-2xl text-red-500">Acceso no autorizado</h1>
         <p className="mt-4 text-sm text-paper/80">
-          ROOT está reservado para la gobernanza del instituto. Una cuenta autenticada puede seguir utilizando las superficies que tenga asignadas.
+          Esta cuenta no tiene una superficie institucional asignada para esta ruta.
         </p>
         <div className="mt-6 flex flex-wrap justify-center gap-3">
           <Link href="/member" className="border border-gold/50 px-4 py-2 text-gold">Ir a mi espacio</Link>


### PR DESCRIPTION
Fixes a stale access contradiction in `/unauthorized`: registered ROOT observers such as Edwin were still being redirected to `/member` after any accidental unauthorized transition. The route now resolves the authoritative server user context and immediately returns any authenticated `canObserveRoot` identity to `/root`. Truly unauthorized identities still see the denial page. No sovereign authority is granted.