### PR TITLE
Guard ROOT evidence edge contract and trigger fresh deploy

### DIFF
--- a/scripts/qa-sfi-root-graph-navigation.ts
+++ b/scripts/qa-sfi-root-graph-navigation.ts
@@ -18,6 +18,7 @@ check('legacy graph edge storage remains compatible', reconcile.includes("LEGACY
 check('semantic graph meaning survives storage compatibility', reconcile.includes('semanticRelationType: input.relationType') && reconcile.includes('declaredRelation: input.relation'));
 check('evidence reader prefers semantic relation', reader.includes('row.relation ?? attributes.declaredRelation ?? row.relation_type'));
 check('evidence graph exposes temporal edge metadata', reader.includes('observedAt: dateValue(attributes.observedAt') && reader.includes('sourceObservedAt'));
+check('RootEvidenceEdge adapter satisfies semantic and temporal contract', reader.includes('relationClass: text(attributes.semanticRelationType') && reader.includes('observedAt: dateValue(attributes.observedAt'));
 check('static index-circle evidence layout was removed', !workspace.includes('index / Math.max(1, nodes.length) * Math.PI * 2') && !workspace.includes('.slice(0, 28)'));
 check('graph uses persisted connectivity for expansion', workspace.includes('graphDegrees') && workspace.includes('graphLevels') && workspace.includes('adjacency') && workspace.includes('setDepth(value)') && workspace.includes('maxDepth'));
 check('graph supports longitudinal movement', workspace.includes('Mover el grafo de evidencia longitudinalmente') && workspace.includes('cutoffMs') && workspace.includes('timeEdges'));


### PR DESCRIPTION
The reported Vercel build compiled the pre-#188 `readRootEvidenceGraph.ts` from commit 56d1091, where `edgeFrom()` lacked `relationClass` and `observedAt`. Current main at 8297d5c already contains both fields and passed typecheck/build.

This PR does not weaken the contract or make those fields optional. It adds an explicit regression assertion to ROOT QA requiring the adapter to keep both semantic (`relationClass`) and temporal (`observedAt`) edge fields. Merging also creates a fresh main commit so Git-integrated deployment cannot reuse the old source snapshot by commit identity.

No runtime behavior changes.