### PR TITLE
Build SFI Cognitive Olympics 2026 laboratory

### DIFF
--- a/.github/workflows/sfi-cl-verify.yml
+++ b/.github/workflows/sfi-cl-verify.yml
@@ -1,0 +1,31 @@
+name: SFI Cognitive Lab Verify
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/cognitive-olympics/**'
+      - '.github/workflows/sfi-cl-verify.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/cognitive-olympics/**'
+      - '.github/workflows/sfi-cl-verify.yml'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm install --no-audit --no-fund
+      - name: Syntax check lab modules
+        shell: bash
+        run: |
+          for f in scripts/cognitive-olympics/*.mjs scripts/cognitive-olympics/lib/*.mjs; do node --check "$f"; done
+      - name: Cognitive Olympics smoke tests
+        run: node --test scripts/cognitive-olympics/smoke.test.mjs
+      - name: Typecheck SFI agent bridge
+        run: npx tsc --noEmit --pretty false --incremental false

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ sfi_delete_or_migrate_candidates.txt
 docs/db/SFI_DB_VERIFY_*.json
 docs/db/SFI_LIVE_PROOF_*.json
 _sfi_local_junk_*/
+
+# SFI Cognitive Olympics local datasets, runs and sealed lab state
+.sfi-cl/

--- a/scripts/cognitive-olympics/README.md
+++ b/scripts/cognitive-olympics/README.md
@@ -1,0 +1,94 @@
+# SFI Cognitive Olympics 2026 · SFI_CL
+
+**No se trata de llegar. Se trata de aprender a saber llegar.**
+
+Local longitudinal cognitive laboratory for replaying 2010→2026 under sealed temporal cutoffs. The object under test is the Cognitive Twin / derived cognitive constitutions under System Friction Institute (SFI) constraints. Forecasting algorithms, statistical baselines, Ollama, Groq and other engines are instruments, not claimed SFI inventions.
+
+## What is implemented
+
+- Track A historical replay, 2010→2026.
+- Track B shadow-world pseudonymization to reduce direct entity/indicator recognition.
+- 5,000 problems/year in `full` and `congress` profiles; smaller smoke/quick profiles for calibration.
+- World Bank public-data preparation with explicit `REFERENCE_ONLY` temporal-integrity warning: current historical series are **not** treated as historical-vintage proof.
+- Cognitive constitutions: `origin-core`, `origin-augmented`, `origin-patched`, `sfi-evolver`, `sfi-mandatory`, `generic-control`.
+- Engine separation: statistical persistence baseline, every installed Ollama model selected by `ollama:auto`, and optional Groq models.
+- Real deterministic bridge to the repository's registered 21 SFI agent executors via `executeRegisteredAgent()`; the lab intentionally bypasses runtime event persistence so experiments do not contaminate institutional telemetry.
+- Two-stage evidence behavior for LLM athletes: plan evidence requests first, then answer after only requested auxiliary evidence is revealed.
+- Annual prediction seals (SHA-256), deterministic scoring, rule/temporal violations, annual learning memory, checkpoints, final leaderboard.
+- Optional annual Congress after scoring: each LLM athlete may send at most two messages per pseudonymous peer.
+- Local loopback API on `127.0.0.1:4316`.
+- Auxiliary method cards derived from *Instrumentalización de una Mente Fragmentada · Founder Edition v1.2 FINAL* with original method maturity labels preserved.
+
+## Run
+
+```bash
+node --test scripts/cognitive-olympics/smoke.test.mjs
+node scripts/cognitive-olympics/prepare.mjs
+node scripts/cognitive-olympics/runner.mjs --profile quick
+```
+
+Full 5K/year race:
+
+```bash
+node scripts/cognitive-olympics/runner.mjs --profile full --engines stats,ollama:auto
+```
+
+Explicit Ollama models:
+
+```bash
+node scripts/cognitive-olympics/runner.mjs --profile full --engines stats,ollama:model-a,ollama:model-b
+```
+
+Optional Groq exhibition lane (server-side/local env only):
+
+```bash
+set GROQ_API_KEY=...
+node scripts/cognitive-olympics/runner.mjs --profile full --engines stats,ollama:auto,groq:<model-id>
+```
+
+The runner never prints secret values.
+
+Congress league:
+
+```bash
+node scripts/cognitive-olympics/runner.mjs --profile congress --engines stats,ollama:auto
+```
+
+Shadow-world track:
+
+```bash
+node scripts/cognitive-olympics/runner.mjs --profile full --track B
+```
+
+## Local API
+
+```bash
+node scripts/cognitive-olympics/server.mjs
+```
+
+- `GET /v1/health`
+- `GET /v1/manifest`
+- `GET /v1/runs/latest`
+- `POST /v1/runs` with `{ "profile":"quick", "track":"A", "engines":"stats,ollama:auto" }`
+
+## Experimental boundaries
+
+1. Track A is useful for calibration and learning but not definitive proof of strict historical ignorance, because contemporary LLM weights and current revised historical series may contain later knowledge.
+2. The future partition is never included in an athlete problem payload. Outcomes are read only by the scorer after answers are sealed.
+3. An unregistered failure cannot be relabeled after the fact as an experimental perturbation.
+4. `SFI_METHODS` are auxiliary method cards. Their presence in a heat does not validate the methods themselves.
+5. `sfi-evolver` may change explicit policy state after scored outcomes; `origin-core` remains a frozen cognitive control.
+6. 2026 is a terminal current frame. Unobserved future outcomes are not fabricated.
+
+## Output
+
+Runs live under `.sfi-cl/runs/<run-id>/` and include:
+
+- experiment manifest
+- pseudonymous athlete registry
+- append-only JSONL ledger
+- sealed predictions + hashes per year/athlete
+- score rows and annual leaderboards
+- annual checkpoints / learned state
+- optional Congress messages
+- final longitudinal leaderboard

--- a/scripts/cognitive-olympics/lib/config.mjs
+++ b/scripts/cognitive-olympics/lib/config.mjs
@@ -1,0 +1,65 @@
+export const EXPERIMENT_VERSION = 'SFI-CL-COGNITIVE-OLYMPICS-2026.08.1';
+export const START_YEAR = 2010;
+export const END_YEAR = 2026;
+
+export const PROFILES = {
+  smoke: { problemsPerYear: 60, batchSize: 20, congress: false },
+  quick: { problemsPerYear: 500, batchSize: 50, congress: false },
+  full: { problemsPerYear: 5000, batchSize: 100, congress: false },
+  congress: { problemsPerYear: 5000, batchSize: 100, congress: true },
+};
+
+export const DEFAULT_DOMAINS = [
+  'economy', 'labor', 'demography', 'health', 'energy', 'environment',
+  'trade', 'technology', 'production', 'inequality', 'institutions',
+];
+
+export const WORLD_BANK_INDICATORS = [
+  ['NY.GDP.MKTP.KD.ZG', 'GDP growth', 'economy'],
+  ['NY.GDP.PCAP.KD.ZG', 'GDP per-capita growth', 'economy'],
+  ['FP.CPI.TOTL.ZG', 'Inflation, consumer prices', 'economy'],
+  ['SL.UEM.TOTL.ZS', 'Unemployment rate', 'labor'],
+  ['SL.TLF.CACT.ZS', 'Labor force participation', 'labor'],
+  ['SL.EMP.TOTL.SP.ZS', 'Employment to population ratio', 'labor'],
+  ['SP.POP.GROW', 'Population growth', 'demography'],
+  ['SP.URB.TOTL.IN.ZS', 'Urban population share', 'demography'],
+  ['SP.POP.0014.TO.ZS', 'Population ages 0-14', 'demography'],
+  ['SP.POP.65UP.TO.ZS', 'Population ages 65+', 'demography'],
+  ['SP.DYN.LE00.IN', 'Life expectancy', 'health'],
+  ['SP.DYN.IMRT.IN', 'Infant mortality', 'health'],
+  ['SH.XPD.CHEX.GD.ZS', 'Current health expenditure', 'health'],
+  ['EG.ELC.ACCS.ZS', 'Access to electricity', 'energy'],
+  ['EG.USE.PCAP.KG.OE', 'Energy use per capita', 'energy'],
+  ['EN.ATM.CO2E.PC', 'CO2 emissions per capita', 'environment'],
+  ['AG.LND.FRST.ZS', 'Forest area', 'environment'],
+  ['NE.TRD.GNFS.ZS', 'Trade as share of GDP', 'trade'],
+  ['NE.EXP.GNFS.ZS', 'Exports as share of GDP', 'trade'],
+  ['NE.IMP.GNFS.ZS', 'Imports as share of GDP', 'trade'],
+  ['BX.KLT.DINV.WD.GD.ZS', 'FDI net inflows as share of GDP', 'trade'],
+  ['IT.NET.USER.ZS', 'Individuals using the Internet', 'technology'],
+  ['IT.CEL.SETS.P2', 'Mobile cellular subscriptions', 'technology'],
+  ['NV.IND.MANF.ZS', 'Manufacturing value added share', 'production'],
+  ['NV.AGR.TOTL.ZS', 'Agriculture value added share', 'production'],
+  ['NV.SRV.TOTL.ZS', 'Services value added share', 'production'],
+  ['SI.POV.GINI', 'Gini index', 'inequality'],
+  ['SI.POV.NAHC', 'National poverty headcount', 'inequality'],
+  ['SG.GEN.PARL.ZS', 'Women in national parliaments', 'institutions'],
+];
+
+export function parseCli(argv = process.argv.slice(2)) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    const [key, inline] = arg.slice(2).split('=', 2);
+    if (inline !== undefined) out[key] = inline;
+    else if (argv[i + 1] && !argv[i + 1].startsWith('--')) out[key] = argv[++i];
+    else out[key] = true;
+  }
+  return out;
+}
+
+export function profileFrom(value) {
+  const name = String(value || process.env.SFI_CL_PROFILE || 'quick').toLowerCase();
+  return { name, ...(PROFILES[name] || PROFILES.quick) };
+}

