### PR TITLE
Make ROOT diagnostic instead of generic

### DIFF
--- a/src/components/root/reports/RootReportsConsole.tsx
+++ b/src/components/root/reports/RootReportsConsole.tsx
@@ -4,38 +4,157 @@ import Link from 'next/link';
 import { useMemo, useState } from 'react';
 
 type Row = Record<string, unknown>;
+type ReportType =
+  | 'world_vector_internal'
+  | 'world_vector_public'
+  | 'ifnorm'
+  | 'sfi_dr01'
+  | 'neural_graph_evidence'
+  | 'amv_recurrence'
+  | 'calibration'
+  | 'atlas_entry'
+  | 'linkedin_draft'
+  | 'contact_draft';
 
-const REPORT_TYPES = [
-  'world_vector_internal',
-  'world_vector_public',
-  'ifnorm',
-  'sfi_dr01',
-  'neural_graph_evidence',
-  'amv_recurrence',
-  'calibration',
-  'atlas_entry',
-  'linkedin_draft',
-  'contact_draft',
-] as const;
+type ReportOption = {
+  type: ReportType;
+  label: string;
+  question: string;
+  description: string;
+  requiresSubject: boolean;
+  acceptsSubject: boolean;
+  subjectLabel?: string;
+  subjectPlaceholder?: string;
+  inputExplanation: string;
+  recommended?: boolean;
+};
+
+const REPORT_OPTIONS: ReportOption[] = [
+  {
+    type: 'world_vector_internal',
+    label: 'Estado institucional',
+    question: '¿Qué está viendo SFI ahora?',
+    description: 'Resume señales, tensiones, fuentes degradadas y lectura interna del World Vector sin convertirla en publicación.',
+    requiresSubject: false,
+    acceptsSubject: false,
+    inputExplanation: 'Nada. SFI usa el estado institucional y la evidencia persistida disponible.',
+    recommended: true,
+  },
+  {
+    type: 'neural_graph_evidence',
+    label: 'Evidencia y trazabilidad',
+    question: '¿Qué está sustentado y qué no?',
+    description: 'Lee el grafo para separar nodos con soporte, huecos de linaje, contradicciones y evidencia relacionada.',
+    requiresSubject: false,
+    acceptsSubject: true,
+    subjectLabel: 'FOCO OPCIONAL',
+    subjectPlaceholder: 'Ej. Governance, REM618, Caso 01, Cognitive Twin',
+    inputExplanation: 'No necesitas escribir nada para una lectura global. Si quieres revisar un objeto concreto, escribe su nombre.',
+    recommended: true,
+  },
+  {
+    type: 'calibration',
+    label: 'Calibración',
+    question: '¿Dónde puede SFI estar sobreafirmando?',
+    description: 'Busca desajustes entre evidencia, confianza, claims, ejecución y estado declarado.',
+    requiresSubject: false,
+    acceptsSubject: true,
+    subjectLabel: 'FOCO OPCIONAL',
+    subjectPlaceholder: 'Ej. continuidad institucional, MIHM, Studio',
+    inputExplanation: 'Nada para calibración global; un foco sólo limita la lectura a un dominio concreto.',
+    recommended: true,
+  },
+  {
+    type: 'amv_recurrence',
+    label: 'Recurrencias AMV',
+    question: '¿Qué patrón está reapareciendo?',
+    description: 'Busca recurrencias en memoria, evidencia y trayectoria para señalar patrones persistentes sin confundir recurrencia con causalidad.',
+    requiresSubject: false,
+    acceptsSubject: true,
+    subjectLabel: 'FOCO OPCIONAL',
+    subjectPlaceholder: 'Ej. latencia, cierre prematuro, señal cultural',
+    inputExplanation: 'Nada para una búsqueda global; puedes dar un patrón o fenómeno para acotar la memoria consultada.',
+    recommended: true,
+  },
+  {
+    type: 'sfi_dr01',
+    label: 'Expediente SFI-DR01',
+    question: '¿Qué fricción muestra este caso?',
+    description: 'Construye una lectura diagnóstica de un caso concreto usando evidencia disponible y límites explícitos.',
+    requiresSubject: true,
+    acceptsSubject: true,
+    subjectLabel: 'CASO / SISTEMA',
+    subjectPlaceholder: 'Ej. Caso 01 · Kavak',
+    inputExplanation: 'Escribe el caso, sistema u objeto que quieres diagnosticar. El reporte no adivinará el foco.',
+  },
+  {
+    type: 'ifnorm',
+    label: 'IFNORM / oportunidad',
+    question: '¿Qué señal externa vale investigar?',
+    description: 'Organiza una entidad o señal como oportunidad potencial y explicita qué falta verificar antes de tratarla como prospecto.',
+    requiresSubject: true,
+    acceptsSubject: true,
+    subjectLabel: 'ENTIDAD / SEÑAL',
+    subjectPlaceholder: 'Ej. FEMSA · fricción entre operación y seguimiento',
+    inputExplanation: 'Escribe la entidad, fenómeno o señal externa que quieres evaluar.',
+  },
+  {
+    type: 'atlas_entry',
+    label: 'Entrada Atlas',
+    question: '¿Qué fenómeno debe conservarse?',
+    description: 'Prepara una entrada de memoria relacional para un fenómeno concreto, con procedencia y límites de interpretación.',
+    requiresSubject: true,
+    acceptsSubject: true,
+    subjectLabel: 'FENÓMENO / OBJETO',
+    subjectPlaceholder: 'Ej. REM618 · apertura de campo',
+    inputExplanation: 'Nombra el fenómeno u objeto que debe convertirse en entrada Atlas.',
+  },
+  {
+    type: 'world_vector_public',
+    label: 'World Vector público',
+    question: '¿Qué lectura podría hacerse pública?',
+    description: 'Genera un borrador público desde el estado disponible. Sigue siendo borrador y requiere aprobación humana.',
+    requiresSubject: false,
+    acceptsSubject: false,
+    inputExplanation: 'Nada. Parte del estado World Vector disponible y conserva la separación entre borrador y publicación.',
+  },
+  {
+    type: 'linkedin_draft',
+    label: 'Borrador LinkedIn',
+    question: '¿Qué puede comunicarse sin sobreafirmar?',
+    description: 'Produce un borrador editorial a partir de evidencia y estado persistidos. No publica automáticamente.',
+    requiresSubject: false,
+    acceptsSubject: true,
+    subjectLabel: 'TEMA OPCIONAL',
+    subjectPlaceholder: 'Ej. Caso 01 · latencia de ejecución',
+    inputExplanation: 'Puedes dejarlo vacío para que SFI use el estado más relevante o indicar el tema que quieres convertir en borrador.',
+  },
+  {
+    type: 'contact_draft',
+    label: 'Borrador de contacto',
+    question: '¿Qué mensaje se podría preparar?',
+    description: 'Prepara un borrador de contacto para una entidad o persona. No envía nada y debe pasar por aprobación.',
+    requiresSubject: true,
+    acceptsSubject: true,
+    subjectLabel: 'DESTINATARIO / FOCO',
+    subjectPlaceholder: 'Ej. Empresa X · responsable de operaciones',
+    inputExplanation: 'Indica para quién o para qué relación quieres preparar el mensaje.',
+  },
+];
 
 function record(value: unknown): Row {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
 }
-
 function strings(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
 }
-
 function text(value: unknown, fallback = '—') {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }
