### PR TITLE
Connect World Field cognition and make SFI time-navigable

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Verify cognitive agent convergence
         run: node --import tsx --test src/lib/sfi/cognitive-runtime/agentConvergence.test.ts
 
+      - name: Verify Field and Observatory temporal surfaces
+        run: npx tsx scripts/qa-sfi-temporal-surfaces.ts
+
       - name: Verify Studio Field surface
         run: npm run qa:sfi-studio-workspace
 

--- a/scripts/qa-sfi-temporal-surfaces.ts
+++ b/scripts/qa-sfi-temporal-surfaces.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(path.join(root, relative), 'utf8');
+
+const worldApi = read('src/app/api/field/map/world/route.ts');
+const worldUi = read('src/components/field/map/WorldFieldObservatory.tsx');
+const cognitive = read('src/app/api/field/map/world/cognitive/route.ts');
+const publicTimeline = read('src/lib/observatory/public/worldSnapshotTimeline.ts');
+const publicTimelineUi = read('src/components/observatory/public/PublicObservatoryTimelineNavigator.tsx');
+const observatoryPage = read('src/app/observatory/page.tsx');
+
+assert.ok(worldApi.includes('readPagedRows'), 'world_history_must_paginate');
+assert.ok(worldApi.includes("'world_hypotheses', 'cutoff_at'"), 'world_hypotheses_must_be_temporally_read');
+assert.ok(worldApi.includes("'world_hypothesis_outcomes', 'evaluated_at'"), 'world_outcomes_must_be_temporally_read');
+assert.ok(worldApi.includes("'world_learning_events', 'created_at'"), 'world_learning_must_be_temporally_read');
+assert.ok(!worldApi.includes(".from('world_hypotheses').select('*').order('created_at', { ascending: false }).limit(100)"), 'legacy_first_100_hypothesis_limit_present');
+
+for (const token of [
+  'type="range"',
+  'windowHours',
+  'visibleNodes',
+  'visibleHypotheses',
+  'Timeline completa',
+  '/api/field/map/world/cognitive',
+  'ANALIZAR FRAME CON SFI',
+  'sticky top-',
+]) assert.ok(worldUi.includes(token), `world_field_temporal_contract_missing:${token}`);
+assert.ok(!worldUi.includes('hypotheses.slice(0, 8)'), 'world_field_still_hides_hypotheses_after_eight');
+assert.ok(!worldUi.includes('<path key={`${previous.id}:${node.id}`'), 'world_field_still_draws_unpersisted_previous_node_edges');
+
+for (const token of [
+  'executeSfiRuntime',
+  'runLlmTask',
+  "sfi_cognitive_twin_memory",
+  "sfi_cognitive_twin_decisions",
+  "eq('status', 'CANONICAL')",
+  "eq('status', 'APPROVED')",
+  "role: 'world_field_frame_analysis'",
+  'llmAugmentation: false',
+  "epistemicClass: 'PROPOSED'",
+]) assert.ok(cognitive.includes(token), `world_field_cognitive_bridge_missing:${token}`);
+assert.ok(!/Math\.random|setInterval|setTimeout|while\s*\(\s*true\s*\)/.test(cognitive), 'world_field_cognitive_bridge_must_be_bounded_and_non_synthetic');
+assert.ok(/cannot rewrite observations|cannot rewrite/i.test(cognitive), 'world_field_cognitive_mutation_boundary_missing');
+
+for (const token of [
+  "from('worldspect_snapshots')",
+  'readPublicWorldSnapshotTimeline',
+  'VECTOR_DEFINITIONS',
+  'Historical frames are reconstructed only from persisted WorldSpect snapshots.',
+]) assert.ok(publicTimeline.includes(token), `public_timeline_source_contract_missing:${token}`);
+assert.ok(publicTimelineUi.includes('/api/observatory/timeline'), 'public_timeline_ui_not_wired');
+assert.ok(publicTimelineUi.includes('type="range"'), 'public_timeline_cursor_missing');
+assert.ok(publicTimelineUi.includes('Cada posición corresponde a un snapshot WorldSpect almacenado'), 'public_timeline_epistemic_boundary_missing');
+assert.ok(observatoryPage.includes('<PublicObservatoryTimelineNavigator />'), 'public_observatory_timeline_not_rendered');
+assert.ok(!publicTimelineUi.includes('sfi_cognitive_twin_'), 'public_observatory_must_not_expose_private_cognitive_twin_corpus');
+
+console.log(JSON.stringify({
+  ok: true,
+  worldField: {
+    paginatedHistory: true,
+    temporalNodeFiltering: true,
+    allHypothesesVisible: true,
+    stickyMapContext: true,
+    cognitiveFrameExecution: true,
+  },
+  cognitiveBridge: {
+    agents: true,
+    oneLlmSynthesis: true,
+    canonicalTwinMemoryOnly: true,
+    approvedRulesOnly: true,
+    proposedNotObserved: true,
+  },
+  publicObservatory: {
+    persistedWorldSpectFrames: true,
+    interactiveTimeline: true,
+    privateTwinExposure: false,
+  },
+}, null, 2));