--- a/scripts/cognitive-olympics/lib/constitutions.mjs
+++ b/scripts/cognitive-olympics/lib/constitutions.mjs
@@ -1,0 +1,43 @@
+const founderOps = [
+  'audit preconditions before accepting the question framing',
+  'separate REAL / OBSERVED / DERIVED / INFERRED / MISSING',
+  'expand context before escalating a local anomaly',
+  'identify function before declaring failure',
+  'preserve invariants and degrees of freedom',
+  'inspect node history and relational structure',
+  'test structural isomorphism by roles/relations, not appearance',
+  'detect false coherence and delayed execution',
+  'delay closure when evidence is insufficient',
+];
+
+export const CONSTITUTIONS = {
+  'origin-core': { label: 'ORIGIN CORE', provenance: 'FOUNDER_EXTRACTED_CONTROL', mutable: false, sfiMode: 'AVAILABLE', rules: founderOps, patches: [] },
+  'origin-augmented': { label: 'ORIGIN AUGMENTED', provenance: 'FOUNDER_EXTRACTED_PLUS_AUGMENTATION', mutable: false, sfiMode: 'AVAILABLE', rules: founderOps, patches: ['use parallel evidence retrieval and statistical tools before spending language-model reasoning', 'retain explicit episodic memory of prior scored outcomes', 'actively search for counterexamples when confidence exceeds 0.70'] },
+  'origin-patched': { label: 'ORIGIN PATCHED', provenance: 'FOUNDER_EXTRACTED_PLUS_EXOGENOUS_BLIND_SPOT_PATCHES', mutable: false, sfiMode: 'AVAILABLE', rules: founderOps, patches: ['do not escalate bug→architecture→governance without recurrence or cross-surface evidence', 'confirmation evidence is insufficient without an explicit rival or discriminating observation', 'multiple sources that copy one upstream are one evidential lineage, not independent confirmations', 'prefer abstention over invented continuity', 'never retroactively relabel an unregistered failure as an experimental perturbation'] },
+  'sfi-evolver': { label: 'SFI EVOLVER', provenance: 'DERIVED_COGNITIVE_ARCHITECTURE', mutable: true, sfiMode: 'AVAILABLE', rules: founderOps, patches: ['rules are retained by out-of-sample performance, not by founder resemblance', 'when a rule loses repeatedly, lower its weight and record the mutation', 'select SFI methods only when their stated scope fits the problem', 'seek evidence that could make the current hypothesis lose'] },
+  'sfi-mandatory': { label: 'SFI MANDATORY CONTROL', provenance: 'SFI_INSTRUMENT_EFFECT_CONTROL', mutable: false, sfiMode: 'MANDATORY', rules: [], patches: ['use an applicable SFI method card on every problem, even when a generic strategy might suffice'] },
+  'generic-control': { label: 'GENERIC CONTROL', provenance: 'NO_FOUNDER_NO_SFI_CONTROL', mutable: false, sfiMode: 'NONE', rules: [], patches: ['use ordinary evidence-sensitive reasoning; no founder-derived or SFI-specific rule is available'] },
+};
+
+export const DEFAULT_CONSTITUTIONS = ['origin-core', 'origin-augmented', 'origin-patched', 'sfi-evolver', 'generic-control'];
+
+export function constitutionPrompt(id, state = {}) {
+  const c = CONSTITUTIONS[id];
+  if (!c) throw new Error(`Unknown constitution: ${id}`);
+  const weights = state.ruleWeights || {};
+  const ruleText = [...c.rules, ...c.patches].map((r, i) => `- ${r} [w=${Number(weights[i] ?? 1).toFixed(2)}]`).join('\n');
+  return [`Constitution: ${c.label}. Provenance: ${c.provenance}.`, `SFI mode: ${c.sfiMode}. Mutable constitution: ${c.mutable}.`, ruleText || '- No special cognitive rules.', 'You are scored against later outcomes. Do not claim future knowledge. Treat missing evidence as missing.'].join('\n');
+}
+
+export function evolveState(id, priorState, score) {
+  const c = CONSTITUTIONS[id];
+  if (!c?.mutable) return priorState || {};
+  const state = structuredClone(priorState || {});
+  state.ruleWeights ||= {};
+  const penalty = Math.max(-0.15, Math.min(0.15, (score?.accuracy ?? 0.5) - 0.5));
+  const abstainPenalty = (score?.abstentionQuality ?? 0.5) - 0.5;
+  state.ruleWeights[0] = Math.max(0.4, Math.min(1.8, (state.ruleWeights[0] ?? 1) + penalty * 0.2));
+  state.ruleWeights[1] = Math.max(0.4, Math.min(1.8, (state.ruleWeights[1] ?? 1) + abstainPenalty * 0.15));
+  state.lastMutation = { atYear: score?.year, reason: 'OUTCOME_SCORE_UPDATE', accuracy: score?.accuracy ?? null };
+  return state;
+}

