### PR TITLE
Build INEGI national observation field for Cognitive Twin

### DIFF
--- a/scripts/qa-sfi-temporal-surfaces.ts
+++ b/scripts/qa-sfi-temporal-surfaces.ts
@@ -97,7 +97,7 @@ for (const token of [
   "epistemicClass: 'IMPORTED'",
   "role: 'national_field_scenario_analysis'",
   "status: llm.ok ? 'PROPOSED' : 'REJECTED'",
-  "llm.ok ? 'READY' :",
+  "const runStatus = !llm.ok ? 'BLOCKED'",
 ]) assert.ok(nationalScenario.includes(token), `national_scenario_runtime_missing:${token}`);
 assert.ok(nationalScenarioRoute.includes("requireRootActor('national_field.analyze')"), 'national_scenario_analysis_must_be_root_governed');
 

--- a/scripts/qa-sfi-temporal-surfaces.ts
+++ b/scripts/qa-sfi-temporal-surfaces.ts
@@ -8,9 +8,17 @@ const read = (relative: string) => readFileSync(path.join(root, relative), 'utf8
 const worldApi = read('src/app/api/field/map/world/route.ts');
 const worldUi = read('src/components/field/map/WorldFieldObservatory.tsx');
 const cognitive = read('src/app/api/field/map/world/cognitive/route.ts');
+const worldCycle = read('src/lib/world-observatory/worldCycle.ts');
 const publicTimeline = read('src/lib/observatory/public/worldSnapshotTimeline.ts');
 const publicTimelineUi = read('src/components/observatory/public/PublicObservatoryTimelineNavigator.tsx');
 const observatoryPage = read('src/app/observatory/page.tsx');
+const nationalField = read('src/lib/world-observatory/inegiNationalField.ts');
+const nationalFieldRoute = read('src/app/api/root/cognitive-twin/national-field/route.ts');
+const nationalScenario = read('src/lib/cognitive-twin/nationalFieldScenario.ts');
+const nationalScenarioRoute = read('src/app/api/root/cognitive-twin/national-field/analyze/route.ts');
+const directTwin = read('src/app/api/root/cognitive-twin/deliberate/route.ts');
+const twinState = read('src/lib/cognitive-twin/readState.ts');
+const twinUi = read('src/components/root/cognitive-twin/CognitiveTwinConsole.tsx');
 
 assert.ok(worldApi.includes('readPagedRows'), 'world_history_must_paginate');
 assert.ok(worldApi.includes("'world_hypotheses', 'cutoff_at'"), 'world_hypotheses_must_be_temporally_read');
@@ -40,10 +48,17 @@ for (const token of [
   "eq('status', 'APPROVED')",
   "role: 'world_field_frame_analysis'",
   'llmAugmentation: false',
-  "epistemicClass: 'PROPOSED'",
+  "epistemicClass: llm.ok ? 'PROPOSED' : 'MISSING'",
+  ".lte('fetched_at', cutoffAt)",
+  'knownByCutoff',
+  "status: llm.ok ? 'PROPOSED' : 'REJECTED'",
 ]) assert.ok(cognitive.includes(token), `world_field_cognitive_bridge_missing:${token}`);
 assert.ok(!/Math\.random|setInterval|setTimeout|while\s*\(\s*true\s*\)/.test(cognitive), 'world_field_cognitive_bridge_must_be_bounded_and_non_synthetic');
 assert.ok(/cannot rewrite observations|cannot rewrite/i.test(cognitive), 'world_field_cognitive_mutation_boundary_missing');
+
+assert.ok(worldCycle.includes(".gt('fetched_at', hypothesis.cutoff_at)"), 'world_outcome_calibration_must_use_acquisition_time');
+assert.ok(worldCycle.includes(".lte('fetched_at', now)"), 'world_outcome_calibration_must_bound_acquisition_time');
+assert.ok(!worldCycle.includes(".gt('observed_at', hypothesis.cutoff_at)"), 'world_outcome_calibration_must_not_backdate_knowledge');
 
 for (const token of [
   "from('worldspect_snapshots')",
@@ -57,6 +72,43 @@ assert.ok(publicTimelineUi.includes('Cada posición corresponde a un snapshot Wo
 assert.ok(observatoryPage.includes('<PublicObservatoryTimelineNavigator />'), 'public_observatory_timeline_not_rendered');
 assert.ok(!publicTimelineUi.includes('sfi_cognitive_twin_'), 'public_observatory_must_not_expose_private_cognitive_twin_corpus');
 
+for (const token of [
+  "INEGI_NATIONAL_FIELD_VERSION",
+  "sourceId: 'inegi-indicators'",
+  "sourceId: 'inegi-denue'",
+  "from('world_source_observations').upsert",
+  "epistemicClass: 'IMPORTED'",
+  'noAutomaticFrictionReading: true',
+  'noAutomaticHypothesisPromotion: true',
+  "rawPersonLevelEmbedding: false",
+  "plannedPrograms: ['ENOE', 'ENIGH', 'ENVIPE']",
+  'ingestionDoesNotBackdateKnowledge: true',
+]) assert.ok(nationalField.includes(token), `inegi_national_field_contract_missing:${token}`);
+assert.ok(!nationalField.includes("from('world_friction_readings')"), 'inegi_import_must_not_create_friction_readings');
+assert.ok(!nationalField.includes("from('world_hypotheses')"), 'inegi_import_must_not_promote_hypotheses');
+assert.ok(nationalFieldRoute.includes("requireRootActor('national_field.ingest')"), 'inegi_ingest_must_be_root_governed');
+
+for (const token of [
+  'INEGI_NATIONAL_SCENARIOS',
+  'executeSfiRuntime',
+  'runLlmTask',
+  ".eq('publisher', 'INEGI')",
+  ".lte('fetched_at', cutoffAt)",
+  "epistemicClass: 'IMPORTED'",
+  "role: 'national_field_scenario_analysis'",
+  "status: llm.ok ? 'PROPOSED' : 'REJECTED'",
+  "llm.ok ? 'READY' :",
+]) assert.ok(nationalScenario.includes(token), `national_scenario_runtime_missing:${token}`);
+assert.ok(nationalScenarioRoute.includes("requireRootActor('national_field.analyze')"), 'national_scenario_analysis_must_be_root_governed');
+
+assert.ok(!directTwin.includes("status: 'READY'"), 'direct_twin_must_not_persist_unconditional_ready');
+assert.ok(directTwin.includes("const runStatus = !llm.ok ? 'BLOCKED'"), 'direct_twin_degraded_provider_must_block_run');
+assert.ok(directTwin.includes("status: llm.ok ? 'PROPOSED' : 'REJECTED'"), 'direct_twin_envelope_must_reflect_provider_failure');
+assert.ok(twinState.includes('providerExecutionObserved'), 'twin_readiness_must_require_observed_provider_execution');
+assert.ok(twinState.includes(".in('status', ['APPROVED', 'APPROVED_WITH_LIMITS'])"), 'twin_model_readiness_must_require_approved_model_status');
+assert.ok(twinUi.includes('EJECUCIÓN LLM NO VERIFICADA'), 'twin_ui_must_distinguish_configuration_from_execution');
+assert.ok(twinUi.includes('<NationalFieldPanel />'), 'twin_ui_must_expose_national_field_surface');
+
 console.log(JSON.stringify({
   ok: true,
   worldField: {
@@ -65,6 +117,7 @@ console.log(JSON.stringify({
     allHypothesesVisible: true,
     stickyMapContext: true,
     cognitiveFrameExecution: true,
+    noTemporalKnowledgeLeakage: true,
   },
   cognitiveBridge: {
     agents: true,
@@ -72,6 +125,15 @@ console.log(JSON.stringify({
     canonicalTwinMemoryOnly: true,
     approvedRulesOnly: true,
     proposedNotObserved: true,
+    degradedProviderCannotBecomeReady: true,
+  },
+  nationalField: {
+    inegiIndicators: true,
+    denue: true,
+    scenarios: true,
+    microdataAggregationBoundary: true,
+    automaticFrictionPromotion: false,
+    automaticHypothesisPromotion: false,
   },
   publicObservatory: {
     persistedWorldSpectFrames: true,

--- a/src/app/api/field/map/world/cognitive/route.ts
+++ b/src/app/api/field/map/world/cognitive/route.ts
@@ -50,6 +50,15 @@ function confidence(value: unknown) {
   return Math.max(0, Math.min(1, finite(value, 0)));
 }
 
+function knownByCutoff(row: Row, cutoffMs: number) {
+  const fetchedAt = Date.parse(text(row.fetched_at));
+  if (!Number.isFinite(fetchedAt) || fetchedAt > cutoffMs) return false;
+  const released = text(row.released_at);
+  if (!released) return true;
+  const releasedAt = Date.parse(released);
+  return !Number.isFinite(releasedAt) || releasedAt <= cutoffMs;
+}
+
 export async function POST(request: Request) {
   const authClient = await createServerSupabaseClient();
   const { data: auth, error: authError } = await authClient.auth.getUser();
@@ -67,9 +76,10 @@ export async function POST(request: Request) {
 
   const [observationsResult, hypothesesResult, canonicalMemoryResult, approvedRulesResult] = await Promise.all([
     db.from('world_source_observations')
-      .select('id,source_id,source_family,publisher,title,summary,observed_at,latitude,longitude,affected_systems,actors,confidence')
+      .select('id,source_id,source_family,publisher,title,summary,observed_at,released_at,fetched_at,latitude,longitude,affected_systems,actors,confidence')
       .gte('observed_at', windowStart)
       .lte('observed_at', cutoffAt)
+      .lte('fetched_at', cutoffAt)
       .order('observed_at', { ascending: true })
       .limit(500),
     db.from('world_hypotheses')
@@ -96,7 +106,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, error: 'WORLD_FRAME_READ_FAILED', details: primaryError.message }, { status: 503 });
   }
 
-  const observations = (observationsResult.data ?? []).map(record);
+  const observations = (observationsResult.data ?? []).map(record).filter((row) => knownByCutoff(row, cutoffMs));
   const hypotheses = (hypothesesResult.data ?? []).map(record);
   const observationIds = observations.map((row) => text(row.id)).filter(Boolean);
   const readingsResult = observationIds.length
@@ -123,11 +133,14 @@ export async function POST(request: Request) {
         title: text(row.title),
         summary: text(row.summary),
         observedAt: text(row.observed_at),
+        releasedAt: text(row.released_at),
+        fetchedAt: text(row.fetched_at),
+        knowledgeAt: text(row.fetched_at),
         affectedSystems: Array.isArray(row.affected_systems) ? row.affected_systems : [],
         actors: Array.isArray(row.actors) ? row.actors : [],
         geography: row.latitude === null || row.longitude === null ? null : { lat: Number(row.latitude), lng: Number(row.longitude) },
         reading,
-        epistemicClass: 'OBSERVED_WITH_DERIVED_SFI_READING',
+        epistemicClass: reading ? 'OBSERVED_WITH_DERIVED_SFI_READING' : 'IMPORTED_OBSERVATION',
       },
     };
   }).filter((item) => item.id);
@@ -155,6 +168,7 @@ export async function POST(request: Request) {
       windowStart,
       windowHours,
       requestedBy: auth.user.id,
+      temporalKnowledgeRule: 'An observation is admissible only if SFI fetched it by the cutoff and, when a release timestamp exists, the source had released it by the cutoff.',
       rule: 'The temporal frame is persisted evidence. Agent output is derived/inferred context. The LLM synthesis is PROPOSED and cannot rewrite observations, hypotheses, outcomes, memory or canon.',
     },
   };
@@ -214,7 +228,7 @@ export async function POST(request: Request) {
   const evidenceRefs = evidence.map((item) => item.id);
   const envelope = createCognitiveTwinEnvelope({
     taskId,
-    status: 'PROPOSED',
+    status: llm.ok ? 'PROPOSED' : 'REJECTED',
     modelId: `${llm.provider}:${llm.model}`,
     result: {
       frame: { cutoffAt, windowStart, windowHours },
@@ -224,6 +238,7 @@ export async function POST(request: Request) {
       hypothesisCount: hypotheses.length,
       provider: llm.provider,
       model: llm.model,
+      providerExecutionSucceeded: llm.ok,
       latencyMs: llm.latency_ms,
       cognitiveTwinCorpus: {
         canonicalMemoryRecords: canonicalMemory.length,
@@ -241,18 +256,19 @@ export async function POST(request: Request) {
     actionsExecuted: [
       ...cycle.executedAgents.map((agent) => `cognitive:${agent}`),
       'read_canonical_cognitive_twin_corpus',
-      'llm_frame_synthesis',
+      llm.ok ? 'llm_frame_synthesis' : 'llm_frame_synthesis_failed',
     ],
-    recommendedTransition: evidence.length ? 'VERIFYING' : 'EVIDENCE_PENDING',
+    recommendedTransition: !llm.ok ? 'BLOCKED' : evidence.length ? 'VERIFYING' : 'EVIDENCE_PENDING',
   });
 
+  const runStatus = !llm.ok ? 'BLOCKED' : evidence.length ? 'READY' : 'EVIDENCE_PENDING';
   const persisted = await db.from('sfi_cognitive_twin_runs').insert({
     task_id: taskId,
     contract_version: envelope.contractVersion,
     provider: llm.provider,
     model: llm.model,
     role: 'world_field_frame_analysis',
-    status: 'READY',
+    status: runStatus,
     objective: `Interpret the persisted World Field frame ending ${cutoffAt} without mutating evidence or world state.`,
     input_snapshot: {
       requestedBy: auth.user.id,
@@ -262,6 +278,7 @@ export async function POST(request: Request) {
       observationCount: evidence.length,
       hypothesisCount: hypotheses.length,
       requestedAgents: FRAME_AGENT_SET,
+      temporalKnowledgeRule: 'fetched_at <= cutoff and released_at <= cutoff when known',
     },
     output_envelope: envelope,
     evidence_refs: evidenceRefs,
@@ -278,10 +295,11 @@ export async function POST(request: Request) {
     ok: true,
     frame: { cutoffAt, windowStart, windowHours },
     synthesis: llm.result,
-    epistemicClass: 'PROPOSED',
+    epistemicClass: llm.ok ? 'PROPOSED' : 'MISSING',
+    cognitiveExecution: llm.ok ? 'EXECUTED' : 'DEGRADED',
     agents: cycle.executedAgents,
-    llm: { provider: llm.provider, model: llm.model, latencyMs: llm.latency_ms, warnings: llm.warnings },
-    twin: { runId: persisted.data.id, role: persisted.data.role, corpusWarnings },
+    llm: { ok: llm.ok, provider: llm.provider, model: llm.model, latencyMs: llm.latency_ms, warnings: llm.warnings },
+    twin: { runId: persisted.data.id, role: persisted.data.role, status: persisted.data.status, corpusWarnings },
     evidenceRefs,
     limitations: envelope.limitations,
   });

--- a/src/app/api/root/cognitive-twin/deliberate/route.ts
+++ b/src/app/api/root/cognitive-twin/deliberate/route.ts
@@ -39,12 +39,13 @@ export async function POST(request: Request) {
   const warnings = [decisions.error?.message, memory.error?.message].filter((item): item is string => Boolean(item));
   const approvedDecisions = decisions.data ?? [];
   const institutionalMemory = memory.data ?? [];
+  const evidencePresent = approvedDecisions.length > 0 || institutionalMemory.length > 0;
   const fallback = [
     'Cognitive Twin deliberation unavailable through an LLM provider.',
     `Question: ${question}`,
     `Approved founder decisions available: ${approvedDecisions.length}.`,
     `Institutional memory records available: ${institutionalMemory.length}.`,
-    'No conclusion is promoted. Review the underlying corpus manually.',
+    'No cognitive execution is declared. Review the underlying corpus manually.',
   ].join('\n');
 
   const llm = await runLlmTask({
@@ -71,7 +72,7 @@ export async function POST(request: Request) {
   const authority = evaluateCognitiveTwinAuthority({
     action: 'propose',
     founderAbsent: false,
-    evidencePresent: approvedDecisions.length > 0 || institutionalMemory.length > 0,
+    evidencePresent,
   });
   const finishedAt = new Date().toISOString();
   const taskId = `cognitive-twin:deliberate:${Date.now()}`;
@@ -81,7 +82,7 @@ export async function POST(request: Request) {
   ])).slice(0, 80);
 
   const envelope = createCognitiveTwinEnvelope({
-    status: 'PROPOSED',
+    status: llm.ok ? 'PROPOSED' : 'REJECTED',
     taskId,
     modelId: `${llm.provider}:${llm.model}`,
     result: {
@@ -94,14 +95,20 @@ export async function POST(request: Request) {
       },
       provider: llm.provider,
       model: llm.model,
+      providerExecutionSucceeded: llm.ok,
       latencyMs: llm.latency_ms,
     },
     limitations: [...warnings, ...llm.warnings],
-    missingEvidence: approvedDecisions.length || institutionalMemory.length ? [] : ['approved_founder_decisions_or_institutional_memory'],
-    actionsExecuted: ['read_approved_decisions', 'read_institutional_memory', 'llm_deliberation'],
-    recommendedTransition: 'VERIFYING',
+    missingEvidence: evidencePresent ? [] : ['approved_founder_decisions_or_institutional_memory'],
+    actionsExecuted: [
+      'read_approved_decisions',
+      'read_institutional_memory',
+      llm.ok ? 'llm_deliberation' : 'llm_deliberation_failed',
+    ],
+    recommendedTransition: !llm.ok ? 'BLOCKED' : evidencePresent ? 'VERIFYING' : 'EVIDENCE_PENDING',
   });
 
+  const runStatus = !llm.ok ? 'BLOCKED' : evidencePresent ? 'READY' : 'EVIDENCE_PENDING';
   const persisted = await gate.ctx.service
     .from('sfi_cognitive_twin_runs')
     .insert({
@@ -110,13 +117,14 @@ export async function POST(request: Request) {
       provider: llm.provider,
       model: llm.model,
       role: 'cognitive_twin_deliberation',
-      status: 'READY',
+      status: runStatus,
       objective: question,
       input_snapshot: {
         question,
         approvedDecisionCount: approvedDecisions.length,
         memoryCount: institutionalMemory.length,
         requestedBy: gate.ctx.user.id,
+        providerExecutionSucceeded: llm.ok,
       },
       output_envelope: envelope,
       evidence_refs: evidenceRefs,
@@ -137,8 +145,10 @@ export async function POST(request: Request) {
     target: taskId,
     payload: {
       runId: persisted.data.id,
+      runStatus,
       provider: llm.provider,
       model: llm.model,
+      providerExecutionSucceeded: llm.ok,
       authorityDecision: authority.decision,
       evidenceRefs: evidenceRefs.length,
     },
@@ -146,5 +156,11 @@ export async function POST(request: Request) {
   });
   if (!audit.ok) return NextResponse.json(audit, { status: 500 });
 
-  return NextResponse.json({ ok: true, run: persisted.data, envelope, audit });
+  return NextResponse.json({
+    ok: llm.ok,
+    cognitiveExecution: llm.ok ? 'EXECUTED' : 'DEGRADED',
+    run: persisted.data,
+    envelope,
+    audit,
+  }, { status: llm.ok ? 200 : 503 });
 }

--- a/src/app/api/root/cognitive-twin/national-field/analyze/route.ts
+++ b/src/app/api/root/cognitive-twin/national-field/analyze/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { runNationalFieldScenario } from '@/lib/cognitive-twin/nationalFieldScenario';
+import { auditRootAction, requireRootActor } from '@/lib/root/server';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 300;
+
+type Row = Record<string, unknown>;
+
+function text(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+export async function POST(request: Request) {
+  const gate = await requireRootActor('national_field.analyze');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+  const body = await request.json().catch(() => ({})) as Row;
+  const scenarioId = text(body.scenarioId);
+  if (!scenarioId) return NextResponse.json({ ok: false, error: 'scenarioId_required' }, { status: 400 });
+
+  const result = await runNationalFieldScenario({
+    scenarioId,
+    cutoffAt: text(body.cutoffAt),
+    referenceStart: text(body.referenceStart),
+    referenceEnd: text(body.referenceEnd),
+    requestedBy: gate.ctx.user.id,
+  });
+
+  if (!result.ok) return NextResponse.json(result, { status: 503 });
+  const audit = await auditRootAction({
+    actorId: gate.ctx.user.id,
+    action: 'national_field.analyze',
+    target: result.run.task_id,
+    payload: {
+      runId: result.run.id,
+      scenarioId,
+      observationCount: result.observationCount,
+      cognitiveExecution: result.cognitiveExecution,
+      provider: result.llm.provider,
+      model: result.llm.model,
+      evidenceRefs: result.evidenceRefs.length,
+    },
+    request,
+  });
+  if (!audit.ok) return NextResponse.json(audit, { status: 500 });
+
+  return NextResponse.json({ ...result, audit });
+}

--- a/src/app/api/root/cognitive-twin/national-field/route.ts
+++ b/src/app/api/root/cognitive-twin/national-field/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { auditRootAction, requireRootActor } from '@/lib/root/server';
+import {
+  ingestInegiNationalField,
+  readInegiNationalFieldConfiguration,
+} from '@/lib/world-observatory/inegiNationalField';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 300;
+
+type Row = Record<string, unknown>;
+
+export async function GET() {
+  const gate = await requireRootActor('national_field.read');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+  return NextResponse.json({ ok: true, nationalField: readInegiNationalFieldConfiguration() });
+}
+
+export async function POST(request: Request) {
+  const gate = await requireRootActor('national_field.ingest');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  const body = await request.json().catch(() => ({})) as Row;
+  const result = await ingestInegiNationalField({
+    includeStates: body.includeStates === true,
+    includeDenue: body.includeDenue === true,
+  });
+
+  const audit = await auditRootAction({
+    actorId: gate.ctx.user.id,
+    action: 'national_field.ingest',
+    target: 'world_source_observations',
+    payload: {
+      collected: result.collected,
+      persisted: result.persisted,
+      sources: result.sources,
+      warningCount: result.warnings.length,
+      includeStates: body.includeStates === true,
+      includeDenue: body.includeDenue === true,
+      epistemicClass: result.epistemicClass,
+      noAutomaticFrictionReading: result.noAutomaticFrictionReading,
+      noAutomaticHypothesisPromotion: result.noAutomaticHypothesisPromotion,
+    },
+    request,
+  });
+
+  if (!audit.ok) return NextResponse.json(audit, { status: 500 });
+  return NextResponse.json({ ok: result.ok, nationalField: result, audit }, { status: result.ok ? 200 : 503 });
+}

--- a/src/components/root/cognitive-twin/CognitiveTwinConsole.tsx
+++ b/src/components/root/cognitive-twin/CognitiveTwinConsole.tsx
@@ -1,6 +1,7 @@
 import { HumanReadableRecord } from '@/components/shared/HumanReadableRecord';
 import { FounderDecisionCandidateForm } from './FounderDecisionCandidateForm';
 import { CognitiveTwinDeliberationPanel } from './CognitiveTwinDeliberationPanel';
+import { NationalFieldPanel } from './NationalFieldPanel';
 import type { CognitiveTwinState } from '@/lib/cognitive-twin/readState';
 
 function yesNo(value: boolean) {
@@ -10,9 +11,11 @@ function yesNo(value: boolean) {
 function implementationLabel(state: CognitiveTwinState) {
   if (!state.implementation.contractImplemented) return 'SIN CONTRATO EJECUTABLE';
   if (!state.implementation.databaseReady) return 'IMPLEMENTADO · PERSISTENCIA PENDIENTE';
+  if (!state.implementation.providerConfigured) return 'NÚCLEO IMPLEMENTADO · PROVEEDOR NO CONFIGURADO';
+  if (!state.implementation.providerExecutionObserved) return 'NÚCLEO IMPLEMENTADO · EJECUCIÓN LLM NO VERIFICADA';
   if (!state.implementation.approvedDecisionCorpusReady) return 'NÚCLEO ACTIVO · CORPUS DEL FUNDADOR PENDIENTE';
-  if (!state.implementation.modelEvaluationRegistryReady) return 'NÚCLEO ACTIVO · MODELOS SIN EVALUAR';
-  if (!state.implementation.institutionalAutonomyProven) return 'OPERABLE · AUTONOMÍA NO DEMOSTRADA';
+  if (!state.implementation.modelEvaluationRegistryReady) return 'NÚCLEO ACTIVO · MODELOS SIN APROBACIÓN EVALUADA';
+  if (!state.implementation.institutionalAutonomyProven) return 'EJECUCIÓN OBSERVADA · AUTONOMÍA NO DEMOSTRADA';
   return 'AUTONOMÍA DEMOSTRADA';
 }
 
@@ -27,10 +30,10 @@ export function CognitiveTwinConsole({ state }: { state: CognitiveTwinState }) {
       </header>
 
       <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(220px,1fr))', gap: 12, marginTop: 18 }}>
-        <article style={card}><small style={eyebrow}>ESTADO</small><strong style={big}>{implementationLabel(state)}</strong><span style={muted}>No se declara autonomía hasta que existan pruebas.</span></article>
+        <article style={card}><small style={eyebrow}>ESTADO</small><strong style={big}>{implementationLabel(state)}</strong><span style={muted}>Configuración no equivale a ejecución; ejecución no equivale a autonomía.</span></article>
         <article style={card}><small style={eyebrow}>MEMORIA INSTITUCIONAL</small><strong style={big}>{state.counts.memory ?? 'N/D'}</strong><span style={muted}>registros persistidos</span></article>
         <article style={card}><small style={eyebrow}>DECISIONES DEL FUNDADOR</small><strong style={big}>{state.counts.approvedDecisions}</strong><span style={muted}>reglas aprobadas en el corpus</span></article>
-        <article style={card}><small style={eyebrow}>MODELOS REGISTRADOS</small><strong style={big}>{state.counts.models}</strong><span style={muted}>ninguno se aprueba por estar configurado</span></article>
+        <article style={card}><small style={eyebrow}>MODELOS</small><strong style={big}>{state.counts.approvedModels}/{state.counts.models}</strong><span style={muted}>aprobados / registrados</span></article>
         <article style={card}><small style={eyebrow}>EVALUACIONES</small><strong style={big}>{state.counts.evaluations ?? 'N/D'}</strong><span style={muted}>pruebas persistidas</span></article>
         <article style={card}><small style={eyebrow}>EJECUCIONES</small><strong style={big}>{state.counts.runs ?? 'N/D'}</strong><span style={muted}>runs institucionales registrados</span></article>
       </section>
@@ -44,6 +47,7 @@ export function CognitiveTwinConsole({ state }: { state: CognitiveTwinState }) {
       ) : null}
 
       <CognitiveTwinDeliberationPanel />
+      <NationalFieldPanel />
 
       <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(320px,1fr))', gap: 12, marginTop: 12 }}>
         <article style={card}>
@@ -51,9 +55,11 @@ export function CognitiveTwinConsole({ state }: { state: CognitiveTwinState }) {
           <dl style={{ display: 'grid', gap: 8, margin: 0 }}>
             <Row label="Contrato ejecutable" value={yesNo(state.implementation.contractImplemented)} />
             <Row label="Persistencia del Twin" value={yesNo(state.implementation.databaseReady)} />
-            <Row label="Router de modelos disponible" value={yesNo(state.implementation.providerRouterReady)} />
+            <Row label="Proveedor configurado" value={yesNo(state.implementation.providerConfigured)} />
+            <Row label="Ejecución LLM observada" value={yesNo(state.implementation.providerExecutionObserved)} />
+            <Row label="Router verificado operativamente" value={yesNo(state.implementation.providerRouterReady)} />
             <Row label="Corpus aprobado del fundador" value={yesNo(state.implementation.approvedDecisionCorpusReady)} />
-            <Row label="Modelos evaluados y registrados" value={yesNo(state.implementation.modelEvaluationRegistryReady)} />
+            <Row label="Modelo aprobado mediante evaluación" value={yesNo(state.implementation.modelEvaluationRegistryReady)} />
             <Row label="Autonomía institucional demostrada" value={yesNo(state.implementation.institutionalAutonomyProven)} />
           </dl>
         </article>
@@ -61,7 +67,7 @@ export function CognitiveTwinConsole({ state }: { state: CognitiveTwinState }) {
         <article style={card}>
           <h2 style={heading}>QUÉ REQUIERE DEL FUNDADOR</h2>
           <p style={paragraph}>Nada adicional para continuar programando el núcleo.</p>
-          <p style={paragraph}>Para constituir tu criterio institucional sí se necesitan decisiones reales: momentos donde corregiste una inferencia, rechazaste una conclusión, exigiste evidencia o reservaste una decisión. No tienes que escribir un manual de tu personalidad.</p>
+          <p style={paragraph}>Para constituir criterio institucional sí se necesitan decisiones reales: momentos donde corregiste una inferencia, rechazaste una conclusión, exigiste evidencia o reservaste una decisión. El campo nacional permite además acumular casos externos sin depender de que el fundador falle.</p>
           <p style={paragraph}>Cada registro entra como candidato. No se convierte automáticamente en regla canónica.</p>
         </article>
 
@@ -74,7 +80,7 @@ export function CognitiveTwinConsole({ state }: { state: CognitiveTwinState }) {
 
       <section style={{ ...card, marginTop: 12 }}>
         <h2 style={heading}>MODELOS DISPONIBLES EN ESTE DESPLIEGUE</h2>
-        <p style={muted}>Configurado no significa aprobado. La autorización depende de evaluaciones persistidas.</p>
+        <p style={muted}>Configurado no significa ejecutado ni aprobado. La autorización depende de ejecución observable y evaluaciones persistidas.</p>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(230px,1fr))', gap: 8, marginTop: 12 }}>
           {state.providers.map((provider) => (
             <div key={provider.id} style={{ border: '1px solid #29251b', padding: 12, display: 'grid', gap: 5 }}>
@@ -86,6 +92,7 @@ export function CognitiveTwinConsole({ state }: { state: CognitiveTwinState }) {
           ))}
         </div>
         {!configured.length ? <p style={{ color: '#d0a58e' }}>No hay ningún proveedor LLM configurado en este runtime. El contrato y la memoria pueden existir, pero no habrá ejecución cognitiva por modelo.</p> : null}
+        {configured.length && !state.implementation.providerExecutionObserved ? <p style={{ color: '#d0a58e' }}>Hay proveedor configurado, pero todavía no existe una ejecución reciente no degradada que permita declararlo operativo.</p> : null}
       </section>
 
       <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(300px,1fr))', gap: 12, marginTop: 12 }}>

--- a/src/components/root/cognitive-twin/NationalFieldPanel.tsx
+++ b/src/components/root/cognitive-twin/NationalFieldPanel.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type Row = Record<string, unknown>;
+
+type Scenario = {
+  id: string;
+  label: string;
+  question: string;
+  lanes: readonly string[];
+};
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown, fallback = '—') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function scenariosFrom(value: unknown): Scenario[] {
+  return Array.isArray(value) ? value.flatMap((item) => {
+    const row = record(item);
+    const id = text(row.id, '');
+    const label = text(row.label, '');
+    const question = text(row.question, '');
+    if (!id || !label || !question) return [];
+    return [{ id, label, question, lanes: Array.isArray(row.lanes) ? row.lanes.map(String) : [] }];
+  }) : [];
+}
+
+export function NationalFieldPanel() {
+  const [configuration, setConfiguration] = useState<Row | null>(null);
+  const [scenarioId, setScenarioId] = useState('');
+  const [referenceStart, setReferenceStart] = useState('');
+  const [referenceEnd, setReferenceEnd] = useState('');
+  const [running, setRunning] = useState<string | null>(null);
+  const [result, setResult] = useState<Row | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch('/api/root/cognitive-twin/national-field', { credentials: 'include', cache: 'no-store' })
+      .then(async (response) => {
+        const body = await response.json().catch(() => null) as Row | null;
+        if (!response.ok || !body?.ok) throw new Error(text(body?.error, `HTTP ${response.status}`));
+        if (cancelled) return;
+        const field = record(body.nationalField);
+        setConfiguration(field);
+        const first = scenariosFrom(field.scenarios)[0];
+        if (first) setScenarioId(first.id);
+      })
+      .catch((caught) => { if (!cancelled) setError(caught instanceof Error ? caught.message : 'No fue posible leer National Field.'); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const scenarios = useMemo(() => scenariosFrom(configuration?.scenarios), [configuration]);
+  const activeScenario = scenarios.find((item) => item.id === scenarioId) ?? scenarios[0] ?? null;
+
+  async function ingest(includeStates: boolean, includeDenue: boolean) {
+    if (running) return;
+    setRunning(includeStates ? 'ingest-full' : 'ingest-national');
+    setError(null);
+    try {
+      const response = await fetch('/api/root/cognitive-twin/national-field', {
+        method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ includeStates, includeDenue }),
+      });
+      const body = await response.json().catch(() => null) as Row | null;
+      if (!response.ok || !body) throw new Error(text(body?.error, `HTTP ${response.status}`));
+      setResult(body);
+      if (body.ok !== true) setError(text(record(body.nationalField).warnings, 'La adquisición terminó degradada.'));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'No fue posible adquirir el campo nacional.');
+    } finally { setRunning(null); }
+  }
+
+  async function analyze() {
+    if (!activeScenario || running) return;
+    setRunning('analyze');
+    setError(null);
+    try {
+      const response = await fetch('/api/root/cognitive-twin/national-field/analyze', {
+        method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          scenarioId: activeScenario.id,
+          referenceStart: referenceStart ? new Date(`${referenceStart}T00:00:00`).toISOString() : null,
+          referenceEnd: referenceEnd ? new Date(`${referenceEnd}T23:59:59`).toISOString() : null,
+        }),
+      });
+      const body = await response.json().catch(() => null) as Row | null;
+      if (!response.ok || !body) throw new Error(text(body?.error, `HTTP ${response.status}`));
+      setResult(body);
+      if (body.ok !== true) setError(text(body.error, 'El escenario no produjo una ejecución válida.'));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'No fue posible ejecutar el escenario nacional.');
+    } finally { setRunning(null); }
+  }
+
+  const fieldResult = record(result?.nationalField);
+  const envelope = record(result?.envelope);
+  const payload = record(envelope.result);
+  const scenarioResult = record(payload.scenario);
+
+  return <section className="ct-national-field">
+    <header>
+      <div><span>EXTERNAL LEARNING SUBSTRATE · MÉXICO</span><h2>INEGI NATIONAL OBSERVATION FIELD</h2></div>
+      <strong>IMPORTED ≠ FRICTION</strong>
+    </header>
+    <p>El Cognitive Twin puede observar series y agregados oficiales sin convertirlos automáticamente en fricción, causalidad o canon. Tiempo de referencia, publicación y adquisición permanecen separados.</p>
+
+    <div className="ct-national-health">
+      <span>INDICADORES <b>{configuration?.indicatorsConfigured === true ? 'CONFIGURADO' : 'TOKEN PENDIENTE'}</b></span>
+      <span>DENUE <b>{configuration?.denueConfigured === true ? 'CONFIGURADO' : 'TOKEN PENDIENTE'}</b></span>
+      <span>MICRODATOS <b>BATCH / AGREGADOS</b></span>
+      <span>PERSON-LEVEL EMBEDDING <b>PROHIBIDO</b></span>
+    </div>
+
+    <div className="ct-national-actions">
+      <button type="button" disabled={Boolean(running)} onClick={() => void ingest(false, false)}>{running === 'ingest-national' ? 'ADQUIRIENDO…' : 'ADQUIRIR SERIES NACIONALES'}</button>
+      <button type="button" disabled={Boolean(running)} onClick={() => void ingest(true, true)}>{running === 'ingest-full' ? 'ADQUIRIENDO…' : 'ADQUIRIR 32 ENTIDADES + DENUE'}</button>
+    </div>
+
+    <div className="ct-national-scenario">
+      <label>ESCENARIO<select value={activeScenario?.id ?? ''} onChange={(event) => setScenarioId(event.target.value)}>{scenarios.map((scenario) => <option key={scenario.id} value={scenario.id}>{scenario.id} · {scenario.label}</option>)}</select></label>
+      <div className="ct-national-window"><label>DESDE<input type="date" value={referenceStart} onChange={(event) => setReferenceStart(event.target.value)} /></label><label>HASTA<input type="date" value={referenceEnd} onChange={(event) => setReferenceEnd(event.target.value)} /></label></div>
+      {activeScenario ? <div className="ct-national-question"><b>{activeScenario.question}</b><span>{activeScenario.lanes.join(' + ')}</span></div> : null}
+      <button type="button" disabled={Boolean(running) || !activeScenario} onClick={() => void analyze()}>{running === 'analyze' ? 'ANALIZANDO…' : 'EJECUTAR COGNITIVE TWIN SOBRE ESCENARIO'}</button>
+    </div>
+
+    {error ? <div className="ct-national-error">{error}</div> : null}
+    {result ? <article className="ct-national-result">
+      {fieldResult.collected !== undefined ? <div><b>ADQUISICIÓN</b><span>{text(fieldResult.collected, '0')} registros recibidos · {text(fieldResult.persisted, '0')} persistidos</span><span>{text(fieldResult.epistemicClass, 'IMPORTED')} · sin MIHM/fricción automática · sin promoción de hipótesis</span></div> : null}
+      {scenarioResult.id ? <div><b>{text(scenarioResult.id)} · {text(scenarioResult.label)}</b><span>{text(result.observationCount, '0')} observaciones admisibles · {text(result.cognitiveExecution)}</span><span>{text(record(result.run).status)} · {text(record(result.llm).provider)}/{text(record(result.llm).model)}</span><pre>{text(payload.synthesis, 'MISSING · no existe síntesis cognitiva válida.')}</pre></div> : null}
+    </article> : null}
+
+    <style jsx>{`
+      .ct-national-field{border:1px solid #343023;background:#0b0a08;padding:18px;margin-top:12px;color:#d8d0bf;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}.ct-national-field header{display:flex;justify-content:space-between;gap:20px;border-bottom:1px solid #2a251a;padding-bottom:13px}.ct-national-field header span{font-size:8px;letter-spacing:.16em;color:#8d7b4f}.ct-national-field h2{margin:5px 0 0;font:400 22px Georgia,serif;color:#d9c37e}.ct-national-field header strong{font-size:8px;color:#c59068;border:1px solid #5c4931;padding:6px 8px;height:max-content}.ct-national-field>p{color:#918878;font:12px/1.65 Georgia,serif;max-width:1100px}.ct-national-health{display:flex;flex-wrap:wrap;gap:7px;margin:12px 0}.ct-national-health span{border:1px solid #29251b;padding:7px 9px;color:#6f685d;font-size:8px}.ct-national-health b{color:#ae9c70}.ct-national-actions{display:flex;flex-wrap:wrap;gap:8px}.ct-national-field button{border:1px solid #6b5930;background:transparent;color:#d2b66c;padding:10px 13px;font:9px inherit;cursor:pointer}.ct-national-field button:disabled{opacity:.4}.ct-national-scenario{display:grid;gap:10px;border-top:1px solid #29251b;margin-top:14px;padding-top:14px}.ct-national-scenario label{display:grid;gap:6px;color:#786c4d;font-size:8px;letter-spacing:.11em}.ct-national-scenario select,.ct-national-scenario input{background:#070706;border:1px solid #2f2a1e;color:#c7bda8;padding:9px;font:10px ui-monospace,monospace}.ct-national-window{display:flex;gap:8px}.ct-national-window label{flex:1}.ct-national-question{display:grid;gap:5px;border-left:2px solid #5d4e2e;padding:8px 10px}.ct-national-question b{color:#c7b982;font:13px/1.5 Georgia,serif}.ct-national-question span{color:#70695e;font-size:8px}.ct-national-error{margin-top:10px;color:#d09a7e;font-size:9px}.ct-national-result{margin-top:14px;border-top:1px solid #29251b;padding-top:12px}.ct-national-result>div{display:grid;gap:6px}.ct-national-result b{color:#c8b371}.ct-national-result span{color:#8e8577;font-size:9px}.ct-national-result pre{white-space:pre-wrap;overflow-wrap:anywhere;color:#bbb2a1;font:13px/1.7 Georgia,serif;margin:10px 0 0}@media(max-width:720px){.ct-national-window{display:grid}.ct-national-field header{display:grid}}
+    `}</style>
+  </section>;
+}

--- a/src/components/root/cognitive-twin/NationalFieldPanel.tsx
+++ b/src/components/root/cognitive-twin/NationalFieldPanel.tsx
@@ -19,6 +19,14 @@ function text(value: unknown, fallback = '—') {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }
 
+function display(value: unknown, fallback = '—') {
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (Array.isArray(value) && value.length) return value.map(String).join(' · ');
+  return fallback;
+}
+
 function scenariosFrom(value: unknown): Scenario[] {
   return Array.isArray(value) ? value.flatMap((item) => {
     const row = record(item);
@@ -70,7 +78,7 @@ export function NationalFieldPanel() {
       const body = await response.json().catch(() => null) as Row | null;
       if (!response.ok || !body) throw new Error(text(body?.error, `HTTP ${response.status}`));
       setResult(body);
-      if (body.ok !== true) setError(text(record(body.nationalField).warnings, 'La adquisición terminó degradada.'));
+      if (body.ok !== true) setError(display(record(body.nationalField).warnings, 'La adquisición terminó degradada.'));
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'No fue posible adquirir el campo nacional.');
     } finally { setRunning(null); }
@@ -92,7 +100,7 @@ export function NationalFieldPanel() {
       const body = await response.json().catch(() => null) as Row | null;
       if (!response.ok || !body) throw new Error(text(body?.error, `HTTP ${response.status}`));
       setResult(body);
-      if (body.ok !== true) setError(text(body.error, 'El escenario no produjo una ejecución válida.'));
+      if (body.ok !== true) setError(display(body.error, 'El escenario no produjo una ejecución válida.'));
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'No fue posible ejecutar el escenario nacional.');
     } finally { setRunning(null); }
@@ -131,8 +139,8 @@ export function NationalFieldPanel() {
 
     {error ? <div className="ct-national-error">{error}</div> : null}
     {result ? <article className="ct-national-result">
-      {fieldResult.collected !== undefined ? <div><b>ADQUISICIÓN</b><span>{text(fieldResult.collected, '0')} registros recibidos · {text(fieldResult.persisted, '0')} persistidos</span><span>{text(fieldResult.epistemicClass, 'IMPORTED')} · sin MIHM/fricción automática · sin promoción de hipótesis</span></div> : null}
-      {scenarioResult.id ? <div><b>{text(scenarioResult.id)} · {text(scenarioResult.label)}</b><span>{text(result.observationCount, '0')} observaciones admisibles · {text(result.cognitiveExecution)}</span><span>{text(record(result.run).status)} · {text(record(result.llm).provider)}/{text(record(result.llm).model)}</span><pre>{text(payload.synthesis, 'MISSING · no existe síntesis cognitiva válida.')}</pre></div> : null}
+      {fieldResult.collected !== undefined ? <div><b>ADQUISICIÓN</b><span>{display(fieldResult.collected, '0')} registros recibidos · {display(fieldResult.persisted, '0')} persistidos</span><span>{display(fieldResult.epistemicClass, 'IMPORTED')} · sin MIHM/fricción automática · sin promoción de hipótesis</span></div> : null}
+      {scenarioResult.id ? <div><b>{display(scenarioResult.id)} · {display(scenarioResult.label)}</b><span>{display(result.observationCount, '0')} observaciones admisibles · {display(result.cognitiveExecution)}</span><span>{display(record(result.run).status)} · {display(record(result.llm).provider)}/{display(record(result.llm).model)}</span><pre>{display(payload.synthesis, 'MISSING · no existe síntesis cognitiva válida.')}</pre></div> : null}
     </article> : null}
 
     <style jsx>{`

--- a/src/lib/cognitive-twin/nationalFieldScenario.ts
+++ b/src/lib/cognitive-twin/nationalFieldScenario.ts
@@ -1,0 +1,298 @@
+import 'server-only';
+
+import { runLlmTask } from '@/lib/ai/providerRouter';
+import { createCognitiveTwinEnvelope } from '@/lib/cognitive-twin/contract';
+import type { KernelContext, KernelEvidence } from '@/lib/sfi/cognitive-runtime/kernelContext';
+import { executeSfiRuntime } from '@/lib/sfi/cognitive-runtime/runtime';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { INEGI_NATIONAL_SCENARIOS } from '@/lib/world-observatory/inegiNationalField';
+
+const NATIONAL_AGENT_SET = [
+  'field_observer',
+  'evidence_hunter',
+  'temporal_resolver',
+  'context_builder',
+  'cross_impact',
+  'trajectory_agent',
+  'risk_agent',
+  'opportunity_agent',
+] as const;
+
+type Row = Record<string, unknown>;
+
+type NationalScenarioInput = {
+  scenarioId: string;
+  cutoffAt?: string | null;
+  referenceStart?: string | null;
+  referenceEnd?: string | null;
+  requestedBy: string;
+};
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function rows(value: unknown): Row[] {
+  return Array.isArray(value) ? value.map(record).filter((row) => Object.keys(row).length > 0) : [];
+}
+
+function text(value: unknown, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && Boolean(item.trim())) : [];
+}
+
+function confidence(value: unknown) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, Math.min(1, parsed)) : 0;
+}
+
+function isoOrNow(value: string | null | undefined) {
+  if (!value) return new Date().toISOString();
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime())) return new Date().toISOString();
+  return parsed.toISOString();
+}
+
+function optionalIso(value: string | null | undefined) {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null;
+}
+
+function scenarioIds(row: Row) {
+  return strings(record(row.payload).scenarioIds);
+}
+
+export async function runNationalFieldScenario(input: NationalScenarioInput) {
+  const scenario = INEGI_NATIONAL_SCENARIOS.find((item) => item.id === input.scenarioId);
+  if (!scenario) return { ok: false as const, error: 'NATIONAL_SCENARIO_NOT_FOUND' };
+
+  const cutoffAt = isoOrNow(input.cutoffAt);
+  const cutoffMs = Date.parse(cutoffAt);
+  const referenceStart = optionalIso(input.referenceStart);
+  const referenceEnd = optionalIso(input.referenceEnd);
+  const db = createServiceSupabaseClient();
+  const startedAt = new Date().toISOString();
+  const taskId = `national-field:${scenario.id}:${Date.now()}`;
+  const cycleId = crypto.randomUUID();
+
+  let observationQuery = db.from('world_source_observations')
+    .select('id,source_id,source_family,publisher,observation_kind,external_id,title,summary,observed_at,released_at,fetched_at,country_codes,actors,affected_systems,payload,confidence')
+    .eq('publisher', 'INEGI')
+    .contains('country_codes', ['MX'])
+    .lte('fetched_at', cutoffAt)
+    .order('observed_at', { ascending: true })
+    .limit(1500);
+  if (referenceStart) observationQuery = observationQuery.gte('observed_at', referenceStart);
+  if (referenceEnd) observationQuery = observationQuery.lte('observed_at', referenceEnd);
+
+  const [observationResult, memoryResult, decisionResult] = await Promise.all([
+    observationQuery,
+    db.from('sfi_cognitive_twin_memory')
+      .select('id,memory_key,memory_type,status,content,evidence_refs,version,updated_at')
+      .eq('status', 'CANONICAL')
+      .in('memory_type', ['CANON', 'METHOD', 'DEFINITION', 'CAPABILITY'])
+      .order('updated_at', { ascending: false })
+      .limit(60),
+    db.from('sfi_cognitive_twin_decisions')
+      .select('id,decision_id,general_rule,required_evidence,evidence_refs,approved_at')
+      .eq('status', 'APPROVED')
+      .order('approved_at', { ascending: false })
+      .limit(60),
+  ]);
+
+  if (observationResult.error) return { ok: false as const, error: `NATIONAL_FIELD_READ_FAILED:${observationResult.error.message}` };
+
+  const observations = (observationResult.data ?? []).map(record).filter((row) => {
+    const released = text(row.released_at);
+    if (released) {
+      const releaseMs = Date.parse(released);
+      if (Number.isFinite(releaseMs) && releaseMs > cutoffMs) return false;
+    }
+    return scenarioIds(row).includes(scenario.id);
+  });
+
+  const evidence: KernelEvidence[] = observations.map((row) => ({
+    id: text(row.id),
+    source: `inegi:${text(row.source_id, 'unknown')}`,
+    confidence: confidence(row.confidence),
+    payload: {
+      publisher: 'INEGI',
+      sourceFamily: text(row.source_family),
+      observationKind: text(row.observation_kind),
+      title: text(row.title),
+      summary: text(row.summary),
+      referenceAt: text(row.observed_at),
+      releasedAt: text(row.released_at),
+      fetchedAt: text(row.fetched_at),
+      affectedSystems: strings(row.affected_systems),
+      actors: strings(row.actors),
+      statisticalPayload: record(row.payload),
+      epistemicClass: 'IMPORTED',
+      claimBoundary: 'Official statistical evidence is an input to analysis. It is not itself a friction score, causal claim, hypothesis validation or canonical memory.',
+    },
+  })).filter((item) => item.id);
+
+  const context: KernelContext = {
+    taskId,
+    cycleId,
+    logbookId: `national-field:${scenario.id}`,
+    currentEvent: 'SFI_NATIONAL_FIELD_SCENARIO_ANALYSIS',
+    evidence,
+    hypotheses: [],
+    contradictions: [],
+    simulations: [],
+    predictions: [],
+    risks: [],
+    opportunities: [],
+    metadata: {
+      requestedAgents: [...NATIONAL_AGENT_SET],
+      llmAugmentation: false,
+      scenarioId: scenario.id,
+      scenarioLabel: scenario.label,
+      scenarioQuestion: scenario.question,
+      sourceInstitution: 'INEGI',
+      cutoffAt,
+      referenceStart,
+      referenceEnd,
+      requestedBy: input.requestedBy,
+      temporalKnowledgeRule: 'Only records fetched by SFI by cutoffAt and released by the publisher by cutoffAt are admissible.',
+      epistemicRule: 'Imported official statistics may support comparison and hypothesis generation; they do not automatically become SFI friction measurements or truth claims.',
+    },
+  };
+
+  const cycle = await executeSfiRuntime(context);
+  const canonicalMemory = rows(memoryResult.data).map((row) => ({
+    memoryKey: row.memory_key,
+    memoryType: row.memory_type,
+    content: row.content,
+    version: row.version,
+  }));
+  const approvedRules = rows(decisionResult.data).map((row) => ({
+    decisionId: row.decision_id,
+    generalRule: row.general_rule,
+    requiredEvidence: row.required_evidence,
+  }));
+  const corpusWarnings = [memoryResult.error?.message, decisionResult.error?.message].filter((value): value is string => Boolean(value));
+
+  const fallback = [
+    `National scenario ${scenario.id} could not be synthesized by an LLM provider.`,
+    `${evidence.length} INEGI observations were admissible at cutoff ${cutoffAt}.`,
+    `Agents executed: ${cycle.executedAgents.join(', ') || 'none'}.`,
+    'No Cognitive Twin synthesis is declared. Inspect evidence and deterministic agent outputs.',
+  ].join('\n');
+
+  const llm = await runLlmTask({
+    task: 'deep_report',
+    system: [
+      'You are the bounded synthesis layer of the System Friction Institute Cognitive Twin for the Mexico National Observation Field.',
+      'Use INEGI statistical records as IMPORTED evidence, not as pre-labeled friction.',
+      'Separate reference time, publication time and SFI acquisition time.',
+      'Do not infer individual persons from microdata or aggregate records.',
+      'Do not claim causality from correlation or geographic co-movement.',
+      'Use the supplied Cognitive Twin canon/rules only as method, never as evidence about Mexico.',
+      'Return: observed structure, longitudinal contrasts, cross-domain contradictions, alternative hypotheses, missing variables, one prospectively testable prediction, and the evidence that would falsify it.',
+      'All conclusions remain PROPOSED until independently verified and later confronted with an outcome.',
+    ].join(' '),
+    prompt: JSON.stringify({
+      scenario,
+      cutoffAt,
+      referenceWindow: { start: referenceStart, end: referenceEnd },
+      evidence: evidence.slice(-500),
+      agentExecution: {
+        executedAgents: cycle.executedAgents,
+        contradictions: cycle.context.contradictions,
+        predictions: cycle.context.predictions,
+        risks: cycle.context.risks,
+        opportunities: cycle.context.opportunities,
+        metadata: cycle.context.metadata,
+      },
+      cognitiveTwinCanonicalMemory: canonicalMemory,
+      approvedInstitutionalRules: approvedRules,
+      corpusWarnings,
+    }),
+    fallbackResult: fallback,
+    maxTokens: 1800,
+  });
+
+  const evidenceRefs = evidence.map((item) => item.id);
+  const envelope = createCognitiveTwinEnvelope({
+    taskId,
+    status: llm.ok ? 'PROPOSED' : 'REJECTED',
+    modelId: `${llm.provider}:${llm.model}`,
+    result: {
+      scenario,
+      cutoffAt,
+      referenceWindow: { start: referenceStart, end: referenceEnd },
+      synthesis: llm.result,
+      provider: llm.provider,
+      model: llm.model,
+      providerExecutionSucceeded: llm.ok,
+      executedAgents: cycle.executedAgents,
+      observationCount: evidence.length,
+      agentContradictions: cycle.context.contradictions,
+      agentPredictions: cycle.context.predictions,
+      risks: cycle.context.risks,
+      opportunities: cycle.context.opportunities,
+    },
+    limitations: [
+      'INEGI evidence is official statistical evidence, not an SFI causal label.',
+      'Backfilled records cannot be used as if SFI possessed them before fetched_at.',
+      'Aggregate and microdata-derived statistics cannot identify or reconstruct individuals.',
+      'Agent output is derived/inferred; LLM synthesis is PROPOSED.',
+      ...corpusWarnings,
+      ...llm.warnings,
+    ],
+    missingEvidence: evidence.length ? [] : [`inegi_evidence_for:${scenario.id}`],
+    actionsExecuted: [
+      ...cycle.executedAgents.map((agent) => `cognitive:${agent}`),
+      'read_inegi_national_field',
+      'read_canonical_cognitive_twin_corpus',
+      llm.ok ? 'llm_national_synthesis' : 'llm_national_synthesis_failed',
+    ],
+    recommendedTransition: !llm.ok ? 'BLOCKED' : evidence.length ? 'VERIFYING' : 'EVIDENCE_PENDING',
+  });
+
+  const runStatus = !llm.ok ? 'BLOCKED' : evidence.length ? 'READY' : 'EVIDENCE_PENDING';
+  const persisted = await db.from('sfi_cognitive_twin_runs').insert({
+    task_id: taskId,
+    contract_version: envelope.contractVersion,
+    provider: llm.provider,
+    model: llm.model,
+    role: 'national_field_scenario_analysis',
+    status: runStatus,
+    objective: `${scenario.label}: ${scenario.question}`,
+    input_snapshot: {
+      scenarioId: scenario.id,
+      cutoffAt,
+      referenceStart,
+      referenceEnd,
+      requestedBy: input.requestedBy,
+      observationCount: evidence.length,
+      requestedAgents: NATIONAL_AGENT_SET,
+      temporalKnowledgeRule: 'fetched_at <= cutoff and released_at <= cutoff when known',
+    },
+    output_envelope: envelope,
+    evidence_refs: evidenceRefs.slice(0, 500),
+    limitations: envelope.limitations,
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+  }).select('id,task_id,status,provider,model,role,objective,created_at').single();
+
+  if (persisted.error) return { ok: false as const, error: `NATIONAL_FIELD_RUN_PERSISTENCE_FAILED:${persisted.error.message}`, envelope };
+
+  return {
+    ok: true as const,
+    cognitiveExecution: llm.ok ? 'EXECUTED' as const : 'DEGRADED' as const,
+    run: persisted.data,
+    envelope,
+    scenario,
+    observationCount: evidence.length,
+    evidenceRefs,
+    agents: cycle.executedAgents,
+    llm: { ok: llm.ok, provider: llm.provider, model: llm.model, latencyMs: llm.latency_ms, warnings: llm.warnings },
+  };
+}

--- a/src/lib/cognitive-twin/readState.ts
+++ b/src/lib/cognitive-twin/readState.ts
@@ -12,7 +12,23 @@ const TABLES = [
   'sfi_cognitive_twin_runs',
 ] as const;
 
+type Row = Record<string, unknown>;
+
 export type CognitiveTwinState = Awaited<ReturnType<typeof readCognitiveTwinState>>;
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function providerExecutionSucceeded(value: unknown) {
+  const row = record(value);
+  const provider = typeof row.provider === 'string' ? row.provider : '';
+  const status = typeof row.status === 'string' ? row.status : '';
+  const envelope = record(row.output_envelope);
+  const result = record(envelope.result);
+  if (result.providerExecutionSucceeded === false) return false;
+  return Boolean(provider && provider !== 'degraded' && status !== 'BLOCKED' && status !== 'REJECTED');
+}
 
 export async function readCognitiveTwinState() {
   const db = createServiceSupabaseClient();
@@ -32,17 +48,25 @@ export async function readCognitiveTwinState() {
   const [recentDecisions, recentRuns, recentEvaluations] = databaseReady
     ? await Promise.all([
         db.from('sfi_cognitive_twin_decisions').select('*').order('created_at', { ascending: false }).limit(12),
-        db.from('sfi_cognitive_twin_runs').select('*').order('created_at', { ascending: false }).limit(12),
+        db.from('sfi_cognitive_twin_runs').select('*').order('created_at', { ascending: false }).limit(24),
         db.from('sfi_cognitive_twin_evaluations').select('*').order('executed_at', { ascending: false }).limit(20),
       ])
     : [null, null, null];
 
   const providers = getLlmProviderStatus();
   const configuredProviders = providers.filter((item) => item.available);
-  const approvedModelCount = tableMap.get('sfi_cognitive_twin_model_registry')?.count ?? 0;
-  const approvedDecisionCount = databaseReady
-    ? await db.from('sfi_cognitive_twin_decisions').select('*', { count: 'exact', head: true }).eq('status', 'APPROVED').then((result) => result.count ?? 0)
-    : 0;
+  const registeredModelCount = tableMap.get('sfi_cognitive_twin_model_registry')?.count ?? 0;
+  const [approvedDecisionCountResult, approvedModelCountResult] = databaseReady
+    ? await Promise.all([
+        db.from('sfi_cognitive_twin_decisions').select('*', { count: 'exact', head: true }).eq('status', 'APPROVED'),
+        db.from('sfi_cognitive_twin_model_registry').select('*', { count: 'exact', head: true }).in('status', ['APPROVED', 'APPROVED_WITH_LIMITS']),
+      ])
+    : [null, null];
+  const approvedDecisionCount = approvedDecisionCountResult?.count ?? 0;
+  const approvedModelCount = approvedModelCountResult?.count ?? 0;
+  const providerExecutionObserved = (recentRuns?.data ?? []).some(providerExecutionSucceeded);
+  const providerConfigured = configuredProviders.length > 0;
+  const providerRouterReady = providerConfigured && providerExecutionObserved;
 
   return {
     generatedAt: new Date().toISOString(),
@@ -50,9 +74,11 @@ export async function readCognitiveTwinState() {
     implementation: {
       contractImplemented: true,
       databaseReady,
-      providerRouterReady: configuredProviders.length > 0,
+      providerConfigured,
+      providerExecutionObserved,
+      providerRouterReady,
       approvedDecisionCorpusReady: approvedDecisionCount > 0,
-      modelEvaluationRegistryReady: Number(approvedModelCount) > 0,
+      modelEvaluationRegistryReady: approvedModelCount > 0,
       institutionalAutonomyProven: false,
     },
     providers,
@@ -61,7 +87,8 @@ export async function readCognitiveTwinState() {
       memory: tableMap.get('sfi_cognitive_twin_memory')?.count ?? null,
       decisions: tableMap.get('sfi_cognitive_twin_decisions')?.count ?? null,
       approvedDecisions: approvedDecisionCount,
-      models: approvedModelCount,
+      models: registeredModelCount,
+      approvedModels: approvedModelCount,
       evaluations: tableMap.get('sfi_cognitive_twin_evaluations')?.count ?? null,
       runs: tableMap.get('sfi_cognitive_twin_runs')?.count ?? null,
     },
@@ -73,6 +100,8 @@ export async function readCognitiveTwinState() {
       ...(recentDecisions?.error ? [`decisions: ${recentDecisions.error.message}`] : []),
       ...(recentRuns?.error ? [`runs: ${recentRuns.error.message}`] : []),
       ...(recentEvaluations?.error ? [`evaluations: ${recentEvaluations.error.message}`] : []),
+      ...(approvedDecisionCountResult?.error ? [`approved decisions: ${approvedDecisionCountResult.error.message}`] : []),
+      ...(approvedModelCountResult?.error ? [`approved models: ${approvedModelCountResult.error.message}`] : []),
     ],
   };
 }

--- a/src/lib/world-observatory/inegiNationalField.ts
+++ b/src/lib/world-observatory/inegiNationalField.ts
@@ -1,0 +1,400 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+export const INEGI_NATIONAL_FIELD_VERSION = 'SFI-INEGI-NATIONAL-2026.08.1';
+
+export type InegiIndicatorSpec = {
+  key: string;
+  indicatorId: string;
+  label: string;
+  geography: string;
+  source: 'BISE' | 'BIE';
+  affectedSystems: string[];
+  actors: string[];
+  scenarioIds: string[];
+};
+
+export const INEGI_NATIONAL_SCENARIOS = [
+  {
+    id: 'MEX-LABOR-01',
+    label: 'Trabajo, informalidad y transición ocupacional',
+    question: '¿Qué configuraciones laborales persisten, se desplazan o divergen entre entidades y cohortes?',
+    lanes: ['API_INDICATORS', 'ENOE_MICRODATA'],
+  },
+  {
+    id: 'MEX-HOUSEHOLD-01',
+    label: 'Presión sobre hogares',
+    question: '¿Dónde divergen ingreso, gasto, precios y capacidad material de los hogares?',
+    lanes: ['API_INDICATORS', 'ENIGH_MICRODATA', 'INPC'],
+  },
+  {
+    id: 'MEX-PRODUCTIVE-01',
+    label: 'Estructura productiva territorial',
+    question: '¿Cómo cambia la densidad, composición y concentración de unidades económicas por territorio?',
+    lanes: ['DENUE_API', 'CENSOS_ECONOMICOS'],
+  },
+  {
+    id: 'MEX-SECURITY-01',
+    label: 'Seguridad, victimización y confianza institucional',
+    question: '¿Dónde divergen incidencia, percepción, denuncia y confianza en instituciones?',
+    lanes: ['ENVIPE_MICRODATA', 'ENSU', 'GOVERNMENT_STATISTICS'],
+  },
+  {
+    id: 'MEX-TERRITORY-01',
+    label: 'Territorio, demografía y acceso',
+    question: '¿Qué cambios demográficos y territoriales alteran acceso, concentración y dependencia regional?',
+    lanes: ['API_INDICATORS', 'CENSUS', 'GEOSTATISTICAL_DATA', 'DENUE_API'],
+  },
+  {
+    id: 'MEX-WELLBEING-01',
+    label: 'Bienestar observado y condiciones materiales',
+    question: '¿Dónde convergen o se contradicen bienestar reportado y condiciones económicas observables?',
+    lanes: ['ENBIARE', 'ENIGH_MICRODATA', 'API_INDICATORS'],
+  },
+] as const;
+
+const DEFAULT_INDICATORS: InegiIndicatorSpec[] = [
+  {
+    key: 'population_total',
+    indicatorId: '1002000001',
+    label: 'Población total',
+    geography: '00',
+    source: 'BISE',
+    affectedSystems: ['population', 'territory', 'public_services'],
+    actors: ['households', 'government'],
+    scenarioIds: ['MEX-TERRITORY-01'],
+  },
+];
+
+const STATE_CODES = Array.from({ length: 32 }, (_, index) => String(index + 1).padStart(2, '0'));
+const INDICATORS_DOC_URL = 'https://www.inegi.org.mx/servicios/api_indicadores.html';
+const DENUE_DOC_URL = 'https://www.inegi.org.mx/servicios/api_denue.html';
+
+type Row = Record<string, unknown>;
+
+type NationalObservation = {
+  sourceId: string;
+  sourceFamily: string;
+  publisher: string;
+  observationKind: string;
+  externalId: string;
+  title: string;
+  summary: string | null;
+  observedAt: string | null;
+  releasedAt: string | null;
+  countryCodes: string[];
+  actors: string[];
+  affectedSystems: string[];
+  payload: Row;
+  sourceUrl: string;
+  confidence: number;
+};
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function rows(value: unknown): Row[] {
+  return Array.isArray(value) ? value.map(record).filter((row) => Object.keys(row).length > 0) : [];
+}
+
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function numberValue(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value.replaceAll(',', ''));
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function hash(value: unknown) {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+function parseInegiDate(value: unknown): string | null {
+  const raw = text(value);
+  if (!raw) return null;
+  const dmy = raw.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})/);
+  if (dmy) {
+    const parsed = new Date(Date.UTC(Number(dmy[3]), Number(dmy[2]) - 1, Number(dmy[1]), 12));
+    return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null;
+  }
+  const parsed = new Date(raw);
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : null;
+}
+
+function referencePeriodEnd(value: unknown): string | null {
+  const raw = text(value);
+  if (!raw) return null;
+  const year = raw.match(/^(\d{4})$/);
+  if (year) return new Date(Date.UTC(Number(year[1]), 11, 31, 23, 59, 59, 999)).toISOString();
+
+  const month = raw.match(/^(\d{4})[-/]([01]?\d)$/);
+  if (month) return new Date(Date.UTC(Number(month[1]), Number(month[2]), 0, 23, 59, 59, 999)).toISOString();
+
+  const quarter = raw.match(/^(\d{4})[-/ ]?(?:Q|T|TRIM(?:ESTRE)?)[ -]?([1-4])$/i);
+  if (quarter) return new Date(Date.UTC(Number(quarter[1]), Number(quarter[2]) * 3, 0, 23, 59, 59, 999)).toISOString();
+
+  return null;
+}
+
+function configuredIndicatorSpecs(): InegiIndicatorSpec[] {
+  const raw = process.env.INEGI_INDICATOR_MANIFEST_JSON;
+  if (!raw) return DEFAULT_INDICATORS;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return DEFAULT_INDICATORS;
+    const custom = parsed.flatMap((item): InegiIndicatorSpec[] => {
+      const row = record(item);
+      const indicatorId = text(row.indicatorId);
+      const key = text(row.key);
+      const label = text(row.label);
+      if (!indicatorId || !key || !label) return [];
+      return [{
+        key,
+        indicatorId,
+        label,
+        geography: text(row.geography) ?? '00',
+        source: row.source === 'BIE' ? 'BIE' : 'BISE',
+        affectedSystems: Array.isArray(row.affectedSystems) ? row.affectedSystems.map(String) : [],
+        actors: Array.isArray(row.actors) ? row.actors.map(String) : [],
+        scenarioIds: Array.isArray(row.scenarioIds) ? row.scenarioIds.map(String) : [],
+      }];
+    });
+    return custom.length ? custom : DEFAULT_INDICATORS;
+  } catch {
+    return DEFAULT_INDICATORS;
+  }
+}
+
+function indicatorsToken() {
+  return process.env.INEGI_INDICATORS_TOKEN ?? process.env.INEGI_API_TOKEN ?? null;
+}
+
+function denueToken() {
+  return process.env.INEGI_DENUE_TOKEN ?? process.env.INEGI_API_TOKEN ?? null;
+}
+
+async function fetchJson(url: string, timeoutMs = 20_000): Promise<unknown> {
+  const response = await fetch(url, {
+    cache: 'no-store',
+    headers: { 'user-agent': 'SystemFrictionInstitute/INEGI-National-Field' },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) throw new Error(`INEGI_HTTP_${response.status}`);
+  return response.json();
+}
+
+function indicatorUrl(spec: InegiIndicatorSpec, token: string) {
+  return `https://www.inegi.org.mx/app/api/indicadores/desarrolladores/jsonxml/INDICATOR/${encodeURIComponent(spec.indicatorId)}/es/${encodeURIComponent(spec.geography)}/false/${spec.source}/2.0/${encodeURIComponent(token)}?type=json`;
+}
+
+async function collectIndicator(spec: InegiIndicatorSpec, token: string): Promise<NationalObservation[]> {
+  const payload = record(await fetchJson(indicatorUrl(spec, token)));
+  const series = rows(payload.Series)[0] ?? {};
+  const observations = rows(series.OBSERVATIONS);
+  const releasedAt = parseInegiDate(series.LASTUPDATE);
+
+  return observations.flatMap((observation) => {
+    const period = text(observation.TIME_PERIOD);
+    const value = numberValue(observation.OBS_VALUE);
+    if (!period || value === null) return [];
+    const geo = text(observation.COBER_GEO) ?? spec.geography;
+    const raw = {
+      indicatorId: spec.indicatorId,
+      indicatorKey: spec.key,
+      referencePeriod: period,
+      value,
+      unit: series.UNIT ?? null,
+      frequency: series.FREQ ?? null,
+      topic: series.TOPIC ?? null,
+      source: series.SOURCE ?? spec.source,
+      observationStatus: observation.OBS_STATUS ?? null,
+      observationException: observation.OBS_EXCEPTION ?? null,
+      observationSource: observation.OBS_SOURCE ?? null,
+      observationNote: observation.OBS_NOTE ?? null,
+      geography: geo,
+      scenarioIds: spec.scenarioIds,
+      knowledgeBoundary: {
+        referenceAt: referencePeriodEnd(period),
+        releasedAt,
+        ingestionDoesNotBackdateKnowledge: true,
+      },
+    };
+    return [{
+      sourceId: 'inegi-indicators',
+      sourceFamily: 'official_statistics',
+      publisher: 'INEGI',
+      observationKind: 'statistical_series_point',
+      externalId: `indicator:${spec.indicatorId}:${geo}:${period}`,
+      title: `${spec.label} · ${geo} · ${period}`,
+      summary: `${spec.label}: ${value}${text(series.UNIT) ? ` ${text(series.UNIT)}` : ''}`,
+      observedAt: referencePeriodEnd(period),
+      releasedAt,
+      countryCodes: ['MX'],
+      actors: spec.actors,
+      affectedSystems: spec.affectedSystems,
+      payload: raw,
+      sourceUrl: INDICATORS_DOC_URL,
+      confidence: 0.98,
+    } satisfies NationalObservation];
+  });
+}
+
+function denueValue(row: Row, patterns: RegExp[], fallbackIndex: number): unknown {
+  for (const [key, value] of Object.entries(row)) {
+    if (patterns.some((pattern) => pattern.test(key))) return value;
+  }
+  return Object.values(row)[fallbackIndex];
+}
+
+async function collectDenueStateCounts(token: string): Promise<NationalObservation[]> {
+  const areas = STATE_CODES.join(',');
+  const url = `https://www.inegi.org.mx/app/api/denue/v1/consulta/Cuantificar/0/${areas}/0/${encodeURIComponent(token)}`;
+  const fetchedAt = new Date().toISOString();
+  const responseRows = rows(await fetchJson(url));
+
+  return responseRows.flatMap((row) => {
+    const activity = text(denueValue(row, [/actividad/i, /^ae$/i, /id.*act/i], 0)) ?? '0';
+    const area = text(denueValue(row, [/area/i, /^ag$/i, /geo/i], 1));
+    const total = numberValue(denueValue(row, [/total/i, /establec/i], 2));
+    if (!area || total === null) return [];
+    const payload = {
+      activity,
+      geographicArea: area,
+      establishmentCount: total,
+      stratum: '0',
+      raw: row,
+      scenarioIds: ['MEX-PRODUCTIVE-01', 'MEX-TERRITORY-01'],
+      knowledgeBoundary: {
+        currentSnapshot: true,
+        releasedAt: fetchedAt,
+        ingestionDoesNotBackdateKnowledge: true,
+      },
+    };
+    return [{
+      sourceId: 'inegi-denue',
+      sourceFamily: 'official_economic_directory',
+      publisher: 'INEGI',
+      observationKind: 'establishment_count_snapshot',
+      externalId: `denue:count:${activity}:${area}:stratum:0`,
+      title: `DENUE · establecimientos · ${area}`,
+      summary: `${total} establecimientos observados en el corte DENUE consultado`,
+      observedAt: fetchedAt,
+      releasedAt: fetchedAt,
+      countryCodes: ['MX'],
+      actors: ['businesses', 'workers', 'local_government'],
+      affectedSystems: ['economic_structure', 'employment', 'territory', 'business_ecology'],
+      payload,
+      sourceUrl: DENUE_DOC_URL,
+      confidence: 0.98,
+    } satisfies NationalObservation];
+  });
+}
+
+async function persistObservations(observations: NationalObservation[]) {
+  const db = createServiceSupabaseClient();
+  let persisted = 0;
+  const failures: string[] = [];
+
+  for (const observation of observations) {
+    const rawHash = hash(observation.payload);
+    const result = await db.from('world_source_observations').upsert({
+      source_id: observation.sourceId,
+      source_family: observation.sourceFamily,
+      publisher: observation.publisher,
+      observation_kind: observation.observationKind,
+      external_id: observation.externalId,
+      title: observation.title,
+      summary: observation.summary,
+      observed_at: observation.observedAt,
+      released_at: observation.releasedAt,
+      latitude: null,
+      longitude: null,
+      country_codes: observation.countryCodes,
+      actors: observation.actors,
+      affected_systems: observation.affectedSystems,
+      payload: observation.payload,
+      raw_hash: rawHash,
+      source_url: observation.sourceUrl,
+      collector_version: INEGI_NATIONAL_FIELD_VERSION,
+      confidence: observation.confidence,
+    }, { onConflict: 'source_id,external_id,raw_hash' }).select('id').maybeSingle();
+    if (result.error) failures.push(`${observation.externalId}:${result.error.message}`);
+    else if (result.data) persisted += 1;
+  }
+
+  return { persisted, failures };
+}
+
+export function readInegiNationalFieldConfiguration() {
+  const indicatorSpecs = configuredIndicatorSpecs();
+  return {
+    version: INEGI_NATIONAL_FIELD_VERSION,
+    indicatorsConfigured: Boolean(indicatorsToken()),
+    denueConfigured: Boolean(denueToken()),
+    indicatorManifest: indicatorSpecs.map((item) => ({ ...item, token: undefined })),
+    scenarios: INEGI_NATIONAL_SCENARIOS,
+    microdata: {
+      policy: 'BATCH_AGGREGATION_ONLY',
+      rawPersonLevelEmbedding: false,
+      required: ['survey weights', 'data dictionary', 'geographic grain', 'reference period', 'release/acquisition time', 'provenance'],
+      plannedPrograms: ['ENOE', 'ENIGH', 'ENVIPE'],
+    },
+    epistemicBoundary: 'INEGI records are imported evidence. They do not become friction readings, causal claims, hypotheses or canonical Cognitive Twin memory automatically.',
+  };
+}
+
+export async function ingestInegiNationalField(input?: { includeStates?: boolean; includeDenue?: boolean }) {
+  const specs = configuredIndicatorSpecs();
+  const indicatorKey = indicatorsToken();
+  const denueKey = denueToken();
+  const warnings: string[] = [];
+  const collected: NationalObservation[] = [];
+
+  if (indicatorKey) {
+    const expanded = input?.includeStates
+      ? specs.flatMap((spec) => spec.geography === '00'
+        ? [spec, ...STATE_CODES.map((geography) => ({ ...spec, geography }))]
+        : [spec])
+      : specs;
+    const settled = await Promise.allSettled(expanded.map((spec) => collectIndicator(spec, indicatorKey)));
+    settled.forEach((result, index) => {
+      if (result.status === 'fulfilled') collected.push(...result.value);
+      else warnings.push(`indicator:${expanded[index].key}:${expanded[index].geography}:${String(result.reason)}`);
+    });
+  } else {
+    warnings.push('INEGI_INDICATORS_TOKEN_MISSING');
+  }
+
+  if (input?.includeDenue) {
+    if (denueKey) {
+      try {
+        collected.push(...await collectDenueStateCounts(denueKey));
+      } catch (error) {
+        warnings.push(`denue:${error instanceof Error ? error.message : String(error)}`);
+      }
+    } else {
+      warnings.push('INEGI_DENUE_TOKEN_MISSING');
+    }
+  }
+
+  const persistence = await persistObservations(collected);
+  return {
+    ok: persistence.failures.length === 0 && collected.length > 0,
+    collected: collected.length,
+    persisted: persistence.persisted,
+    warnings: [...warnings, ...persistence.failures],
+    sources: Array.from(new Set(collected.map((item) => item.sourceId))),
+    generatedAt: new Date().toISOString(),
+    epistemicClass: 'IMPORTED',
+    noAutomaticFrictionReading: true,
+    noAutomaticHypothesisPromotion: true,
+  };
+}

--- a/src/lib/world-observatory/worldCycle.ts
+++ b/src/lib/world-observatory/worldCycle.ts
@@ -203,7 +203,15 @@ export async function runWorldCalibrationCycle() {
   for (const hypothesis of hypotheses ?? []) {
     const expected = Array.isArray(hypothesis.expected_signals) ? hypothesis.expected_signals as string[] : [];
     const contradictions = Array.isArray(hypothesis.contradiction_signals) ? hypothesis.contradiction_signals as string[] : [];
-    const { data: later } = await db.from('world_source_observations').select('id,title,summary,affected_systems,observed_at').gt('observed_at', hypothesis.cutoff_at).lte('observed_at', now).limit(500);
+    // Outcome evidence is bounded by SFI acquisition time, not the phenomenon/reference date.
+    // This prevents backfilled historical statistics from masquerading as evidence that SFI
+    // possessed prospectively when the hypothesis was created.
+    const { data: later } = await db.from('world_source_observations')
+      .select('id,title,summary,affected_systems,observed_at,released_at,fetched_at')
+      .gt('fetched_at', hypothesis.cutoff_at)
+      .lte('fetched_at', now)
+      .order('fetched_at', { ascending: true })
+      .limit(500);
     const corpus = JSON.stringify(later ?? []).toLowerCase();
     const expectedHits = expected.filter((signal) => corpus.includes(signal.toLowerCase()));
     const contradictionHits = contradictions.filter((signal) => corpus.includes(signal.toLowerCase()));


### PR DESCRIPTION
Creates the first external national learning substrate for the SFI Cognitive Twin without turning official statistics into synthetic friction labels.

Changes:
- Add INEGI Indicators and DENUE adapters into existing `world_source_observations` rather than a parallel store.
- Add six Mexico national scenarios: labor, households, productive structure, security, territory and wellbeing.
- Add ROOT-governed acquisition and scenario-analysis endpoints.
- Run the existing SFI cognitive runtime/agents over admissible INEGI evidence, followed by one bounded LLM synthesis and persisted Cognitive Twin run.
- Keep INEGI observations IMPORTED: no automatic MIHM/friction reading, causal claim, hypothesis promotion or canonical memory.
- Define microdata policy as weighted/batch aggregation only; no person-level embedding; planned ENOE, ENIGH and ENVIPE lanes.
- Enforce three clocks: reference time, publisher release time and SFI acquisition time.
- Fix WORLD calibration so backfilled historical data cannot validate predictions retroactively: outcomes use `fetched_at` after the hypothesis cutoff.
- Fix World Field historical frames so only data actually acquired/released by the selected cutoff are admissible.
- Stop direct Cognitive Twin and World Field LLM fallbacks from being persisted as `READY`; degraded provider executions are BLOCKED.
- Make Cognitive Twin readiness distinguish provider configuration from observed successful execution and registered models from approved/evaluated models.
- Add a Cognitive Twin National Observation Field control surface and QA assertions.

This PR does not claim that the Twin has learned Mexico or achieved autonomy. It creates an external, prospectively testable evidence substrate and blocks two sources of false intelligence: retrospective temporal leakage and fallback-as-success.