--- a/src/app/api/field/map/world/cognitive/route.ts
+++ b/src/app/api/field/map/world/cognitive/route.ts
@@ -1,0 +1,288 @@
+import { NextResponse } from 'next/server';
+import { runLlmTask } from '@/lib/ai/providerRouter';
+import { createCognitiveTwinEnvelope } from '@/lib/cognitive-twin/contract';
+import type { KernelContext, KernelEvidence } from '@/lib/sfi/cognitive-runtime/kernelContext';
+import { executeSfiRuntime } from '@/lib/sfi/cognitive-runtime/runtime';
+import { createServerSupabaseClient, createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+const FRAME_AGENT_SET = [
+  'field_observer',
+  'evidence_hunter',
+  'temporal_resolver',
+  'context_builder',
+  'cross_impact',
+  'friction_field_simulator',
+  'trajectory_agent',
+  'risk_agent',
+] as const;
+
+type Row = Record<string, unknown>;
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function finite(value: unknown, fallback: number) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function iso(value: unknown, fallback = new Date().toISOString()) {
+  const candidate = text(value);
+  if (!candidate) return fallback;
+  const parsed = new Date(candidate);
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : fallback;
+}
+
+function clampHours(value: unknown) {
+  return Math.max(6, Math.min(24 * 7, Math.round(finite(value, 72))));
+}
+
+function confidence(value: unknown) {
+  return Math.max(0, Math.min(1, finite(value, 0)));
+}
+
+export async function POST(request: Request) {
+  const authClient = await createServerSupabaseClient();
+  const { data: auth, error: authError } = await authClient.auth.getUser();
+  if (authError || !auth.user) return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+
+  const body = await request.json().catch(() => ({})) as Row;
+  const cutoffAt = iso(body.cutoffAt);
+  const windowHours = clampHours(body.windowHours);
+  const cutoffMs = new Date(cutoffAt).getTime();
+  const windowStart = new Date(cutoffMs - windowHours * 60 * 60 * 1000).toISOString();
+  const db = createServiceSupabaseClient();
+  const startedAt = new Date().toISOString();
+  const taskId = `world-field-frame:${auth.user.id}:${Date.now()}`;
+  const cycleId = crypto.randomUUID();
+
+  const [observationsResult, hypothesesResult, canonicalMemoryResult, approvedRulesResult] = await Promise.all([
+    db.from('world_source_observations')
+      .select('id,source_id,source_family,publisher,title,summary,observed_at,latitude,longitude,affected_systems,actors,confidence')
+      .gte('observed_at', windowStart)
+      .lte('observed_at', cutoffAt)
+      .order('observed_at', { ascending: true })
+      .limit(500),
+    db.from('world_hypotheses')
+      .select('id,statement,status,current_confidence,cutoff_at,validation_ends_at,evidence_ids,graph_snapshot')
+      .gte('cutoff_at', windowStart)
+      .lte('cutoff_at', cutoffAt)
+      .order('cutoff_at', { ascending: true })
+      .limit(300),
+    db.from('sfi_cognitive_twin_memory')
+      .select('id,memory_key,memory_type,status,content,evidence_refs,source_kind,version,updated_at')
+      .eq('status', 'CANONICAL')
+      .in('memory_type', ['CANON', 'METHOD', 'DEFINITION', 'CAPABILITY'])
+      .order('updated_at', { ascending: false })
+      .limit(40),
+    db.from('sfi_cognitive_twin_decisions')
+      .select('id,decision_id,general_rule,required_evidence,evidence_refs,approved_at')
+      .eq('status', 'APPROVED')
+      .order('approved_at', { ascending: false })
+      .limit(40),
+  ]);
+
+  const primaryError = observationsResult.error ?? hypothesesResult.error;
+  if (primaryError) {
+    return NextResponse.json({ ok: false, error: 'WORLD_FRAME_READ_FAILED', details: primaryError.message }, { status: 503 });
+  }
+
+  const observations = (observationsResult.data ?? []).map(record);
+  const hypotheses = (hypothesesResult.data ?? []).map(record);
+  const observationIds = observations.map((row) => text(row.id)).filter(Boolean);
+  const readingsResult = observationIds.length
+    ? await db.from('world_friction_readings')
+      .select('id,observation_id,systemic_friction,interaction_density,friction_gradient,systemic_coherence,tension,pain_map,field_drivers,permissions,trajectory,minimum_viable_perturbation,created_at')
+      .in('observation_id', observationIds)
+      .order('created_at', { ascending: true })
+    : { data: [], error: null };
+
+  if (readingsResult.error) {
+    return NextResponse.json({ ok: false, error: 'WORLD_FRAME_READING_FAILED', details: readingsResult.error.message }, { status: 503 });
+  }
+
+  const readingByObservation = new Map((readingsResult.data ?? []).map((row) => [String(row.observation_id), record(row)]));
+  const evidence: KernelEvidence[] = observations.map((row) => {
+    const id = text(row.id);
+    const reading = readingByObservation.get(id) ?? null;
+    return {
+      id,
+      source: `world_source_observations:${text(row.source_family, 'unknown')}`,
+      confidence: confidence(row.confidence),
+      payload: {
+        publisher: text(row.publisher),
+        title: text(row.title),
+        summary: text(row.summary),
+        observedAt: text(row.observed_at),
+        affectedSystems: Array.isArray(row.affected_systems) ? row.affected_systems : [],
+        actors: Array.isArray(row.actors) ? row.actors : [],
+        geography: row.latitude === null || row.longitude === null ? null : { lat: Number(row.latitude), lng: Number(row.longitude) },
+        reading,
+        epistemicClass: 'OBSERVED_WITH_DERIVED_SFI_READING',
+      },
+    };
+  }).filter((item) => item.id);
+
+  const context: KernelContext = {
+    taskId,
+    cycleId,
+    logbookId: `world-field-frame:${taskId}`,
+    currentEvent: 'SFI_WORLD_FIELD_FRAME_ANALYSIS',
+    evidence,
+    hypotheses: hypotheses.map((row) => ({
+      id: text(row.id),
+      statement: text(row.statement),
+      confidence: confidence(row.current_confidence),
+    })).filter((item) => item.id && item.statement),
+    contradictions: [],
+    simulations: [],
+    predictions: [],
+    risks: [],
+    opportunities: [],
+    metadata: {
+      requestedAgents: [...FRAME_AGENT_SET],
+      llmAugmentation: false,
+      cutoffAt,
+      windowStart,
+      windowHours,
+      requestedBy: auth.user.id,
+      rule: 'The temporal frame is persisted evidence. Agent output is derived/inferred context. The LLM synthesis is PROPOSED and cannot rewrite observations, hypotheses, outcomes, memory or canon.',
+    },
+  };
+
+  const cycle = await executeSfiRuntime(context);
+  const canonicalMemory = (canonicalMemoryResult.data ?? []).map((row) => ({
+    memoryKey: row.memory_key,
+    memoryType: row.memory_type,
+    content: row.content,
+    version: row.version,
+  }));
+  const approvedRules = (approvedRulesResult.data ?? []).map((row) => ({
+    decisionId: row.decision_id,
+    generalRule: row.general_rule,
+    requiredEvidence: row.required_evidence,
+  }));
+  const corpusWarnings = [canonicalMemoryResult.error?.message, approvedRulesResult.error?.message].filter((value): value is string => Boolean(value));
+
+  const fallback = [
+    `Temporal frame ${windowStart} → ${cutoffAt}.`,
+    `${evidence.length} persisted observations and ${hypotheses.length} hypotheses were available.`,
+    `Executed agents: ${cycle.executedAgents.join(', ') || 'none'}.`,
+    'LLM synthesis unavailable. Inspect the persisted evidence and agent trace directly.',
+  ].join('\n');
+
+  const llm = await runLlmTask({
+    task: 'deep_report',
+    system: [
+      'You are the bounded synthesis layer for System Friction Institute World Field.',
+      'Evidence before inference. The map frame and persisted WORLD records are evidence/context; agent output is derived or inferred; your text is PROPOSED.',
+      'Use the supplied canonical Cognitive Twin corpus only as institutional method/rules, never as new evidence about the world.',
+      'Do not invent measurements, causes, routing, geography, probabilities or events.',
+      'Separate OBSERVED, DERIVED, INFERRED, PROPOSED and MISSING explicitly.',
+      'Return a concise operational reading: what changed inside the frame, active contradictions, trajectory, missing evidence, and one next observation question. Do not authorize external execution.',
+    ].join(' '),
+    prompt: JSON.stringify({
+      frame: { cutoffAt, windowStart, windowHours },
+      observations: evidence.slice(-80),
+      persistedHypotheses: hypotheses.slice(-80),
+      agentExecution: {
+        executedAgents: cycle.executedAgents,
+        contradictions: cycle.context.contradictions,
+        predictions: cycle.context.predictions,
+        risks: cycle.context.risks,
+        opportunities: cycle.context.opportunities,
+        metadata: cycle.context.metadata,
+      },
+      cognitiveTwinCanonicalMemory: canonicalMemory,
+      approvedInstitutionalRules: approvedRules,
+      corpusWarnings,
+    }),
+    fallbackResult: fallback,
+    maxTokens: 1400,
+  });
+
+  const finishedAt = new Date().toISOString();
+  const evidenceRefs = evidence.map((item) => item.id);
+  const envelope = createCognitiveTwinEnvelope({
+    taskId,
+    status: 'PROPOSED',
+    modelId: `${llm.provider}:${llm.model}`,
+    result: {
+      frame: { cutoffAt, windowStart, windowHours },
+      synthesis: llm.result,
+      executedAgents: cycle.executedAgents,
+      observationCount: evidence.length,
+      hypothesisCount: hypotheses.length,
+      provider: llm.provider,
+      model: llm.model,
+      latencyMs: llm.latency_ms,
+      cognitiveTwinCorpus: {
+        canonicalMemoryRecords: canonicalMemory.length,
+        approvedInstitutionalRules: approvedRules.length,
+      },
+    },
+    limitations: [
+      'Temporal proximity and shared affected systems do not prove causal relation.',
+      'Agent execution is not independent validation.',
+      'LLM synthesis is a proposed interpretation and is not persisted as WORLD observation or hypothesis truth.',
+      ...corpusWarnings,
+      ...llm.warnings,
+    ],
+    missingEvidence: evidence.length ? [] : ['world_frame_observations'],
+    actionsExecuted: [
+      ...cycle.executedAgents.map((agent) => `cognitive:${agent}`),
+      'read_canonical_cognitive_twin_corpus',
+      'llm_frame_synthesis',
+    ],
+    recommendedTransition: evidence.length ? 'VERIFYING' : 'EVIDENCE_PENDING',
+  });
+
+  const persisted = await db.from('sfi_cognitive_twin_runs').insert({
+    task_id: taskId,
+    contract_version: envelope.contractVersion,
+    provider: llm.provider,
+    model: llm.model,
+    role: 'world_field_frame_analysis',
+    status: 'READY',
+    objective: `Interpret the persisted World Field frame ending ${cutoffAt} without mutating evidence or world state.`,
+    input_snapshot: {
+      requestedBy: auth.user.id,
+      cutoffAt,
+      windowStart,
+      windowHours,
+      observationCount: evidence.length,
+      hypothesisCount: hypotheses.length,
+      requestedAgents: FRAME_AGENT_SET,
+    },
+    output_envelope: envelope,
+    evidence_refs: evidenceRefs,
+    limitations: envelope.limitations,
+    started_at: startedAt,
+    finished_at: finishedAt,
+  }).select('id,task_id,role,status,provider,model,created_at').single();
+
+  if (persisted.error) {
+    return NextResponse.json({ ok: false, error: 'WORLD_FRAME_TWIN_RUN_PERSISTENCE_FAILED', details: persisted.error.message, envelope }, { status: 503 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    frame: { cutoffAt, windowStart, windowHours },
+    synthesis: llm.result,
+    epistemicClass: 'PROPOSED',
+    agents: cycle.executedAgents,
+    llm: { provider: llm.provider, model: llm.model, latencyMs: llm.latency_ms, warnings: llm.warnings },
+    twin: { runId: persisted.data.id, role: persisted.data.role, corpusWarnings },
+    evidenceRefs,
+    limitations: envelope.limitations,
+  });
+}

--- a/src/app/api/field/map/world/route.ts
+++ b/src/app/api/field/map/world/route.ts
@@ -9,7 +9,14 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
-function isMissingWorldSchema(error: { code?: string | null; message?: string | null }) {
+const WORLD_HORIZON_DAYS = 30;
+const PAGE_SIZE = 500;
+
+type DbError = { code?: string | null; message?: string | null };
+type Row = Record<string, unknown>;
+type ServiceDb = ReturnType<typeof createServiceSupabaseClient>;
+
+function isMissingWorldSchema(error: DbError) {
   const code = String(error.code ?? '').toUpperCase();
   const message = String(error.message ?? '').toLowerCase();
   return code === 'PGRST205'
@@ -18,11 +25,12 @@ function isMissingWorldSchema(error: { code?: string | null; message?: string | 
     || message.includes('relation "public.world_');
 }
 
-function pendingSchemaResponse(error: { code?: string | null; message?: string | null }) {
+function pendingSchemaResponse(error: DbError) {
   return NextResponse.json({
     ok: true,
     generatedAt: new Date().toISOString(),
     sourceState: 'WORLD_SCHEMA_PENDING',
+    horizonDays: WORLD_HORIZON_DAYS,
     nodes: [],
     hypotheses: [],
     outcomes: [],
@@ -40,6 +48,28 @@ function pendingSchemaResponse(error: { code?: string | null; message?: string |
   });
 }
 
+async function readPagedRows(db: ServiceDb, table: string, timeColumn: string, since: string, ascending = false) {
+  const rows: Row[] = [];
+  let from = 0;
+
+  for (;;) {
+    const result = await db
+      .from(table)
+      .select('*')
+      .gte(timeColumn, since)
+      .order(timeColumn, { ascending })
+      .range(from, from + PAGE_SIZE - 1);
+
+    if (result.error) return { data: rows, error: result.error };
+    const page = Array.isArray(result.data) ? result.data as Row[] : [];
+    rows.push(...page);
+    if (page.length < PAGE_SIZE) break;
+    from += PAGE_SIZE;
+  }
+
+  return { data: rows, error: null };
+}
+
 export async function GET() {
   const authClient = await createServerSupabaseClient();
   const { data: auth, error: authError } = await authClient.auth.getUser();
@@ -50,19 +80,12 @@ export async function GET() {
   // Authentication is enforced with the user's session. All WORLD reads then use
   // the server-only service client so RLS/grant drift cannot hide persisted data.
   const db = createServiceSupabaseClient();
-  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const since = new Date(Date.now() - WORLD_HORIZON_DAYS * 24 * 60 * 60 * 1000).toISOString();
 
-  let observationsQuery = await db
-    .from('world_source_observations')
-    .select('*')
-    .gte('observed_at', since)
-    .order('observed_at', { ascending: false })
-    .limit(500);
+  let observationsQuery = await readPagedRows(db, 'world_source_observations', 'observed_at', since, false);
 
   if (observationsQuery.error) {
-    if (isMissingWorldSchema(observationsQuery.error)) {
-      return pendingSchemaResponse(observationsQuery.error);
-    }
+    if (isMissingWorldSchema(observationsQuery.error)) return pendingSchemaResponse(observationsQuery.error);
     return NextResponse.json({
       ok: false,
       error: 'world_observations_query_failed',
@@ -72,21 +95,16 @@ export async function GET() {
   }
 
   let bootstrap: Awaited<ReturnType<typeof bootstrapWorldObservatory>> | null = null;
-  if ((observationsQuery.data ?? []).length === 0) {
+  if (observationsQuery.data.length === 0) {
     bootstrap = await bootstrapWorldObservatory();
-    observationsQuery = await db
-      .from('world_source_observations')
-      .select('*')
-      .gte('observed_at', since)
-      .order('observed_at', { ascending: false })
-      .limit(500);
+    observationsQuery = await readPagedRows(db, 'world_source_observations', 'observed_at', since, false);
   }
 
   const [readingsQuery, hypothesesQuery, outcomesQuery, learningQuery] = await Promise.all([
-    db.from('world_friction_readings').select('*').order('created_at', { ascending: false }).limit(500),
-    db.from('world_hypotheses').select('*').order('created_at', { ascending: false }).limit(100),
-    db.from('world_hypothesis_outcomes').select('*').order('evaluated_at', { ascending: false }).limit(100),
-    db.from('world_learning_events').select('*').order('created_at', { ascending: false }).limit(100),
+    readPagedRows(db, 'world_friction_readings', 'created_at', since, false),
+    readPagedRows(db, 'world_hypotheses', 'cutoff_at', since, true),
+    readPagedRows(db, 'world_hypothesis_outcomes', 'evaluated_at', since, true),
+    readPagedRows(db, 'world_learning_events', 'created_at', since, true),
   ]);
 
   const secondaryError = observationsQuery.error
@@ -106,34 +124,45 @@ export async function GET() {
     }, { status: 503 });
   }
 
-  const readings = readingsQuery.data ?? [];
-  const hypotheses = hypothesesQuery.data ?? [];
-  const outcomes = outcomesQuery.data ?? [];
-  const learning = learningQuery.data ?? [];
-  const readingByObservation = new Map(readings.map((item) => [item.observation_id, item]));
+  const readings = readingsQuery.data;
+  const hypotheses = hypothesesQuery.data;
+  const outcomes = outcomesQuery.data;
+  const learning = learningQuery.data;
+  const readingByObservation = new Map(readings.map((item) => [String(item.observation_id), item]));
 
-  const nodes = (observationsQuery.data ?? []).map((item) => ({
-    id: item.id,
+  const nodes = observationsQuery.data.map((item) => ({
+    id: String(item.id),
     kind: 'observed' as const,
-    sourceFamily: item.source_family,
-    publisher: item.publisher,
-    title: item.title,
-    summary: item.summary,
-    observedAt: item.observed_at,
-    lat: item.latitude === null ? null : Number(item.latitude),
-    lng: item.longitude === null ? null : Number(item.longitude),
+    sourceFamily: String(item.source_family ?? 'unknown'),
+    publisher: String(item.publisher ?? 'unknown'),
+    title: String(item.title ?? 'Untitled observation'),
+    summary: typeof item.summary === 'string' ? item.summary : null,
+    observedAt: String(item.observed_at ?? item.created_at ?? ''),
+    lat: item.latitude === null || typeof item.latitude === 'undefined' ? null : Number(item.latitude),
+    lng: item.longitude === null || typeof item.longitude === 'undefined' ? null : Number(item.longitude),
     affectedSystems: Array.isArray(item.affected_systems) ? item.affected_systems : [],
     actors: Array.isArray(item.actors) ? item.actors : [],
     confidence: Number(item.confidence ?? 0),
-    reading: readingByObservation.get(item.id) ?? null,
+    reading: readingByObservation.get(String(item.id)) ?? null,
   }));
 
   const locatedCount = nodes.filter((node) => Number.isFinite(node.lat) && Number.isFinite(node.lng)).length;
+  const timestamps = [
+    ...nodes.map((node) => node.observedAt),
+    ...hypotheses.map((row) => String(row.cutoff_at ?? '')),
+    ...outcomes.map((row) => String(row.evaluated_at ?? '')),
+    ...learning.map((row) => String(row.created_at ?? '')),
+  ].filter(Boolean).sort();
 
   return NextResponse.json({
     ok: true,
     generatedAt: new Date().toISOString(),
     sourceState: nodes.length ? 'OBSERVED_WORLD' : 'NO_WORLD_OBSERVATIONS',
+    horizonDays: WORLD_HORIZON_DAYS,
+    temporalBounds: {
+      firstAt: timestamps[0] ?? null,
+      lastAt: timestamps.at(-1) ?? null,
+    },
     nodes,
     hypotheses,
     outcomes,
@@ -148,12 +177,16 @@ export async function GET() {
       hypotheses: hypotheses.length,
       outcomes: outcomes.length,
       learning: learning.length,
+      paginated: true,
+      pageSize: PAGE_SIZE,
+      horizonDays: WORLD_HORIZON_DAYS,
     },
     limits: [
       'External source scores are not imported.',
       'Every node is a real observation with publisher and time.',
       'Missing or failed sources remain missing; no simulated values are generated.',
       'SFI readings use the canonical Φ and F_s implementation.',
+      'Map geometry is geographic presentation. Temporal filtering changes which persisted observations are visible; it does not create graph relations.',
     ],
   });
 }

--- a/src/app/api/field/map/world/route.ts
+++ b/src/app/api/field/map/world/route.ts
@@ -35,6 +35,7 @@ function pendingSchemaResponse(error: DbError) {
     hypotheses: [],
     outcomes: [],
     learning: [],
+    cognitiveRuns: [],
     sourceFamilies: [],
     diagnostic: {
       code: error.code ?? null,
@@ -60,6 +61,28 @@ async function readPagedRows(db: ServiceDb, table: string, timeColumn: string, s
       .order(timeColumn, { ascending })
       .range(from, from + PAGE_SIZE - 1);
 
+    if (result.error) return { data: rows, error: result.error };
+    const page = Array.isArray(result.data) ? result.data as Row[] : [];
+    rows.push(...page);
+    if (page.length < PAGE_SIZE) break;
+    from += PAGE_SIZE;
+  }
+
+  return { data: rows, error: null };
+}
+
+async function readOwnerCognitiveRuns(db: ServiceDb, since: string, ownerId: string) {
+  const rows: Row[] = [];
+  let from = 0;
+
+  for (;;) {
+    const result = await db.from('sfi_cognitive_twin_runs')
+      .select('id,task_id,role,status,provider,model,objective,input_snapshot,output_envelope,evidence_refs,limitations,started_at,finished_at,created_at')
+      .eq('role', 'world_field_frame_analysis')
+      .contains('input_snapshot', { requestedBy: ownerId })
+      .gte('created_at', since)
+      .order('created_at', { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
     if (result.error) return { data: rows, error: result.error };
     const page = Array.isArray(result.data) ? result.data as Row[] : [];
     rows.push(...page);
@@ -100,11 +123,12 @@ export async function GET() {
     observationsQuery = await readPagedRows(db, 'world_source_observations', 'observed_at', since, false);
   }
 
-  const [readingsQuery, hypothesesQuery, outcomesQuery, learningQuery] = await Promise.all([
+  const [readingsQuery, hypothesesQuery, outcomesQuery, learningQuery, cognitiveRunsQuery] = await Promise.all([
     readPagedRows(db, 'world_friction_readings', 'created_at', since, false),
     readPagedRows(db, 'world_hypotheses', 'cutoff_at', since, true),
     readPagedRows(db, 'world_hypothesis_outcomes', 'evaluated_at', since, true),
     readPagedRows(db, 'world_learning_events', 'created_at', since, true),
+    readOwnerCognitiveRuns(db, since, auth.user.id),
   ]);
 
   const secondaryError = observationsQuery.error
@@ -128,6 +152,7 @@ export async function GET() {
   const hypotheses = hypothesesQuery.data;
   const outcomes = outcomesQuery.data;
   const learning = learningQuery.data;
+  const cognitiveRuns = cognitiveRunsQuery.data;
   const readingByObservation = new Map(readings.map((item) => [String(item.observation_id), item]));
 
   const nodes = observationsQuery.data.map((item) => ({
@@ -152,6 +177,7 @@ export async function GET() {
     ...hypotheses.map((row) => String(row.cutoff_at ?? '')),
     ...outcomes.map((row) => String(row.evaluated_at ?? '')),
     ...learning.map((row) => String(row.created_at ?? '')),
+    ...cognitiveRuns.map((row) => String(row.finished_at ?? row.created_at ?? '')),
   ].filter(Boolean).sort();
 
   return NextResponse.json({
@@ -167,6 +193,7 @@ export async function GET() {
     hypotheses,
     outcomes,
     learning,
+    cognitiveRuns,
     sourceFamilies: [...new Set(nodes.map((node) => node.sourceFamily))],
     bootstrap,
     diagnostic: {
@@ -177,6 +204,8 @@ export async function GET() {
       hypotheses: hypotheses.length,
       outcomes: outcomes.length,
       learning: learning.length,
+      cognitiveRuns: cognitiveRuns.length,
+      cognitiveRunReadWarning: cognitiveRunsQuery.error?.message ?? null,
       paginated: true,
       pageSize: PAGE_SIZE,
       horizonDays: WORLD_HORIZON_DAYS,
@@ -187,6 +216,7 @@ export async function GET() {
       'Missing or failed sources remain missing; no simulated values are generated.',
       'SFI readings use the canonical Φ and F_s implementation.',
       'Map geometry is geographic presentation. Temporal filtering changes which persisted observations are visible; it does not create graph relations.',
+      'Cognitive frame runs are owner-scoped interpretations. They are not WORLD observations and are never shared across member accounts by this route.',
     ],
   });
 }

--- a/src/app/api/observatory/timeline/route.ts
+++ b/src/app/api/observatory/timeline/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { readPublicWorldSnapshotTimeline } from '@/lib/observatory/public/worldSnapshotTimeline';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 300;
+
+export async function GET() {
+  try {
+    const state = await readPublicWorldSnapshotTimeline();
+    return NextResponse.json({ ok: true, ...state });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: 'PUBLIC_OBSERVATORY_TIMELINE_FAILED',
+      details: error instanceof Error ? error.message : String(error),
+      frames: [],
+    }, { status: 503 });
+  }
+}

--- a/src/app/observatory/page.tsx
+++ b/src/app/observatory/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { AmvPhaseStatusPanel } from '@/components/amv/AmvPhaseStatusPanel';
+import { PublicObservatoryTimelineNavigator } from '@/components/observatory/public/PublicObservatoryTimelineNavigator';
 import { PublicWorldVectorObservatory } from '@/components/observatory/public/PublicWorldVectorObservatory';
 import { SfiSurfaceGuide } from '@/components/sfi/SfiSurfaceGuide';
 import { readPublicObservatoryState } from '@/lib/observatory/public/readPublicObservatoryState';
@@ -39,6 +40,7 @@ export default async function ObservatoryPage() {
       <div className="bg-[#060605] px-4 pt-4">
         <AmvPhaseStatusPanel endpoint="/api/observatory/instrument-status" compact title="MADUREZ DEL INSTRUMENTO" />
       </div>
+      <PublicObservatoryTimelineNavigator />
       <PublicWorldVectorObservatory state={state} />
     </main>
   );

--- a/src/components/field/map/WorldFieldObservatory.tsx
+++ b/src/components/field/map/WorldFieldObservatory.tsx
@@ -175,7 +175,6 @@ export function WorldFieldObservatory() {
   const hypotheses = data?.hypotheses ?? [];
   const outcomes = data?.outcomes ?? [];
   const learning = data?.learning ?? [];
-  const outcomeByHypothesis = useMemo(() => new Map(outcomes.map((item) => [item.hypothesis_id, item])), [outcomes]);
   const hypothesisByObservation = useMemo(() => {
     const map = new Map<string, WorldHypothesis[]>();
     hypotheses.forEach((item) => {
@@ -211,6 +210,7 @@ export function WorldFieldObservatory() {
   const visibleHypotheses = useMemo(() => hypotheses.filter((item) => millis(item.cutoff_at) <= cursorMs), [hypotheses, cursorMs]);
   const visibleOutcomes = useMemo(() => outcomes.filter((item) => millis(item.evaluated_at) <= cursorMs), [outcomes, cursorMs]);
   const visibleLearning = useMemo(() => learning.filter((item) => millis(item.created_at) <= cursorMs), [learning, cursorMs]);
+  const outcomeByHypothesis = useMemo(() => new Map(visibleOutcomes.map((item) => [item.hypothesis_id, item])), [visibleOutcomes]);
   const selected = visibleNodes.find((node) => node.id === selectedId) ?? visibleNodes.at(-1) ?? null;
   const reading = selected?.reading ?? null;
 

--- a/src/components/field/map/WorldFieldObservatory.tsx
+++ b/src/components/field/map/WorldFieldObservatory.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Activity, Aperture, CircleDot, RefreshCw, Route, ShieldCheck } from 'lucide-react';
+import { Activity, Aperture, BrainCircuit, CircleDot, Clock3, RefreshCw, Route, ShieldCheck } from 'lucide-react';
 
 type Reading = {
   systemic_friction: number;
@@ -33,18 +33,69 @@ type WorldNode = {
   reading: Reading | null;
 };
 
+type WorldHypothesis = {
+  id: string;
+  statement: string;
+  status: string;
+  cutoff_at: string;
+  validation_ends_at: string;
+  current_confidence: number;
+  evidence_ids?: string[];
+  graph_snapshot?: Record<string, unknown>;
+};
+
+type WorldOutcome = {
+  id: string;
+  hypothesis_id: string;
+  classification: string;
+  observed_outcome: string;
+  evaluated_at: string;
+};
+
+type WorldLearning = {
+  id: string;
+  hypothesis_id: string;
+  outcome_id: string;
+  confidence_before: number;
+  confidence_after: number;
+  created_at: string;
+};
+
 type WorldResponse = {
   ok: boolean;
   generatedAt?: string;
   sourceState?: string;
+  horizonDays?: number;
+  temporalBounds?: { firstAt: string | null; lastAt: string | null };
   nodes?: WorldNode[];
-  hypotheses?: Array<Record<string, unknown>>;
-  outcomes?: Array<Record<string, unknown>>;
-  learning?: Array<Record<string, unknown>>;
+  hypotheses?: WorldHypothesis[];
+  outcomes?: WorldOutcome[];
+  learning?: WorldLearning[];
   sourceFamilies?: string[];
   limits?: string[];
   error?: string;
   details?: string;
+};
+
+type CognitiveFrame = {
+  ok: boolean;
+  synthesis?: string;
+  epistemicClass?: string;
+  agents?: string[];
+  llm?: { provider?: string | null; model?: string | null; latencyMs?: number | null; warnings?: string[] };
+  twin?: { runId?: string; role?: string; corpusWarnings?: string[] };
+  limitations?: string[];
+  error?: string;
+  details?: string;
+};
+
+type TimelineEvent = {
+  id: string;
+  at: string;
+  kind: 'OBSERVATION' | 'HYPOTHESIS' | 'OUTCOME' | 'LEARNING';
+  label: string;
+  hypothesisId: string | null;
+  observationId: string | null;
 };
 
 function point(lat: number, lng: number) {
@@ -58,15 +109,40 @@ function pct(value: unknown) {
 
 function date(value: string | null | undefined) {
   if (!value) return 'sin fecha';
-  return new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value));
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime())) return value;
+  return new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(parsed);
 }
 
-function nodeClass(family: string, selected: boolean) {
-  const base = selected ? 'h-9 w-9 border-[#ffe0a0]' : 'h-5 w-5';
-  if (family === 'aviation') return `${base} border-[#e7a66c] bg-[#bd643755] shadow-[0_0_28px_rgba(210,112,58,.72)]`;
-  if (family === 'natural_event') return `${base} border-[#80c6d0] bg-[#4b9eaa55] shadow-[0_0_28px_rgba(89,184,198,.72)]`;
-  if (family === 'gnss') return `${base} border-[#db7c67] bg-[#a83f3555] shadow-[0_0_28px_rgba(209,74,62,.75)]`;
-  return `${base} border-[#c7a65b] bg-[#a9813555] shadow-[0_0_28px_rgba(198,158,69,.66)]`;
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function hypothesisObservationId(hypothesis: WorldHypothesis) {
+  const snapshot = asRecord(hypothesis.graph_snapshot);
+  return typeof snapshot.observationId === 'string' ? snapshot.observationId : null;
+}
+
+function millis(value: string | null | undefined) {
+  const parsed = value ? new Date(value).getTime() : NaN;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function nodeClass(family: string, selected: boolean, outcome: string | null, hasHypothesis: boolean) {
+  const base = selected ? 'h-10 w-10 ring-2 ring-[#ffe0a0]/70' : hasHypothesis ? 'h-7 w-7' : 'h-5 w-5';
+  if (outcome === 'VALIDATED') return `${base} border-[#7fd4b2] bg-[#4d9d7a88] shadow-[0_0_30px_rgba(96,211,163,.72)]`;
+  if (outcome === 'CONTRADICTED') return `${base} border-[#e37c69] bg-[#a8423588] shadow-[0_0_30px_rgba(220,92,72,.72)]`;
+  if (family === 'aviation') return `${base} border-[#e7a66c] bg-[#bd643777] shadow-[0_0_24px_rgba(210,112,58,.6)]`;
+  if (family === 'natural_event') return `${base} border-[#80c6d0] bg-[#4b9eaa77] shadow-[0_0_24px_rgba(89,184,198,.6)]`;
+  if (family === 'gnss') return `${base} border-[#db7c67] bg-[#a83f3577] shadow-[0_0_24px_rgba(209,74,62,.62)]`;
+  return `${base} border-[#c7a65b] bg-[#a9813577] shadow-[0_0_24px_rgba(198,158,69,.55)]`;
+}
+
+function eventTone(kind: TimelineEvent['kind']) {
+  if (kind === 'HYPOTHESIS') return 'text-[#d3a85c] border-[#6b542c]';
+  if (kind === 'OUTCOME') return 'text-[#8ac7d0] border-[#365a62]';
+  if (kind === 'LEARNING') return 'text-[#c28ac3] border-[#5f385f]';
+  return 'text-[#9aa9ad] border-[#34444a]';
 }
 
 export function WorldFieldObservatory() {
@@ -74,6 +150,10 @@ export function WorldFieldObservatory() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [windowHours, setWindowHours] = useState(72);
+  const [cursorIndex, setCursorIndex] = useState(0);
+  const [cognitive, setCognitive] = useState<CognitiveFrame | null>(null);
+  const [cognitiveLoading, setCognitiveLoading] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true); setError(null);
@@ -83,6 +163,7 @@ export function WorldFieldObservatory() {
       if (!response.ok || !body.ok) throw new Error(body.details ?? body.error ?? `HTTP ${response.status}`);
       setData(body);
       setSelectedId((current) => current ?? body.nodes?.[0]?.id ?? null);
+      setCognitive(null);
     } catch (nextError) {
       setError(nextError instanceof Error ? nextError.message : 'world_observatory_load_failed');
     } finally { setLoading(false); }
@@ -91,93 +172,184 @@ export function WorldFieldObservatory() {
   useEffect(() => { void load(); }, [load]);
 
   const nodes = data?.nodes ?? [];
-  const located = useMemo(() => nodes.filter((node) => node.lat !== null && node.lng !== null), [nodes]);
-  const selected = nodes.find((node) => node.id === selectedId) ?? null;
-  const reading = selected?.reading ?? null;
   const hypotheses = data?.hypotheses ?? [];
   const outcomes = data?.outcomes ?? [];
-  const openHypotheses = hypotheses.filter((item) => ['OPEN', 'AWAITING_OUTCOME'].includes(String(item.status)));
+  const learning = data?.learning ?? [];
+  const outcomeByHypothesis = useMemo(() => new Map(outcomes.map((item) => [item.hypothesis_id, item])), [outcomes]);
+  const hypothesisByObservation = useMemo(() => {
+    const map = new Map<string, WorldHypothesis[]>();
+    hypotheses.forEach((item) => {
+      const observationId = hypothesisObservationId(item);
+      if (!observationId) return;
+      map.set(observationId, [...(map.get(observationId) ?? []), item]);
+    });
+    return map;
+  }, [hypotheses]);
+
+  const timeline = useMemo<TimelineEvent[]>(() => {
+    const events: TimelineEvent[] = [
+      ...nodes.map((node) => ({ id: `o:${node.id}`, at: node.observedAt, kind: 'OBSERVATION' as const, label: node.title, hypothesisId: null, observationId: node.id })),
+      ...hypotheses.map((item) => ({ id: `h:${item.id}`, at: item.cutoff_at, kind: 'HYPOTHESIS' as const, label: item.statement, hypothesisId: item.id, observationId: hypothesisObservationId(item) })),
+      ...outcomes.map((item) => ({ id: `r:${item.id}`, at: item.evaluated_at, kind: 'OUTCOME' as const, label: `${item.classification} · ${item.observed_outcome}`, hypothesisId: item.hypothesis_id, observationId: null })),
+      ...learning.map((item) => ({ id: `l:${item.id}`, at: item.created_at, kind: 'LEARNING' as const, label: `confianza ${pct(item.confidence_before)} → ${pct(item.confidence_after)}`, hypothesisId: item.hypothesis_id, observationId: null })),
+    ].filter((item) => millis(item.at) > 0);
+    return events.sort((a, b) => millis(a.at) - millis(b.at));
+  }, [nodes, hypotheses, outcomes, learning]);
+
+  useEffect(() => {
+    if (timeline.length) setCursorIndex(timeline.length - 1);
+  }, [timeline.length]);
+
+  const cursorAt = timeline[cursorIndex]?.at ?? data?.temporalBounds?.lastAt ?? data?.generatedAt ?? new Date().toISOString();
+  const cursorMs = millis(cursorAt);
+  const startMs = cursorMs - windowHours * 60 * 60 * 1000;
+  const visibleNodes = useMemo(() => nodes.filter((node) => {
+    const at = millis(node.observedAt);
+    return at > 0 && at <= cursorMs && at >= startMs;
+  }), [nodes, cursorMs, startMs]);
+  const located = useMemo(() => visibleNodes.filter((node) => node.lat !== null && node.lng !== null), [visibleNodes]);
+  const visibleHypotheses = useMemo(() => hypotheses.filter((item) => millis(item.cutoff_at) <= cursorMs), [hypotheses, cursorMs]);
+  const visibleOutcomes = useMemo(() => outcomes.filter((item) => millis(item.evaluated_at) <= cursorMs), [outcomes, cursorMs]);
+  const visibleLearning = useMemo(() => learning.filter((item) => millis(item.created_at) <= cursorMs), [learning, cursorMs]);
+  const selected = visibleNodes.find((node) => node.id === selectedId) ?? visibleNodes.at(-1) ?? null;
+  const reading = selected?.reading ?? null;
+
+  useEffect(() => {
+    if (selected && selected.id !== selectedId) setSelectedId(selected.id);
+  }, [selected, selectedId]);
+
+  async function analyzeFrame() {
+    setCognitiveLoading(true); setCognitive(null); setError(null);
+    try {
+      const response = await fetch('/api/field/map/world/cognitive', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ cutoffAt: cursorAt, windowHours }),
+      });
+      const body = await response.json() as CognitiveFrame;
+      if (!response.ok || !body.ok) throw new Error(body.details ?? body.error ?? `HTTP ${response.status}`);
+      setCognitive(body);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'world_frame_cognitive_failed');
+    } finally { setCognitiveLoading(false); }
+  }
 
   return (
     <main className="min-h-screen bg-[#020507] text-[#d9e2df]">
-      <header className="border-b border-[#26343b] bg-[#04080b] px-5 py-5 md:px-8">
-        <div className="mx-auto flex max-w-[1800px] flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+      <header className="sticky top-0 z-50 border-b border-[#26343b] bg-[#04080bf2] px-4 py-3 backdrop-blur-xl md:px-6">
+        <div className="mx-auto flex max-w-[1900px] flex-wrap items-center justify-between gap-3">
           <div>
-            <div className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#c29b54]">SFI · WORLD / FIELD OBSERVATORY</div>
-            <h1 className="mt-3 text-3xl font-semibold tracking-[-0.03em] text-[#f1ead7] md:text-5xl">Navegación de tensión.</h1>
-            <p className="mt-3 max-w-4xl text-sm leading-7 text-[#87949a]">No clasifica países ni replica puntuaciones externas. Observa señales reales, pregunta qué tensión aparece, a quién le duele, qué mueve el campo, qué permanece permitido y hacia dónde se desplaza la trayectoria.</p>
+            <div className="font-mono text-[9px] uppercase tracking-[0.25em] text-[#c29b54]">SFI · WORLD / FIELD OBSERVATORY</div>
+            <div className="mt-1 text-lg text-[#f1ead7]">Campo temporal · evidencia localizada</div>
           </div>
-          <div className="flex gap-2">
-            <button onClick={() => void load()} disabled={loading} className="inline-flex items-center gap-2 border border-[#34505a] px-3 py-2 font-mono text-[9px] uppercase tracking-[0.15em] text-[#9bc3cc]"><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} /> Reobservar</button>
-            <Link href="/field" className="border border-[#68542f] px-3 py-2 font-mono text-[9px] uppercase tracking-[0.15em] text-[#d0aa61]">FIELD</Link>
+          <div className="flex flex-wrap gap-2">
+            <button onClick={() => void load()} disabled={loading} className="inline-flex items-center gap-2 border border-[#34505a] px-3 py-2 font-mono text-[9px] uppercase tracking-[0.12em] text-[#9bc3cc]"><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} /> Reobservar</button>
+            <Link href="/field" className="border border-[#68542f] px-3 py-2 font-mono text-[9px] uppercase tracking-[0.12em] text-[#d0aa61]">FIELD</Link>
+            <Link href="/observatory" className="border border-[#68542f] px-3 py-2 font-mono text-[9px] uppercase tracking-[0.12em] text-[#d0aa61]">OBSERVATORY</Link>
           </div>
         </div>
       </header>
 
-      <section className="relative min-h-[72vh] overflow-hidden border-b border-[#26343b] bg-[#020609]">
-        <div className="absolute inset-0 bg-[url('/field/sfi_map.png')] bg-cover bg-center opacity-90" />
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(195,154,77,.08),transparent_32%),linear-gradient(rgba(88,123,135,.07)_1px,transparent_1px),linear-gradient(90deg,rgba(88,123,135,.07)_1px,transparent_1px)] bg-[size:auto,5%_10%,5%_10%]" />
-        <svg className="pointer-events-none absolute inset-0 z-[4] h-full w-full" viewBox="0 0 100 100" preserveAspectRatio="none">
-          {located.slice(0, 120).map((node, index) => {
-            if (index === 0) return null;
-            const previous = located[index - 1];
-            if (previous.lat === null || previous.lng === null || node.lat === null || node.lng === null) return null;
-            const a = { x: ((previous.lng + 180) / 360) * 100, y: ((90 - previous.lat) / 180) * 100 };
-            const b = { x: ((node.lng + 180) / 360) * 100, y: ((90 - node.lat) / 180) * 100 };
-            const sameSystem = previous.affectedSystems.some((system) => node.affectedSystems.includes(system));
-            if (!sameSystem) return null;
-            return <path key={`${previous.id}:${node.id}`} d={`M ${a.x} ${a.y} Q ${(a.x + b.x) / 2} ${Math.min(a.y, b.y) - 4} ${b.x} ${b.y}`} fill="none" stroke="#b49450" strokeOpacity="0.18" strokeWidth="0.18" vectorEffect="non-scaling-stroke" />;
+      {error ? <div className="mx-auto max-w-[1900px] border-x border-b border-[#673d32] bg-[#2b100d] px-4 py-3 text-xs text-[#e6a38e]">{error}</div> : null}
+
+      <section className="mx-auto grid max-w-[1900px] items-start gap-px bg-[#26343b] xl:grid-cols-[minmax(0,1.35fr)_minmax(430px,.65fr)]">
+        <div className="sticky top-[69px] h-[calc(100vh-69px)] min-h-[620px] overflow-hidden bg-[#020609]">
+          <div className="absolute inset-0 bg-[url('/field/sfi_map.png')] bg-cover bg-center opacity-90" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(195,154,77,.08),transparent_32%),linear-gradient(rgba(88,123,135,.07)_1px,transparent_1px),linear-gradient(90deg,rgba(88,123,135,.07)_1px,transparent_1px)] bg-[size:auto,5%_10%,5%_10%]" />
+
+          {located.map((node) => {
+            const linked = hypothesisByObservation.get(node.id) ?? [];
+            const latestHypothesis = linked.filter((item) => millis(item.cutoff_at) <= cursorMs).at(-1) ?? null;
+            const outcome = latestHypothesis ? outcomeByHypothesis.get(latestHypothesis.id) ?? null : null;
+            return (
+              <button key={node.id} onClick={() => setSelectedId(node.id)} className="absolute z-10 -translate-x-1/2 -translate-y-1/2" style={point(node.lat as number, node.lng as number)} title={`${node.publisher} · ${node.title}`}>
+                <span className={`block rounded-full border transition-all duration-300 ${nodeClass(node.sourceFamily, node.id === selected?.id, outcome?.classification ?? null, Boolean(latestHypothesis))}`} />
+              </button>
+            );
           })}
-        </svg>
 
-        {located.map((node) => (
-          <button key={node.id} onClick={() => setSelectedId(node.id)} className="absolute z-10 -translate-x-1/2 -translate-y-1/2" style={point(node.lat as number, node.lng as number)} title={`${node.publisher} · ${node.title}`}>
-            <span className={`block rounded-full border transition-all ${nodeClass(node.sourceFamily, node.id === selectedId)}`} />
-          </button>
-        ))}
+          {!located.length ? <div className="absolute inset-0 z-20 grid place-items-center"><div className="max-w-lg border border-[#6a5530] bg-[#05090ce8] p-7 text-center"><Aperture className="mx-auto h-8 w-8 text-[#c9a35c]" /><strong className="mt-4 block text-xl text-[#efe4ca]">SIN NODOS EN ESTE FRAME</strong><p className="mt-3 text-sm leading-7 text-[#829097]">Mueve la línea temporal o amplía la ventana. No se inventan nodos para mantener el mapa poblado.</p></div></div> : null}
 
-        {!located.length ? <div className="absolute inset-0 z-20 grid place-items-center"><div className="max-w-lg border border-[#6a5530] bg-[#05090ce8] p-7 text-center"><Aperture className="mx-auto h-8 w-8 text-[#c9a35c]" /><strong className="mt-4 block text-xl text-[#efe4ca]">SIN OBSERVACIONES WORLD PERSISTIDAS</strong><p className="mt-3 text-sm leading-7 text-[#829097]">No se inventan nodos. La primera ejecución del ciclo de ingesta debe persistir observaciones reales.</p></div></div> : null}
+          <div className="absolute left-4 top-4 z-20 border border-[#304149] bg-[#03080be8] px-3 py-2 font-mono text-[9px] uppercase tracking-[0.12em] text-[#8da1a9]">frame {date(cursorAt)} · ventana {windowHours}h · nodos {visibleNodes.length}/{nodes.length}</div>
+          <div className="absolute bottom-28 left-4 z-20 max-w-[70%] border border-[#304149] bg-[#03080be8] px-3 py-2 font-mono text-[8px] uppercase tracking-[0.12em] text-[#718087]">geometría = ubicación persistida · aparición/desaparición = frame temporal · no se infieren aristas causales</div>
 
-        <div className="absolute left-4 top-4 z-20 border border-[#304149] bg-[#03080bdc] px-3 py-2 font-mono text-[9px] uppercase tracking-[0.14em] text-[#8da1a9]">observadas {nodes.length} · localizadas {located.length} · hipótesis abiertas {openHypotheses.length}</div>
-        <div className="absolute bottom-4 left-4 z-20 border border-[#304149] bg-[#03080bdc] px-3 py-2 font-mono text-[9px] uppercase tracking-[0.14em] text-[#8da1a9]">{data?.sourceFamilies?.join(' · ') || 'NO SOURCE FAMILIES'} · {date(data?.generatedAt)}</div>
-      </section>
-
-      <section className="mx-auto grid max-w-[1800px] gap-px bg-[#26343b] xl:grid-cols-[minmax(0,1.25fr)_minmax(360px,.75fr)]">
-        <article className="bg-[#05090c] p-5 md:p-7">
-          <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.17em] text-[#c49d55]"><CircleDot className="h-4 w-4" /> Observación seleccionada</div>
-          {selected ? <>
-            <div className="mt-4 flex flex-wrap items-center gap-2"><span className="border border-[#33464e] px-2 py-1 font-mono text-[9px] uppercase text-[#91a8b1]">{selected.publisher}</span><span className="border border-[#33464e] px-2 py-1 font-mono text-[9px] uppercase text-[#91a8b1]">{selected.sourceFamily}</span><span className="text-xs text-[#718087]">{date(selected.observedAt)}</span></div>
-            <h2 className="mt-4 text-2xl text-[#f0e5cd]">{selected.title}</h2>
-            <p className="mt-3 max-w-4xl text-sm leading-7 text-[#8d9a9f]">{selected.summary || 'Observación sin resumen editorial.'}</p>
-            {reading ? <div className="mt-6 grid gap-4 md:grid-cols-2">
-              {[
-                ['¿Qué tensión aparece?', reading.tension?.between?.join(' ↔ ')],
-                ['¿A quién le duele?', reading.pain_map?.affectedSystems?.join(' · ')],
-                ['¿Qué mueve el campo?', reading.field_drivers?.drivers?.join(' · ')],
-                ['¿Qué se permitirá?', `permite: ${reading.permissions?.enabled?.join(', ')} · restringe: ${reading.permissions?.constrained?.join(', ')}`],
-                ['¿Hacia dónde va?', `${reading.trajectory?.direction} · ${reading.trajectory?.expectedSignal}`],
-                ['¿Qué puede hacerse mínimamente?', reading.minimum_viable_perturbation?.action],
-              ].map(([question, answer]) => <div key={question} className="border border-[#273840] bg-[#071015] p-4"><div className="font-mono text-[9px] uppercase tracking-[0.14em] text-[#c49d55]">{question}</div><p className="mt-3 text-sm leading-6 text-[#a0aaac]">{answer || 'MISSING'}</p></div>)}
-            </div> : <p className="mt-6 border border-[#604d2d] p-4 text-sm text-[#c5a66b]">La observación existe, pero aún no tiene lectura SFI persistida.</p>}
-          </> : <p className="mt-4 text-sm text-[#78868c]">Selecciona un nodo observado.</p>}
-        </article>
-
-        <aside className="bg-[#04080a] p-5 md:p-7">
-          <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.17em] text-[#c49d55]"><Activity className="h-4 w-4" /> Estado matemático</div>
-          {reading ? <div className="mt-4 grid grid-cols-2 gap-px bg-[#25343a]">
-            {[['F_s', reading.systemic_friction], ['D_i', reading.interaction_density], ['G_f', reading.friction_gradient], ['Φ', reading.systemic_coherence]].map(([label, value]) => <div key={String(label)} className="bg-[#071015] p-4"><div className="font-mono text-[9px] text-[#73878f]">{label}</div><div className="mt-2 text-2xl text-[#efe4cb]">{pct(value)}</div></div>)}
-          </div> : null}
-
-          <div className="mt-7 flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.17em] text-[#c49d55]"><Route className="h-4 w-4" /> Hipótesis y retorno</div>
-          <div className="mt-4 space-y-3">
-            {hypotheses.slice(0, 8).map((item) => <article key={String(item.id)} className="border border-[#283940] p-4"><div className="flex justify-between gap-3 font-mono text-[9px] uppercase"><span className="text-[#9eb1b8]">{String(item.status)}</span><span className="text-[#c9a35b]">{pct(item.current_confidence)}</span></div><p className="mt-3 text-xs leading-6 text-[#89969b]">{String(item.statement)}</p><div className="mt-2 text-[10px] text-[#65757c]">retorno · {date(String(item.validation_ends_at))}</div></article>)}
-            {!hypotheses.length ? <p className="text-xs leading-6 text-[#78868c]">Todavía no existe una hipótesis WORLD congelada.</p> : null}
+          <div className="absolute inset-x-4 bottom-4 z-30 border border-[#4b4535] bg-[#030608ef] p-3 backdrop-blur">
+            <div className="flex items-center justify-between gap-3 font-mono text-[9px] uppercase tracking-[0.13em]">
+              <span className="inline-flex items-center gap-2 text-[#d0aa61]"><Clock3 className="h-4 w-4" /> TIME MOVEMENT</span>
+              <span className="text-[#87949a]">{cursorIndex + 1}/{Math.max(1, timeline.length)}</span>
+            </div>
+            <input aria-label="Mover tiempo del Campo Mundial" type="range" min={0} max={Math.max(0, timeline.length - 1)} value={Math.min(cursorIndex, Math.max(0, timeline.length - 1))} onChange={(event) => { setCursorIndex(Number(event.target.value)); setCognitive(null); }} className="mt-3 w-full accent-[#c59b52]" disabled={!timeline.length} />
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-[10px] text-[#718087]">
+              <span>{date(timeline[0]?.at)}</span>
+              <div className="flex gap-1">
+                {[24, 72, 168].map((hours) => <button key={hours} type="button" onClick={() => { setWindowHours(hours); setCognitive(null); }} className={`border px-2 py-1 font-mono text-[8px] ${windowHours === hours ? 'border-[#c59b52] text-[#e1bd76]' : 'border-[#34444a] text-[#75858b]'}`}>{hours === 168 ? '7D' : `${hours}H`}</button>)}
+              </div>
+              <span>{date(timeline.at(-1)?.at)}</span>
+            </div>
           </div>
+        </div>
 
-          <div className="mt-7 flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.17em] text-[#c49d55]"><ShieldCheck className="h-4 w-4" /> Contrato</div>
-          {(data?.limits ?? []).map((limit) => <p key={limit} className="mt-3 text-xs leading-6 text-[#78868c]">{limit}</p>)}
-          <p className="mt-3 text-xs leading-6 text-[#78868c]">Outcomes persistidos: {outcomes.length}. Aprendizajes persistidos: {data?.learning?.length ?? 0}.</p>
-          {error ? <div className="mt-5 border border-[#743e32] bg-[#170c09] p-4 text-xs text-[#d48d7c]">{error}</div> : null}
+        <aside className="min-h-screen bg-[#04080a]">
+          <section className="border-b border-[#26343b] p-5">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.16em] text-[#c49d55]"><CircleDot className="h-4 w-4" /> Estado del frame</div>
+              <span className="font-mono text-[8px] text-[#75858b]">{visibleHypotheses.length} H · {visibleOutcomes.length} O · {visibleLearning.length} L</span>
+            </div>
+            {selected ? <>
+              <div className="mt-4 flex flex-wrap items-center gap-2"><span className="border border-[#33464e] px-2 py-1 font-mono text-[8px] uppercase text-[#91a8b1]">{selected.publisher}</span><span className="border border-[#33464e] px-2 py-1 font-mono text-[8px] uppercase text-[#91a8b1]">{selected.sourceFamily}</span></div>
+              <h2 className="mt-3 text-xl text-[#f0e5cd]">{selected.title}</h2>
+              <p className="mt-2 text-xs leading-6 text-[#8d9a9f]">{selected.summary || 'Observación sin resumen editorial.'}</p>
+              {reading ? <div className="mt-4 grid grid-cols-2 gap-px bg-[#25343a]">{[['F_s', reading.systemic_friction], ['D_i', reading.interaction_density], ['G_f', reading.friction_gradient], ['Φ', reading.systemic_coherence]].map(([label, value]) => <div key={String(label)} className="bg-[#071015] p-3"><div className="font-mono text-[8px] text-[#73878f]">{label}</div><div className="mt-1 text-xl text-[#efe4cb]">{pct(value)}</div></div>)}</div> : <p className="mt-4 border border-[#604d2d] p-3 text-xs text-[#c5a66b]">Lectura SFI todavía MISSING para esta observación.</p>}
+            </> : <p className="mt-4 text-xs text-[#78868c]">No existe observación dentro del frame seleccionado.</p>}
+          </section>
+
+          {reading ? <section className="border-b border-[#26343b] p-5">
+            <div className="font-mono text-[9px] uppercase tracking-[0.16em] text-[#c49d55]">Lectura SFI persistida</div>
+            <div className="mt-4 space-y-3">{[
+              ['TENSIÓN', reading.tension?.between?.join(' ↔ ')],
+              ['DOLOR', reading.pain_map?.affectedSystems?.join(' · ')],
+              ['DRIVERS', reading.field_drivers?.drivers?.join(' · ')],
+              ['TRAYECTORIA', `${reading.trajectory?.direction ?? 'MISSING'} · ${reading.trajectory?.expectedSignal ?? 'MISSING'}`],
+              ['PERTURBACIÓN MÍNIMA', reading.minimum_viable_perturbation?.action],
+            ].map(([label, value]) => <div key={label} className="border-l border-[#604d2d] pl-3"><span className="font-mono text-[8px] text-[#846b3e]">{label}</span><p className="mt-1 text-xs leading-5 text-[#929da1]">{value || 'MISSING'}</p></div>)}</div>
+          </section> : null}
+
+          <section className="border-b border-[#26343b] p-5">
+            <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.16em] text-[#c49d55]"><BrainCircuit className="h-4 w-4" /> LLM + AGENTES + COGNITIVE TWIN</div>
+            <p className="mt-3 text-xs leading-6 text-[#7f8d92]">Ejecuta una lectura explícita del frame persistido. Los agentes derivan contexto; el LLM sintetiza una propuesta usando sólo canon/métodos institucionales del Twin. No modifica observaciones ni convierte inferencias en evidencia.</p>
+            <button type="button" onClick={() => void analyzeFrame()} disabled={cognitiveLoading || !visibleNodes.length} className="mt-4 w-full border border-[#6b552e] bg-[#171107] px-3 py-3 font-mono text-[9px] uppercase tracking-[0.13em] text-[#d8b56f] disabled:opacity-40">{cognitiveLoading ? 'EJECUTANDO FRAME…' : 'ANALIZAR FRAME CON SFI'}</button>
+            {cognitive ? <div className="mt-4 border border-[#35474e] bg-[#071015] p-4"><div className="flex flex-wrap justify-between gap-2 font-mono text-[8px] uppercase"><span className="text-[#c9a35b]">{cognitive.epistemicClass ?? 'PROPOSED'}</span><span className="text-[#7c9198]">{cognitive.llm?.provider ?? 'fallback'} · {cognitive.llm?.model ?? 'n/d'}</span></div><p className="mt-3 whitespace-pre-wrap text-xs leading-6 text-[#a0aaac]">{cognitive.synthesis}</p><div className="mt-3 border-t border-[#26343b] pt-3 text-[9px] leading-5 text-[#69797f]">AGENTES · {(cognitive.agents ?? []).join(' · ') || 'ninguno'}<br />TWIN RUN · {cognitive.twin?.runId ?? 'MISSING'}</div></div> : null}
+          </section>
+
+          <section className="border-b border-[#26343b] p-5">
+            <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.16em] text-[#c49d55]"><Route className="h-4 w-4" /> Hipótesis longitudinales</div>
+            <p className="mt-2 text-[10px] leading-5 text-[#718087]">Se muestran todas las hipótesis persistidas del horizonte hasta el cursor, no las primeras ocho.</p>
+            <div className="mt-4 max-h-[520px] space-y-2 overflow-y-auto pr-1">
+              {[...visibleHypotheses].reverse().map((item) => {
+                const outcome = outcomeByHypothesis.get(item.id) ?? null;
+                return <article key={item.id} className="border border-[#283940] p-3"><div className="flex justify-between gap-3 font-mono text-[8px] uppercase"><span className="text-[#9eb1b8]">{outcome?.classification ?? item.status}</span><span className="text-[#c9a35b]">{pct(item.current_confidence)}</span></div><p className="mt-2 text-xs leading-5 text-[#89969b]">{item.statement}</p><div className="mt-2 flex justify-between gap-2 text-[9px] text-[#65757c]"><span>T0 {date(item.cutoff_at)}</span><span>retorno {date(item.validation_ends_at)}</span></div>{outcome ? <p className="mt-2 border-l border-[#35606a] pl-2 text-[10px] leading-5 text-[#7baab2]">{outcome.observed_outcome}</p> : null}</article>;
+              })}
+              {!visibleHypotheses.length ? <p className="text-xs leading-6 text-[#78868c]">Todavía no existe una hipótesis WORLD antes de este cursor.</p> : null}
+            </div>
+          </section>
+
+          <section className="p-5">
+            <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.16em] text-[#c49d55]"><Clock3 className="h-4 w-4" /> Timeline completa</div>
+            <div className="mt-4 max-h-[640px] space-y-2 overflow-y-auto pr-1">
+              {[...timeline].reverse().map((event, reverseIndex) => {
+                const originalIndex = timeline.length - 1 - reverseIndex;
+                const active = originalIndex === cursorIndex;
+                return <button key={event.id} type="button" onClick={() => { setCursorIndex(originalIndex); setCognitive(null); }} className={`block w-full border p-3 text-left transition ${eventTone(event.kind)} ${active ? 'bg-[#19150d] ring-1 ring-[#c59b52]/60' : 'bg-[#05090c]'}`}><div className="flex items-center justify-between gap-2 font-mono text-[8px]"><span>{event.kind}</span><time>{date(event.at)}</time></div><p className="mt-2 line-clamp-3 text-[10px] leading-5 text-[#87949a]">{event.label}</p></button>;
+              })}
+              {!timeline.length ? <p className="text-xs text-[#78868c]">Sin eventos temporales persistidos.</p> : null}
+            </div>
+          </section>
+
+          <section className="border-t border-[#26343b] p-5">
+            <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.16em] text-[#c49d55]"><ShieldCheck className="h-4 w-4" /> Contrato</div>
+            {(data?.limits ?? []).map((limit) => <p key={limit} className="mt-2 text-[10px] leading-5 text-[#78868c]">{limit}</p>)}
+          </section>
         </aside>
       </section>
     </main>

--- a/src/components/observatory/gold/visual/observatoryGoldTypes.ts
+++ b/src/components/observatory/gold/visual/observatoryGoldTypes.ts
@@ -11,6 +11,22 @@ export type ObservatoryLongitudinalPoint = {
   ingestMode: string;
 };
 
+export type ObservatoryTemporalFrame = {
+  observedAt: string;
+  wsi: number | null;
+  nti: number | null;
+  confidence: number | null;
+  sourceState: string;
+  ingestMode: string;
+  vectors: Array<{
+    id: string;
+    label: string;
+    value: number | null;
+    sourceCount: number;
+    trust: number | null;
+  }>;
+};
+
 export type ObservatoryGoldState = {
   generatedAt: string;
   systemState: ObservatoryGoldSystemState;
@@ -44,6 +60,8 @@ export type ObservatoryGoldState = {
       confidence: number | null;
     };
   };
+
+  temporalFrames?: ObservatoryTemporalFrame[];
 
   explanation: {
     title: string;

--- a/src/components/observatory/public/PublicObservatoryTimelineNavigator.tsx
+++ b/src/components/observatory/public/PublicObservatoryTimelineNavigator.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Clock3, RefreshCw } from 'lucide-react';
+
+type Frame = {
+  observedAt: string;
+  wsi: number | null;
+  nti: number | null;
+  confidence: number | null;
+  sourceState: string;
+  ingestMode: string;
+  vectors: Array<{ id: string; label: string; value: number | null; sourceCount: number; trust: number | null }>;
+};
+
+type Response = {
+  ok: boolean;
+  horizonDays?: number;
+  generatedAt?: string;
+  frames?: Frame[];
+  limits?: string[];
+  error?: string;
+  details?: string;
+};
+
+function value(number: number | null) {
+  return number === null ? 'n/d' : number.toFixed(3);
+}
+
+function date(value: string | null | undefined) {
+  if (!value) return 'SIN FECHA';
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime())) return value;
+  return parsed.toLocaleString('es-MX', { dateStyle: 'medium', timeStyle: 'short', timeZone: 'UTC' }) + ' UTC';
+}
+
+export function PublicObservatoryTimelineNavigator() {
+  const [data, setData] = useState<Response | null>(null);
+  const [index, setIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true); setError(null);
+    try {
+      const response = await fetch('/api/observatory/timeline', { cache: 'no-store' });
+      const body = await response.json() as Response;
+      if (!response.ok || !body.ok) throw new Error(body.details ?? body.error ?? `HTTP ${response.status}`);
+      setData(body);
+      setIndex(Math.max(0, (body.frames?.length ?? 1) - 1));
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : 'observatory_timeline_failed');
+    } finally { setLoading(false); }
+  }
+
+  useEffect(() => { void load(); }, []);
+
+  const frames = data?.frames ?? [];
+  const frame = frames[Math.min(index, Math.max(0, frames.length - 1))] ?? null;
+  const activeVectors = useMemo(() => frame?.vectors.filter((vector) => vector.value !== null) ?? [], [frame]);
+
+  return (
+    <section id="time-movement" className="border-y border-[#78592f66] bg-[#07090b] px-4 py-5 text-[#ddd7c9] md:px-6">
+      <div className="mx-auto max-w-[1900px]">
+        <header className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.2em] text-[#d79742]"><Clock3 className="h-4 w-4" /> TIME MOVEMENT · WORLD VECTOR</div>
+            <h2 className="mt-2 text-xl tracking-[-0.02em] text-[#f2e5c8]">Mover el observatorio por estados realmente persistidos.</h2>
+            <p className="mt-2 max-w-4xl font-mono text-[10px] leading-5 text-[#7f786c]">El cursor no interpola ni inventa días. Cada posición corresponde a un snapshot WorldSpect almacenado y reconstruye únicamente los dominios que tenían fuentes utilizables en ese instante.</p>
+          </div>
+          <button type="button" onClick={() => void load()} disabled={loading} className="inline-flex items-center gap-2 border border-[#78592f] px-3 py-2 font-mono text-[8px] uppercase tracking-[0.15em] text-[#d7a85e]"><RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} /> RECARGAR SERIE</button>
+        </header>
+
+        {error ? <div className="mt-4 border border-[#6d3f32] bg-[#24110d] p-3 font-mono text-[10px] text-[#d98670]">{error}</div> : null}
+
+        {frame ? <>
+          <div className="mt-5 grid gap-px bg-[#6b512d55] md:grid-cols-4">
+            {[
+              ['FRAME', date(frame.observedAt), frame.sourceState.toUpperCase()],
+              ['WSV', value(frame.wsi), 'estado mundial agregado'],
+              ['NTI', value(frame.nti), 'tensión del snapshot'],
+              ['CONFIANZA', value(frame.confidence), frame.ingestMode.toUpperCase()],
+            ].map(([label, metric, meta]) => <div key={label} className="bg-[#0a0c0f] p-4"><span className="font-mono text-[8px] tracking-[0.15em] text-[#7f786c]">{label}</span><strong className="mt-2 block text-lg font-normal text-[#e7c987]">{metric}</strong><small className="mt-1 block font-mono text-[8px] text-[#665f55]">{meta}</small></div>)}
+          </div>
+
+          <div className="mt-5 border border-[#78592f55] bg-[#050708] p-4">
+            <div className="flex items-center justify-between gap-3 font-mono text-[8px] uppercase tracking-[0.14em] text-[#8f816b]"><span>{date(frames[0]?.observedAt)}</span><span>{index + 1}/{frames.length} · {data?.horizonDays ?? 90} DÍAS</span><span>{date(frames.at(-1)?.observedAt)}</span></div>
+            <input aria-label="Mover la línea temporal del Observatorio Público" type="range" min={0} max={Math.max(0, frames.length - 1)} value={Math.min(index, Math.max(0, frames.length - 1))} onChange={(event) => setIndex(Number(event.target.value))} className="mt-4 w-full accent-[#d79742]" />
+          </div>
+
+          <div className="mt-5 grid gap-px bg-[#6b512d55] sm:grid-cols-2 lg:grid-cols-5">
+            {frame.vectors.map((vector) => <article key={vector.id} className={`bg-[#090b0d] p-4 ${vector.value === null ? 'opacity-45' : ''}`}><span className="font-mono text-[8px] uppercase tracking-[0.12em] text-[#887960]">{vector.label}</span><strong className="mt-2 block text-2xl font-normal text-[#e7c987]">{value(vector.value)}</strong><div className="mt-2 h-1 border border-[#6e542f55] bg-[#030405]"><i className="block h-full bg-[#b84e9a]" style={{ width: `${Math.max(0, Math.min(1, vector.value ?? 0)) * 100}%` }} /></div><small className="mt-2 block font-mono text-[8px] leading-4 text-[#685f53]">{vector.sourceCount} fuentes · trust {value(vector.trust)}</small></article>)}
+          </div>
+
+          {!activeVectors.length ? <div className="mt-4 border border-[#604d2d] p-3 font-mono text-[10px] text-[#a38655]">Este snapshot existe, pero no contiene dominios públicos calculables. Se conserva como ausencia observada, no se rellena.</div> : null}
+
+          <div className="mt-4 flex flex-wrap gap-x-5 gap-y-1 font-mono text-[8px] leading-4 text-[#625c53]">{(data?.limits ?? []).map((limit) => <span key={limit}>· {limit}</span>)}</div>
+        </> : !loading ? <div className="mt-5 border border-[#604d2d] p-5 font-mono text-[10px] text-[#a38655]">NO EXISTEN SNAPSHOTS PERSISTIDOS EN EL HORIZONTE PÚBLICO.</div> : null}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/observatory/public/worldSnapshotTimeline.ts
+++ b/src/lib/observatory/public/worldSnapshotTimeline.ts
@@ -1,0 +1,134 @@
+import 'server-only';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+type Row = Record<string, unknown>;
+type DomainDefinition = { id: string; label: string; domains: string[] };
+
+const HORIZON_DAYS = 90;
+const PAGE_SIZE = 250;
+
+const VECTOR_DEFINITIONS: DomainDefinition[] = [
+  { id: 'cultural', label: 'Cultural', domains: ['CULTURAL'] },
+  { id: 'memetic', label: 'Memético', domains: ['MEMETIC'] },
+  { id: 'affective', label: 'Afectivo', domains: ['AFFECTIVE'] },
+  { id: 'tech', label: 'Tecnológico', domains: ['TECH'] },
+  { id: 'geo-digital', label: 'Geodigital', domains: ['GEO_DIGITAL'] },
+  { id: 'economy', label: 'Económico', domains: ['ECONOMY'] },
+  { id: 'geopolitical', label: 'Geopolítico', domains: ['GEOPOLITICAL'] },
+  { id: 'institutional', label: 'Institucional', domains: ['INSTITUTIONAL'] },
+  { id: 'climate', label: 'Climático', domains: ['CLIMATE'] },
+  { id: 'bio', label: 'Biológico', domains: ['BIO'] },
+];
+
+const KNOWN_DOMAINS = new Set(VECTOR_DEFINITIONS.flatMap((item) => item.domains));
+
+function rows(value: unknown): Row[] {
+  return Array.isArray(value) ? value.filter((item): item is Row => Boolean(item) && typeof item === 'object' && !Array.isArray(item)) : [];
+}
+
+function text(value: unknown, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function numeric(value: unknown): number | null {
+  if (value === null || typeof value === 'undefined' || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalize(value: unknown): number | null {
+  const parsed = numeric(value);
+  if (parsed === null) return null;
+  return Math.max(0, Math.min(1, parsed > 1 ? parsed / 100 : parsed));
+}
+
+function sourceDomain(source: Row) {
+  const explicit = text(source.domain ?? source.mihm_var).toUpperCase().replace(/[\s-]+/g, '_');
+  if (KNOWN_DOMAINS.has(explicit)) return explicit;
+  const key = text(source.key).toLowerCase();
+  if (key.startsWith('cultural_')) return 'CULTURAL';
+  if (key.startsWith('memetic_')) return 'MEMETIC';
+  if (key.startsWith('affective_')) return 'AFFECTIVE';
+  if (key.startsWith('tech_')) return 'TECH';
+  if (key.startsWith('geo_digital_')) return 'GEO_DIGITAL';
+  if (key.startsWith('economy_')) return 'ECONOMY';
+  if (key.startsWith('geopolitical_')) return 'GEOPOLITICAL';
+  if (key.startsWith('institutional_')) return 'INSTITUTIONAL';
+  if (key.startsWith('climate_')) return 'CLIMATE';
+  if (key.startsWith('bio_')) return 'BIO';
+  return null;
+}
+
+function average(values: number[]) {
+  return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : null;
+}
+
+function vectorAt(snapshotSources: Row[], definition: DomainDefinition) {
+  const matching = snapshotSources.filter((source) => {
+    const domain = sourceDomain(source);
+    return domain !== null && definition.domains.includes(domain) && source.simulated !== true && !text(source.error);
+  });
+  const values = matching.map((source) => normalize(source.value)).filter((value): value is number => value !== null);
+  const trusts = matching.map((source) => normalize(source.trust ?? source.confidence)).filter((value): value is number => value !== null);
+  return {
+    id: definition.id,
+    label: definition.label,
+    value: average(values),
+    sourceCount: values.length,
+    trust: average(trusts),
+  };
+}
+
+export type PublicWorldTemporalFrame = {
+  observedAt: string;
+  wsi: number | null;
+  nti: number | null;
+  confidence: number | null;
+  sourceState: string;
+  ingestMode: string;
+  vectors: Array<{ id: string; label: string; value: number | null; sourceCount: number; trust: number | null }>;
+};
+
+export async function readPublicWorldSnapshotTimeline() {
+  const db = createServiceSupabaseClient();
+  const since = new Date(Date.now() - HORIZON_DAYS * 86400000).toISOString();
+  const snapshots: Row[] = [];
+  let from = 0;
+
+  for (;;) {
+    const result = await db.from('worldspect_snapshots')
+      .select('observed_at,created_at,source_state,confidence,wsi,nti,ingest_mode,sources')
+      .gte('observed_at', since)
+      .order('observed_at', { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+    if (result.error) throw new Error(`worldspect_public_timeline_failed:${result.error.message}`);
+    const page = rows(result.data);
+    snapshots.push(...page);
+    if (page.length < PAGE_SIZE) break;
+    from += PAGE_SIZE;
+  }
+
+  const frames: PublicWorldTemporalFrame[] = snapshots.map((snapshot) => {
+    const snapshotSources = rows(snapshot.sources);
+    return {
+      observedAt: text(snapshot.observed_at ?? snapshot.created_at),
+      wsi: normalize(snapshot.wsi),
+      nti: normalize(snapshot.nti),
+      confidence: normalize(snapshot.confidence),
+      sourceState: text(snapshot.source_state, 'unknown'),
+      ingestMode: text(snapshot.ingest_mode, 'unknown'),
+      vectors: VECTOR_DEFINITIONS.map((definition) => vectorAt(snapshotSources, definition)),
+    };
+  }).filter((frame) => frame.observedAt);
+
+  return {
+    horizonDays: HORIZON_DAYS,
+    generatedAt: new Date().toISOString(),
+    frames,
+    limits: [
+      'Historical frames are reconstructed only from persisted WorldSpect snapshots.',
+      'Vector values are aggregate readings of sources present in that snapshot; missing domains remain null.',
+      'Moving the timeline changes the historical frame only; it does not rewrite the current Observatory state.',
+    ],
+  };
+}


### PR DESCRIPTION
Connects the previously separated WORLD observation surfaces without adding schema, mock state or parallel graph storage.

FIELD / MAP
- replaces the vertically detached map + truncated hypothesis rail with one sticky temporal workspace;
- paginates the full persisted 30-day WORLD horizon for observations, hypotheses, outcomes and learning instead of returning only the first 100 hypothesis rows;
- adds 24h / 72h / 7d temporal windows and a real event cursor; nodes enter/leave only according to persisted observation timestamps;
- removes the presentation-derived previous-node arcs that could look like graph relations even though no relation was persisted;
- shows every persisted hypothesis longitudinally and integrates outcomes/learning in the same event timeline;
- adds an explicit bounded `ANALIZAR FRAME CON SFI` action: selected agents execute over the persisted frame, then exactly one LLM synthesis uses only canonical METHOD/CANON/DEFINITION/CAPABILITY Cognitive Twin memory and approved institutional rules;
- the resulting interpretation is PROPOSED, persists as a `world_field_frame_analysis` Cognitive Twin run, and cannot mutate WORLD observations, hypotheses, outcomes or canon.

PUBLIC OBSERVATORY
- adds a public Time Movement lens over persisted `worldspect_snapshots` for the existing 90-day horizon;
- the cursor reconstructs WSV, NTI, confidence and the ten domain vector aggregates for the exact selected snapshot;
- missing domains remain null; no interpolation or current-state backfill is used;
- no Cognitive Twin memory/runs are exposed publicly.

QA
- adds a temporal-surfaces contract check to SFI Verify covering pagination, time cursor, hypothesis visibility, bounded agent/LLM/Twin bridge, public timeline provenance and privacy boundaries.

No migrations. No new data tables. No seeded/fake nodes or metrics.