-
 function when(value: unknown) {
   if (typeof value !== 'string') return 'SIN FECHA';
   const date = new Date(value);
-  return Number.isFinite(date.valueOf())
-    ? new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(date)
-    : value;
+  return Number.isFinite(date.valueOf()) ? new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(date) : value;
 }
 
 export function RootReportsConsole({ initialReports, canGenerate, actorLabel }: {
@@ -45,11 +164,12 @@ export function RootReportsConsole({ initialReports, canGenerate, actorLabel }: 
 }) {
   const [reports, setReports] = useState<Row[]>(initialReports);
   const [selectedId, setSelectedId] = useState<string | null>(() => text(initialReports[0]?.id, '') || null);
-  const [type, setType] = useState<(typeof REPORT_TYPES)[number]>('world_vector_internal');
+  const [type, setType] = useState<ReportType>('world_vector_internal');
   const [subject, setSubject] = useState('');
   const [running, setRunning] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
+  const option = REPORT_OPTIONS.find((item) => item.type === type) ?? REPORT_OPTIONS[0];
   const selected = useMemo(
     () => reports.find((row) => text(row.id, '') === selectedId) ?? reports[0] ?? null,
     [reports, selectedId],
@@ -58,9 +178,16 @@ export function RootReportsConsole({ initialReports, canGenerate, actorLabel }: 
   const trace = record(output.trace);
   const evidence = strings(output.evidence).length ? strings(output.evidence) : strings(selected?.evidence_refs);
   const warnings = strings(output.warnings).length ? strings(output.warnings) : strings(selected?.limitations);
+  const canRunSelection = canGenerate && !running && (!option.requiresSubject || Boolean(subject.trim()));
+
+  function choose(nextType: ReportType) {
+    setType(nextType);
+    setSubject('');
+    setMessage(null);
+  }
 
   async function generate() {
-    if (!canGenerate || running) return;
+    if (!canRunSelection) return;
     setRunning(true);
     setMessage(null);
     try {
@@ -68,18 +195,16 @@ export function RootReportsConsole({ initialReports, canGenerate, actorLabel }: 
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ type, subject: subject.trim() || undefined }),
+        body: JSON.stringify({ type, subject: option.acceptsSubject && subject.trim() ? subject.trim() : undefined }),
       });
       const body = await response.json().catch(() => null) as Row | null;
-      if (!response.ok || !body || body.ok !== true) {
-        throw new Error(text(body?.details ?? body?.error, `HTTP ${response.status}`));
-      }
+      if (!response.ok || !body || body.ok !== true) throw new Error(text(body?.details ?? body?.error, `HTTP ${response.status}`));
       const run = record(body.reportRun);
       if (text(run.id, '')) {
         setReports((current) => [run, ...current.filter((row) => text(row.id, '') !== text(run.id, ''))]);
         setSelectedId(text(run.id, ''));
       }
-      setMessage('Reporte generado y persistido en Cognitive Twin Runs.');
+      setMessage('Reporte generado y persistido en Cognitive Twin Runs. Sigue siendo un output para lectura/revisión, no una verdad canónica.');
     } catch (error) {
       setMessage(error instanceof Error ? error.message : 'No fue posible generar el reporte.');
     } finally {
@@ -91,23 +216,44 @@ export function RootReportsConsole({ initialReports, canGenerate, actorLabel }: 
     <header className="rr-header">
       <div>
         <span>SFI · ROOT · REPORTES</span>
-        <h1>Bandeja de reportes de agentes</h1>
-        <p>Lectura humana de outputs persistidos. Un reporte generado no equivale a aprobación, publicación ni verdad canónica.</p>
+        <h1>¿Qué quieres que SFI te explique?</h1>
+        <p>No necesitas conocer el nombre técnico del agente. Elige la pregunta que quieres resolver; ROOT selecciona el contrato de reporte correspondiente y usa evidencia persistida.</p>
       </div>
       <div className="rr-meta"><strong>{actorLabel}</strong><Link href="/root">VOLVER A ROOT</Link></div>
     </header>
 
+    <section className="rr-question-zone">
+      <div className="rr-zone-title"><span>PREGUNTAS RECOMENDADAS</span><small>empieza aquí si sólo quieres entender el estado de SFI</small></div>
+      <div className="rr-question-grid">
+        {REPORT_OPTIONS.filter((item) => item.recommended).map((item) => <button key={item.type} type="button" className={type === item.type ? 'active' : ''} onClick={() => choose(item.type)} disabled={!canGenerate || running}>
+          <span>{item.label}</span><strong>{item.question}</strong><p>{item.description}</p>
+        </button>)}
+      </div>
+      <details className="rr-more">
+        <summary>OTROS REPORTES / BORRADORES</summary>
+        <div className="rr-more-grid">{REPORT_OPTIONS.filter((item) => !item.recommended).map((item) => <button key={item.type} type="button" className={type === item.type ? 'active' : ''} onClick={() => choose(item.type)} disabled={!canGenerate || running}><span>{item.label}</span><strong>{item.question}</strong></button>)}</div>
+      </details>
+    </section>
+
     <section className="rr-compose">
-      <label>TIPO
-        <select value={type} onChange={(event) => setType(event.target.value as (typeof REPORT_TYPES)[number])} disabled={!canGenerate || running}>
-          {REPORT_TYPES.map((item) => <option key={item} value={item}>{item.replaceAll('_', ' ')}</option>)}
-        </select>
-      </label>
-      <label>SUJETO / FOCO
-        <input value={subject} onChange={(event) => setSubject(event.target.value)} placeholder="Opcional: empresa, fenómeno, caso o vector" disabled={!canGenerate || running}/>
-      </label>
-      <button type="button" onClick={() => void generate()} disabled={!canGenerate || running}>{running ? 'GENERANDO…' : canGenerate ? 'GENERAR REPORTE' : 'OBSERVER · SOLO LECTURA'}</button>
-      {message ? <p>{message}</p> : null}
+      <div className="rr-selected-question">
+        <span>VAS A GENERAR</span>
+        <strong>{option.question}</strong>
+        <p>{option.description}</p>
+        <small>CONTRATO INTERNO · {option.type}</small>
+      </div>
+      <div className="rr-needed">
+        <span>QUÉ NECESITA DE TI</span>
+        <p>{option.inputExplanation}</p>
+        {option.acceptsSubject ? <label>{option.subjectLabel ?? 'FOCO'}{option.requiresSubject ? <b>REQUERIDO</b> : <i>OPCIONAL</i>}
+          <input value={subject} onChange={(event) => setSubject(event.target.value)} placeholder={option.subjectPlaceholder} disabled={!canGenerate || running} />
+        </label> : <div className="rr-no-input">SIN INPUT MANUAL · usa estado persistido</div>}
+      </div>
+      <div className="rr-generate">
+        <button type="button" onClick={() => void generate()} disabled={!canRunSelection}>{running ? 'GENERANDO…' : canGenerate ? 'GENERAR ESTE REPORTE' : 'OBSERVER · SOLO LECTURA'}</button>
+        {option.requiresSubject && !subject.trim() ? <small>Falta indicar {option.subjectLabel?.toLowerCase() ?? 'el foco'}.</small> : <small>Generar no aprueba, publica ni ejecuta acciones externas.</small>}
+      </div>
+      {message ? <p className="rr-message">{message}</p> : null}
     </section>
 
     <section className="rr-workspace">
@@ -120,45 +266,29 @@ export function RootReportsConsole({ initialReports, canGenerate, actorLabel }: 
             <span>{text(envelope.title, text(row.objective, 'Reporte'))}</span>
             <small>{when(row.created_at)} · {text(row.status, 'UNKNOWN')}</small>
           </button>;
-        }) : <div className="rr-empty">MISSING · todavía no hay reportes persistidos del ReportAgent.</div>}
+        }) : <div className="rr-empty"><strong>TODAVÍA NO HAY REPORTES.</strong><p>Elige una pregunta arriba. Para “¿Qué está viendo SFI ahora?” no tienes que escribir absolutamente nada.</p></div>}
       </aside>
 
       <article className="rr-reader">
         {selected ? <>
           <div className="rr-kicker">{text(output.type, 'report').replaceAll('_', ' ')} · {text(selected.status, 'UNKNOWN')}</div>
           <h2>{text(output.title, text(selected.objective, 'Reporte'))}</h2>
-          <div className="rr-runmeta">
-            <span>{when(selected.created_at)}</span>
-            <span>{text(selected.provider, text(output.provider, 'provider n/d'))}</span>
-            <span>{evidence.length} evidencias referenciadas</span>
-          </div>
+          <div className="rr-runmeta"><span>{when(selected.created_at)}</span><span>{text(selected.provider, text(output.provider, 'provider n/d'))}</span><span>{evidence.length} evidencias referenciadas</span></div>
           <div className="rr-body">{text(output.body, 'MISSING · el run no contiene body legible.')}</div>
-
-          <details open>
-            <summary>EVIDENCIA UTILIZADA · {evidence.length}</summary>
-            {evidence.length ? <ul>{evidence.map((item, index) => <li key={`${item}-${index}`}>{item}</li>)}</ul> : <p>MISSING · no hay referencias de evidencia persistidas para este reporte.</p>}
-          </details>
-
-          <details>
-            <summary>PROVENANCE / TRACE</summary>
-            <pre>{Object.keys(trace).length ? JSON.stringify(trace, null, 2) : 'MISSING · no hay trace persistido.'}</pre>
-          </details>
-
-          <details>
-            <summary>LIMITACIONES / WARNINGS · {warnings.length}</summary>
-            {warnings.length ? <ul>{warnings.map((item, index) => <li key={`${item}-${index}`}>{item}</li>)}</ul> : <p>Sin warnings declarados en este run.</p>}
-          </details>
-
-          <details>
-            <summary>ESTADO DE APROBACIÓN</summary>
-            <pre>{JSON.stringify(record(output.approval_queue), null, 2)}</pre>
-          </details>
-        </> : <div className="rr-empty-reader">Selecciona un reporte o genera el primero.</div>}
+          <details open><summary>EVIDENCIA UTILIZADA · {evidence.length}</summary>{evidence.length ? <ul>{evidence.map((item, index) => <li key={`${item}-${index}`}>{item}</li>)}</ul> : <p>MISSING · no hay referencias de evidencia persistidas para este reporte.</p>}</details>
+          <details><summary>PROVENANCE / TRACE</summary><pre>{Object.keys(trace).length ? JSON.stringify(trace, null, 2) : 'MISSING · no hay trace persistido.'}</pre></details>
+          <details><summary>LIMITACIONES / WARNINGS · {warnings.length}</summary>{warnings.length ? <ul>{warnings.map((item, index) => <li key={`${item}-${index}`}>{item}</li>)}</ul> : <p>Sin warnings declarados en este run.</p>}</details>
+          <details><summary>ESTADO DE APROBACIÓN</summary><pre>{JSON.stringify(record(output.approval_queue), null, 2)}</pre></details>
+        </> : <div className="rr-empty-reader"><strong>NO HAY NADA QUE LEER TODAVÍA.</strong><p>Selecciona una pregunta en la parte superior y genera el primer reporte.</p></div>}
       </article>
     </section>
 
     <style jsx>{`
-      .rr-root{min-height:100vh;background:#060605;color:#c8c4b8;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;padding:28px;box-sizing:border-box}.rr-header{display:flex;justify-content:space-between;gap:30px;border-bottom:1px solid rgba(200,169,81,.18);padding-bottom:22px}.rr-header span,.rr-kicker{font-size:10px;letter-spacing:.18em;color:#9d8654}.rr-header h1{margin:7px 0 8px;font:400 32px Georgia,serif;color:#e3d4b0}.rr-header p{margin:0;max-width:840px;color:#777065;font:14px/1.6 Georgia,serif}.rr-meta{display:flex;align-items:flex-start;gap:10px;font-size:9px}.rr-meta strong,.rr-meta a{border:1px solid rgba(200,169,81,.24);padding:8px 10px;color:#baa665;text-decoration:none}.rr-compose{display:grid;grid-template-columns:260px minmax(320px,1fr) auto;gap:12px;align-items:end;padding:18px 0;border-bottom:1px solid rgba(200,169,81,.1)}.rr-compose label{display:grid;gap:6px;color:#756a4d;font-size:8px;letter-spacing:.14em}.rr-compose select,.rr-compose input{background:#0a0a09;border:1px solid rgba(200,169,81,.22);color:#d5c7a7;padding:10px;font:11px ui-monospace,monospace}.rr-compose button{height:36px;border:1px solid rgba(200,169,81,.38);background:transparent;color:#d3b96e;padding:0 15px;font:9px ui-monospace,monospace;letter-spacing:.08em}.rr-compose button:disabled{opacity:.45}.rr-compose>p{grid-column:1/-1;margin:0;color:#a28e60;font-size:9px}.rr-workspace{display:grid;grid-template-columns:minmax(280px,360px) 1fr;min-height:calc(100vh - 210px)}.rr-list{border-right:1px solid rgba(200,169,81,.1);padding:15px 14px 15px 0;max-height:calc(100vh - 210px);overflow:auto;scrollbar-width:thin;scrollbar-color:rgba(200,169,81,.24) transparent}.rr-list::-webkit-scrollbar,.rr-reader::-webkit-scrollbar{width:6px;height:6px}.rr-list::-webkit-scrollbar-track,.rr-reader::-webkit-scrollbar-track{background:transparent}.rr-list::-webkit-scrollbar-thumb,.rr-reader::-webkit-scrollbar-thumb{background:rgba(200,169,81,.18);border-radius:10px}.rr-list-title{display:flex;justify-content:space-between;padding:0 5px 10px;color:#6f644a;font-size:8px;letter-spacing:.15em}.rr-list button{width:100%;display:grid;gap:4px;text-align:left;background:transparent;border:0;border-bottom:1px solid rgba(200,169,81,.06);padding:11px 8px;color:#aaa399;font:10px ui-monospace,monospace;cursor:pointer}.rr-list button.active{background:rgba(200,169,81,.06);color:#e0c987;border-left:2px solid #a98b45}.rr-list button small{color:#5d584e;font-size:8px}.rr-reader{padding:30px 38px;max-height:calc(100vh - 210px);overflow:auto;scrollbar-width:thin;scrollbar-color:rgba(200,169,81,.24) transparent}.rr-reader h2{font:400 28px/1.2 Georgia,serif;color:#e7d8b4;margin:8px 0 12px}.rr-runmeta{display:flex;gap:14px;flex-wrap:wrap;color:#5e594f;font-size:8px;padding-bottom:22px}.rr-body{white-space:pre-wrap;font:15px/1.72 Georgia,serif;color:#bbb3a5;max-width:1050px;padding:0 0 25px}.rr-reader details{border-top:1px solid rgba(200,169,81,.08);padding:13px 0}.rr-reader summary{cursor:pointer;color:#8d7b50;font-size:8px;letter-spacing:.12em}.rr-reader ul,.rr-reader p,.rr-reader pre{color:#827b70;font-size:10px;line-height:1.6;white-space:pre-wrap;overflow-wrap:anywhere}.rr-empty,.rr-empty-reader{color:#5f594e;font:italic 13px Georgia,serif;padding:30px 10px}.rr-empty-reader{padding:80px 20px;text-align:center}@media(max-width:900px){.rr-root{padding:18px}.rr-header{display:grid}.rr-compose{grid-template-columns:1fr}.rr-workspace{grid-template-columns:1fr}.rr-list{border-right:0;border-bottom:1px solid rgba(200,169,81,.1);max-height:240px;padding-right:0}.rr-reader{max-height:none;padding:25px 4px}.rr-compose>p{grid-column:1}}
+      .rr-root{min-height:100vh;background:#060605;color:#c8c4b8;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;padding:28px;box-sizing:border-box}.rr-header{display:flex;justify-content:space-between;gap:30px;border-bottom:1px solid rgba(200,169,81,.18);padding-bottom:22px}.rr-header span,.rr-kicker,.rr-zone-title span,.rr-selected-question>span,.rr-needed>span{font-size:9px;letter-spacing:.16em;color:#9d8654}.rr-header h1{margin:7px 0 8px;font:400 34px Georgia,serif;color:#e3d4b0}.rr-header p{margin:0;max-width:900px;color:#81796c;font:14px/1.6 Georgia,serif}.rr-meta{display:flex;align-items:flex-start;gap:10px;font-size:9px}.rr-meta strong,.rr-meta a{border:1px solid rgba(200,169,81,.24);padding:8px 10px;color:#baa665;text-decoration:none}
+      .rr-question-zone{padding:20px 0;border-bottom:1px solid rgba(200,169,81,.1)}.rr-zone-title{display:flex;justify-content:space-between;gap:15px;margin-bottom:12px}.rr-zone-title small{font-size:8px;color:#5f594e}.rr-question-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:9px}.rr-question-grid button{min-height:150px;text-align:left;border:1px solid rgba(200,169,81,.12);background:#090908;padding:15px;color:#a69e90;cursor:pointer}.rr-question-grid button:hover,.rr-question-grid button.active,.rr-more-grid button.active{border-color:rgba(200,169,81,.52);background:rgba(200,169,81,.045)}.rr-question-grid button span,.rr-more-grid button span{display:block;font-size:8px;color:#89774d;letter-spacing:.08em}.rr-question-grid button strong,.rr-more-grid button strong{display:block;margin-top:8px;color:#dec88d;font:400 17px/1.25 Georgia,serif}.rr-question-grid button p{font:11px/1.55 Georgia,serif;color:#716b60}.rr-question-grid button:disabled,.rr-more-grid button:disabled{opacity:.45;cursor:not-allowed}.rr-more{margin-top:12px}.rr-more summary{cursor:pointer;color:#75684a;font-size:8px;letter-spacing:.12em}.rr-more-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:7px;margin-top:10px}.rr-more-grid button{text-align:left;border:1px solid rgba(200,169,81,.08);background:#080807;padding:11px;color:#999;cursor:pointer}.rr-more-grid button strong{font-size:14px}
+      .rr-compose{display:grid;grid-template-columns:1.25fr 1fr 240px;gap:18px;align-items:stretch;padding:20px 0;border-bottom:1px solid rgba(200,169,81,.1)}.rr-selected-question,.rr-needed,.rr-generate{border:1px solid rgba(200,169,81,.08);padding:15px;background:#080807}.rr-selected-question strong{display:block;margin-top:8px;color:#e1cd95;font:400 21px/1.3 Georgia,serif}.rr-selected-question p,.rr-needed p{color:#827a6c;font:11px/1.6 Georgia,serif}.rr-selected-question small{font-size:7px;color:#4e4a42}.rr-needed label{display:grid;gap:7px;margin-top:12px;color:#766b50;font-size:8px;letter-spacing:.1em}.rr-needed label b,.rr-needed label i{font-size:7px;font-style:normal;color:#b67d63}.rr-needed label i{color:#6e675a}.rr-needed input{background:#0a0a09;border:1px solid rgba(200,169,81,.22);color:#d5c7a7;padding:10px;font:11px ui-monospace,monospace}.rr-no-input{margin-top:14px;border-left:2px solid rgba(91,151,101,.55);padding:10px;color:#7cad83;font-size:8px}.rr-generate{display:flex;flex-direction:column;justify-content:center}.rr-generate button{min-height:48px;border:1px solid rgba(200,169,81,.42);background:rgba(200,169,81,.03);color:#d3b96e;padding:0 15px;font:9px ui-monospace,monospace;letter-spacing:.08em}.rr-generate button:disabled{opacity:.35}.rr-generate small{margin-top:9px;color:#625c51;font-size:8px;line-height:1.5}.rr-message{grid-column:1/-1;margin:0;color:#ad9967;font-size:9px}
+      .rr-workspace{display:grid;grid-template-columns:minmax(280px,360px) 1fr;min-height:520px}.rr-list{border-right:1px solid rgba(200,169,81,.1);padding:15px 14px 15px 0;max-height:720px;overflow:auto;scrollbar-width:thin;scrollbar-color:rgba(200,169,81,.24) transparent}.rr-list-title{display:flex;justify-content:space-between;padding:0 5px 10px;color:#6f644a;font-size:8px;letter-spacing:.15em}.rr-list button{width:100%;display:grid;gap:4px;text-align:left;background:transparent;border:0;border-bottom:1px solid rgba(200,169,81,.06);padding:11px 8px;color:#aaa399;font:10px ui-monospace,monospace;cursor:pointer}.rr-list button.active{background:rgba(200,169,81,.06);color:#e0c987;border-left:2px solid #a98b45}.rr-list button small{color:#5d584e;font-size:8px}.rr-reader{padding:30px 38px;max-height:720px;overflow:auto;scrollbar-width:thin;scrollbar-color:rgba(200,169,81,.24) transparent}.rr-reader h2{font:400 28px/1.2 Georgia,serif;color:#e7d8b4;margin:8px 0 12px}.rr-runmeta{display:flex;gap:14px;flex-wrap:wrap;color:#5e594f;font-size:8px;padding-bottom:22px}.rr-body{white-space:pre-wrap;font:15px/1.72 Georgia,serif;color:#bbb3a5;max-width:1050px;padding:0 0 25px}.rr-reader details{border-top:1px solid rgba(200,169,81,.08);padding:13px 0}.rr-reader summary{cursor:pointer;color:#8d7b50;font-size:8px;letter-spacing:.12em}.rr-reader ul,.rr-reader p,.rr-reader pre{color:#827b70;font-size:10px;line-height:1.6;white-space:pre-wrap;overflow-wrap:anywhere}.rr-empty,.rr-empty-reader{color:#70685b;font:13px/1.6 Georgia,serif;padding:30px 10px}.rr-empty strong,.rr-empty-reader strong{color:#9b8756;font:9px ui-monospace,monospace;letter-spacing:.1em}.rr-empty p,.rr-empty-reader p{margin-top:8px}.rr-empty-reader{padding:80px 20px;text-align:center}
+      @media(max-width:1100px){.rr-question-grid{grid-template-columns:repeat(2,1fr)}.rr-compose{grid-template-columns:1fr 1fr}.rr-generate{grid-column:1/-1}.rr-more-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:760px){.rr-root{padding:18px}.rr-header{display:grid}.rr-question-grid,.rr-more-grid,.rr-compose,.rr-workspace{grid-template-columns:1fr}.rr-list{border-right:0;border-bottom:1px solid rgba(200,169,81,.1);max-height:240px;padding-right:0}.rr-reader{max-height:none;padding:25px 4px}}
     `}</style>
   </main>;
 }