--- a/scripts/cognitive-olympics/lib/dataset.mjs
+++ b/scripts/cognitive-olympics/lib/dataset.mjs
@@ -1,0 +1,84 @@
+import { WORLD_BANK_INDICATORS, START_YEAR, END_YEAR } from './config.mjs';
+import { ensureDir, sleep, writeJson, readJson } from './utils.mjs';
+import path from 'node:path';
+import { writeFile, readFile } from 'node:fs/promises';
+
+const WB = 'https://api.worldbank.org/v2';
+
+async function fetchJson(url, attempts = 4) {
+  let last;
+  for (let i = 0; i < attempts; i += 1) {
+    try {
+      const response = await fetch(url, { headers: { 'User-Agent': 'SFI-CL-Cognitive-Olympics/2026.08' } });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return await response.json();
+    } catch (error) { last = error; await sleep(500 * (i + 1)); }
+  }
+  throw last;
+}
+
+async function countryCatalog() {
+  const payload = await fetchJson(`${WB}/country?format=json&per_page=400`);
+  const rows = Array.isArray(payload?.[1]) ? payload[1] : [];
+  return new Map(rows.filter((r) => r?.region?.value && r.region.value !== 'Aggregates').map((r) => [r.id, {
+    iso3: r.id, iso2: r.iso2Code, name: r.name, region: r.region.value, income: r.incomeLevel?.value || null,
+  }]));
+}
+
+export async function prepareWorldBankDataset({ outDir, startYear = START_YEAR - 3, endYear = END_YEAR } = {}) {
+  if (!outDir) throw new Error('outDir required');
+  await ensureDir(outDir);
+  const countries = await countryCatalog();
+  const records = [];
+  const failures = [];
+  for (const [code, label, domain] of WORLD_BANK_INDICATORS) {
+    try {
+      const payload = await fetchJson(`${WB}/country/all/indicator/${encodeURIComponent(code)}?format=json&date=${startYear}:${endYear}&per_page=20000`);
+      const rows = Array.isArray(payload?.[1]) ? payload[1] : [];
+      for (const row of rows) {
+        const country = countries.get(row?.countryiso3code);
+        const year = Number(row?.date);
+        const value = row?.value == null ? null : Number(row.value);
+        if (!country || !Number.isFinite(year) || !Number.isFinite(value)) continue;
+        records.push({
+          source: 'WORLD_BANK_API', sourceUrl: `${WB}/country/all/indicator/${code}`,
+          country, indicator: { code, label, domain }, year, value,
+          referenceTime: `${year}-12-31T00:00:00.000Z`, releaseTime: null,
+          acquiredAt: new Date().toISOString(),
+          temporalIntegrity: 'REFERENCE_ONLY',
+          temporalNote: 'World Bank current historical series does not prove the exact revision vintage available at the simulated cutoff. Track A only.',
+        });
+      }
+    } catch (error) { failures.push({ code, error: String(error?.message || error) }); }
+  }
+  const manifest = {
+    datasetVersion: `wb-${new Date().toISOString()}`,
+    startYear, endYear, indicatorsRequested: WORLD_BANK_INDICATORS.length,
+    records: records.length, countries: new Set(records.map((r) => r.country.iso3)).size,
+    failures, strictReplayEligible: false,
+    boundary: 'Historical replay dataset. Do not describe as strict no-lookahead vintage data unless release/revision vintages are added.',
+  };
+  await writeJson(path.join(outDir, 'manifest.json'), manifest);
+  await writeFile(path.join(outDir, 'world-bank.jsonl'), records.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  return manifest;
+}
+
+export async function loadDataset(outDir) {
+  const text = await readFile(path.join(outDir, 'world-bank.jsonl'), 'utf8');
+  const records = text.split(/\r?\n/).filter(Boolean).map((line) => JSON.parse(line));
+  let manifest = null;
+  try { manifest = await readJson(path.join(outDir, 'manifest.json')); } catch {}
+  return { records, manifest };
+}
+
+export function indexDataset(records) {
+  const byKey = new Map();
+  const byCountryYear = new Map();
+  for (const r of records) {
+    byKey.set(`${r.country.iso3}|${r.indicator.code}|${r.year}`, r);
+    const cy = `${r.country.iso3}|${r.year}`;
+    if (!byCountryYear.has(cy)) byCountryYear.set(cy, []);
+    byCountryYear.get(cy).push(r);
+  }
+  return { byKey, byCountryYear };
+}

--- a/scripts/cognitive-olympics/lib/engines.mjs
+++ b/scripts/cognitive-olympics/lib/engines.mjs
@@ -1,0 +1,114 @@
+import { parseJsonLoose, clamp01 } from './utils.mjs';
+import { constitutionPrompt } from './constitutions.mjs';
+
+function heuristicAnswer(p) {
+  const xs = p.history || [];
+  const last = xs.at(-1)?.value;
+  const prev = xs.at(-2)?.value;
+  let decision = 'ABSTAIN';
+  if (Number.isFinite(last) && Number.isFinite(prev)) {
+    const scale = Math.max(1, Math.abs(prev));
+    const d = (last - prev) / scale;
+    decision = Math.abs(d) <= 0.01 ? 'STABLE' : d > 0 ? 'UP' : 'DOWN';
+  }
+  return {
+    problemId: p.problemId, decision, confidence: decision === 'ABSTAIN' ? 0.2 : 0.55,
+    hypothesis: 'Persistence baseline: the most recent direction continues one step.',
+    rivals: [], evidenceUsed: [], evidenceRequests: [], sfiMethods: [], agentsUsed: [], abstainReason: decision === 'ABSTAIN' ? 'insufficient history' : null,
+  };
+}
+
+export function statsEngine() {
+  return {
+    id: 'stats:persistence', kind: 'stats', label: 'STATISTICAL PERSISTENCE CONTROL',
+    async planEvidence(problems) { return Object.fromEntries(problems.map((p) => [p.problemId, []])); },
+    async solve(problems) { return problems.map(heuristicAnswer); },
+    async congress() { return []; },
+  };
+}
+
+async function ollamaChat({ baseUrl, model, messages, format = 'json', options = {} }) {
+  const response = await fetch(`${baseUrl.replace(/\/$/, '')}/api/chat`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ model, messages, stream: false, format, options }),
+  });
+  if (!response.ok) throw new Error(`OLLAMA_HTTP_${response.status}:${await response.text()}`);
+  const body = await response.json();
+  return body?.message?.content || '';
+}
+
+async function groqChat({ model, messages, maxTokens = 8000 }) {
+  const key = process.env.GROQ_API_KEY;
+  if (!key) throw new Error('GROQ_API_KEY missing');
+  const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: { authorization: `Bearer ${key}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ model, messages, temperature: 0.1, max_tokens: maxTokens, response_format: { type: 'json_object' } }),
+  });
+  if (!response.ok) throw new Error(`GROQ_HTTP_${response.status}:${await response.text()}`);
+  const body = await response.json();
+  return body?.choices?.[0]?.message?.content || '';
+}
+
+function normalizeAnswers(raw, problems) {
+  const parsed = parseJsonLoose(raw);
+  const answers = Array.isArray(parsed) ? parsed : (Array.isArray(parsed?.answers) ? parsed.answers : []);
+  const byId = new Map(answers.map((a) => [a?.problemId, a]));
+  return problems.map((p) => {
+    const a = byId.get(p.problemId) || {};
+    const decision = ['UP', 'DOWN', 'STABLE', 'ABSTAIN'].includes(a.decision) ? a.decision : 'ABSTAIN';
+    return {
+      problemId: p.problemId,
+      decision, confidence: clamp01(a.confidence ?? 0.1),
+      hypothesis: String(a.hypothesis || ''),
+      rivals: Array.isArray(a.rivals) ? a.rivals.slice(0, 4).map(String) : [],
+      evidenceUsed: Array.isArray(a.evidenceUsed) ? a.evidenceUsed.slice(0, 8).map(String) : [],
+      evidenceRequests: Array.isArray(a.evidenceRequests) ? a.evidenceRequests.slice(0, 4).map(String) : [],
+      sfiMethods: Array.isArray(a.sfiMethods) ? a.sfiMethods.slice(0, 4).map(String) : [],
+      agentsUsed: Array.isArray(a.agentsUsed) ? a.agentsUsed.slice(0, 21).map(String) : [],
+      abstainReason: a.abstainReason ? String(a.abstainReason) : null,
+    };
+  });
+}
+
+function planPrompt(problems, constitution, memory, sfiAgentPacket) {
+  return `${constitution}\nAnnual memory (scored past only): ${JSON.stringify(memory).slice(0, 12000)}\n\nFor each problem, choose at most 4 evidenceId values from evidenceCatalog that you genuinely need before deciding. Do not guess future values. Return JSON {"plans":[{"problemId":"...","evidenceRequests":["E:..."]}]}.\nSFI agent packet (may be absent): ${JSON.stringify(sfiAgentPacket || null).slice(0, 18000)}\nProblems: ${JSON.stringify(problems)}`;
+}
+
+function solvePrompt(problems, constitution, memory, sfiAgentPacket) {
+  return `${constitution}\nAnnual memory (scored past only): ${JSON.stringify(memory).slice(0, 12000)}\n\nSolve every problem. Required fields: problemId, decision=UP|DOWN|STABLE|ABSTAIN, confidence 0..1, hypothesis, rivals[], evidenceUsed[], evidenceRequests[], sfiMethods[], agentsUsed[], abstainReason. If requiredMethod exists and SFI is available, use it only within its stated scope. Evidence IDs must come from the supplied problem. If an SFI agent packet is available, agentsUsed must name only agents actually used in your reasoning. No information after year is admissible. Return JSON {"answers":[...]}.\nSFI agent packet (may be absent): ${JSON.stringify(sfiAgentPacket || null).slice(0, 18000)}\nProblems: ${JSON.stringify(problems)}`;
+}
+
+export function llmEngine({ provider, model, baseUrl = process.env.OLLAMA_BASE_URL || 'http://127.0.0.1:11434' }) {
+  const id = `${provider}:${model}`;
+  const call = async (messages) => provider === 'ollama'
+    ? ollamaChat({ baseUrl, model, messages })
+    : provider === 'groq'
+      ? groqChat({ model, messages })
+      : Promise.reject(new Error(`Unsupported provider ${provider}`));
+  return {
+    id, kind: 'llm', label: id,
+    async planEvidence(problems, ctx) {
+      const c = constitutionPrompt(ctx.constitutionId, ctx.constitutionState);
+      const raw = await call([{ role: 'system', content: 'You are an evidence acquisition planner in a temporally sealed cognitive laboratory.' }, { role: 'user', content: planPrompt(problems, c, ctx.memory, ctx.sfiAgentPacket) }]);
+      const parsed = parseJsonLoose(raw); const plans = Array.isArray(parsed?.plans) ? parsed.plans : [];
+      return Object.fromEntries(plans.map((p) => [p.problemId, Array.isArray(p.evidenceRequests) ? p.evidenceRequests.slice(0, 4) : []]));
+    },
+    async solve(problems, ctx) {
+      const c = constitutionPrompt(ctx.constitutionId, ctx.constitutionState);
+      const raw = await call([{ role: 'system', content: 'You are a cognitive athlete. You may lose. Preserve temporal integrity and evidence boundaries.' }, { role: 'user', content: solvePrompt(problems, c, ctx.memory, ctx.sfiAgentPacket) }]);
+      return normalizeAnswers(raw, problems);
+    },
+    async congress({ self, peers, year, memory }) {
+      const raw = await call([{ role: 'system', content: 'Annual congress occurs only after the year has been scored. Peer identities are pseudonymous.' }, { role: 'user', content: `You are ${self}. Year ${year} is already scored. For each peer, you may send at most two short messages. Share, question, warn, challenge or decline. Do not invent unobserved facts. Return JSON {"messages":[{"to":"...","text":"..."}]}. Peers: ${JSON.stringify(peers)} Memory: ${JSON.stringify(memory).slice(0, 8000)}` }]);
+      const parsed = parseJsonLoose(raw); return Array.isArray(parsed?.messages) ? parsed.messages.slice(0, peers.length * 2) : [];
+    },
+  };
+}
+
+export async function discoverOllamaModels(baseUrl = process.env.OLLAMA_BASE_URL || 'http://127.0.0.1:11434') {
+  const response = await fetch(`${baseUrl.replace(/\/$/, '')}/api/tags`);
+  if (!response.ok) throw new Error(`OLLAMA_TAGS_HTTP_${response.status}`);
+  const body = await response.json();
+  return (body?.models || []).map((m) => m.name).filter(Boolean);
+}

--- a/scripts/cognitive-olympics/lib/manifest.mjs
+++ b/scripts/cognitive-olympics/lib/manifest.mjs
@@ -1,0 +1,29 @@
+import { EXPERIMENT_VERSION, START_YEAR, END_YEAR } from './config.mjs';
+import { CONSTITUTIONS } from './constitutions.mjs';
+import { SFI_METHODS, FOUNDER_EDITION_SOURCE } from './sfi-methods.mjs';
+
+export function experimentManifest() {
+  return {
+    experiment: 'SFI Cognitive Olympics 2026',
+    version: EXPERIMENT_VERSION,
+    motto: 'No se trata de llegar. Se trata de aprender a saber llegar.',
+    years: { start: START_YEAR, end: END_YEAR },
+    objectUnderTest: 'Cognitive Twin and derived cognitive constitutions under System Friction Institute constraints; forecasting/learning algorithms are instruments, not claimed SFI inventions.',
+    tracks: {
+      A: 'historical replay; current historical series may contain revision/model-weight leakage and is not the definitive validation',
+      B: 'shadow-world replay with pseudonymized entities/indicators to reduce recognition effects',
+      C: 'prospective live validation from 2026 forward; definitive temporal test when outcomes occur',
+    },
+    rules: [
+      'future partition is never exposed to an athlete',
+      'predictions are hashed before outcomes are scored',
+      'same datasets and scoring are used for comparable heats',
+      'an unregistered failure cannot be relabeled retrospectively as an experimental perturbation',
+      'model engine, cognitive constitution, SFI access and learning policy are separately recorded',
+      'SFI auxiliary methods keep their original canon/stability status',
+    ],
+    constitutions: CONSTITUTIONS,
+    auxiliaryMethodSource: FOUNDER_EDITION_SOURCE,
+    sfiMethods: SFI_METHODS,
+  };
+}

--- a/scripts/cognitive-olympics/lib/problem-forge.mjs
+++ b/scripts/cognitive-olympics/lib/problem-forge.mjs
@@ -1,0 +1,91 @@
+import { SFI_METHODS } from './sfi-methods.mjs';
+import { sampleDeterministic, seededRandom, sha256 } from './utils.mjs';
+
+function direction(a, b) {
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return 'MISSING';
+  const scale = Math.max(1, Math.abs(a));
+  const delta = (b - a) / scale;
+  if (Math.abs(delta) <= 0.01) return 'STABLE';
+  return delta > 0 ? 'UP' : 'DOWN';
+}
+
+function history(index, country, indicator, year, depth = 4) {
+  const out = [];
+  for (let y = year - depth + 1; y <= year; y += 1) {
+    const row = index.byKey.get(`${country}|${indicator}|${y}`);
+    if (row) out.push({ year: y, value: row.value });
+  }
+  return out;
+}
+
+function makeCatalog(index, row, year, rnd) {
+  const same = index.byCountryYear.get(`${row.country.iso3}|${year}`) || [];
+  const candidates = same.filter((x) => x.indicator.code !== row.indicator.code);
+  const picked = sampleDeterministic(candidates, 6, `${row.country.iso3}:${row.indicator.code}:${year}:${rnd()}`);
+  return picked.map((x) => ({
+    evidenceId: `E:${x.country.iso3}:${x.indicator.code}:${year}`,
+    label: x.indicator.label,
+    domain: x.indicator.domain,
+    value: x.value,
+    year,
+    source: x.source,
+  }));
+}
+
+export function forgeProblems({ records, index, year, count = 5000, seed = 'SFI_CL' }) {
+  const rnd = seededRandom(`${seed}:${year}`);
+  const currentRows = records.filter((r) => r.year === year && index.byKey.has(`${r.country.iso3}|${r.indicator.code}|${year + 1}`));
+  if (!currentRows.length) return [];
+  const base = [];
+  const methodEvery = Math.max(2, Math.floor(1 / 0.08));
+  for (let i = 0; i < count * 2 && base.length < count; i += 1) {
+    const row = currentRows[Math.floor(rnd() * currentRows.length)];
+    const next = index.byKey.get(`${row.country.iso3}|${row.indicator.code}|${year + 1}`);
+    const hist = history(index, row.country.iso3, row.indicator.code, year, 4);
+    if (!next || hist.length < 2) continue;
+    const typeRoll = rnd();
+    let type = 'FORECAST_DIRECTION';
+    if (typeRoll > 0.72 && typeRoll <= 0.86) type = 'EVIDENCE_DISCIPLINE';
+    else if (typeRoll > 0.86 && typeRoll <= 0.94) type = 'RIVAL_HYPOTHESIS';
+    else if (typeRoll > 0.94) type = 'SFI_AUXILIARY';
+    if (base.length % methodEvery === 0) type = 'SFI_AUXILIARY';
+    const method = type === 'SFI_AUXILIARY' ? SFI_METHODS[Math.floor(rnd() * SFI_METHODS.length)] : null;
+    const evidenceCatalog = makeCatalog(index, row, year, rnd);
+    const problemId = `P:${year}:${String(base.length + 1).padStart(5, '0')}:${row.country.iso3}:${row.indicator.code}`;
+    base.push({
+      problemId, year, targetYear: year + 1, type,
+      geography: { iso3: row.country.iso3, alias: `G-${sha256(row.country.iso3).slice(0, 6)}`, name: row.country.name },
+      indicator: row.indicator,
+      history: hist,
+      currentValue: row.value,
+      evidenceCatalog,
+      requiredMethod: method ? { id: method.id, status: method.status, purpose: method.purpose, operations: method.operations } : null,
+      hiddenOutcome: { value: next.value, direction: direction(row.value, next.value) },
+      admissibleThrough: year,
+      strictVintageEligible: false,
+    });
+  }
+  return base;
+}
+
+export function publicProblem(problem, { shadow = false, revealCatalogValues = true } = {}) {
+  return {
+    problemId: problem.problemId,
+    year: problem.year,
+    targetYear: problem.targetYear,
+    type: problem.type,
+    geography: shadow ? { alias: problem.geography.alias } : { iso3: problem.geography.iso3, name: problem.geography.name },
+    indicator: shadow ? { code: `I-${sha256(problem.indicator.code).slice(0, 8)}`, domain: problem.indicator.domain } : problem.indicator,
+    history: problem.history,
+    currentValue: problem.currentValue,
+    evidenceCatalog: problem.evidenceCatalog.map((e) => revealCatalogValues ? e : ({ evidenceId: e.evidenceId, label: shadow ? `AUX-${sha256(e.label).slice(0, 6)}` : e.label, domain: e.domain, year: e.year, source: e.source })),
+    requiredMethod: problem.requiredMethod,
+    admissibleThrough: problem.admissibleThrough,
+    temporalBoundary: `No evidence after ${problem.year} is admissible. You are evaluated against ${problem.targetYear} only after the answer is sealed.`,
+  };
+}
+
+export function enrichWithEvidence(problem, requested = []) {
+  const allowed = new Set(requested.slice(0, 4));
+  return problem.evidenceCatalog.filter((e) => allowed.has(e.evidenceId));
+}

--- a/scripts/cognitive-olympics/lib/problem-forge.mjs
+++ b/scripts/cognitive-olympics/lib/problem-forge.mjs
@@ -23,7 +23,7 @@ function makeCatalog(index, row, year, rnd) {
   const candidates = same.filter((x) => x.indicator.code !== row.indicator.code);
   const picked = sampleDeterministic(candidates, 6, `${row.country.iso3}:${row.indicator.code}:${year}:${rnd()}`);
   return picked.map((x) => ({
-    evidenceId: `E:${x.country.iso3}:${x.indicator.code}:${year}`,
+    evidenceId: `E-${sha256(`${x.country.iso3}|${x.indicator.code}|${year}`).slice(0, 16)}`,
     label: x.indicator.label,
     domain: x.indicator.domain,
     value: x.value,
@@ -51,7 +51,7 @@ export function forgeProblems({ records, index, year, count = 5000, seed = 'SFI_
     if (base.length % methodEvery === 0) type = 'SFI_AUXILIARY';
     const method = type === 'SFI_AUXILIARY' ? SFI_METHODS[Math.floor(rnd() * SFI_METHODS.length)] : null;
     const evidenceCatalog = makeCatalog(index, row, year, rnd);
-    const problemId = `P:${year}:${String(base.length + 1).padStart(5, '0')}:${row.country.iso3}:${row.indicator.code}`;
+    const problemId = `P:${year}:${String(base.length + 1).padStart(5, '0')}:${sha256(`${row.country.iso3}|${row.indicator.code}`).slice(0, 10)}`;
     base.push({
       problemId, year, targetYear: year + 1, type,
       geography: { iso3: row.country.iso3, alias: `G-${sha256(row.country.iso3).slice(0, 6)}`, name: row.country.name },

--- a/scripts/cognitive-olympics/lib/scorer.mjs
+++ b/scripts/cognitive-olympics/lib/scorer.mjs
@@ -1,0 +1,56 @@
+import { mean, clamp01 } from './utils.mjs';
+import { CONSTITUTIONS } from './constitutions.mjs';
+
+function futureLeak(answer, cutoffYear, targetYear) {
+  const text = JSON.stringify(answer);
+  const years = [...text.matchAll(/\b(20\d{2})\b/g)].map((m) => Number(m[1]));
+  return years.some((y) => y > targetYear); // naming the forecast target year itself is allowed
+}
+
+export function scoreAnswers(problems, answers, { constitutionId, engineId, year }) {
+  const byProblem = new Map(problems.map((p) => [p.problemId, p]));
+  const rows = [];
+  for (const answer of answers) {
+    const p = byProblem.get(answer.problemId); if (!p) continue;
+    const outcome = p.hiddenOutcome?.direction;
+    const answered = answer.decision !== 'ABSTAIN';
+    const hit = answered && answer.decision === outcome ? 1 : 0;
+    const evidenceIds = new Set(p.evidenceCatalog.map((e) => e.evidenceId));
+    const invalidEvidence = (answer.evidenceUsed || []).filter((id) => !evidenceIds.has(id));
+    const requiredMethod = p.requiredMethod?.id || null;
+    const sfiMode = CONSTITUTIONS[constitutionId]?.sfiMode || 'NONE';
+    const methodCompliance = requiredMethod && sfiMode !== 'NONE' ? Number((answer.sfiMethods || []).includes(requiredMethod)) : 1;
+    const sfiBoundaryViolation = sfiMode === 'NONE' && ((answer.sfiMethods || []).length > 0 || (answer.agentsUsed || []).length > 0);
+    const leaked = futureLeak(answer, p.year, p.targetYear);
+    const confidence = clamp01(answer.confidence);
+    rows.push({
+      problemId: p.problemId, type: p.type, outcome, decision: answer.decision, confidence,
+      answered, hit, brier: answered ? (confidence - hit) ** 2 : null,
+      rivals: (answer.rivals || []).length,
+      evidenceInvalid: invalidEvidence.length,
+      methodCompliance,
+      agentUse: Array.isArray(answer.agentsUsed) && answer.agentsUsed.length ? 1 : 0,
+      sfiBoundaryViolation: sfiBoundaryViolation ? 1 : 0,
+      temporalViolation: leaked ? 1 : 0,
+      abstentionJustified: answer.decision === 'ABSTAIN' && (!p.history || p.history.length < 2) ? 1 : 0,
+    });
+  }
+  const answeredRows = rows.filter((r) => r.answered);
+  const abstained = rows.filter((r) => !r.answered);
+  const score = {
+    year, constitutionId, engineId, problems: rows.length,
+    coverage: rows.length ? answeredRows.length / rows.length : 0,
+    accuracy: answeredRows.length ? mean(answeredRows.map((r) => r.hit)) : 0,
+    brier: answeredRows.length ? mean(answeredRows.map((r) => r.brier)) : 1,
+    rivalRate: rows.length ? mean(rows.map((r) => Number(r.rivals > 0))) : 0,
+    evidenceDiscipline: rows.length ? 1 - mean(rows.map((r) => Number(r.evidenceInvalid > 0))) : 0,
+    sfiMethodCompliance: rows.length ? mean(rows.map((r) => r.methodCompliance)) : 0,
+    agentUseRate: rows.length ? mean(rows.map((r) => r.agentUse)) : 0,
+    sfiBoundaryIntegrity: rows.length ? 1 - mean(rows.map((r) => r.sfiBoundaryViolation)) : 1,
+    temporalIntegrity: rows.length ? 1 - mean(rows.map((r) => r.temporalViolation)) : 0,
+    abstentionRate: rows.length ? abstained.length / rows.length : 0,
+    abstentionQuality: abstained.length ? mean(abstained.map((r) => r.abstentionJustified)) : 1,
+  };
+  score.composite = 0.36 * score.accuracy + 0.14 * (1 - score.brier) + 0.12 * score.evidenceDiscipline + 0.12 * score.temporalIntegrity + 0.08 * score.rivalRate + 0.05 * score.sfiMethodCompliance + 0.02 * score.agentUseRate + 0.03 * score.sfiBoundaryIntegrity + 0.08 * score.coverage;
+  return { score, rows };
+}

--- a/scripts/cognitive-olympics/lib/sfi-methods.mjs
+++ b/scripts/cognitive-olympics/lib/sfi-methods.mjs
@@ -1,0 +1,23 @@
+export const FOUNDER_EDITION_SOURCE = {
+  title: 'Instrumentalización de una Mente Fragmentada',
+  subtitle: 'Del conocimiento tácito a una arquitectura observable',
+  edition: 'The Founder Edition v1.2 FINAL',
+  institution: 'System Friction Institute',
+  date: '2026-08',
+  role: 'AUXILIARY_METHOD_SOURCE',
+  boundary: 'Method cards guide laboratory procedure; their use is not evidence that the method itself is validated.',
+};
+
+export const SFI_METHODS = [
+  { id: 'MIHM_BASELINE', status: 'CANON', family: 'MIHM v3', purpose: 'Build a sufficiently traceable state configuration without treating an aggregate as the whole system.', operations: ['identify object/domain', 'declare resolution/nodes/context', 'validate source integrity', 'preserve missingness', 'version the vector', 'set re-observation window'] },
+  { id: 'WSV_CONTEXT', status: 'STABLE', family: 'World Spectrum Vector', purpose: 'Build a contextual baseline while preserving provenance and dependency between sources.', operations: ['declare question', 'set contextual scope', 'select justified sources', 'record source dependence', 'capture weak signals', 'classify epistemic state'] },
+  { id: 'DIOL_RETROLONGITUDINAL', status: 'STABLE', family: 'DIOL-SF v2', purpose: 'Update the model of the past without rewriting the original historical record.', operations: ['preserve original reading', 'register new evidence', 'identify changed interpretation', 'construct rival hypotheses', 'inspect precursor capacities', 'update model not record'] },
+  { id: 'MOPH_PRIOR_HYPOTHESIS', status: 'STABLE', family: 'MOP-H', purpose: 'Freeze a prediction before an intervention so the result cannot be rewritten retrospectively.', operations: ['assign case/hypothesis id', 'state baseline', 'state exact perturbation', 'state expected result/time', 'state risk', 'freeze before observation'] },
+  { id: 'SFI_INFERENCE', status: 'IN_DEVELOPMENT', family: 'Método SFI de Inferencia v0.1', purpose: 'Reduce the possibility space without converting interpretation into observation.', operations: ['audit preconditions', 'separate fact/inference', 'enumerate rivals', 'check precursor capacities', 'inspect node history/context', 'seek independent evidence', 'define discriminating observation'] },
+  { id: 'MINIMAL_PERTURBATION', status: 'IN_DEVELOPMENT', family: 'Perturbación Mínima de Campo', purpose: 'Produce information with the smallest reversible change sufficient to discriminate hypotheses.', operations: ['baseline', 'declare objective/hypothesis', 'identify invariants/degrees of freedom', 'assess risk/return', 'one minimal change', 'observe side effects', 'reobserve before escalation'] },
+  { id: 'RESULT_CONTRAST', status: 'IN_DEVELOPMENT', family: 'Método de Observación y Contraste de Resultados', purpose: 'Compare expected and observed results while distinguishing intention, execution and outcome.', operations: ['recover frozen baseline/hypothesis', 'register observed result', 'compare variables/relations', 'identify unplanned effects', 'contrast rivals', 'classify persistence/reversal/new trajectory'] },
+  { id: 'TRANSDIMENSIONAL_CONTRAST', status: 'IN_DEVELOPMENT', family: 'Método de Coherencia Transdimensional', purpose: 'Test whether identity survives a change of domain by preserving roles, relations and invariants rather than superficial similarity.', operations: ['declare source/destination', 'identify vertebral invariants', 'map functions', 'register unavoidable loss', 'contrast attractor/invariants', 'classify loss'] },
+  { id: 'MOPS_BASELINE', status: 'EXPERIMENTAL', family: 'MOP-S', purpose: 'Observe signal persistence across acquisition, signal, publication, visualization, recovery and traceability without collapsing stages.', operations: ['preserve immutable original', 'hash/describe carrier', 'declare detector', 'separate A/S/P/V/G/T', 'register known transformations', 'keep unresolved transformations unresolved'] },
+];
+
+export const SFI_METHOD_BY_ID = Object.fromEntries(SFI_METHODS.map((m) => [m.id, m]));

--- a/scripts/cognitive-olympics/lib/utils.mjs
+++ b/scripts/cognitive-olympics/lib/utils.mjs
@@ -1,0 +1,45 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, appendFile, writeFile, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export const clamp01 = (n) => Math.max(0, Math.min(1, Number(n) || 0));
+export const mean = (xs) => xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0;
+export const sha256 = (value) => createHash('sha256').update(typeof value === 'string' ? value : JSON.stringify(value)).digest('hex');
+export const runId = () => `cl-${Date.now()}-${randomUUID().slice(0, 8)}`;
+export const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export function seededRandom(seed) {
+  let h = 2166136261 >>> 0;
+  for (const ch of String(seed)) { h ^= ch.charCodeAt(0); h = Math.imul(h, 16777619); }
+  return () => {
+    h += 0x6D2B79F5;
+    let t = h;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function sampleDeterministic(items, n, seed) {
+  if (items.length <= n) return [...items];
+  const rnd = seededRandom(seed);
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rnd() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy.slice(0, n);
+}
+
+export async function ensureDir(dir) { await mkdir(dir, { recursive: true }); return dir; }
+export async function writeJson(file, value) { await ensureDir(path.dirname(file)); await writeFile(file, `${JSON.stringify(value, null, 2)}\n`); }
+export async function readJson(file) { return JSON.parse(await readFile(file, 'utf8')); }
+export async function appendJsonl(file, value) { await ensureDir(path.dirname(file)); await appendFile(file, `${JSON.stringify(value)}\n`); }
+
+export function parseJsonLoose(text) {
+  if (typeof text !== 'string') return text;
+  try { return JSON.parse(text); } catch {}
+  const start = text.indexOf('{'); const end = text.lastIndexOf('}');
+  if (start >= 0 && end > start) return JSON.parse(text.slice(start, end + 1));
+  throw new Error('Model did not return valid JSON');
+}

--- a/scripts/cognitive-olympics/prepare.mjs
+++ b/scripts/cognitive-olympics/prepare.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { parseCli } from './lib/config.mjs';
+import { prepareWorldBankDataset } from './lib/dataset.mjs';
+
+const args = parseCli();
+const outDir = path.resolve(args.out || process.env.SFI_CL_DATA_DIR || '.sfi-cl/data/world-bank');
+const manifest = await prepareWorldBankDataset({ outDir });
+console.log(JSON.stringify({ ok: true, outDir, manifest }, null, 2));

--- a/scripts/cognitive-olympics/runner.mjs
+++ b/scripts/cognitive-olympics/runner.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { spawn } from 'node:child_process';
+import { parseCli, profileFrom, START_YEAR, END_YEAR } from './lib/config.mjs';
+import { loadDataset, indexDataset } from './lib/dataset.mjs';
+import { forgeProblems, publicProblem, enrichWithEvidence } from './lib/problem-forge.mjs';
+import { statsEngine, llmEngine, discoverOllamaModels } from './lib/engines.mjs';
+import { DEFAULT_CONSTITUTIONS, CONSTITUTIONS, evolveState } from './lib/constitutions.mjs';
+import { scoreAnswers } from './lib/scorer.mjs';
+import { appendJsonl, ensureDir, runId as makeRunId, sha256, writeJson } from './lib/utils.mjs';
+import { experimentManifest } from './lib/manifest.mjs';
+
+const args = parseCli();
+const profile = profileFrom(args.profile);
+const dataDir = path.resolve(args.data || process.env.SFI_CL_DATA_DIR || '.sfi-cl/data/world-bank');
+const runsDir = path.resolve(args.runs || process.env.SFI_CL_RUNS_DIR || '.sfi-cl/runs');
+const runId = args['run-id'] || makeRunId();
+const runDir = path.join(runsDir, runId);
+const shadow = String(args.track || 'A').toUpperCase() === 'B';
+const congressEnabled = args.congress === true || String(args.congress || profile.congress) === 'true';
+const constitutionIds = String(args.constitutions || process.env.SFI_CL_CONSTITUTIONS || DEFAULT_CONSTITUTIONS.join(',')).split(',').map((s) => s.trim()).filter(Boolean);
+const problemsPerYear = Number(args.problems || process.env.SFI_CL_PROBLEMS_PER_YEAR || profile.problemsPerYear);
+const batchSize = Number(args['batch-size'] || process.env.SFI_CL_BATCH_SIZE || profile.batchSize);
+const startYear = Number(args.start || START_YEAR);
+const endYear = Number(args.end || END_YEAR);
+
+await ensureDir(runDir);
+const ledger = path.join(runDir, 'ledger.jsonl');
+await writeJson(path.join(runDir, 'manifest.json'), { ...experimentManifest(), runId, profile, track: shadow ? 'B' : 'A', problemsPerYear, batchSize, congressEnabled, dataDir, startedAt: new Date().toISOString() });
+await appendJsonl(ledger, { event: 'RUN_STARTED', runId, at: new Date().toISOString(), profile: profile.name, problemsPerYear, batchSize });
+
+const { records, manifest: datasetManifest } = await loadDataset(dataDir);
+const index = indexDataset(records);
+
+async function buildEngines() {
+  const spec = String(args.engines || process.env.SFI_CL_ENGINES || 'stats,ollama:auto').split(',').map((s) => s.trim()).filter(Boolean);
+  const out = [];
+  for (const entry of spec) {
+    if (entry === 'stats') { out.push(statsEngine()); continue; }
+    const [provider, modelRaw] = entry.split(':', 2);
+    if (provider === 'ollama' && (!modelRaw || modelRaw === 'auto')) {
+      try {
+        const models = await discoverOllamaModels();
+        const max = Number(process.env.SFI_CL_OLLAMA_AUTO_COUNT || 3);
+        for (const model of models.slice(0, max)) out.push(llmEngine({ provider: 'ollama', model }));
+      } catch (error) { await appendJsonl(ledger, { event: 'ENGINE_SKIPPED', engine: entry, error: String(error?.message || error) }); }
+      continue;
+    }
+    if (provider === 'groq' && modelRaw) { out.push(llmEngine({ provider: 'groq', model: modelRaw })); continue; }
+    if (provider === 'ollama' && modelRaw) { out.push(llmEngine({ provider: 'ollama', model: modelRaw })); continue; }
+  }
+  if (!out.length) out.push(statsEngine());
+  return out;
+}
+
+const engines = await buildEngines();
+const athletes = [];
+for (const engine of engines) {
+  if (engine.kind === 'stats') athletes.push({ id: `A-${sha256(engine.id).slice(0, 8)}`, engine, constitutionId: 'generic-control', constitutionState: {}, memory: [] });
+  else for (const constitutionId of constitutionIds) {
+    if (!CONSTITUTIONS[constitutionId]) continue;
+    athletes.push({ id: `A-${sha256(`${engine.id}|${constitutionId}`).slice(0, 8)}`, engine, constitutionId, constitutionState: {}, memory: [] });
+  }
+}
+await writeJson(path.join(runDir, 'athletes.json'), athletes.map((a) => ({ id: a.id, engine: a.engine.id, constitutionId: a.constitutionId, constitution: CONSTITUTIONS[a.constitutionId] })));
+await appendJsonl(ledger, { event: 'ATHLETES_REGISTERED', count: athletes.length, athletes: athletes.map((a) => ({ id: a.id, engine: a.engine.id, constitution: a.constitutionId })) });
+
+async function runSfiAgentBridge(year, problems) {
+  const evidence = problems.slice(0, 250).map((p) => ({
+    id: p.problemId,
+    source: 'SFI_CL_WORLD_FRAME',
+    confidence: 0.8,
+    payload: {
+      year, country: p.geography.iso3, indicator: p.indicator, history: p.history,
+      currentValue: p.currentValue, epistemicClass: 'IMPORTED_HISTORICAL_REPLAY',
+    },
+  }));
+  const context = {
+    taskId: `cl:${runId}:${year}`,
+    cycleId: `cl-cycle:${runId}:${year}`,
+    logbookId: `cl:${runId}`,
+    currentEvent: 'SFI_CL_WORLD_FRAME',
+    evidence, hypotheses: [], contradictions: [], simulations: [], predictions: [], risks: [], opportunities: [],
+    metadata: { requestedAgents: 'ALL_REGISTERED', llmAugmentation: false, laboratory: true, cutoffYear: year },
+  };
+  return await new Promise((resolve) => {
+    const child = spawn(process.execPath, ['--import', 'tsx', path.join(import.meta.dirname, 'sfi-agent-bridge.ts')], { stdio: ['pipe', 'pipe', 'pipe'], env: process.env });
+    let stdout = ''; let stderr = '';
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+    child.on('exit', (code) => {
+      if (code !== 0) return resolve({ ok: false, error: stderr.slice(-4000), executedAgents: [] });
+      try { resolve(JSON.parse(stdout)); } catch { resolve({ ok: false, error: 'INVALID_BRIDGE_JSON', raw: stdout.slice(-4000), executedAgents: [] }); }
+    });
+    child.stdin.end(JSON.stringify({ context }));
+  });
+}
+
+const totalStarted = performance.now();
+const cumulative = new Map(athletes.map((a) => [a.id, []]));
+
+for (let year = startYear; year < endYear; year += 1) {
+  const yearStart = performance.now();
+  const problems = forgeProblems({ records, index, year, count: problemsPerYear, seed: `${runId}:${profile.name}` });
+  await appendJsonl(ledger, { event: 'YEAR_STARTED', year, problems: problems.length, at: new Date().toISOString() });
+  if (!problems.length) { await appendJsonl(ledger, { event: 'YEAR_SKIPPED', year, reason: 'NO_SCORABLE_PROBLEMS' }); continue; }
+
+  const annualScores = [];
+  const sfiAgentPacket = await runSfiAgentBridge(year, problems);
+  await appendJsonl(ledger, { event: 'SFI_AGENT_BRIDGE_COMPLETED', year, ok: Boolean(sfiAgentPacket?.ok), executedAgents: sfiAgentPacket?.executedAgents || [], error: sfiAgentPacket?.error || null });
+  const needsSfiBridge = athletes.some((a) => (CONSTITUTIONS[a.constitutionId]?.sfiMode || 'NONE') !== 'NONE');
+  if (needsSfiBridge && !sfiAgentPacket?.ok) throw new Error(`SFI_AGENT_BRIDGE_REQUIRED:${sfiAgentPacket?.error || 'unknown bridge failure'}`);
+  for (const athlete of athletes) {
+    const athleteStart = performance.now();
+    const answers = [];
+    let errors = 0;
+    const sfiMode = CONSTITUTIONS[athlete.constitutionId]?.sfiMode || 'NONE';
+    if (sfiMode !== 'NONE') athlete.sfiAgentPacket = sfiAgentPacket;
+    else athlete.sfiAgentPacket = null;
+    for (let offset = 0; offset < problems.length; offset += batchSize) {
+      const rawBatch = problems.slice(offset, offset + batchSize);
+      const publicBatch = rawBatch.map((p) => publicProblem(p, { shadow, revealCatalogValues: athlete.engine.kind === 'stats' }));
+      try {
+        let plans = {};
+        if (athlete.engine.kind === 'llm') plans = await athlete.engine.planEvidence(publicBatch, athlete);
+        const enriched = publicBatch.map((p, i) => ({ ...p, acquiredEvidence: enrichWithEvidence(rawBatch[i], plans[p.problemId] || []) }));
+        const batchAnswers = await athlete.engine.solve(enriched, athlete);
+        answers.push(...batchAnswers);
+        await appendJsonl(ledger, { event: 'HEAT_COMPLETED', year, athleteId: athlete.id, offset, size: rawBatch.length, at: new Date().toISOString() });
+      } catch (error) {
+        errors += 1;
+        await appendJsonl(ledger, { event: 'HEAT_FAILED', year, athleteId: athlete.id, offset, error: String(error?.message || error), at: new Date().toISOString() });
+        answers.push(...rawBatch.map((p) => ({ problemId: p.problemId, decision: 'ABSTAIN', confidence: 0, hypothesis: '', rivals: [], evidenceUsed: [], evidenceRequests: [], sfiMethods: [], agentsUsed: [], abstainReason: 'engine failure' })));
+      }
+    }
+    athlete.sfiAgentPacket = null;
+    const sealed = { runId, year, athleteId: athlete.id, engine: athlete.engine.id, constitutionId: athlete.constitutionId, cutoffYear: year, answers, sealedAt: new Date().toISOString() };
+    const sealHash = sha256(sealed);
+    await writeJson(path.join(runDir, `year-${year}`, `${athlete.id}.sealed.json`), { ...sealed, sealHash });
+    await appendJsonl(ledger, { event: 'PREDICTIONS_SEALED', year, athleteId: athlete.id, sealHash, answers: answers.length });
+
+    const { score, rows } = scoreAnswers(problems, answers, { constitutionId: athlete.constitutionId, engineId: athlete.engine.id, year });
+    score.durationMs = Math.round(performance.now() - athleteStart); score.engineErrors = errors; score.sealHash = sealHash;
+    annualScores.push({ athleteId: athlete.id, ...score });
+    cumulative.get(athlete.id).push(score);
+    const misses = rows.filter((r) => r.answered && !r.hit).slice(0, 20).map((r) => ({ problemId: r.problemId, type: r.type, decision: r.decision, outcome: r.outcome, confidence: r.confidence }));
+    athlete.memory.push({ year, score: { accuracy: score.accuracy, brier: score.brier, composite: score.composite, coverage: score.coverage, temporalIntegrity: score.temporalIntegrity, evidenceDiscipline: score.evidenceDiscipline }, misses, lesson: 'These outcomes are revealed only after sealing and become legitimate past experience for the next simulated year.' });
+    athlete.memory = athlete.memory.slice(-6);
+    athlete.constitutionState = evolveState(athlete.constitutionId, athlete.constitutionState, score);
+    await writeJson(path.join(runDir, `year-${year}`, `${athlete.id}.score.json`), { score, rows });
+    await writeJson(path.join(runDir, `checkpoints`, `${athlete.id}.json`), { athleteId: athlete.id, lastCompletedYear: year, memory: athlete.memory, constitutionState: athlete.constitutionState });
+    await appendJsonl(ledger, { event: 'YEAR_SCORED', year, athleteId: athlete.id, score });
+  }
+
+  annualScores.sort((a, b) => b.composite - a.composite);
+  await writeJson(path.join(runDir, `year-${year}`, 'leaderboard.json'), annualScores);
+
+  if (congressEnabled) {
+    const peers = annualScores.map((x) => ({ athleteId: x.athleteId, composite: x.composite, accuracy: x.accuracy, temporalIntegrity: x.temporalIntegrity }));
+    for (const athlete of athletes.filter((a) => a.engine.kind === 'llm')) {
+      try {
+        const messages = await athlete.engine.congress({ self: athlete.id, peers: peers.filter((p) => p.athleteId !== athlete.id), year, memory: athlete.memory });
+        await appendJsonl(path.join(runDir, `year-${year}`, 'congress.jsonl'), { from: athlete.id, year, messages, at: new Date().toISOString() });
+      } catch (error) { await appendJsonl(ledger, { event: 'CONGRESS_FAILED', year, athleteId: athlete.id, error: String(error?.message || error) }); }
+    }
+  }
+  await appendJsonl(ledger, { event: 'YEAR_COMPLETED', year, durationMs: Math.round(performance.now() - yearStart), leader: annualScores[0]?.athleteId || null });
+}
+
+const final = athletes.map((a) => {
+  const xs = cumulative.get(a.id) || [];
+  return {
+    athleteId: a.id, engine: a.engine.id, constitutionId: a.constitutionId,
+    yearsScored: xs.length,
+    meanComposite: xs.length ? xs.reduce((s, x) => s + x.composite, 0) / xs.length : 0,
+    meanAccuracy: xs.length ? xs.reduce((s, x) => s + x.accuracy, 0) / xs.length : 0,
+    meanTemporalIntegrity: xs.length ? xs.reduce((s, x) => s + x.temporalIntegrity, 0) / xs.length : 0,
+    totalDurationMs: xs.reduce((s, x) => s + (x.durationMs || 0), 0),
+  };
+}).sort((a, b) => b.meanComposite - a.meanComposite);
+
+await writeJson(path.join(runDir, 'leaderboard.final.json'), final);
+await writeJson(path.join(runDir, 'terminal-2026.json'), { year: endYear, note: 'Terminal current frame. Outcomes beyond the currently available 2026 data are not fabricated or scored.', datasetManifest });
+await appendJsonl(ledger, { event: 'RUN_FINISHED', runId, at: new Date().toISOString(), durationMs: Math.round(performance.now() - totalStarted), winner: final[0]?.athleteId || null });
+console.log(JSON.stringify({ ok: true, runId, runDir, athletes: athletes.length, final }, null, 2));

--- a/scripts/cognitive-olympics/runner.mjs
+++ b/scripts/cognitive-olympics/runner.mjs
@@ -72,8 +72,9 @@ async function runSfiAgentBridge(year, problems) {
     source: 'SFI_CL_WORLD_FRAME',
     confidence: 0.8,
     payload: {
-      year, country: p.geography.iso3, indicator: p.indicator, history: p.history,
-      currentValue: p.currentValue, epistemicClass: 'IMPORTED_HISTORICAL_REPLAY',
+      year, country: shadow ? p.geography.alias : p.geography.iso3,
+      indicator: shadow ? { code: `I-${sha256(p.indicator.code).slice(0, 8)}`, domain: p.indicator.domain } : p.indicator,
+      history: p.history, currentValue: p.currentValue, epistemicClass: 'IMPORTED_HISTORICAL_REPLAY',
     },
   }));
   const context = {

--- a/scripts/cognitive-olympics/server.mjs
+++ b/scripts/cognitive-olympics/server.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import http from 'node:http';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { readdir, readFile } from 'node:fs/promises';
+import { experimentManifest } from './lib/manifest.mjs';
+
+const host = process.env.SFI_CL_HOST || '127.0.0.1';
+const port = Number(process.env.SFI_CL_PORT || 4316);
+const runsDir = path.resolve(process.env.SFI_CL_RUNS_DIR || '.sfi-cl/runs');
+const jobs = new Map();
+
+const json = (res, status, body) => { res.writeHead(status, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' }); res.end(JSON.stringify(body, null, 2)); };
+async function latestRun() {
+  try { const names = await readdir(runsDir); return names.sort().at(-1) || null; } catch { return null; }
+}
+async function readJson(file) { return JSON.parse(await readFile(file, 'utf8')); }
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, `http://${host}:${port}`);
+    if (req.method === 'GET' && url.pathname === '/v1/health') return json(res, 200, { ok: true, service: 'SFI_CL', jobs: [...jobs.entries()].map(([id, j]) => ({ id, status: j.status })) });
+    if (req.method === 'GET' && url.pathname === '/v1/manifest') return json(res, 200, experimentManifest());
+    if (req.method === 'GET' && url.pathname === '/v1/runs/latest') {
+      const id = await latestRun(); if (!id) return json(res, 404, { ok: false, error: 'NO_RUNS' });
+      const board = await readJson(path.join(runsDir, id, 'leaderboard.final.json')).catch(() => null);
+      return json(res, 200, { ok: true, runId: id, leaderboard: board, job: jobs.get(id) || null });
+    }
+    if (req.method === 'POST' && url.pathname === '/v1/runs') {
+      let body = ''; for await (const chunk of req) body += chunk;
+      const cfg = body ? JSON.parse(body) : {};
+      const id = `api-${Date.now()}`;
+      const args = [path.join(import.meta.dirname, 'runner.mjs'), '--run-id', id, '--profile', cfg.profile || 'quick', '--track', cfg.track || 'A'];
+      if (cfg.engines) args.push('--engines', String(cfg.engines));
+      if (cfg.constitutions) args.push('--constitutions', String(cfg.constitutions));
+      if (cfg.problems) args.push('--problems', String(cfg.problems));
+      if (cfg.congress) args.push('--congress');
+      const child = spawn(process.execPath, args, { stdio: ['ignore', 'pipe', 'pipe'], env: process.env });
+      const job = { status: 'RUNNING', pid: child.pid, startedAt: new Date().toISOString(), stdout: '', stderr: '' }; jobs.set(id, job);
+      child.stdout.on('data', (d) => { job.stdout = (job.stdout + d.toString()).slice(-8000); });
+      child.stderr.on('data', (d) => { job.stderr = (job.stderr + d.toString()).slice(-8000); });
+      child.on('exit', (code) => { job.status = code === 0 ? 'COMPLETED' : 'FAILED'; job.exitCode = code; job.finishedAt = new Date().toISOString(); });
+      return json(res, 202, { ok: true, runId: id, status: job.status });
+    }
+    return json(res, 404, { ok: false, error: 'NOT_FOUND' });
+  } catch (error) { return json(res, 500, { ok: false, error: String(error?.message || error) }); }
+});
+server.listen(port, host, () => console.log(JSON.stringify({ ok: true, service: 'SFI_CL', url: `http://${host}:${port}` })));