--- a/src/components/root/sovereign/RootObservatoryWorkspace.tsx
+++ b/src/components/root/sovereign/RootObservatoryWorkspace.tsx
@@ -72,6 +72,10 @@ function tone(value: string | null | undefined) {
 function statusLabel(status: string, context: StatusContext = 'ESTADO') {
   return `${context} · ${status.toUpperCase()}`;
 }
+function systemStatusContext(id: string): StatusContext {
+  if (id.startsWith('mihm-') && id !== 'mihm-llm-providers') return 'CLASE';
+  return 'SALUD';
+}
 function sel(input: {
   kind: string;
   id: string;
@@ -245,7 +249,7 @@ export function RootObservatoryWorkspace({ state, accessMode, actorLabel, refres
           </Panel>
 
           <Panel id="mod-02" module="02 · SISTEMA" label="Salud de superficies" status={state.system.error ? 'degraded' : state.system.dataClass} statusContext="SALUD" source={state.system.source}>
-            <Rows rows={state.system.data.matrix.map((item) => ({ name: item.label, sub: item.openItems.value === null ? undefined : `${item.openItems.value} abiertos`, status: item.state.status, statusContext: 'SALUD', onClick: () => onSelect(sel({ kind: 'system-item', id: item.id, title: item.label, source: item.state.source, observedAt: item.state.observedAt, evidenceIds: item.state.evidenceIds, warning: item.state.warning, data: item })) }))} />
+            <Rows rows={state.system.data.matrix.map((item) => ({ name: item.label, sub: item.openItems.value === null ? undefined : `${item.openItems.value} abiertos`, status: item.state.status, statusContext: systemStatusContext(item.id), onClick: () => onSelect(sel({ kind: 'system-item', id: item.id, title: item.label, source: item.state.source, observedAt: item.state.observedAt, evidenceIds: item.state.evidenceIds, warning: item.state.warning, data: item })) }))} />
           </Panel>
 
           <Panel id="mod-03" module="03 · IDENTIDAD" label="Sesión / autoridad" status="observed" statusContext="ESTADO" source="server user context"><Rows rows={[{ name: actorLabel, sub: accessMode === 'sovereign' ? 'ROOT · SOVEREIGN' : 'ROOT · OBSERVER', status: 'observed', statusContext: 'ESTADO' }]} /></Panel>

--- a/src/components/root/sovereign/RootObservatoryWorkspace.tsx
+++ b/src/components/root/sovereign/RootObservatoryWorkspace.tsx
@@ -8,77 +8,282 @@ import './root-observatory.css';
 
 type TopologyId = 'I' | 'II' | 'III';
 type AccessMode = 'sovereign' | 'observer';
-type PanelProps = { id:string; module:string; label:string; status?:string; source?:string; width?:'s'|'m'|'l'|'xl'; children:ReactNode; onOpen?:()=>void };
-
-const TOPOLOGIES: Record<TopologyId,{title:string;question:string}> = {
-  I:{title:'SISTEMA',question:'¿Qué existe y qué responde?'},
-  II:{title:'CAMPO COGNITIVO',question:'¿Qué está comprendiendo SFI y qué podría hacer?'},
-  III:{title:'TRAYECTORIA',question:'¿Qué cambió y qué aprendimos?'},
+type StatusContext = 'CLASE' | 'SALUD' | 'ESTADO';
+type PanelProps = {
+  id: string;
+  module: string;
+  label: string;
+  status?: string;
+  statusContext?: StatusContext;
+  source?: string;
+  width?: 's' | 'm' | 'l' | 'xl';
+  children: ReactNode;
+  onOpen?: () => void;
 };
+type LiveRow = { name: string; sub?: string; status?: string; statusContext?: StatusContext; onClick?: () => void };
+
+const TOPOLOGIES: Record<TopologyId, { title: string; question: string }> = {
+  I: { title: 'SISTEMA', question: '¿Qué existe y qué responde?' },
+  II: { title: 'CAMPO COGNITIVO', question: '¿Qué está comprendiendo SFI y qué podría hacer?' },
+  III: { title: 'TRAYECTORIA', question: '¿Qué cambió y qué aprendimos?' },
+};
+
 const MODULES = [
-  ['01','Estado Institucional'],['02','Sistema / Infraestructura'],['03','Identidad / Autoridad'],['04','Evidencia / Grafo'],['05','Cognitive Runtime'],
-  ['06','Cognitive Twin'],['07','Proyección / Predicción'],['08','Atractores / PPOI'],['09','Memoria / Trayectoria'],['10','Gobernanza / Operación'],
+  ['01', 'Estado Institucional'], ['02', 'Sistema / Infraestructura'], ['03', 'Identidad / Autoridad'], ['04', 'Evidencia / Grafo'], ['05', 'Cognitive Runtime'],
+  ['06', 'Cognitive Twin'], ['07', 'Proyección / Predicción'], ['08', 'Atractores / PPOI'], ['09', 'Memoria / Trayectoria'], ['10', 'Gobernanza / Operación'],
 ] as const;
 
-function text(v:unknown,f='—'){return typeof v==='string'&&v.trim()?v.trim():f}
-function rec(v:unknown):RootRow{return v&&typeof v==='object'&&!Array.isArray(v)?v as RootRow:{}}
-function strings(v:unknown){return Array.isArray(v)?v.filter((x):x is string=>typeof x==='string'):[]}
-function rowDate(r:RootRow){return text(r.observed_at??r.occurred_at??r.executed_at??r.updated_at??r.created_at??r.timestamp,'')||null}
-function rid(r:RootRow,f:string){return text(r.id??r.event_id??r.run_id??r.node_key??r.node_id??r.attractor_key??r.hypothesis_id,f)}
-function when(v:string|null|undefined){if(!v)return'SIN FECHA';const d=new Date(v);return Number.isFinite(d.valueOf())?new Intl.DateTimeFormat('es-MX',{dateStyle:'medium',timeStyle:'short'}).format(d):v}
-function tone(v:string|null|undefined){const s=(v??'').toLowerCase();if(['observed','operational','available','accepted','verified','active'].includes(s))return'ok';if(['derived','thin','declared','proposed','waiting_evidence'].includes(s))return'warn';if(['degraded','conflicted','blocked','error','blocking'].includes(s))return'bad';return'idle'}
-function sel(i:{kind:string;id:string;title:string;source:string;observedAt?:string|null;evidenceIds?:string[];warning?:string|null;data:unknown}):RootSelection{return{kind:i.kind,id:i.id,title:i.title,source:i.source,observedAt:i.observedAt??null,confidence:null,evidenceIds:i.evidenceIds??[],warning:i.warning??null,data:i.data}}
+const DIVERGENCE_FACT: Record<string, string> = {
+  'reader-errors': 'source-health',
+  'cognitive-continuity': 'cognitive-execution',
+  'graph-traceability': 'traceability',
+  'capability-gap': 'execution-capability',
+  'attractor-reader-gap': 'institutional-attractor',
+  'institutional-position-gap': 'institutional-position',
+};
 
-function Panel({id,module,label,status,source,width='m',children,onOpen}:PanelProps){return <section id={id} className={`row-panel pw-${width}`} onClick={onOpen}><header><div><b>{module}</b><span>{label}</span></div>{status?<em data-tone={tone(status)}>{status.toUpperCase()}</em>:null}</header><div className="row-panel-body">{children}</div>{source?<footer>fuente: <strong>{source}</strong></footer>:null}</section>}
-function Rows({rows}:{rows:Array<{name:string;sub?:string;status?:string;onClick?:()=>void}>}){return <div className="live-list">{rows.length?rows.map((r,i)=><button key={`${r.name}-${i}`} type="button" onClick={e=>{e.stopPropagation();r.onClick?.()}}><span>{r.name}{r.sub?<small>{r.sub}</small>:null}</span>{r.status?<i data-tone={tone(r.status)}>{r.status}</i>:null}</button>):<p className="empty">MISSING · no hay registros persistidos para este panel.</p>}</div>}
-
-function EvidenceGraph({state,onSelect}:{state:RootSovereignState;onSelect:(s:RootSelection)=>void}){
-  const nodes=state.evidence.data.nodes.slice(0,28), edges=state.evidence.data.edges.slice(0,64);
-  const pts=useMemo(()=>new Map(nodes.map((n,i)=>{const a=i/Math.max(1,nodes.length)*Math.PI*2,r=28+(i%3)*7;return[n.id,{x:50+Math.cos(a)*r,y:50+Math.sin(a)*r}] as const})),[nodes]);
-  return <svg className="graph-svg" viewBox="0 0 100 100">{edges.map(e=>{const a=pts.get(e.from),b=pts.get(e.to);return a&&b?<line key={e.id} x1={a.x} y1={a.y} x2={b.x} y2={b.y}/>:null})}{nodes.map(n=>{const p=pts.get(n.id)!;return <g key={n.id} onClick={e=>{e.stopPropagation();onSelect(sel({kind:'evidence-node',id:n.id,title:n.label,source:n.source,observedAt:n.observedAt,evidenceIds:n.evidenceIds,data:n.payload}))}}><circle cx={p.x} cy={p.y} r="1.8" data-tone={tone(n.epistemicClass)}/><text x={p.x+2.5} y={p.y+1}>{n.label.slice(0,18)}</text></g>})}{!nodes.length?<text x="50" y="50" textAnchor="middle" className="graph-empty">MISSING</text>:null}</svg>
+function text(value: unknown, fallback = '—') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+function rec(value: unknown): RootRow {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as RootRow : {};
+}
+function strings(value: unknown) {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+function rowDate(row: RootRow) {
+  return text(row.observed_at ?? row.occurred_at ?? row.executed_at ?? row.updated_at ?? row.created_at ?? row.timestamp, '') || null;
+}
+function rid(row: RootRow, fallback: string) {
+  return text(row.id ?? row.event_id ?? row.run_id ?? row.node_key ?? row.node_id ?? row.attractor_key ?? row.hypothesis_id, fallback);
+}
+function when(value: string | null | undefined) {
+  if (!value) return 'SIN FECHA';
+  const date = new Date(value);
+  return Number.isFinite(date.valueOf()) ? new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(date) : value;
+}
+function tone(value: string | null | undefined) {
+  const status = (value ?? '').toLowerCase();
+  if (['observed', 'imported', 'operational', 'available', 'accepted', 'verified', 'active', 'canonical'].includes(status)) return 'ok';
+  if (['derived', 'thin', 'declared', 'proposed', 'waiting_evidence', 'inferred', 'extracted'].includes(status)) return 'warn';
+  if (['degraded', 'conflicted', 'blocked', 'error', 'blocking', 'rejected'].includes(status)) return 'bad';
+  return 'idle';
+}
+function statusLabel(status: string, context: StatusContext = 'ESTADO') {
+  return `${context} · ${status.toUpperCase()}`;
+}
+function sel(input: {
+  kind: string;
+  id: string;
+  title: string;
+  source: string;
+  observedAt?: string | null;
+  evidenceIds?: string[];
+  warning?: string | null;
+  data: unknown;
+}): RootSelection {
+  return {
+    kind: input.kind,
+    id: input.id,
+    title: input.title,
+    source: input.source,
+    observedAt: input.observedAt ?? null,
+    confidence: null,
+    evidenceIds: input.evidenceIds ?? [],
+    warning: input.warning ?? null,
+    data: input.data,
+  };
 }
 
-function AttractorField({state,onSelect}:{state:RootSovereignState;onSelect:(s:RootSelection)=>void}){
-  const a=state.amv.data.attractors[0]??null,v=rec(a?.vector),dims=strings(v.dimensions),sup=new Set(strings(v.supportedDimensions)),con=new Set(strings(v.contradictedDimensions)),mis=new Set(strings(v.missingDimensions));
-  return <div className="attractor-field" onClick={e=>{e.stopPropagation();if(a)onSelect(sel({kind:'attractor',id:rid(a,'attractor'),title:text(a.label??a.attractor_key,'Atractor'),source:state.amv.source,observedAt:rowDate(a),data:a}))}}><div className="living-grid"/><div className="attractor-core"><span>{a?text(a.label??a.attractor_key):'SIN ATRACTOR DECLARADO'}</span><small>{a?text(a.status,'DECLARED'):'MISSING'}</small></div>{dims.map((d,i)=>{const ang=i/Math.max(1,dims.length)*Math.PI*2,x=50+Math.cos(ang)*32,y=50+Math.sin(ang)*32,s=con.has(d)?'bad':sup.has(d)?'ok':mis.has(d)?'idle':'warn';return <span className="orbit-node" data-tone={s} key={d} style={{left:`${x}%`,top:`${y}%`}} title={d}>{i+1}</span>})}</div>
+function Panel({ id, module, label, status, statusContext = 'ESTADO', source, width = 'm', children, onOpen }: PanelProps) {
+  return <section id={id} className={`row-panel pw-${width} ${onOpen ? 'is-clickable' : ''}`} onClick={onOpen}>
+    <header><div><b>{module}</b><span>{label}</span></div>{status ? <em data-tone={tone(status)}>{statusLabel(status, statusContext)}</em> : null}</header>
+    <div className="row-panel-body">{children}</div>
+    {source ? <footer>fuente: <strong>{source}</strong></footer> : null}
+  </section>;
 }
 
-export function RootObservatoryWorkspace({state,accessMode,actorLabel,refreshing,warning,onRefresh,onSelect,onAction}:{state:RootSovereignState;accessMode:AccessMode;actorLabel:string;refreshing:boolean;warning:string|null;onRefresh:()=>void;onSelect:(v:RootSelection)=>void;onAction:(a:RootActionRequest)=>void}){
-  const [filter,setFilter]=useState<'all'|TopologyId>('all'),[clock,setClock]=useState(()=>new Date());
-  useEffect(()=>{const id=window.setInterval(()=>setClock(new Date()),1000);return()=>window.clearInterval(id)},[]);
-  const phiFact=state.interpretation.facts.find(f=>f.id==='institutional-position'),phi=phiFact?.value.match(/([0-9]+(?:\.[0-9]+)?)/)?.[1]??'—';
-  const agents=state.cognitiveRuntime.data.agents,executed=agents.filter(a=>a.status==='operational').length,caps=state.execution.data.capabilities,available=caps.filter(c=>c.state==='available').length;
-  const evidenceCount=state.evidence.data.entries.length+state.evidence.data.ledger.length,graphStatus=state.evidence.error?'DEGRADED':state.evidence.data.nodes.length?'OBSERVED':'MISSING',attractor=state.amv.data.attractors[0]??null,divergences=state.interpretation.divergences.length;
-  const sources=[state.system,state.governance,state.agents,state.predictions,state.amv,state.evidence,state.execution,state.telemetry,state.cognitiveRuntime],sourceOk=sources.filter(s=>!s.error).length;
-  const hypotheses=[...state.predictions.data.runs,...state.predictions.data.legacyEntries],recentEvents=state.cognitiveRuntime.data.eventGraph.recentEvents.slice(0,30);
-  const trajectory=[...state.evidence.data.entries.map(row=>({kind:'evidence',row})),...hypotheses.map(row=>({kind:'prediction',row})),...state.predictions.data.outcomes.map(row=>({kind:'outcome',row})),...state.predictions.data.learningEvents.map(row=>({kind:'learning',row})),...state.governance.data.audits.map(row=>({kind:'audit',row}))].sort((a,b)=>new Date(rowDate(b.row)??0).valueOf()-new Date(rowDate(a.row)??0).valueOf()).slice(0,40);
-  const byFamily=new Map<string,typeof caps>();for(const c of caps){const f=c.id==='daily'||c.id==='audit'?'OBSERVAR':c.id==='evidence'||c.id==='amv-ingest'?'INTEGRAR':c.id==='amv-search'||c.id==='graph'?'CONSULTAR':c.id==='simulation'?'MODELAR':c.id==='report'||c.id==='reports'?'REPORTAR':c.id==='all'||c.id==='institutional-cycle'?'ORQUESTAR':'GOBERNAR';byFamily.set(f,[...(byFamily.get(f)??[]),c])}
-  const focus=(t:TopologyId)=>filter==='all'||filter===t,jump=(id:string)=>document.getElementById(id)?.scrollIntoView({behavior:'smooth',inline:'start',block:'center'});
-  const agentEvidenceIds=(agentId:string)=>recentEvents.filter(e=>e.sourceId===agentId&&e.eventId).map(e=>e.eventId);
+function Rows({ rows }: { rows: LiveRow[] }) {
+  return <div className="live-list">
+    {rows.length ? rows.map((row, index) => <button key={`${row.name}-${index}`} type="button" onClick={(event) => { event.stopPropagation(); row.onClick?.(); }}>
+      <span>{row.name}{row.sub ? <small>{row.sub}</small> : null}</span>
+      {row.status ? <i data-tone={tone(row.status)}>{statusLabel(row.status, row.statusContext)}</i> : null}
+    </button>) : <p className="empty">MISSING · no hay registros persistidos para este panel.</p>}
+  </div>;
+}
 
-  return <div className="root-observatory"><header className="root-hdr"><strong>SFI · ROOT</strong><span>01 · ESTADO INSTITUCIONAL</span><b>ΦSFI <em>{phi}</em></b><span>AGENTES <i>{executed}/{agents.length||'—'}</i></span><span>CAPACIDADES <i>{available}/{caps.length||'—'}</i></span><span>EVIDENCIA <i>{evidenceCount}</i></span><span>GRAFO <i data-tone={tone(graphStatus)}>{graphStatus}</i></span><span>ATRACTOR <i>{attractor?text(attractor.status,'DECLARED').toUpperCase():'MISSING'}</i></span><span>DIVERGENCIAS <i>{divergences}</i></span><div className="root-hdr-right"><button type="button" onClick={onRefresh}>{refreshing?'ACTUALIZANDO':'ACTUALIZAR'}</button><span>{actorLabel} · {accessMode==='sovereign'?'SOVEREIGN':'OBSERVER'}</span><time>{clock.toLocaleTimeString('es-MX')}</time></div></header>
-    <aside className="root-side"><small>TOPOLOGÍA</small>{(['all','I','II','III'] as const).map(t=><button key={t} className={filter===t?'active':''} onClick={()=>setFilter(t)}>{t==='all'?'Ø':t}</button>)}<small>MÓDULOS</small>{MODULES.map(([id,label])=><button key={id} onClick={()=>jump(`mod-${id}`)}>{id}<span>{label}</span></button>)}<small>SUPERFICIES</small><Link href="/root/institutionalization" title="Institutionalization">IN</Link><Link href="/root/reports" title="Reportes de agentes">RP</Link><Link href="/field">FD</Link><Link href="/field/map">FM</Link><Link href="/studio">ST</Link><Link href="/interface/observatory">OB</Link><Link href="/library">LB</Link></aside>
-    <main className="root-observatory-main">{warning?<div className="root-warning">{warning}</div>:null}
-      <section className={`topology-row ${focus('I')?'':'dim'}`}><header><b>I</b><strong>{TOPOLOGIES.I.title}</strong><em>{TOPOLOGIES.I.question}</em></header><div className="panel-strip">
-        <Panel id="mod-01" module="01 · ESTADO INSTITUCIONAL" label="ΦSFI · interpretación" status={phiFact?.status??'missing'} source={phiFact?.source} width="l" onOpen={()=>phiFact&&onSelect(sel({kind:'institutional-fact',id:phiFact.id,title:phiFact.label,source:phiFact.source,observedAt:phiFact.observedAt,evidenceIds:phiFact.evidenceIds,warning:phiFact.warning,data:phiFact}))}><div className="phi-live"><strong>{phi}</strong><span>{state.interpretation.headline}</span><small>{sourceOk}/{sources.length} fuentes sin error · {when(state.generatedAt)}</small></div></Panel>
-        <Panel id="mod-02" module="02 · SISTEMA" label="Salud de superficies" status={state.system.error?'degraded':state.system.dataClass} source={state.system.source}><Rows rows={state.system.data.matrix.map(m=>({name:m.label,sub:m.openItems.value===null?undefined:`${m.openItems.value} abiertos`,status:m.state.status,onClick:()=>onSelect(sel({kind:'system-item',id:m.id,title:m.label,source:m.state.source,observedAt:m.state.observedAt,evidenceIds:m.state.evidenceIds,warning:m.state.warning,data:m}))}))}/></Panel>
-        <Panel id="mod-03" module="03 · IDENTIDAD" label="Sesión / autoridad" status="observed" source="server user context"><Rows rows={[{name:actorLabel,sub:accessMode==='sovereign'?'ROOT · SOVEREIGN':'ROOT · OBSERVER',status:'observed'}]}/></Panel>
-        <Panel id="mod-institution" module="01a · INSTITUCIONALIZACIÓN" label="Founder dependency / transferencia" status="declared" source="FEP-01 + Cognitive Twin memory" width="l"><div className="intake-live"><p>Observa dónde SFI todavía depende del fundador, separa criterio transferible de autoridad reservada y exige reproducción antes de declarar capacidad institucional.</p><Link href="/root/institutionalization">ABRIR INSTITUTIONALIZATION →</Link><Link href="/root/reports">LEER REPORTES DE AGENTES →</Link></div></Panel>
-        <Panel id="mod-04-intake" module="04a · EVIDENCIA" label="Evidence Intake" status="observed" source="root_evidence_entries" width="l"><div className="intake-live"><p>Captura evidencia con procedencia explícita. El contenido no se autopromueve a CANONICAL.</p><Link href="/root/evidence/intake">REGISTRAR / VINCULAR EVIDENCIA →</Link></div></Panel>
-        <Panel id="mod-10" module="10 · GOBERNANZA" label="Capacidades ejecutables" status={state.execution.error?'degraded':state.execution.dataClass} source={state.execution.source} width="l"><div className="cap-groups">{[...byFamily.entries()].map(([f,items])=><div key={f}><b>{f}</b>{items.map(c=><button key={c.id} type="button" data-tone={tone(c.state)} onClick={e=>{e.stopPropagation();onAction({id:c.id,label:c.label,effect:c.description,target:c.endpoint??c.id,endpoint:c.endpoint,method:'POST'})}}>{c.label}<i>{c.state}</i></button>)}</div>)}</div></Panel>
-      </div></section>
-      <section className={`topology-row ${focus('II')?'':'dim'}`}><header><b>II</b><strong>{TOPOLOGIES.II.title}</strong><em>{TOPOLOGIES.II.question}</em></header><div className="panel-strip">
-        <Panel id="mod-04" module="04 · EVIDENCIA" label="Grafo de evidencia" status={graphStatus} source={state.evidence.source} width="l"><EvidenceGraph state={state} onSelect={onSelect}/></Panel>
-        <Panel id="mod-05" module="05 · RUNTIME" label={`${agents.length} agentes`} status={state.cognitiveRuntime.data.status} source={state.cognitiveRuntime.source} width="l"><Rows rows={agents.map(a=>({name:a.name,sub:`${a.layer} · ${a.domain}`,status:a.status,onClick:()=>onSelect(sel({kind:'agent',id:a.id,title:a.name,source:state.cognitiveRuntime.source,observedAt:state.cognitiveRuntime.observedAt,evidenceIds:agentEvidenceIds(a.id),data:a}))}))}/></Panel>
-        <Panel id="mod-06" module="06 · COGNITIVE TWIN" label="Hipótesis / contradicciones" status={hypotheses.length?'derived':'missing'} source={state.predictions.source}><Rows rows={hypotheses.slice(0,20).map((r,i)=>({name:text(r.title??r.hypothesis??r.status,`Hipótesis ${i+1}`),sub:text(r.learning_state??r.status,''),status:text(r.epistemic_class??r.status,'derived'),onClick:()=>onSelect(sel({kind:'hypothesis',id:rid(r,`hyp-${i}`),title:text(r.title??r.hypothesis,`Hipótesis ${i+1}`),source:state.predictions.source,observedAt:rowDate(r),evidenceIds:strings(r.evidence_refs),data:r}))}))}/></Panel>
-        <Panel id="mod-07" module="07 · PROYECCIÓN" label="Predicción / outcome" status={state.predictions.error?'degraded':state.predictions.dataClass} source={state.predictions.source}><div className="metric-cluster"><b>{state.predictions.data.runs.length+state.predictions.data.legacyEntries.length}<small>PREDICCIONES</small></b><b>{state.predictions.data.outcomes.length}<small>OUTCOMES</small></b><b>{state.predictions.data.learningEvents.length}<small>LEARNING</small></b></div></Panel>
-        <Panel id="mod-08" module="08 · ATRACTORES" label="Campo institucional" status={attractor?text(attractor.status,'declared'):'missing'} source={state.amv.source} width="xl"><AttractorField state={state} onSelect={onSelect}/></Panel>
-      </div></section>
-      <section className={`topology-row ${focus('III')?'':'dim'}`}><header><b>III</b><strong>{TOPOLOGIES.III.title}</strong><em>{TOPOLOGIES.III.question}</em></header><div className="panel-strip">
-        <Panel id="mod-09" module="09 · TRAYECTORIA" label="Evidencia → aprendizaje" status={trajectory.length?'derived':'missing'} source="evidence + prediction + outcome + learning + audit" width="xl"><div className="trajectory-live">{trajectory.map((it,i)=><button key={`${it.kind}-${rid(it.row,String(i))}`} type="button" onClick={e=>{e.stopPropagation();onSelect(sel({kind:it.kind,id:rid(it.row,`${it.kind}-${i}`),title:text(it.row.title??it.row.event_name??it.row.action??it.row.status,it.kind),source:it.kind,observedAt:rowDate(it.row),evidenceIds:strings(it.row.evidence_refs),data:it.row}))}}><time>{when(rowDate(it.row))}</time><i>{it.kind}</i><span>{text(it.row.title??it.row.event_name??it.row.action??it.row.status??it.row.learning_state,it.kind)}</span></button>)}</div></Panel>
-        <Panel id="mod-09-memory" module="09 · MEMORIA" label="AMV / MIHM" status={state.amv.error?'degraded':state.amv.dataClass} source={state.amv.source}><div className="metric-cluster"><b>{state.amv.data.memories.length}<small>AMV MEMORY</small></b><b>{state.predictions.data.learningEvents.length}<small>LEARNING EVENTS</small></b><b>{state.governance.data.audits.length}<small>AUDITED ACTIONS</small></b></div></Panel>
-        <Panel id="mod-10-log" module="10 · GOBERNANZA" label="Bitácora / eventos cognitivos" status={state.governance.error?'degraded':state.governance.dataClass} source={state.governance.source} width="l"><Rows rows={[...recentEvents.map(e=>({name:e.eventName,sub:`${when(e.occurredAt)} · ${e.sourceId??'runtime'}`,status:e.epistemicClass,onClick:()=>onSelect(sel({kind:'cognitive-event',id:e.eventId,title:e.eventName,source:e.sourceId??state.cognitiveRuntime.source,observedAt:e.occurredAt,data:e}))})),...state.governance.data.audits.slice(0,10).map((r,i)=>({name:text(r.action,`audit ${i+1}`),sub:when(rowDate(r)),status:'observed',onClick:()=>onSelect(sel({kind:'audit',id:rid(r,`audit-${i}`),title:text(r.action,'Audit'),source:state.governance.source,observedAt:rowDate(r),data:r}))}))]}/></Panel>
-        <Panel id="mod-10-div" module="10 · GOBERNANZA" label="Divergencias" status={divergences?'degraded':'observed'} source="institutional interpretation"><Rows rows={state.interpretation.divergences.map(d=>({name:d.title,sub:d.observation,status:d.status,onClick:()=>onSelect(sel({kind:'divergence',id:d.id,title:d.title,source:d.source,data:d}))}))}/></Panel>
-      </div></section>
-    </main></div>
+function EvidenceGraph({ state, onSelect }: { state: RootSovereignState; onSelect: (selection: RootSelection) => void }) {
+  const nodes = state.evidence.data.nodes.slice(0, 28);
+  const edges = state.evidence.data.edges.slice(0, 64);
+  const points = useMemo(() => new Map(nodes.map((node, index) => {
+    const angle = index / Math.max(1, nodes.length) * Math.PI * 2;
+    const radius = 28 + (index % 3) * 7;
+    return [node.id, { x: 50 + Math.cos(angle) * radius, y: 50 + Math.sin(angle) * radius }] as const;
+  })), [nodes]);
+
+  return <svg className="graph-svg" viewBox="0 0 100 100">
+    {edges.map((edge) => {
+      const from = points.get(edge.from);
+      const to = points.get(edge.to);
+      return from && to ? <line key={edge.id} x1={from.x} y1={from.y} x2={to.x} y2={to.y} /> : null;
+    })}
+    {nodes.map((node) => {
+      const point = points.get(node.id)!;
+      return <g key={node.id} onClick={(event) => {
+        event.stopPropagation();
+        onSelect(sel({ kind: 'evidence-node', id: node.id, title: node.label, source: node.source, observedAt: node.observedAt, evidenceIds: node.evidenceIds, data: { ...node.payload, epistemicClass: node.epistemicClass, confidence: node.confidence, lineage: node.lineage } }));
+      }}>
+        <circle cx={point.x} cy={point.y} r="1.8" data-tone={tone(node.epistemicClass)} />
+        <text x={point.x + 2.5} y={point.y + 1}>{node.label.slice(0, 18)}</text>
+      </g>;
+    })}
+    {!nodes.length ? <text x="50" y="50" textAnchor="middle" className="graph-empty">MISSING</text> : null}
+  </svg>;
+}
+
+function AttractorField({ state, onSelect }: { state: RootSovereignState; onSelect: (selection: RootSelection) => void }) {
+  const attractor = state.amv.data.attractors[0] ?? null;
+  const vector = rec(attractor?.vector);
+  const dimensions = strings(vector.dimensions);
+  const supported = new Set(strings(vector.supportedDimensions));
+  const contradicted = new Set(strings(vector.contradictedDimensions));
+  const missing = new Set(strings(vector.missingDimensions));
+  return <div className="attractor-field" onClick={(event) => {
+    event.stopPropagation();
+    if (attractor) onSelect(sel({ kind: 'attractor', id: rid(attractor, 'attractor'), title: text(attractor.label ?? attractor.attractor_key, 'Atractor'), source: state.amv.source, observedAt: rowDate(attractor), data: attractor }));
+  }}>
+    <div className="living-grid" />
+    <div className="attractor-core"><span>{attractor ? text(attractor.label ?? attractor.attractor_key) : 'SIN ATRACTOR DECLARADO'}</span><small>{attractor ? text(attractor.status, 'DECLARED') : 'MISSING'}</small></div>
+    {dimensions.map((dimension, index) => {
+      const angle = index / Math.max(1, dimensions.length) * Math.PI * 2;
+      const x = 50 + Math.cos(angle) * 32;
+      const y = 50 + Math.sin(angle) * 32;
+      const status = contradicted.has(dimension) ? 'bad' : supported.has(dimension) ? 'ok' : missing.has(dimension) ? 'idle' : 'warn';
+      return <span className="orbit-node" data-tone={status} key={dimension} style={{ left: `${x}%`, top: `${y}%` }} title={dimension}>{index + 1}</span>;
+    })}
+  </div>;
+}
+
+export function RootObservatoryWorkspace({ state, accessMode, actorLabel, refreshing, warning, onRefresh, onSelect, onAction }: {
+  state: RootSovereignState;
+  accessMode: AccessMode;
+  actorLabel: string;
+  refreshing: boolean;
+  warning: string | null;
+  onRefresh: () => void;
+  onSelect: (value: RootSelection) => void;
+  onAction: (action: RootActionRequest) => void;
+}) {
+  const [filter, setFilter] = useState<'all' | TopologyId>('all');
+  const [clock, setClock] = useState(() => new Date());
+  useEffect(() => { const id = window.setInterval(() => setClock(new Date()), 1000); return () => window.clearInterval(id); }, []);
+
+  const phiFact = state.interpretation.facts.find((fact) => fact.id === 'institutional-position');
+  const phi = phiFact?.value.match(/([0-9]+(?:\.[0-9]+)?)/)?.[1] ?? '—';
+  const agents = state.cognitiveRuntime.data.agents;
+  const executed = agents.filter((agent) => agent.status === 'operational').length;
+  const capabilities = state.execution.data.capabilities;
+  const available = capabilities.filter((capability) => capability.state === 'available').length;
+  const evidenceCount = state.evidence.data.entries.length + state.evidence.data.ledger.length;
+  const graphStatus = state.evidence.error ? 'DEGRADED' : state.evidence.data.nodes.length ? 'OBSERVED' : 'MISSING';
+  const attractor = state.amv.data.attractors[0] ?? null;
+  const divergenceCount = state.interpretation.divergences.length;
+  const sources = [state.system, state.governance, state.agents, state.predictions, state.amv, state.evidence, state.execution, state.telemetry, state.cognitiveRuntime];
+  const sourceOk = sources.filter((source) => !source.error).length;
+  const hypotheses = [...state.predictions.data.runs, ...state.predictions.data.legacyEntries];
+  const recentEvents = state.cognitiveRuntime.data.eventGraph.recentEvents.slice(0, 30);
+  const trajectory = [
+    ...state.evidence.data.entries.map((row) => ({ kind: 'evidence', row })),
+    ...hypotheses.map((row) => ({ kind: 'prediction', row })),
+    ...state.predictions.data.outcomes.map((row) => ({ kind: 'outcome', row })),
+    ...state.predictions.data.learningEvents.map((row) => ({ kind: 'learning', row })),
+    ...state.governance.data.audits.map((row) => ({ kind: 'audit', row })),
+  ].sort((a, b) => new Date(rowDate(b.row) ?? 0).valueOf() - new Date(rowDate(a.row) ?? 0).valueOf()).slice(0, 40);
+
+  const byFamily = new Map<string, typeof capabilities>();
+  for (const capability of capabilities) {
+    const family = capability.id === 'daily' || capability.id === 'audit' ? 'OBSERVAR'
+      : capability.id === 'evidence' || capability.id === 'amv-ingest' ? 'INTEGRAR'
+        : capability.id === 'amv-search' || capability.id === 'graph' ? 'CONSULTAR'
+          : capability.id === 'simulation' ? 'MODELAR'
+            : capability.id === 'report' || capability.id === 'reports' ? 'REPORTAR'
+              : capability.id === 'all' || capability.id === 'institutional-cycle' ? 'ORQUESTAR' : 'GOBERNAR';
+    byFamily.set(family, [...(byFamily.get(family) ?? []), capability]);
+  }
+
+  const focus = (topology: TopologyId) => filter === 'all' || filter === topology;
+  const jump = (id: string) => document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', inline: 'start', block: 'center' });
+  const agentEvidenceIds = (agentId: string) => recentEvents.filter((event) => event.sourceId === agentId && event.eventId).map((event) => event.eventId);
+  const relatedFact = (divergenceId: string) => state.interpretation.facts.find((fact) => fact.id === DIVERGENCE_FACT[divergenceId]) ?? null;
+  const institutionalEvidence = Array.from(new Set(state.interpretation.facts.flatMap((fact) => fact.evidenceIds)));
+
+  return <div className="root-observatory">
+    <header className="root-hdr">
+      <strong>SFI · ROOT</strong><span>01 · ESTADO INSTITUCIONAL</span><b>ΦSFI <em>{phi}</em></b>
+      <span>AGENTES <i>{executed}/{agents.length || '—'}</i></span><span>CAPACIDADES <i>{available}/{capabilities.length || '—'}</i></span><span>EVIDENCIA <i>{evidenceCount}</i></span>
+      <span>GRAFO <i data-tone={tone(graphStatus)}>{graphStatus}</i></span><span>ATRACTOR <i>{attractor ? text(attractor.status, 'DECLARED').toUpperCase() : 'MISSING'}</i></span><span>DIVERGENCIAS <i>{divergenceCount}</i></span>
+      <div className="root-hdr-right"><button type="button" onClick={onRefresh}>{refreshing ? 'ACTUALIZANDO' : 'ACTUALIZAR'}</button><span>{actorLabel} · {accessMode === 'sovereign' ? 'SOVEREIGN' : 'OBSERVER'}</span><time>{clock.toLocaleTimeString('es-MX')}</time></div>
+    </header>
+
+    <aside className="root-side">
+      <small>TOPOLOGÍA</small>{(['all', 'I', 'II', 'III'] as const).map((topology) => <button key={topology} className={filter === topology ? 'active' : ''} onClick={() => setFilter(topology)}>{topology === 'all' ? 'Ø' : topology}</button>)}
+      <small>MÓDULOS</small>{MODULES.map(([id, label]) => <button key={id} onClick={() => jump(`mod-${id}`)}>{id}<span>{label}</span></button>)}
+      <small>SUPERFICIES</small><Link href="/root/institutionalization" title="Institutionalization">IN</Link><Link href="/root/reports" title="Reportes de agentes">RP</Link><Link href="/field">FD</Link><Link href="/field/map">FM</Link><Link href="/studio">ST</Link><Link href="/interface/observatory">OB</Link><Link href="/library">LB</Link>
+    </aside>
+
+    <main className="root-observatory-main">
+      {warning ? <div className="root-warning">{warning}</div> : null}
+
+      <section className={`topology-row ${focus('I') ? '' : 'dim'}`}>
+        <header><b>I</b><strong>{TOPOLOGIES.I.title}</strong><em>{TOPOLOGIES.I.question}</em></header>
+        <div className="panel-strip">
+          <Panel id="mod-01" module="01 · ESTADO INSTITUCIONAL" label="ΦSFI · interpretación" status={phiFact?.status ?? 'missing'} statusContext="CLASE" source={phiFact?.source} width="l" onOpen={() => phiFact && onSelect(sel({
+            kind: 'institutional-position', id: phiFact.id, title: state.interpretation.headline, source: phiFact.source, observedAt: phiFact.observedAt, evidenceIds: institutionalEvidence, warning: phiFact.warning,
+            data: { phiFact, headline: state.interpretation.headline, narrative: state.interpretation.narrative, divergences: state.interpretation.divergences, facts: state.interpretation.facts, sourceHealth: { ok: sourceOk, total: sources.length } },
+          }))}>
+            <div className="phi-live"><strong>{phi}</strong><span>{state.interpretation.headline}</span><small>{sourceOk}/{sources.length} fuentes sin error · {divergenceCount} divergencias · {when(state.generatedAt)}</small></div>
+          </Panel>
+
+          <Panel id="mod-02" module="02 · SISTEMA" label="Salud de superficies" status={state.system.error ? 'degraded' : state.system.dataClass} statusContext="SALUD" source={state.system.source}>
+            <Rows rows={state.system.data.matrix.map((item) => ({ name: item.label, sub: item.openItems.value === null ? undefined : `${item.openItems.value} abiertos`, status: item.state.status, statusContext: 'SALUD', onClick: () => onSelect(sel({ kind: 'system-item', id: item.id, title: item.label, source: item.state.source, observedAt: item.state.observedAt, evidenceIds: item.state.evidenceIds, warning: item.state.warning, data: item })) }))} />
+          </Panel>
+
+          <Panel id="mod-03" module="03 · IDENTIDAD" label="Sesión / autoridad" status="observed" statusContext="ESTADO" source="server user context"><Rows rows={[{ name: actorLabel, sub: accessMode === 'sovereign' ? 'ROOT · SOVEREIGN' : 'ROOT · OBSERVER', status: 'observed', statusContext: 'ESTADO' }]} /></Panel>
+
+          <Panel id="mod-institution" module="01a · INSTITUCIONALIZACIÓN" label="Founder dependency / transferencia" status="declared" statusContext="CLASE" source="FEP-01 + Cognitive Twin memory" width="l"><div className="intake-live"><p>Observa dónde SFI todavía depende del fundador, separa criterio transferible de autoridad reservada y exige reproducción antes de declarar capacidad institucional.</p><Link href="/root/institutionalization">ABRIR INSTITUTIONALIZATION →</Link><Link href="/root/reports">LEER REPORTES DE AGENTES →</Link></div></Panel>
+
+          <Panel id="mod-04-intake" module="04a · EVIDENCIA" label="Evidence Intake" status="observed" statusContext="ESTADO" source="root_evidence_entries" width="l"><div className="intake-live"><p>Captura evidencia con procedencia explícita. El contenido no se autopromueve a CANONICAL.</p><Link href="/root/evidence/intake">REGISTRAR / VINCULAR EVIDENCIA →</Link></div></Panel>
+
+          <Panel id="mod-10" module="10 · GOBERNANZA" label="Capacidades ejecutables" status={state.execution.error ? 'degraded' : state.execution.dataClass} statusContext="SALUD" source={state.execution.source} width="l"><div className="cap-groups">{[...byFamily.entries()].map(([family, items]) => <div key={family}><b>{family}</b>{items.map((capability) => <button key={capability.id} type="button" data-tone={tone(capability.state)} onClick={(event) => { event.stopPropagation(); onAction({ id: capability.id, label: capability.label, effect: capability.description, target: capability.endpoint ?? capability.id, endpoint: capability.endpoint, method: 'POST' }); }}>{capability.label}<i>{statusLabel(capability.state, 'ESTADO')}</i></button>)}</div>)}</div></Panel>
+        </div>
+      </section>
+
+      <section className={`topology-row ${focus('II') ? '' : 'dim'}`}>
+        <header><b>II</b><strong>{TOPOLOGIES.II.title}</strong><em>{TOPOLOGIES.II.question}</em></header>
+        <div className="panel-strip">
+          <Panel id="mod-04" module="04 · EVIDENCIA" label="Grafo de evidencia" status={graphStatus} statusContext="SALUD" source={state.evidence.source} width="l"><EvidenceGraph state={state} onSelect={onSelect} /></Panel>
+          <Panel id="mod-05" module="05 · RUNTIME" label={`${agents.length} agentes`} status={state.cognitiveRuntime.data.status} statusContext="SALUD" source={state.cognitiveRuntime.source} width="l"><Rows rows={agents.map((agent) => ({ name: agent.name, sub: `${agent.layer} · ${agent.domain}`, status: agent.status, statusContext: 'ESTADO', onClick: () => onSelect(sel({ kind: 'agent', id: agent.id, title: agent.name, source: state.cognitiveRuntime.source, observedAt: state.cognitiveRuntime.observedAt, evidenceIds: agentEvidenceIds(agent.id), data: agent })) }))} /></Panel>
+          <Panel id="mod-06" module="06 · COGNITIVE TWIN" label="Hipótesis / contradicciones" status={hypotheses.length ? 'derived' : 'missing'} statusContext="CLASE" source={state.predictions.source}><Rows rows={hypotheses.slice(0, 20).map((row, index) => ({ name: text(row.title ?? row.hypothesis ?? row.status, `Hipótesis ${index + 1}`), sub: text(row.learning_state ?? row.status, ''), status: text(row.epistemic_class ?? row.status, 'derived'), statusContext: 'CLASE', onClick: () => onSelect(sel({ kind: 'hypothesis', id: rid(row, `hyp-${index}`), title: text(row.title ?? row.hypothesis, `Hipótesis ${index + 1}`), source: state.predictions.source, observedAt: rowDate(row), evidenceIds: strings(row.evidence_refs), data: row })) }))} /></Panel>
+          <Panel id="mod-07" module="07 · PROYECCIÓN" label="Predicción / outcome" status={state.predictions.error ? 'degraded' : state.predictions.dataClass} statusContext="SALUD" source={state.predictions.source}><div className="metric-cluster"><b>{state.predictions.data.runs.length + state.predictions.data.legacyEntries.length}<small>PREDICCIONES</small></b><b>{state.predictions.data.outcomes.length}<small>OUTCOMES</small></b><b>{state.predictions.data.learningEvents.length}<small>LEARNING</small></b></div></Panel>
+          <Panel id="mod-08" module="08 · ATRACTORES" label="Campo institucional" status={attractor ? text(attractor.status, 'declared') : 'missing'} statusContext="CLASE" source={state.amv.source} width="xl"><AttractorField state={state} onSelect={onSelect} /></Panel>
+        </div>
+      </section>
+
+      <section className={`topology-row ${focus('III') ? '' : 'dim'}`}>
+        <header><b>III</b><strong>{TOPOLOGIES.III.title}</strong><em>{TOPOLOGIES.III.question}</em></header>
+        <div className="panel-strip">
+          <Panel id="mod-09" module="09 · TRAYECTORIA" label="Evidencia → aprendizaje" status={trajectory.length ? 'derived' : 'missing'} statusContext="CLASE" source="evidence + prediction + outcome + learning + audit" width="xl"><div className="trajectory-live">{trajectory.map((item, index) => <button key={`${item.kind}-${rid(item.row, String(index))}`} type="button" onClick={(event) => { event.stopPropagation(); onSelect(sel({ kind: item.kind, id: rid(item.row, `${item.kind}-${index}`), title: text(item.row.title ?? item.row.event_name ?? item.row.action ?? item.row.status, item.kind), source: item.kind, observedAt: rowDate(item.row), evidenceIds: strings(item.row.evidence_refs), data: item.row })); }}><time>{when(rowDate(item.row))}</time><i>{item.kind}</i><span>{text(item.row.title ?? item.row.event_name ?? item.row.action ?? item.row.status ?? item.row.learning_state, item.kind)}</span></button>)}</div></Panel>
+          <Panel id="mod-09-memory" module="09 · MEMORIA" label="AMV / MIHM" status={state.amv.error ? 'degraded' : state.amv.dataClass} statusContext="SALUD" source={state.amv.source}><div className="metric-cluster"><b>{state.amv.data.memories.length}<small>AMV MEMORY</small></b><b>{state.predictions.data.learningEvents.length}<small>LEARNING EVENTS</small></b><b>{state.governance.data.audits.length}<small>AUDITED ACTIONS</small></b></div></Panel>
+          <Panel id="mod-10-log" module="10 · GOBERNANZA" label="Bitácora / eventos cognitivos" status={state.governance.error ? 'degraded' : state.governance.dataClass} statusContext="SALUD" source={state.governance.source} width="l"><Rows rows={[
+            ...recentEvents.map((event) => ({ name: event.eventName, sub: `${when(event.occurredAt)} · ${event.sourceId ?? 'runtime'}`, status: event.epistemicClass, statusContext: 'CLASE' as const, onClick: () => onSelect(sel({ kind: 'cognitive-event', id: event.eventId, title: event.eventName, source: event.sourceId ?? state.cognitiveRuntime.source, observedAt: event.occurredAt, data: event })) })),
+            ...state.governance.data.audits.slice(0, 10).map((row, index) => ({ name: text(row.action, `audit ${index + 1}`), sub: when(rowDate(row)), status: 'observed', statusContext: 'ESTADO' as const, onClick: () => onSelect(sel({ kind: 'audit', id: rid(row, `audit-${index}`), title: text(row.action, 'Audit'), source: state.governance.source, observedAt: rowDate(row), data: row })) })),
+          ]} /></Panel>
+          <Panel id="mod-10-div" module="10 · GOBERNANZA" label="Divergencias" status={divergenceCount ? 'degraded' : 'observed'} statusContext="SALUD" source="institutional interpretation"><Rows rows={state.interpretation.divergences.map((divergence) => {
+            const fact = relatedFact(divergence.id);
+            return { name: divergence.title, sub: divergence.observation, status: divergence.status, statusContext: 'SALUD', onClick: () => onSelect(sel({ kind: 'divergence', id: divergence.id, title: divergence.title, source: divergence.source, observedAt: fact?.observedAt ?? state.generatedAt, evidenceIds: fact?.evidenceIds ?? [], warning: fact?.warning ?? null, data: { ...divergence, relatedFact: fact } })) };
+          })} /></Panel>
+        </div>
+      </section>
+    </main>
+  </div>;
 }

--- a/src/components/root/sovereign/RootSemanticInspector.tsx
+++ b/src/components/root/sovereign/RootSemanticInspector.tsx
@@ -33,7 +33,7 @@ function strings(value: unknown): string[] {
 
 function contextualAction(kind: string) {
   const normalized = kind.toLowerCase();
-  if (normalized.includes('attractor')) return { href: '/root/attractor', label: 'ABRIR CAMPO DEL ATRACTOR' };
+  if (normalized.includes('attractor')) return { href: '/root#mod-08', label: 'VOLVER AL CAMPO DEL ATRACTOR' };
   if (
     normalized.includes('hypothesis') ||
     normalized.includes('prediction') ||

--- a/src/components/root/sovereign/RootSemanticInspector.tsx
+++ b/src/components/root/sovereign/RootSemanticInspector.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useEffect } from 'react';
 import type { RootRow } from '@/lib/root/sovereign/rootSovereignState';
 import type { RootSelection } from './sovereignTypes';
 import { describeRootSelection } from '@/lib/root/sovereign/selectionNarrative';
@@ -16,39 +17,175 @@ function rootRow(value: unknown): RootRow {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as RootRow : {};
 }
 
+function text(value: unknown, fallback = 'MISSING') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function list(value: unknown): RootRow[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is RootRow => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+    : [];
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && Boolean(item.trim())) : [];
+}
+
+function contextualAction(kind: string) {
+  const normalized = kind.toLowerCase();
+  if (normalized.includes('attractor')) return { href: '/root/attractor', label: 'ABRIR CAMPO DEL ATRACTOR' };
+  if (
+    normalized.includes('hypothesis') ||
+    normalized.includes('prediction') ||
+    normalized.includes('proposal')
+  ) return { href: '/root/evidence/intake', label: 'VINCULAR EVIDENCIA DE CONTRASTE' };
+  if (normalized.includes('evidence') || normalized.includes('ledger')) {
+    return { href: '/root/evidence/intake', label: 'VINCULAR EVIDENCIA RELACIONADA' };
+  }
+  return null;
+}
+
+function divergenceTone(status: string) {
+  const normalized = status.toLowerCase();
+  if (normalized === 'blocking') return 'blocking';
+  if (normalized === 'degraded') return 'degraded';
+  return 'open';
+}
+
 export function RootSemanticInspector({ value, onClose }: { value: RootSelection | null; onClose: () => void }) {
+  useEffect(() => {
+    if (!value) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [value, onClose]);
+
   if (!value) return null;
+
+  const data = rootRow(value.data);
   const narrative = describeRootSelection({
     kind: value.kind,
     technicalTitle: value.title,
-    data: rootRow(value.data),
+    data,
     evidenceCount: value.evidenceIds.length,
   });
+  const action = contextualAction(value.kind);
+  const divergences = list(data.divergences);
+  const institutionalNarrative = Array.isArray(data.narrative)
+    ? data.narrative.filter((item): item is string => typeof item === 'string')
+    : [];
+  const systemState = rootRow(data.state);
+  const openItems = rootRow(data.openItems);
+  const relatedFact = rootRow(data.relatedFact);
+  const isSystemItem = value.kind.toLowerCase() === 'system-item';
+  const isDivergence = value.kind.toLowerCase() === 'divergence';
+  const isInstitutional = ['institutional-position', 'institutional-fact'].includes(value.kind.toLowerCase());
+  const isEvidence = value.kind.toLowerCase().includes('evidence') || value.kind.toLowerCase().includes('ledger');
+  const payloadEvidence = strings(data.evidenceIds ?? data.evidence_ids ?? data.lineage);
+  const evidenceRefs = Array.from(new Set([...value.evidenceIds, ...payloadEvidence]));
 
   return (
-    <aside className="rsi-root" aria-live="polite">
-      <header>
-        <div><span>{value.kind}</span><h2>{narrative.title}</h2></div>
-        <button type="button" onClick={onClose}>×</button>
-      </header>
-      <section className="rsi-primary"><strong>{narrative.statement}</strong><p>{narrative.meaning}</p></section>
-      <section className="rsi-next"><span>QUÉ SIGUE</span><p>{narrative.nextState}</p></section>
-      <dl>
-        <div><dt>FUENTE</dt><dd>{value.source}</dd></div>
-        <div><dt>FECHA</dt><dd>{displayTime(value.observedAt)}</dd></div>
-        <div><dt>PROCEDENCIA</dt><dd>{narrative.evidenceLabel}</dd></div>
-        {narrative.facts.map((fact) => <div key={`${fact.label}-${fact.value}`}><dt>{fact.label}</dt><dd>{fact.value}</dd></div>)}
-      </dl>
-      {value.warning ? <p className="rsi-warning">{value.warning}</p> : null}
-      <details><summary>DATOS TÉCNICOS</summary><pre>{JSON.stringify({ id: value.id, technicalTitle: value.title, evidenceIds: value.evidenceIds, payload: value.data }, null, 2)}</pre></details>
-      <Link href="/root/evidence/intake">ADJUNTAR / VINCULAR EVIDENCIA</Link>
+    <div className="rsi-backdrop" role="presentation" onMouseDown={(event) => { if (event.target === event.currentTarget) onClose(); }}>
+      <section className="rsi-modal" role="dialog" aria-modal="true" aria-labelledby="rsi-title">
+        <header>
+          <div><span>{value.kind}</span><h2 id="rsi-title">{narrative.title}</h2></div>
+          <button type="button" onClick={onClose} aria-label="Cerrar">×</button>
+        </header>
+
+        <div className="rsi-scroll">
+          <section className="rsi-primary">
+            <strong>{narrative.statement}</strong>
+            <p>{narrative.meaning}</p>
+          </section>
+
+          {isInstitutional && divergences.length ? (
+            <section className="rsi-diagnostic">
+              <div className="rsi-section-title">DÓNDE ESTÁ LA DIVERGENCIA · {divergences.length}</div>
+              <div className="rsi-divergence-grid">
+                {divergences.map((entry, index) => {
+                  const status = text(entry.status, 'open');
+                  return <article key={text(entry.id, `div-${index}`)} data-severity={divergenceTone(status)}>
+                    <div><b>{status.toUpperCase()}</b><span>{text(entry.source, 'FUENTE NO DECLARADA')}</span></div>
+                    <h3>{text(entry.title, `Divergencia ${index + 1}`)}</h3>
+                    <p>{text(entry.observation, 'Sin detalle persistido.')}</p>
+                  </article>;
+                })}
+              </div>
+            </section>
+          ) : null}
+
+          {isInstitutional && institutionalNarrative.length ? (
+            <section className="rsi-diagnostic">
+              <div className="rsi-section-title">LECTURA INSTITUCIONAL</div>
+              <ol>{institutionalNarrative.map((item) => <li key={item}>{item}</li>)}</ol>
+            </section>
+          ) : null}
+
+          {isSystemItem ? (
+            <section className="rsi-diagnostic">
+              <div className="rsi-section-title">LECTURA DEL SISTEMA</div>
+              <div className="rsi-system-grid">
+                <div><span>SALUD DE LECTURA</span><strong>{text(systemState.status).toUpperCase()}</strong></div>
+                <div><span>ESTADO REPORTADO</span><strong>{text(systemState.value)}</strong></div>
+                <div><span>ELEMENTOS ABIERTOS</span><strong>{typeof openItems.value === 'number' ? openItems.value : text(openItems.value)}</strong></div>
+              </div>
+              <p className="rsi-explanation">{text(systemState.explanation, 'Sin explicación persistida.')}</p>
+              {text(systemState.warning, '') ? <div className="rsi-cause"><span>CAUSA DE DEGRADACIÓN</span><strong>{text(systemState.warning)}</strong></div> : null}
+            </section>
+          ) : null}
+
+          {isDivergence ? (
+            <section className="rsi-diagnostic">
+              <div className="rsi-section-title">DIAGNÓSTICO DE DIVERGENCIA</div>
+              <div className="rsi-cause"><span>HUECO OBSERVADO</span><strong>{text(data.observation)}</strong></div>
+              {Object.keys(relatedFact).length ? <div className="rsi-related">
+                <span>LECTURA RELACIONADA</span>
+                <strong>{text(relatedFact.label)} · {text(relatedFact.value)}</strong>
+                <small>CLASE · {text(relatedFact.status).toUpperCase()}</small>
+              </div> : null}
+            </section>
+          ) : null}
+
+          {isEvidence ? (
+            <section className="rsi-diagnostic">
+              <div className="rsi-section-title">PROCEDENCIA / LINAJE</div>
+              {evidenceRefs.length ? <div className="rsi-refs">{evidenceRefs.map((ref) => <code key={ref}>{ref}</code>)}</div> : <p className="rsi-empty">Este nodo no expone referencias adicionales. No significa que debas cargar otra evidencia.</p>}
+            </section>
+          ) : null}
+
+          <section className="rsi-next"><span>QUÉ SIGUE</span><p>{narrative.nextState}</p></section>
+
+          <dl>
+            <div><dt>FUENTE</dt><dd>{value.source}</dd></div>
+            <div><dt>FECHA</dt><dd>{displayTime(value.observedAt)}</dd></div>
+            <div><dt>PROCEDENCIA</dt><dd>{narrative.evidenceLabel}</dd></div>
+            {narrative.facts.map((fact) => <div key={`${fact.label}-${fact.value}`}><dt>{fact.label}</dt><dd>{fact.value}</dd></div>)}
+          </dl>
+
+          {value.warning ? <p className="rsi-warning">{value.warning}</p> : null}
+
+          <details>
+            <summary>DATOS TÉCNICOS</summary>
+            <pre>{JSON.stringify({ id: value.id, technicalTitle: value.title, evidenceIds: value.evidenceIds, payload: value.data }, null, 2)}</pre>
+          </details>
+
+          {action ? <Link className="rsi-action" href={action.href}>{action.label}</Link> : null}
+        </div>
+      </section>
+
       <style jsx global>{`
         .rtf-inspector{display:none!important}.rtf-layout{grid-template-columns:minmax(0,1fr)!important}.rtf-stage{border-right:0!important}
-        .rs-console-host.has-semantic-selection .rtf-stage{padding-right:370px}
-        .rsi-root{position:fixed;z-index:95;right:0;top:42px;width:min(370px,94vw);height:calc(100vh - 42px);overflow:auto;background:#070706;border-left:1px solid rgba(201,170,84,.2);padding:22px;color:#d7cfbd;font-family:var(--sfi-font-mono),ui-monospace,SFMono-Regular,Menlo,monospace;box-shadow:-18px 0 35px rgba(0,0,0,.22)}
-        .rsi-root header{display:flex;justify-content:space-between;gap:12px;padding-bottom:16px;border-bottom:1px solid rgba(255,255,255,.06)}.rsi-root header span,.rsi-next span{color:#8a7547;font-size:8px;letter-spacing:.13em}.rsi-root h2{margin:5px 0 0;color:#ded0ae;font:400 20px/1.25 Georgia,serif}.rsi-root header button{border:0;background:transparent;color:#746d61;font-size:18px;cursor:pointer}.rsi-primary{padding:18px 0;border-bottom:1px solid rgba(255,255,255,.05)}.rsi-primary strong{display:block;color:#e0ca87;font:400 17px/1.35 Georgia,serif}.rsi-primary p,.rsi-next p{color:#918878;font-size:10px;line-height:1.7}.rsi-next{padding:16px 0;border-bottom:1px solid rgba(255,255,255,.05)}.rsi-root dl{margin:0}.rsi-root dl div{padding:9px 0;border-bottom:1px solid rgba(255,255,255,.04)}.rsi-root dt{color:#5f5a50;font-size:7px}.rsi-root dd{margin:4px 0 0;color:#a79d88;font-size:8px;line-height:1.5;overflow-wrap:anywhere}.rsi-warning{color:#b9896d;font-size:9px;line-height:1.6}.rsi-root details{margin-top:16px;padding-top:14px;border-top:1px solid rgba(201,170,84,.14)}.rsi-root summary{color:#8d7748;font-size:8px;cursor:pointer}.rsi-root pre{white-space:pre-wrap;overflow-wrap:anywhere;color:#777168;font-size:7px;line-height:1.55}.rsi-root>a{display:inline-block;margin-top:16px;border:1px solid #5e5032;padding:9px 11px;color:#bca35f;text-decoration:none;font-size:8px}
-        @media(max-width:980px){.rs-console-host.has-semantic-selection .rtf-stage{padding-right:0}.rsi-root{position:relative;top:0;width:100%;height:auto;border-left:0;border-top:1px solid rgba(201,170,84,.2)}}
+        .rsi-backdrop{position:fixed;z-index:120;inset:0;background:rgba(0,0,0,.72);display:flex;align-items:center;justify-content:center;padding:38px 5vw;backdrop-filter:blur(2px)}
+        .rsi-modal{width:min(980px,94vw);max-height:min(860px,90vh);background:#070706;border:1px solid rgba(201,170,84,.28);color:#d7cfbd;font-family:var(--sfi-font-mono),ui-monospace,SFMono-Regular,Menlo,monospace;box-shadow:0 28px 90px rgba(0,0,0,.72);display:flex;flex-direction:column}
+        .rsi-modal>header{display:flex;justify-content:space-between;gap:18px;padding:20px 24px;border-bottom:1px solid rgba(255,255,255,.06);background:#090908}.rsi-modal>header span,.rsi-section-title,.rsi-next>span{color:#a68d53;font-size:8px;letter-spacing:.16em}.rsi-modal h2{margin:6px 0 0;color:#eadbb7;font:400 25px/1.2 Georgia,serif}.rsi-modal>header button{border:1px solid rgba(201,170,84,.12);background:transparent;color:#887f70;width:32px;height:32px;font-size:20px;cursor:pointer}.rsi-modal>header button:hover{color:#e6d6b2;border-color:rgba(201,170,84,.4)}
+        .rsi-scroll{overflow:auto;padding:0 24px 24px;scrollbar-width:thin;scrollbar-color:rgba(200,169,81,.24) transparent}.rsi-primary{padding:22px 0;border-bottom:1px solid rgba(255,255,255,.05)}.rsi-primary strong{display:block;color:#e3c979;font:400 20px/1.4 Georgia,serif}.rsi-primary p,.rsi-next p,.rsi-diagnostic p{color:#9b9281;font-size:11px;line-height:1.75}.rsi-next{padding:18px 0;border-bottom:1px solid rgba(255,255,255,.05)}
+        .rsi-diagnostic{padding:19px 0;border-bottom:1px solid rgba(255,255,255,.05)}.rsi-divergence-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px;margin-top:12px}.rsi-divergence-grid article{border:1px solid rgba(201,170,84,.12);background:#0a0a09;padding:13px}.rsi-divergence-grid article[data-severity=blocking]{border-color:rgba(190,72,72,.55)}.rsi-divergence-grid article[data-severity=degraded]{border-color:rgba(201,143,79,.42)}.rsi-divergence-grid article[data-severity=open]{border-color:rgba(201,170,84,.24)}.rsi-divergence-grid article>div{display:flex;justify-content:space-between;gap:12px}.rsi-divergence-grid article b{font-size:7px;color:#c88865}.rsi-divergence-grid article span{font-size:7px;color:#5e594f;text-align:right}.rsi-divergence-grid h3{margin:9px 0 3px;font:400 16px Georgia,serif;color:#d9c8a2}.rsi-divergence-grid p{margin:0;font-size:9px;line-height:1.55}.rsi-diagnostic ol{margin:12px 0 0;padding-left:22px;color:#958c7c;font:12px/1.7 Georgia,serif}.rsi-diagnostic li+li{margin-top:7px}
+        .rsi-system-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:12px}.rsi-system-grid>div,.rsi-related{border:1px solid rgba(201,170,84,.1);background:#0a0a09;padding:12px}.rsi-system-grid span,.rsi-related span,.rsi-cause span{display:block;font-size:7px;letter-spacing:.12em;color:#655f53}.rsi-system-grid strong,.rsi-related strong{display:block;margin-top:7px;color:#d4bd7b;font-size:11px}.rsi-related small{display:block;margin-top:5px;color:#7d7465;font-size:7px}.rsi-explanation{margin:12px 0 0}.rsi-cause{margin-top:10px;border-left:2px solid #b86f55;background:rgba(184,111,85,.06);padding:11px 13px}.rsi-cause strong{display:block;margin-top:6px;color:#cba18b;font-size:10px;line-height:1.6;overflow-wrap:anywhere}
+        .rsi-refs{display:flex;flex-wrap:wrap;gap:6px;margin-top:12px}.rsi-refs code{border:1px solid rgba(95,151,102,.28);background:rgba(69,128,77,.06);color:#7fb786;padding:6px 8px;font-size:8px;overflow-wrap:anywhere}.rsi-empty{font-style:italic}.rsi-modal dl{margin:0}.rsi-modal dl div{display:grid;grid-template-columns:180px 1fr;gap:18px;padding:10px 0;border-bottom:1px solid rgba(255,255,255,.04)}.rsi-modal dt{color:#5f5a50;font-size:7px;letter-spacing:.09em}.rsi-modal dd{margin:0;color:#aaa08b;font-size:9px;line-height:1.55;overflow-wrap:anywhere}.rsi-warning{color:#c28e70;font-size:9px;line-height:1.6}.rsi-modal details{margin-top:17px;padding-top:14px;border-top:1px solid rgba(201,170,84,.14)}.rsi-modal summary{color:#8d7748;font-size:8px;cursor:pointer}.rsi-modal pre{white-space:pre-wrap;overflow-wrap:anywhere;color:#777168;font-size:8px;line-height:1.55}.rsi-action{display:inline-block;margin-top:18px;border:1px solid #5e5032;padding:10px 12px;color:#c7aa63;text-decoration:none;font-size:8px;letter-spacing:.08em}.rsi-action:hover{border-color:#9b8245;color:#e3c77e}
+        @media(max-width:720px){.rsi-backdrop{padding:10px}.rsi-modal{width:100%;max-height:95vh}.rsi-scroll{padding:0 16px 18px}.rsi-modal>header{padding:16px}.rsi-divergence-grid{grid-template-columns:1fr}.rsi-system-grid{grid-template-columns:1fr}.rsi-modal dl div{grid-template-columns:1fr;gap:3px}}
       `}</style>
-    </aside>
+    </div>
   );
 }

--- a/src/lib/root/sovereign/institutionalInterpretation.ts
+++ b/src/lib/root/sovereign/institutionalInterpretation.ts
@@ -92,7 +92,16 @@ export function interpretRootInstitution(state: RootStateInput): RootInstitution
   ];
 
   const divergences: RootInstitutionalDivergence[] = [];
-  if (failedSources.length) divergences.push({ id: 'reader-errors', status: healthySources.length ? 'degraded' : 'blocking', title: 'Lectores con error', observation: `${failedSources.length}/${sources.length} fuentes no respondieron limpiamente.`, source: 'rootSovereignAdapter readers' });
+  if (failedSources.length) {
+    const failures = failedSources.map((source) => `${source.source}: ${source.error}`).join(' | ');
+    divergences.push({
+      id: 'reader-errors',
+      status: healthySources.length ? 'degraded' : 'blocking',
+      title: 'Lectores con error',
+      observation: `${failedSources.length}/${sources.length} fuentes no respondieron limpiamente. ${failures}`,
+      source: 'rootSovereignAdapter readers',
+    });
+  }
   if (runtime.status !== 'operational') divergences.push({ id: 'cognitive-continuity', status: runtime.status === 'missing' ? 'blocking' : 'degraded', title: 'Continuidad cognitiva no demostrada', observation: `${runtimeOperational}/${runtime.agents.length} agentes tienen ejecución observada en la ventana del propio runtime.`, source: state.cognitiveRuntime.source });
   if (trace.status !== 'observed') divergences.push({ id: 'graph-traceability', status: trace.total === 0 ? 'blocking' : 'degraded', title: 'Trazabilidad incompleta', observation: trace.total === 0 ? 'No existe grafo persistido en este lector.' : `${trace.total - trace.traced}/${trace.total} elementos carecen de evidencia o linaje.`, source: state.evidence.source });
   if (capability.status !== 'observed') divergences.push({ id: 'capability-gap', status: capability.available === 0 ? 'blocking' : 'degraded', title: 'Capacidad declarada mayor que capacidad disponible', observation: `${capability.available}/${capability.total} capacidades están disponibles; ${capability.partial} parciales; ${capability.gated} gated.`, source: state.execution.source });

--- a/src/lib/root/sovereign/selectionNarrative.ts
+++ b/src/lib/root/sovereign/selectionNarrative.ts
@@ -13,6 +13,10 @@ function text(value: unknown) {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
 
+function record(value: unknown): RootRow {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as RootRow : {};
+}
+
 function first(data: RootRow, keys: string[]) {
   for (const key of keys) {
     const value = text(data[key]);
@@ -30,6 +34,44 @@ function countEvidence(data: RootRow, explicitCount: number) {
 function sentenceCase(value: string) {
   const normalized = value.replace(/[._-]+/g, ' ').replace(/\s+/g, ' ').trim();
   return normalized ? normalized.charAt(0).toUpperCase() + normalized.slice(1) : 'Registro institucional';
+}
+
+function display(value: unknown, fallback = 'MISSING') {
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  if (typeof value === 'boolean') return value ? 'SÍ' : 'NO';
+  return text(value) ?? fallback;
+}
+
+function divergenceMeaning(id: string, observation: string) {
+  if (id === 'reader-errors') {
+    return 'Una o más fuentes que ROOT necesita para describir el estado institucional devolvieron error o timeout. La degradación está en la adquisición/lectura del estado, no necesariamente en el objeto institucional que esas fuentes representan.';
+  }
+  if (id === 'cognitive-continuity') {
+    return 'La continuidad cognitiva no puede declararse completa porque no todos los agentes registrados tienen ejecución observada en la ventana utilizada por el runtime. Registro de agente y ejecución observada son estados distintos.';
+  }
+  if (id === 'graph-traceability') {
+    return 'Hay elementos del grafo sin referencia de evidencia o linaje explícito. El problema no es que el nodo no exista: es que ROOT no puede recorrer todavía una cadena probatoria completa para todos los elementos.';
+  }
+  if (id === 'capability-gap') {
+    return 'El catálogo conoce más capacidades de las que están disponibles para ejecución en este corte. Una capacidad registrada, parcial o gated no debe contarse como capacidad ejecutable.';
+  }
+  if (id === 'attractor-reader-gap') {
+    return 'ROOT no está recibiendo desde este lector un atractor suficiente para comparar dirección declarada contra trayectoria observada. La interfaz no debe reconstruir esa dirección a partir de texto decorativo.';
+  }
+  if (id === 'institutional-position-gap') {
+    return 'No hay datos suficientes para calcular una posición ΦSFI en este corte. MISSING significa ausencia de lectura suficiente, no un valor cero.';
+  }
+  return observation || 'La divergencia identifica una diferencia explícita entre estados que ROOT no debe colapsar en una sola etiqueta.';
+}
+
+function divergenceNext(id: string) {
+  if (id === 'reader-errors') return 'Revisar las fuentes listadas como fallidas y recuperar su lectura. No requiere cargar evidencia por defecto.';
+  if (id === 'cognitive-continuity') return 'Revisar qué agentes carecen de ejecución observada y distinguir si están gated, degradados o realmente sin ejecución.';
+  if (id === 'graph-traceability') return 'Identificar los nodos o relaciones sin linaje y vincular procedencia sólo donde exista una relación probatoria real.';
+  if (id === 'capability-gap') return 'Abrir el registro de capacidades y localizar cuáles están partial/gated y cuál es la condición que impide su disponibilidad.';
+  if (id === 'attractor-reader-gap') return 'Abrir el campo del atractor y verificar si existe una declaración persistida y una trayectoria comparable.';
+  if (id === 'institutional-position-gap') return 'Revisar las métricas de entrada requeridas por Math Core antes de intentar interpretar ΦSFI.';
+  return 'Seguir la fuente indicada y contrastar los dos estados que producen la divergencia.';
 }
 
 export function humanEventLabel(eventName: string) {
@@ -62,7 +104,82 @@ export function describeRootSelection(input: {
   const evidenceCount = countEvidence(data, input.evidenceCount);
   const evidenceLabel = evidenceCount > 0
     ? `${evidenceCount} referencia${evidenceCount === 1 ? '' : 's'} vinculada${evidenceCount === 1 ? '' : 's'}`
-    : 'Sin referencias de evidencia vinculadas';
+    : 'Sin referencias vinculadas';
+
+  if (kind === 'institutional-position' || kind === 'institutional-fact') {
+    const phiFact = record(data.phiFact ?? data);
+    const divergences = Array.isArray(data.divergences) ? data.divergences : [];
+    const sourceHealth = record(data.sourceHealth);
+    const phiValue = display(phiFact.value ?? data.value, 'NO DETERMINADA');
+    const phiClass = display(phiFact.status ?? data.status, 'MISSING').toUpperCase();
+    const facts = [
+      { label: 'CLASE DEL DATO', value: phiClass },
+      { label: 'POSICIÓN', value: phiValue },
+      { label: 'SALUD DE FUENTES', value: sourceHealth.total ? `${display(sourceHealth.ok, '0')}/${display(sourceHealth.total, '0')} sin error` : 'MISSING' },
+      { label: 'DIVERGENCIAS ACTIVAS', value: String(divergences.length) },
+    ];
+    return {
+      title: 'Lectura institucional de ROOT',
+      statement: `${phiValue}. ROOT detecta ${divergences.length} divergencia${divergences.length === 1 ? '' : 's'} activa${divergences.length === 1 ? '' : 's'} en este corte.`,
+      meaning: 'DERIVED describe la clase epistémica de ΦSFI: es un valor calculado. DEGRADED describe la salud o cobertura de una fuente/lector. No son estados rivales: un valor puede ser DERIVED y, al mismo tiempo, provenir de un sistema con una o más fuentes DEGRADED. La ventana debe mostrar ambos ejes por separado.',
+      nextState: divergences.length
+        ? 'Revisar “DÓNDE ESTÁ LA DIVERGENCIA” en esta misma ventana. Cada entrada identifica el hueco observado, su fuente y el siguiente paso operativo.'
+        : 'No hay divergencias activas en las fuentes consultadas; conservar la lectura como derivada y seguir observando longitudinalmente.',
+      evidenceLabel,
+      facts,
+    };
+  }
+
+  if (kind === 'system-item') {
+    const state = record(data.state);
+    const openItems = record(data.openItems);
+    const health = display(state.status, 'MISSING').toUpperCase();
+    const reported = display(state.value, 'MISSING');
+    const explanation = display(state.explanation, 'Sin explicación de lector.');
+    const warning = text(state.warning) ?? text(data.warning);
+    const facts = [
+      { label: 'SALUD DE LECTURA', value: health },
+      { label: 'ESTADO REPORTADO', value: reported },
+      { label: 'ELEMENTOS ABIERTOS', value: display(openItems.value, 'MISSING') },
+      { label: 'EXPLICACIÓN', value: explanation },
+    ];
+    if (warning) facts.push({ label: 'CAUSA DE DEGRADACIÓN', value: warning });
+    return {
+      title: subject ?? input.technicalTitle,
+      statement: warning
+        ? `${input.technicalTitle} aparece con salud ${health} porque su lector reporta una condición concreta: ${warning}`
+        : `${input.technicalTitle} tiene salud de lectura ${health} y reporta estado ${reported}.`,
+      meaning: '“Salud de lectura” responde si ROOT pudo obtener y reconciliar el estado con suficiente integridad. “Estado reportado” describe lo que la fuente dijo sobre el sistema. Una fuente puede responder parcialmente y por eso estar DEGRADED aunque el objeto tenga otro estado funcional.',
+      nextState: warning
+        ? 'Corregir o reintentar la fuente indicada en la causa de degradación. Cargar evidencia sólo corresponde si el problema real es falta de procedencia, no como acción universal.'
+        : 'No hay una degradación explícita que resolver desde este registro. Puede inspeccionarse el estado técnico si se necesita diagnóstico adicional.',
+      evidenceLabel,
+      facts,
+    };
+  }
+
+  if (kind === 'divergence') {
+    const id = display(data.id, input.technicalTitle);
+    const observation = display(data.observation, 'Sin observación detallada.');
+    const divergenceStatus = display(data.status, 'OPEN').toUpperCase();
+    const relatedFact = record(data.relatedFact);
+    const facts = [
+      { label: 'SEVERIDAD', value: divergenceStatus },
+      { label: 'HUECO OBSERVADO', value: observation },
+    ];
+    if (Object.keys(relatedFact).length) {
+      facts.push({ label: 'LECTURA RELACIONADA', value: `${display(relatedFact.label, 'Registro')} · ${display(relatedFact.value)}` });
+      facts.push({ label: 'CLASE RELACIONADA', value: display(relatedFact.status).toUpperCase() });
+    }
+    return {
+      title: subject ?? input.technicalTitle,
+      statement: observation,
+      meaning: divergenceMeaning(id, observation),
+      nextState: divergenceNext(id),
+      evidenceLabel,
+      facts,
+    };
+  }
 
   const facts: Array<{ label: string; value: string }> = [];
   if (actor) facts.push({ label: 'PRODUCIDO POR', value: actor });
@@ -94,7 +211,7 @@ export function describeRootSelection(input: {
         : 'El registro demuestra que el evento fue persistido. No constituye por sí mismo validación del contenido o del resultado asociado.',
       nextState: evidenceCount > 0
         ? 'La evidencia vinculada permite inspeccionar qué sostiene este evento.'
-        : 'Faltan referencias de evidencia en este punto; el evento debe tratarse como no verificable desde esta vista hasta enlazar procedencia.',
+        : 'Si este evento necesita sostener una afirmación, entonces sí debe vincular procedencia; si sólo es telemetría, no se debe forzar una carga de evidencia.',
       evidenceLabel,
       facts,
     };
@@ -107,19 +224,27 @@ export function describeRootSelection(input: {
       statement: status ? `El agente está registrado actualmente como ${status}.` : 'El agente está registrado en el runtime cognitivo.',
       meaning: purpose ?? 'La presencia del agente y su contrato no prueban una ejecución reciente.',
       nextState: status?.toLowerCase() === 'operational'
-        ? 'La vista debe poder rastrear su ejecución reciente y los eventos que produjo.'
-        : 'Para declararlo operativo se requiere evidencia de ejecución atribuible, no sólo registro o contrato.',
+        ? 'Rastrear su ejecución reciente y los eventos atribuibles que produjo.'
+        : 'Para declararlo operativo se requiere ejecución atribuible; no se resuelve automáticamente cargando evidencia manual.',
       evidenceLabel,
       facts,
     };
   }
 
   if (kind.includes('evidence') || kind.includes('ledger')) {
+    const epistemic = (first(data, ['epistemicClass', 'epistemic_class']) ?? 'imported').toLowerCase();
+    const imported = epistemic === 'imported' || epistemic === 'imported_provenance';
     return {
       title: subject ?? 'Evidencia persistida',
-      statement: 'Este punto representa evidencia o una referencia de procedencia persistida.',
-      meaning: 'Su presencia prueba que el registro existe. La fuerza probatoria depende de su fuente, integridad, contexto, linaje y relación explícita con la afirmación que pretende sostener.',
-      nextState: evidenceCount > 0 ? 'Puede seguirse su linaje desde las referencias vinculadas.' : 'No hay referencias adicionales enlazadas desde este punto.',
+      statement: imported
+        ? 'Este nodo conserva una pieza o referencia de evidencia importada con procedencia persistida.'
+        : 'Este nodo conserva evidencia persistida con una clase epistémica explícita.',
+      meaning: imported
+        ? 'La marca IMPORTED no rebaja visualmente la evidencia: indica que SFI conoce y conserva su procedencia histórica, pero no convierte automáticamente las afirmaciones internas del artefacto en observaciones verificadas.'
+        : 'La fuerza probatoria depende de fuente, integridad, contexto, linaje y de la relación explícita entre esta evidencia y la afirmación que pretende sostener.',
+      nextState: evidenceCount > 0
+        ? 'Seguir las referencias vinculadas para inspeccionar linaje o relaciones probatorias.'
+        : 'No hay otra referencia enlazada desde este nodo. Eso no implica que debas cargar algo: sólo significa que este punto termina aquí por ahora.',
       evidenceLabel,
       facts,
     };
@@ -130,7 +255,7 @@ export function describeRootSelection(input: {
       title: subject ?? 'Hipótesis o proyección',
       statement: status ? `La hipótesis/proyección se encuentra en estado ${status}.` : 'Existe una hipótesis o proyección persistida.',
       meaning: 'Es una formulación contrastable, no una observación ni un resultado confirmado.',
-      nextState: evidenceCount > 0 ? 'Debe contrastarse contra su evidencia y regla de verificación.' : 'Requiere evidencia o una regla de verificación antes de elevar su confianza.',
+      nextState: evidenceCount > 0 ? 'Contrastar contra su evidencia y regla de verificación.' : 'Aquí sí corresponde vincular evidencia o una regla de verificación antes de elevar confianza.',
       evidenceLabel,
       facts,
     };
@@ -141,7 +266,7 @@ export function describeRootSelection(input: {
       title: subject ?? input.technicalTitle,
       statement: 'Este punto representa un atractor declarado o persistido.',
       meaning: 'El atractor expresa una dirección de reorganización o convergencia. No demuestra que esa dirección ya haya sido alcanzada.',
-      nextState: evidenceCount > 0 ? 'Debe compararse longitudinalmente con fenómenos y evidencia que lo soporten o contradigan.' : 'Su dirección puede existir como declaración, pero su aproximación no debe inferirse sin evidencia vinculada.',
+      nextState: 'Abrir el campo del atractor para contrastar longitudinalmente dimensiones soportadas, contradichas o todavía sin evidencia.',
       evidenceLabel,
       facts,
     };
@@ -149,9 +274,9 @@ export function describeRootSelection(input: {
 
   return {
     title: subject ?? input.technicalTitle,
-    statement: status ? `Este registro se encuentra en estado ${status}.` : 'Este registro forma parte del estado institucional observado por ROOT.',
-    meaning: 'ROOT muestra su procedencia y contenido sin convertir la representación en una afirmación adicional.',
-    nextState: evidenceCount > 0 ? 'Puede inspeccionarse mediante sus referencias de evidencia.' : 'No hay referencias de evidencia vinculadas en este punto.',
+    statement: status ? `Este registro se encuentra en estado ${status}.` : 'Este registro forma parte del estado institucional leído por ROOT.',
+    meaning: 'ROOT expone este registro en su contexto operativo. La interfaz no debe convertir automáticamente cada objeto en una solicitud de evidencia.',
+    nextState: evidenceCount > 0 ? 'Puede inspeccionarse mediante sus referencias vinculadas.' : 'No existe una acción universal requerida para este registro.',
     evidenceLabel,
     facts,
   };


### PR DESCRIPTION
Corrige la semántica y la interacción de ROOT sin modificar persistencia, tablas, runtime ni autoridad.

Cambios:
- evidencia IMPORTED vuelve a usar el tono visual válido/verde sin cambiar su clase epistémica;
- los estados visibles se califican por eje: CLASE, SALUD o ESTADO, evitando presentar DERIVED y DEGRADED como etiquetas contradictorias;
- el panel ΦSFI abre un modal diagnóstico con las divergencias activas, su observación y fuente;
- Governance y demás system-items dejan de caer en narrativa genérica y muestran salud de lectura, estado reportado, elementos abiertos, explicación y causa concreta de degradación;
- divergencias individuales muestran diagnóstico y lectura relacionada;
- el inspector lateral se sustituye por una ventana modal y elimina la CTA universal de cargar evidencia;
- las acciones de evidencia quedan sólo en objetos donde vincular evidencia tiene sentido contextual;
- Reportes deja de exigir conocimiento de nombres técnicos y se organiza por preguntas: estado institucional, evidencia/trazabilidad, calibración, recurrencias, casos, Atlas y borradores;
- los reportes que no necesitan sujeto pueden generarse sin input manual; los que sí lo requieren explican exactamente qué escribir.

Límite: no cambia el contrato epistémico ni promueve IMPORTED a OBSERVED. El color verde expresa procedencia válida/persistida, no verificación de claims.