--- a/scripts/cognitive-olympics/sfi-agent-bridge.ts
+++ b/scripts/cognitive-olympics/sfi-agent-bridge.ts
@@ -1,0 +1,38 @@
+import { executeRegisteredAgent, SFI_AGENT_EXECUTION_MAP } from '../../src/lib/sfi/cognitive-runtime/agentExecutionMap';
+import type { KernelContext } from '../../src/lib/sfi/cognitive-runtime/kernelContext';
+
+async function readStdin() {
+  let text = '';
+  for await (const chunk of process.stdin) text += chunk.toString();
+  return text ? JSON.parse(text) : {};
+}
+
+const input = await readStdin();
+const requested = Array.isArray(input.agents) && input.agents.length
+  ? input.agents.filter((id: string) => Boolean(SFI_AGENT_EXECUTION_MAP[id]))
+  : Object.keys(SFI_AGENT_EXECUTION_MAP);
+
+let context = input.context as KernelContext;
+const executedAgents: string[] = [];
+for (const agentId of requested) {
+  const before = JSON.stringify(context);
+  context = executeRegisteredAgent(agentId, context);
+  if (JSON.stringify(context) !== before || SFI_AGENT_EXECUTION_MAP[agentId]) executedAgents.push(agentId);
+}
+
+const metadata = context?.metadata && typeof context.metadata === 'object' ? context.metadata : {};
+process.stdout.write(JSON.stringify({
+  ok: true,
+  mode: 'LAB_DETERMINISTIC_BRIDGE_NO_EVENT_PERSISTENCE',
+  executedAgents,
+  contradictions: context?.contradictions ?? [],
+  predictions: context?.predictions ?? [],
+  risks: context?.risks ?? [],
+  opportunities: context?.opportunities ?? [],
+  simulations: context?.simulations ?? [],
+  metadata: {
+    cognitivePlan: (metadata as any).cognitivePlan ?? null,
+    agentInsights: (metadata as any).agentInsights ?? null,
+    taskGraph: (metadata as any).taskGraph ?? null,
+  },
+}));

--- a/scripts/cognitive-olympics/smoke.test.mjs
+++ b/scripts/cognitive-olympics/smoke.test.mjs
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { indexDataset } from './lib/dataset.mjs';
+import { forgeProblems, publicProblem } from './lib/problem-forge.mjs';
+import { statsEngine } from './lib/engines.mjs';
+import { scoreAnswers } from './lib/scorer.mjs';
+import { SFI_METHOD_BY_ID } from './lib/sfi-methods.mjs';
+import { CONSTITUTIONS } from './lib/constitutions.mjs';
+
+const indicators = [
+  { code: 'X', label: 'X', domain: 'economy' },
+  { code: 'Y', label: 'Y', domain: 'labor' },
+  { code: 'Z', label: 'Z', domain: 'health' },
+];
+const records = [];
+for (const iso3 of ['AAA', 'BBB']) for (const indicator of indicators) for (let year = 2008; year <= 2013; year += 1) records.push({ country: { iso3, name: iso3 }, indicator, year, value: year + indicator.code.charCodeAt(0) + (iso3 === 'BBB' ? 2 : 0), source: 'FIXTURE' });
+
+test('forge is deterministic and hides outcomes', () => {
+  const index = indexDataset(records);
+  const a = forgeProblems({ records, index, year: 2010, count: 20, seed: 'x' });
+  const b = forgeProblems({ records, index, year: 2010, count: 20, seed: 'x' });
+  assert.deepEqual(a.map((x) => x.problemId), b.map((x) => x.problemId));
+  const pub = publicProblem(a[0]);
+  assert.equal('hiddenOutcome' in pub, false);
+  assert.equal(JSON.stringify(pub).includes('2011'), true); // target year may be named, target value may not.
+});
+
+test('stats control can be scored', async () => {
+  const index = indexDataset(records);
+  const problems = forgeProblems({ records, index, year: 2010, count: 20, seed: 'y' });
+  const engine = statsEngine();
+  const answers = await engine.solve(problems.map((p) => publicProblem(p)));
+  const { score } = scoreAnswers(problems, answers, { constitutionId: 'generic-control', engineId: engine.id, year: 2010 });
+  assert.equal(score.problems, 20);
+  assert.ok(score.accuracy >= 0 && score.accuracy <= 1);
+  assert.equal(score.temporalIntegrity, 1);
+});
+
+test('book auxiliary statuses are preserved', () => {
+  assert.equal(SFI_METHOD_BY_ID.MIHM_BASELINE.status, 'CANON');
+  assert.equal(SFI_METHOD_BY_ID.WSV_CONTEXT.status, 'STABLE');
+  assert.equal(SFI_METHOD_BY_ID.SFI_INFERENCE.status, 'IN_DEVELOPMENT');
+  assert.equal(SFI_METHOD_BY_ID.MOPS_BASELINE.status, 'EXPERIMENTAL');
+});
+
+test('founder control and evolver are distinct', () => {
+  assert.equal(CONSTITUTIONS['origin-core'].mutable, false);
+  assert.equal(CONSTITUTIONS['sfi-evolver'].mutable, true);
+  assert.equal(CONSTITUTIONS['generic-control'].sfiMode, 'NONE');
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,33 @@
 {
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"agent/sfi-cognitive-olympics-2026\" ]; then exit 0; else exit 1; fi",
+  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in agent/root-runtime-reports-convergence|agent/method-lab-convergence) exit 0 ;; *) exit 1 ;; esac",
   "crons": [
-    { "path": "/api/cron/continuity-heartbeat", "schedule": "15 7 * * *" },
-    { "path": "/api/cron/worldspect", "schedule": "20 7 * * *" },
-    { "path": "/api/cron/world-observatory", "schedule": "25 7 * * *" },
-    { "path": "/api/cron/sfi-institutional-cycle", "schedule": "35 7 * * *" },
-    { "path": "/api/cron/sfi-indicators", "schedule": "0 8 * * *" },
-    { "path": "/api/cron/predictive-engine", "schedule": "30 8 * * *" },
-    { "path": "/api/cron/continuity-report", "schedule": "45 8 * * *" }
+    {
+      "path": "/api/cron/continuity-heartbeat",
+      "schedule": "15 7 * * *"
+    },
+    {
+      "path": "/api/cron/worldspect",
+      "schedule": "20 7 * * *"
+    },
+    {
+      "path": "/api/cron/world-observatory",
+      "schedule": "25 7 * * *"
+    },
+    {
+      "path": "/api/cron/sfi-institutional-cycle",
+      "schedule": "35 7 * * *"
+    },
+    {
+      "path": "/api/cron/sfi-indicators",
+      "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/predictive-engine",
+      "schedule": "30 8 * * *"
+    },
+    {
+      "path": "/api/cron/continuity-report",
+      "schedule": "45 8 * * *"
+    }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,32 +1,12 @@
 {
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"agent/sfi-cognitive-olympics-2026\" ]; then exit 0; else exit 1; fi",
   "crons": [
-    {
-      "path": "/api/cron/continuity-heartbeat",
-      "schedule": "15 7 * * *"
-    },
-    {
-      "path": "/api/cron/worldspect",
-      "schedule": "20 7 * * *"
-    },
-    {
-      "path": "/api/cron/world-observatory",
-      "schedule": "25 7 * * *"
-    },
-    {
-      "path": "/api/cron/sfi-institutional-cycle",
-      "schedule": "35 7 * * *"
-    },
-    {
-      "path": "/api/cron/sfi-indicators",
-      "schedule": "0 8 * * *"
-    },
-    {
-      "path": "/api/cron/predictive-engine",
-      "schedule": "30 8 * * *"
-    },
-    {
-      "path": "/api/cron/continuity-report",
-      "schedule": "45 8 * * *"
-    }
+    { "path": "/api/cron/continuity-heartbeat", "schedule": "15 7 * * *" },
+    { "path": "/api/cron/worldspect", "schedule": "20 7 * * *" },
+    { "path": "/api/cron/world-observatory", "schedule": "25 7 * * *" },
+    { "path": "/api/cron/sfi-institutional-cycle", "schedule": "35 7 * * *" },
+    { "path": "/api/cron/sfi-indicators", "schedule": "0 8 * * *" },
+    { "path": "/api/cron/predictive-engine", "schedule": "30 8 * * *" },
+    { "path": "/api/cron/continuity-report", "schedule": "45 8 * * *" }
   ]
 }


### PR DESCRIPTION
## What changed

Builds the first isolated **SFI Cognitive Olympics 2026 / SFI_CL** longitudinal laboratory under `scripts/cognitive-olympics/`.

The experiment runs a sealed 2010→2026 replay in which cognitive constitutions compete against the same annual world frame, produce predictions/decisions, seal them with SHA-256 before outcome reveal, receive deterministic scoring, retain scored past memory, and continue to the next year.

### Core experiment
- configurable `smoke`, `quick`, `full` (5,000 problems/year) and `congress` profiles
- deterministic annual Problem Forge
- World Bank historical dataset preparation across multiple domains
- Track A historical replay (`REFERENCE_ONLY`, explicitly not strict historical-vintage proof)
- Track B shadow-world pseudonymization
- prospective Track C reserved in the experiment contract for 2026→future validation
- append-only local ledger, annual checkpoints, sealed predictions and longitudinal leaderboard
- 2026 terminal frame; no fabricated future outcome

### Cognitive population
- `origin-core`: frozen founder-extracted control
- `origin-augmented`: founder-derived operations plus retrieval/memory augmentation
- `origin-patched`: explicit blind-spot patches
- `sfi-evolver`: mutable derived architecture updated only after scored outcomes
- `sfi-mandatory`: SFI instrument-effect control
- `generic-control`: no founder-derived rules and no SFI access

The constitution and model engine are recorded independently so the experiment can separate engine effects from cognitive-policy effects.

### Engines
- deterministic statistical persistence baseline
- local Ollama model discovery / explicit model selection
- optional Groq exhibition engines using `GROQ_API_KEY` without printing secrets
- two-stage LLM process: request admissible evidence first, then solve after only requested evidence is revealed

### System Friction Institute integration
The Founder Edition methods are represented as auxiliary method cards while preserving their original maturity labels: MIHM baseline, WSV, DIOL-SF, MOP-H, SFI inference, minimal perturbation, result contrast, transdimensional contrast and MOP-S.

The laboratory also has a real deterministic bridge to the repository's registered SFI agent executors. It intentionally calls `executeRegisteredAgent()` directly rather than `executeSfiRuntime()` so laboratory runs do not write agent/cycle events into institutional telemetry or Supabase.

### Local API
Loopback-only service on `127.0.0.1:4316`:
- `GET /v1/health`
- `GET /v1/manifest`
- `GET /v1/runs/latest`
- `POST /v1/runs`

### Verification
- Node syntax checks for lab modules
- deterministic smoke tests
- full repository TypeScript check to validate the SFI agent bridge
- dedicated `SFI Cognitive Lab Verify` workflow

## Important epistemic boundary

This PR builds the laboratory; it **does not claim the Cognitive Twin is validated**. Track A uses current historical series and contemporary model weights, so it is calibration/replay evidence rather than definitive no-lookahead proof. The future partition is never placed in athlete payloads, but latent model knowledge requires Track B and ultimately prospective Track C for stronger validation.

No production route, Supabase table, migration, ROOT state or institutional memory is modified by the experiment. Local datasets and runs are written under `.sfi-cl/`, which is gitignored.