### PR TITLE
Cognitive Relational Lab v1: provenance, blind Twin contrast and ROOT activation

### DIFF
--- a/docs/COGNITIVE_RELATIONAL_LAB_V1.md
+++ b/docs/COGNITIVE_RELATIONAL_LAB_V1.md
@@ -1,0 +1,159 @@
+# Cognitive Relational Laboratory v1
+
+Status: EXPERIMENTAL · ROOT ONLY · evidence-bound
+
+## Objective
+
+Observe relational coupling rather than treating the founder as an isolated cognitive object.
+
+The laboratory distinguishes:
+
+- what the founder originated;
+- what a model proposed;
+- what the founder merely authorized;
+- what was co-developed;
+- what emerged from system behavior;
+- what came from external actors or sources.
+
+Founder authorization is explicitly **not** evidence of founder origination.
+
+## Activation
+
+After the migration is applied and the application is redeployed, ROOT exposes the `CRL` launcher.
+
+1. Open `/root` as ROOT/founder.
+2. Open `CRL`.
+3. Select a condition.
+4. Define the real objective of the session.
+5. Press `ACTIVAR SESIÓN`.
+
+Activation creates a persisted `sfi_cognitive_lab_sessions` row. It is not a visual-only toggle.
+
+## Initial controlled conditions
+
+### FOUNDER + MODEL
+
+The model receives the current task and recent laboratory chat only. It does **not** receive Cognitive Twin memory. This is the general-model baseline.
+
+### FOUNDER + COGNITIVE TWIN
+
+The execution model receives only:
+
+- `VERIFIED` / `CANONICAL` Cognitive Twin memory;
+- `APPROVED` founder decisions.
+
+It deliberately excludes `CANDIDATE` memory to reduce circular learning.
+
+### FOUNDER SOLO / FOUNDER + HUMAN + TECH
+
+The persistence model supports these conditions, but v1 does not fabricate automatic capture for external activity. Events can be ingested through the governed events endpoint until dedicated adapters exist.
+
+## Provenance classes
+
+- `FOUNDER_ORIGINATED`
+- `MODEL_PROPOSED`
+- `CO_DEVELOPED`
+- `SYSTEM_EMERGENT`
+- `EXTERNAL`
+- `FOUNDER_AUTHORIZATION`
+- `UNKNOWN`
+
+## Operational cycle
+
+```text
+ACTIVATE SESSION
+→ CAPTURE EVENTS + PROVENANCE
+→ EXECUTE REAL TASK
+→ BLIND COGNITIVE TWIN RECONSTRUCTION
+→ FOUNDER READING
+→ DIVERGENCE ANALYSIS
+→ CANDIDATE RELATIONAL LEARNING
+→ LATER REPLICATION / VERIFICATION
+```
+
+The blind Twin is executed **before** the founder reading is supplied.
+
+## “EJECUTA” semantics
+
+The ROOT laboratory console exposes `REGISTRAR “EJECUTA”`.
+
+It records:
+
+- `event_kind = FOUNDER_DECISION`
+- `provenance = FOUNDER_AUTHORIZATION`
+
+This prevents the laboratory from learning that an operation was founder-originated merely because the founder accepted execution.
+
+## Blind analysis
+
+`POST /api/root/cognitive-lab/sessions/:id/blind`
+
+The blind analysis reconstructs:
+
+- objective;
+- founder function;
+- technology function;
+- direction of initiative;
+- expansion;
+- contraction;
+- induced friction;
+- omissions;
+- material trajectory changes;
+- candidate relational phenomena;
+- uncertainty;
+- `WHO CHANGED WHOM` when evidence allows.
+
+It does not promote learning to canon.
+
+## Founder contrast
+
+`POST /api/root/cognitive-lab/sessions/:id/contrast`
+
+The founder reading is persisted after the blind analysis. The divergence stage separates:
+
+- agreement;
+- divergence;
+- provenance conflict;
+- omission;
+- missing relational representation;
+- instrument bias;
+- legitimate ambiguity;
+- genuinely new founder information.
+
+A successful contrast creates exactly one `CANDIDATE` Cognitive Twin memory object for the session. It remains non-canonical and must later be replicated or explicitly verified.
+
+## Persistence
+
+Tables:
+
+- `sfi_cognitive_lab_sessions`
+- `sfi_cognitive_lab_events`
+- `sfi_cognitive_lab_analyses`
+
+Laboratory output can also create a `CANDIDATE` row in `sfi_cognitive_twin_memory` after founder contrast.
+
+No seed data is inserted. Empty laboratory state remains explicit.
+
+## API surface
+
+- `GET /api/root/cognitive-lab/sessions`
+- `POST /api/root/cognitive-lab/sessions`
+- `GET /api/root/cognitive-lab/sessions/:id`
+- `GET /api/root/cognitive-lab/sessions/:id/events`
+- `POST /api/root/cognitive-lab/sessions/:id/events`
+- `POST /api/root/cognitive-lab/sessions/:id/interact`
+- `POST /api/root/cognitive-lab/sessions/:id/blind`
+- `POST /api/root/cognitive-lab/sessions/:id/contrast`
+
+All routes are ROOT-governed server routes.
+
+## Activation dependencies
+
+The feature is operational only when all three conditions are true:
+
+1. the branch is merged/deployed;
+2. migration `20260810003000_cognitive_relational_lab_v1.sql` has been applied to the production Supabase database;
+3. at least one configured LLM provider is available for model/Twin conditions and blind/contrast analysis.
+
+Without database migration, the console must fail visibly rather than simulate a session.
+Without an LLM provider, captured evidence remains valid but synthesis returns degraded/blocked state.

--- a/src/app/api/root/cognitive-lab/sessions/[id]/blind/route.ts
+++ b/src/app/api/root/cognitive-lab/sessions/[id]/blind/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { auditRootAction, requireRootActor } from '@/lib/root/server';
+import { runCognitiveLabBlindTwin } from '@/lib/cognitive-lab/service';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+type RouteContext = { params: Promise<{ id: string }> | { id: string } };
+
+export async function POST(request: Request, context: RouteContext) {
+  const gate = await requireRootActor('cognitive_lab.blind.execute');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  try {
+    const { id } = await Promise.resolve(context.params);
+    const sessionId = decodeURIComponent(id);
+    const result = await runCognitiveLabBlindTwin(gate.ctx.user.id, sessionId);
+
+    const audit = await auditRootAction({
+      actorId: gate.ctx.user.id,
+      action: 'cognitive_lab.blind.executed',
+      target: sessionId,
+      payload: {
+        analysisId: result.analysis.id,
+        cognitiveExecution: result.cognitiveExecution,
+      },
+      request,
+    });
+    if (!audit.ok) return NextResponse.json(audit, { status: 500 });
+
+    return NextResponse.json({
+      ok: result.cognitiveExecution === 'EXECUTED',
+      ...result,
+      audit,
+    }, { status: result.cognitiveExecution === 'EXECUTED' ? 200 : 503 });
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    const status = details.includes('NOT_FOUND') ? 404 : details.includes('REQUIRES_EVENTS') ? 400 : 500;
+    return NextResponse.json({ ok: false, error: 'COGNITIVE_LAB_BLIND_FAILED', details }, { status });
+  }
+}

--- a/src/app/api/root/cognitive-lab/sessions/[id]/contrast/route.ts
+++ b/src/app/api/root/cognitive-lab/sessions/[id]/contrast/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { auditRootAction, requireRootActor } from '@/lib/root/server';
+import { runCognitiveLabFounderContrast } from '@/lib/cognitive-lab/service';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+type RouteContext = { params: Promise<{ id: string }> | { id: string } };
+type Row = Record<string, unknown>;
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  const gate = await requireRootActor('cognitive_lab.contrast.execute');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  try {
+    const { id } = await Promise.resolve(context.params);
+    const sessionId = decodeURIComponent(id);
+    const body = record(await request.json().catch(() => null));
+    const founderReading = body.founderReading;
+
+    if (typeof founderReading === 'undefined' || founderReading === null) {
+      return NextResponse.json({ ok: false, error: 'founderReading_required' }, { status: 400 });
+    }
+
+    const result = await runCognitiveLabFounderContrast(gate.ctx.user.id, sessionId, founderReading);
+
+    const audit = await auditRootAction({
+      actorId: gate.ctx.user.id,
+      action: 'cognitive_lab.contrast.executed',
+      target: sessionId,
+      payload: {
+        founderAnalysisId: result.founderReading.id,
+        divergenceAnalysisId: result.divergence.id,
+        learningPersisted: result.learning.persisted === true,
+        cognitiveExecution: result.cognitiveExecution,
+      },
+      request,
+    });
+    if (!audit.ok) return NextResponse.json(audit, { status: 500 });
+
+    return NextResponse.json({
+      ok: result.cognitiveExecution === 'EXECUTED',
+      ...result,
+      audit,
+    }, { status: result.cognitiveExecution === 'EXECUTED' ? 200 : 503 });
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    const status = details.includes('NOT_FOUND')
+      ? 404
+      : details.includes('REQUIRED') || details.includes('REQUIRES_EVENTS')
+        ? 400
+        : 500;
+    return NextResponse.json({ ok: false, error: 'COGNITIVE_LAB_CONTRAST_FAILED', details }, { status });
+  }
+}

--- a/src/app/api/root/cognitive-lab/sessions/[id]/events/route.ts
+++ b/src/app/api/root/cognitive-lab/sessions/[id]/events/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from 'next/server';
+import { auditRootAction, requireRootActor } from '@/lib/root/server';
+import {
+  appendCognitiveLabEvent,
+  getCognitiveLabSession,
+  type CognitiveLabEventKind,
+  type CognitiveLabProvenance,
+} from '@/lib/cognitive-lab/service';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+type RouteContext = { params: Promise<{ id: string }> | { id: string } };
+type Row = Record<string, unknown>;
+
+const EVENT_KINDS = new Set<CognitiveLabEventKind>([
+  'PROMPT',
+  'MODEL_OUTPUT',
+  'FOUNDER_DECISION',
+  'TOOL_EXECUTION',
+  'ARTIFACT',
+  'OUTCOME',
+  'OBSERVATION',
+  'FRICTION',
+  'OMISSION',
+  'OTHER',
+]);
+
+const PROVENANCE = new Set<CognitiveLabProvenance>([
+  'FOUNDER_ORIGINATED',
+  'MODEL_PROPOSED',
+  'CO_DEVELOPED',
+  'SYSTEM_EMERGENT',
+  'EXTERNAL',
+  'FOUNDER_AUTHORIZATION',
+  'UNKNOWN',
+]);
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown, maximum = 12000) {
+  return typeof value === 'string' ? value.trim().slice(0, maximum) : '';
+}
+
+function strings(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0).map((item) => item.trim()).slice(0, 100)
+    : [];
+}
+
+export async function GET(_request: Request, context: RouteContext) {
+  const gate = await requireRootActor('cognitive_lab.events.read');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  try {
+    const { id } = await Promise.resolve(context.params);
+    const lab = await getCognitiveLabSession(decodeURIComponent(id));
+    return NextResponse.json({ ok: true, events: lab.events }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ ok: false, error: 'COGNITIVE_LAB_EVENTS_READ_FAILED', details }, { status: details.includes('NOT_FOUND') ? 404 : 500 });
+  }
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  const gate = await requireRootActor('cognitive_lab.events.create');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  try {
+    const { id } = await Promise.resolve(context.params);
+    const sessionId = decodeURIComponent(id);
+    const body = record(await request.json().catch(() => null));
+    const eventKind = text(body.eventKind, 80) as CognitiveLabEventKind;
+    const provenance = text(body.provenance, 80) as CognitiveLabProvenance;
+    const actorKey = text(body.actorKey, 160);
+
+    if (!EVENT_KINDS.has(eventKind)) return NextResponse.json({ ok: false, error: 'eventKind_invalid' }, { status: 400 });
+    if (!PROVENANCE.has(provenance)) return NextResponse.json({ ok: false, error: 'provenance_invalid' }, { status: 400 });
+    if (!actorKey) return NextResponse.json({ ok: false, error: 'actorKey_required' }, { status: 400 });
+
+    const event = await appendCognitiveLabEvent(gate.ctx.user.id, sessionId, {
+      eventKind,
+      provenance,
+      actorKey,
+      relationFrom: text(body.relationFrom, 160) || null,
+      relationTo: text(body.relationTo, 160) || null,
+      payload: record(body.payload),
+      evidenceRefs: strings(body.evidenceRefs),
+      sourceRef: text(body.sourceRef, 1000) || null,
+      occurredAt: text(body.occurredAt, 80) || null,
+    });
+
+    const audit = await auditRootAction({
+      actorId: gate.ctx.user.id,
+      action: 'cognitive_lab.event.recorded',
+      target: String(event.id),
+      payload: {
+        sessionId,
+        eventKind: event.event_kind,
+        provenance: event.provenance,
+        actorKey: event.actor_key,
+      },
+      request,
+    });
+    if (!audit.ok) return NextResponse.json(audit, { status: 500 });
+
+    return NextResponse.json({ ok: true, event }, { status: 201 });
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    const status = details.includes('NOT_FOUND') ? 404 : details.includes('NOT_OPEN') ? 409 : 500;
+    return NextResponse.json({ ok: false, error: 'COGNITIVE_LAB_EVENT_CREATE_FAILED', details }, { status });
+  }
+}

--- a/src/app/api/root/cognitive-lab/sessions/[id]/interact/route.ts
+++ b/src/app/api/root/cognitive-lab/sessions/[id]/interact/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+import { auditRootAction, requireRootActor } from '@/lib/root/server';
+import { runCognitiveLabInteraction } from '@/lib/cognitive-lab/interaction';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+type RouteContext = { params: Promise<{ id: string }> | { id: string } };
+type Row = Record<string, unknown>;
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown, maximum = 12000) {
+  return typeof value === 'string' ? value.trim().slice(0, maximum) : '';
+}
+
+function history(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value.slice(-10).map((item) => record(item)).map((item) => ({
+    role: item.role === 'assistant' ? 'assistant' as const : 'user' as const,
+    content: text(item.content, 5000),
+  })).filter((item) => item.content);
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  const gate = await requireRootActor('cognitive_lab.interact');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  try {
+    const { id } = await Promise.resolve(context.params);
+    const sessionId = decodeURIComponent(id);
+    const body = record(await request.json().catch(() => null));
+    const prompt = text(body.prompt, 12000);
+    if (!prompt) return NextResponse.json({ ok: false, error: 'prompt_required' }, { status: 400 });
+
+    const result = await runCognitiveLabInteraction(gate.ctx.user.id, sessionId, {
+      prompt,
+      history: history(body.history),
+    });
+
+    const audit = await auditRootAction({
+      actorId: gate.ctx.user.id,
+      action: 'cognitive_lab.interaction.executed',
+      target: sessionId,
+      payload: {
+        condition: result.condition,
+        promptEventId: result.promptEvent.id,
+        outputEventId: result.outputEvent.id,
+        provider: result.provider,
+        model: result.model,
+        providerExecutionSucceeded: result.ok,
+      },
+      request,
+    });
+    if (!audit.ok) return NextResponse.json(audit, { status: 500 });
+
+    return NextResponse.json({ ...result, audit }, { status: result.ok ? 200 : 503 });
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    const status = details.includes('NOT_FOUND')
+      ? 404
+      : details.includes('REQUIRES_MODEL_CONDITION') || details.includes('NOT_OPEN')
+        ? 409
+        : 500;
+    return NextResponse.json({ ok: false, error: 'COGNITIVE_LAB_INTERACTION_FAILED', details }, { status });
+  }
+}

--- a/src/app/api/root/cognitive-lab/sessions/[id]/route.ts
+++ b/src/app/api/root/cognitive-lab/sessions/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { requireRootActor } from '@/lib/root/server';
+import { getCognitiveLabSession } from '@/lib/cognitive-lab/service';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+type RouteContext = { params: Promise<{ id: string }> | { id: string } };
+
+export async function GET(_request: Request, context: RouteContext) {
+  const gate = await requireRootActor('cognitive_lab.sessions.read');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  try {
+    const { id } = await Promise.resolve(context.params);
+    const sessionId = decodeURIComponent(id);
+    const lab = await getCognitiveLabSession(sessionId);
+    return NextResponse.json({ ok: true, ...lab }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({
+      ok: false,
+      error: 'COGNITIVE_LAB_SESSION_READ_FAILED',
+      details,
+    }, { status: details.includes('NOT_FOUND') ? 404 : 500 });
+  }
+}

--- a/src/app/api/root/cognitive-lab/sessions/route.ts
+++ b/src/app/api/root/cognitive-lab/sessions/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from 'next/server';
+import { auditRootAction, requireRootActor } from '@/lib/root/server';
+import {
+  createCognitiveLabSession,
+  listCognitiveLabSessions,
+  type CognitiveLabCondition,
+} from '@/lib/cognitive-lab/service';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+type Row = Record<string, unknown>;
+
+const CONDITIONS = new Set<CognitiveLabCondition>([
+  'FOUNDER_SOLO',
+  'FOUNDER_MODEL',
+  'FOUNDER_TWIN',
+  'FOUNDER_HUMAN_TECH',
+  'TWIN_ONLY',
+  'OTHER',
+]);
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown, maximum = 5000) {
+  return typeof value === 'string' ? value.trim().slice(0, maximum) : '';
+}
+
+export async function GET() {
+  const gate = await requireRootActor('cognitive_lab.sessions.read');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  try {
+    const sessions = await listCognitiveLabSessions();
+    return NextResponse.json({ ok: true, sessions }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: 'COGNITIVE_LAB_SESSION_LIST_FAILED',
+      details: error instanceof Error ? error.message : String(error),
+    }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const gate = await requireRootActor('cognitive_lab.sessions.create');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  try {
+    const body = record(await request.json().catch(() => null));
+    const title = text(body.title, 240);
+    const objective = text(body.objective, 5000);
+    const condition = text(body.condition, 80) as CognitiveLabCondition;
+
+    if (!title) return NextResponse.json({ ok: false, error: 'title_required' }, { status: 400 });
+    if (!objective) return NextResponse.json({ ok: false, error: 'objective_required' }, { status: 400 });
+    if (!CONDITIONS.has(condition)) return NextResponse.json({ ok: false, error: 'condition_invalid' }, { status: 400 });
+
+    const session = await createCognitiveLabSession(gate.ctx.user.id, {
+      title,
+      objective,
+      condition,
+      technologyNodes: Array.isArray(body.technologyNodes) ? body.technologyNodes : [],
+      humanNodes: Array.isArray(body.humanNodes) ? body.humanNodes : [],
+      baselineSessionId: text(body.baselineSessionId, 120) || null,
+      metadata: record(body.metadata),
+    });
+
+    const audit = await auditRootAction({
+      actorId: gate.ctx.user.id,
+      action: 'cognitive_lab.session.created',
+      target: String(session.id),
+      payload: {
+        sessionKey: session.session_key,
+        condition: session.condition,
+        objective: session.objective,
+      },
+      request,
+    });
+    if (!audit.ok) return NextResponse.json(audit, { status: 500 });
+
+    return NextResponse.json({
+      ok: true,
+      activated: true,
+      session,
+      next: `POST /api/root/cognitive-lab/sessions/${String(session.id)}/events`,
+    }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: 'COGNITIVE_LAB_SESSION_CREATE_FAILED',
+      details: error instanceof Error ? error.message : String(error),
+    }, { status: 500 });
+  }
+}

--- a/src/components/root/cognitive-lab/CognitiveLabConsole.tsx
+++ b/src/components/root/cognitive-lab/CognitiveLabConsole.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+type Row = Record<string, unknown>;
+type Message = { role: 'user' | 'assistant'; content: string };
+
+function text(value: unknown, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+export function CognitiveLabConsole() {
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [session, setSession] = useState<Row | null>(null);
+  const [condition, setCondition] = useState('FOUNDER_TWIN');
+  const [title, setTitle] = useState('RELATIONAL COUPLING CASE');
+  const [objective, setObjective] = useState('Observe qué proviene del fundador, qué proviene de la tecnología y qué emerge únicamente del acoplamiento.');
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [prompt, setPrompt] = useState('');
+  const [founderReading, setFounderReading] = useState('');
+  const [lastBlind, setLastBlind] = useState<string | null>(null);
+  const [lastContrast, setLastContrast] = useState<string | null>(null);
+
+  const sessionId = text(session?.id);
+  const sessionKey = text(session?.session_key);
+  const status = text(session?.status, 'INACTIVE');
+  const modelCondition = ['FOUNDER_MODEL', 'FOUNDER_TWIN'].includes(text(session?.condition, condition));
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem('sfi:cognitive-lab-session');
+    if (!stored) return;
+    void loadSession(stored);
+  }, []);
+
+  async function loadSession(id: string) {
+    try {
+      const response = await fetch(`/api/root/cognitive-lab/sessions/${encodeURIComponent(id)}`, { cache: 'no-store', credentials: 'include' });
+      const body = await response.json().catch(() => null) as Row | null;
+      if (!response.ok || !body || body.ok !== true) return;
+      const nextSession = body.session && typeof body.session === 'object' ? body.session as Row : null;
+      if (nextSession) setSession(nextSession);
+    } catch {
+      // The launcher remains usable even when a previously stored session no longer exists.
+    }
+  }
+
+  async function activate() {
+    if (busy || !title.trim() || !objective.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/root/cognitive-lab/sessions', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title.trim(),
+          objective: objective.trim(),
+          condition,
+          technologyNodes: condition === 'FOUNDER_TWIN' ? ['COGNITIVE_TWIN', 'LLM_ROUTER'] : condition === 'FOUNDER_MODEL' ? ['LLM_ROUTER'] : [],
+          humanNodes: ['FOUNDER'],
+          metadata: { activationSurface: 'ROOT_COGNITIVE_LAB_CONSOLE', protocol: 'CRL-v1' },
+        }),
+      });
+      const body = await response.json().catch(() => null) as Row | null;
+      if (!response.ok || !body || body.ok !== true) throw new Error(text(body?.details ?? body?.error, `HTTP ${response.status}`));
+      const nextSession = body.session && typeof body.session === 'object' ? body.session as Row : null;
+      if (!nextSession) throw new Error('LAB_SESSION_MISSING');
+      setSession(nextSession);
+      setMessages([]);
+      setFounderReading('');
+      setLastBlind(null);
+      setLastContrast(null);
+      window.localStorage.setItem('sfi:cognitive-lab-session', text(nextSession.id));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'No fue posible activar el laboratorio.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function interact() {
+    const content = prompt.trim();
+    if (!sessionId || !content || busy || !modelCondition) return;
+    const nextHistory = [...messages, { role: 'user' as const, content }];
+    setMessages(nextHistory);
+    setPrompt('');
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/root/cognitive-lab/sessions/${encodeURIComponent(sessionId)}/interact`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: content, history: nextHistory.slice(-10) }),
+      });
+      const body = await response.json().catch(() => null) as Row | null;
+      if (!body || (body.ok !== true && !body.answer)) throw new Error(text(body?.details ?? body?.error, `HTTP ${response.status}`));
+      setMessages((current) => [...current, { role: 'assistant', content: text(body.answer, 'MISSING · no model output') }]);
+      await loadSession(sessionId);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'No fue posible ejecutar la interacción.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function recordAuthorization() {
+    if (!sessionId || busy) return;
+    const latest = [...messages].reverse().find((message) => message.role === 'assistant');
+    if (!latest) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/root/cognitive-lab/sessions/${encodeURIComponent(sessionId)}/events`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventKind: 'FOUNDER_DECISION',
+          provenance: 'FOUNDER_AUTHORIZATION',
+          actorKey: 'FOUNDER',
+          relationFrom: 'FOUNDER',
+          relationTo: text(session?.condition) === 'FOUNDER_TWIN' ? 'COGNITIVE_TWIN' : 'MODEL',
+          payload: { decision: 'EXECUTE', targetModelOutput: latest.content, meaning: 'Authorization to proceed; not evidence that the founder originated the proposed operation.' },
+          sourceRef: `root-cognitive-lab:${sessionId}`,
+        }),
+      });
+      const body = await response.json().catch(() => null) as Row | null;
+      if (!response.ok || !body || body.ok !== true) throw new Error(text(body?.details ?? body?.error, `HTTP ${response.status}`));
+      await loadSession(sessionId);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'No fue posible registrar la autorización.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function runBlind() {
+    if (!sessionId || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/root/cognitive-lab/sessions/${encodeURIComponent(sessionId)}/blind`, {
+        method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: '{}',
+      });
+      const body = await response.json().catch(() => null) as Row | null;
+      const analysis = body?.analysis && typeof body.analysis === 'object' ? body.analysis as Row : {};
+      const output = analysis.output && typeof analysis.output === 'object' ? analysis.output as Row : {};
+      if (!body || (body.ok !== true && !output.answer)) throw new Error(text(body?.details ?? body?.error, `HTTP ${response.status}`));
+      setLastBlind(text(output.answer, 'Blind analysis persisted without readable answer.'));
+      await loadSession(sessionId);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'No fue posible ejecutar el análisis ciego.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function runContrast() {
+    if (!sessionId || busy || !founderReading.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/root/cognitive-lab/sessions/${encodeURIComponent(sessionId)}/contrast`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ founderReading: founderReading.trim() }),
+      });
+      const body = await response.json().catch(() => null) as Row | null;
+      const divergence = body?.divergence && typeof body.divergence === 'object' ? body.divergence as Row : {};
+      const output = divergence.output && typeof divergence.output === 'object' ? divergence.output as Row : {};
+      if (!body || (body.ok !== true && !output.answer)) throw new Error(text(body?.details ?? body?.error, `HTTP ${response.status}`));
+      setLastContrast(text(output.answer, 'Contrast persisted without readable answer.'));
+      await loadSession(sessionId);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'No fue posible contrastar el caso.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const phase = useMemo(() => {
+    if (!session) return 'NO SESSION';
+    if (status === 'CLOSED') return 'CONTRAST COMPLETE';
+    if (status === 'BLIND_COMPLETE') return 'FOUNDER CONTRAST';
+    if (status === 'READY_FOR_BLIND') return 'CAPTURE / BLIND READY';
+    return status;
+  }, [session, status]);
+
+  return <>
+    <button className="crl-launch" type="button" onClick={() => setOpen(true)}>
+      <span>CRL</span><b>{sessionId ? 'ACTIVE' : 'OFF'}</b>
+    </button>
+
+    {open ? <div className="crl-backdrop" role="presentation" onMouseDown={(event) => { if (event.target === event.currentTarget) setOpen(false); }}>
+      <section className="crl-panel" role="dialog" aria-modal="true" aria-labelledby="crl-title">
+        <header><div><span>ROOT · EXPERIMENTAL</span><h2 id="crl-title">COGNITIVE RELATIONAL LAB</h2><p>Provenance → interacción → Twin ciego → contraste → aprendizaje candidato.</p></div><button type="button" onClick={() => setOpen(false)}>×</button></header>
+
+        {!sessionId ? <div className="crl-activate">
+          <label>TÍTULO<input value={title} onChange={(event) => setTitle(event.target.value)} /></label>
+          <label>CONDICIÓN<select value={condition} onChange={(event) => setCondition(event.target.value)}><option value="FOUNDER_TWIN">FOUNDER + COGNITIVE TWIN</option><option value="FOUNDER_MODEL">FOUNDER + MODEL</option><option value="FOUNDER_SOLO">FOUNDER SOLO</option><option value="FOUNDER_HUMAN_TECH">FOUNDER + HUMAN + TECH</option></select></label>
+          <label>OBJETIVO<textarea value={objective} onChange={(event) => setObjective(event.target.value)} /></label>
+          <button type="button" disabled={busy || !title.trim() || !objective.trim()} onClick={() => void activate()}>{busy ? 'ACTIVANDO…' : 'ACTIVAR SESIÓN'}</button>
+        </div> : <>
+          <div className="crl-status"><span>{sessionKey}</span><b>{phase}</b><em>{text(session?.condition)}</em></div>
+
+          {modelCondition ? <div className="crl-chat">
+            <div className="crl-log">{!messages.length ? <p>Esta conversación queda dentro de la condición experimental. El modelo no convierte automáticamente tus autorizaciones en operaciones originadas por ti.</p> : messages.map((message, index) => <article key={`${message.role}-${index}`} data-role={message.role}><span>{message.role === 'user' ? 'FOUNDER' : 'MODEL'}</span><p>{message.content}</p></article>)}</div>
+            <textarea value={prompt} onChange={(event) => setPrompt(event.target.value)} placeholder="Ejecuta una tarea real dentro de esta condición…" />
+            <div className="crl-actions"><button type="button" onClick={() => void interact()} disabled={busy || !prompt.trim()}>ENVIAR</button><button type="button" onClick={() => void recordAuthorization()} disabled={busy || !messages.some((message) => message.role === 'assistant')}>REGISTRAR “EJECUTA”</button></div>
+          </div> : <div className="crl-manual"><p>Esta condición no ejecuta un modelo. Registra los eventos mediante el endpoint de eventos o cambia a una condición FOUNDER + MODEL / TWIN para interacción controlada.</p></div>}
+
+          <div className="crl-gate"><button type="button" onClick={() => void runBlind()} disabled={busy || status === 'OPEN' || status === 'CLOSED'}>EJECUTAR TWIN CIEGO</button><small>No usa memoria CANDIDATE ni tu lectura final del caso.</small></div>
+
+          {lastBlind || status === 'BLIND_COMPLETE' ? <div className="crl-contrast"><h3>CONTRASTE DEL FUNDADOR</h3>{lastBlind ? <details><summary>LECTURA CIEGA</summary><pre>{lastBlind}</pre></details> : null}<textarea value={founderReading} onChange={(event) => setFounderReading(event.target.value)} placeholder="Tu lectura del caso. No expliques lo que crees que el Twin quería decir: describe qué ocurrió, quién introdujo qué y dónde consideras que falló/acertó." /><button type="button" onClick={() => void runContrast()} disabled={busy || !founderReading.trim()}>CONTRASTAR Y GENERAR CANDIDATO</button></div> : null}
+
+          {lastContrast ? <details className="crl-result" open><summary>DIVERGENCIA / LEARNING CANDIDATE</summary><pre>{lastContrast}</pre></details> : null}
+        </>}
+
+        {error ? <div className="crl-error">{error}</div> : null}
+      </section>
+    </div> : null}
+
+    <style jsx>{`
+      .crl-launch{position:fixed;z-index:90;right:18px;bottom:18px;display:flex;gap:8px;align-items:center;border:1px solid rgba(186,151,75,.36);background:#080704;color:#c4aa69;padding:8px 11px;font:8px ui-monospace,SFMono-Regular,Menlo,monospace;letter-spacing:.1em;cursor:pointer;box-shadow:0 12px 35px rgba(0,0,0,.45)}.crl-launch span{border:1px solid rgba(186,151,75,.28);padding:3px 4px}.crl-launch b{font-weight:400;color:${sessionId ? '#b8cf95' : '#755f37'}}.crl-backdrop{position:fixed;z-index:190;inset:0;background:rgba(0,0,0,.84);display:flex;align-items:center;justify-content:center;padding:20px;backdrop-filter:blur(4px)}.crl-panel{width:min(1080px,97vw);height:min(900px,95vh);overflow:auto;background:#060604;border:1px solid rgba(186,151,75,.28);color:#c8c2b6;box-shadow:0 35px 120px rgba(0,0,0,.84);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}.crl-panel>header{position:sticky;top:0;z-index:2;display:flex;justify-content:space-between;gap:20px;padding:16px 20px;background:#080704;border-bottom:1px solid rgba(186,151,75,.14)}.crl-panel>header span{font-size:7px;letter-spacing:.16em;color:#7e6b43}.crl-panel h2{margin:4px 0;color:#d0b878;font:400 20px/1.2 ui-monospace,monospace}.crl-panel header p{margin:4px 0;color:#777166;font:11px Georgia,serif}.crl-panel header button{border:0;background:transparent;color:#877655;font-size:24px}.crl-activate,.crl-chat,.crl-contrast,.crl-manual{padding:18px 20px}.crl-activate{display:grid;gap:12px}.crl-activate label{display:grid;gap:6px;font-size:7px;letter-spacing:.12em;color:#806f4d}.crl-activate input,.crl-activate select,.crl-activate textarea,.crl-chat textarea,.crl-contrast textarea{width:100%;box-sizing:border-box;border:1px solid rgba(186,151,75,.16);background:#090805;color:#c8c2b6;padding:10px;font:12px/1.5 ui-monospace,monospace}.crl-activate textarea,.crl-contrast textarea{min-height:100px}.crl-activate button,.crl-actions button,.crl-gate button,.crl-contrast button{border:1px solid rgba(186,151,75,.26);background:#0d0b06;color:#c4aa69;padding:9px 12px;font:8px ui-monospace,monospace;letter-spacing:.1em;cursor:pointer}.crl-activate button:disabled,.crl-actions button:disabled,.crl-gate button:disabled,.crl-contrast button:disabled{opacity:.35;cursor:not-allowed}.crl-status{display:flex;gap:8px;align-items:center;flex-wrap:wrap;padding:9px 20px;border-bottom:1px solid rgba(186,151,75,.1);font-size:8px}.crl-status span{color:#7d6c48}.crl-status b{font-weight:400;color:#aebd88}.crl-status em{font-style:normal;color:#777166}.crl-log{max-height:310px;overflow:auto;border:1px solid rgba(186,151,75,.1);padding:12px;margin-bottom:10px}.crl-log>p{color:#777166;font:12px/1.6 Georgia,serif}.crl-log article{padding:9px 10px;margin-bottom:8px;background:#090805;border-left:2px solid #574826}.crl-log article[data-role=assistant]{border-left-color:#52694c}.crl-log article span{font-size:7px;color:#8c7950}.crl-log article p{white-space:pre-wrap;margin:5px 0 0;color:#bdb6a8;font:12px/1.55 Georgia,serif}.crl-actions{display:flex;gap:8px;margin-top:8px}.crl-gate{display:flex;align-items:center;gap:10px;padding:14px 20px;border-top:1px solid rgba(186,151,75,.1);border-bottom:1px solid rgba(186,151,75,.1)}.crl-gate small{color:#666155;font:10px Georgia,serif}.crl-contrast h3{font-size:9px;letter-spacing:.14em;color:#9d8758}.crl-contrast details,.crl-result{margin-bottom:12px;border:1px solid rgba(186,151,75,.1);padding:8px}.crl-contrast summary,.crl-result summary{cursor:pointer;color:#8d794e;font-size:8px}.crl-contrast pre,.crl-result pre{white-space:pre-wrap;color:#aaa397;font:11px/1.55 Georgia,serif}.crl-contrast button{margin-top:8px}.crl-result{margin:0 20px 18px}.crl-error{margin:0 20px 18px;border:1px solid rgba(170,76,64,.3);background:#120907;color:#c28a7e;padding:10px;font-size:9px}.crl-manual p{color:#777166;font:12px/1.6 Georgia,serif}@media(max-width:720px){.crl-backdrop{padding:8px}.crl-panel{height:97vh}.crl-actions,.crl-gate{align-items:stretch;flex-direction:column}}
+    `}</style>
+  </>;
+}

--- a/src/components/root/sovereign/RootSovereignConsole.tsx
+++ b/src/components/root/sovereign/RootSovereignConsole.tsx
@@ -8,6 +8,7 @@ import { RootSemanticInspector } from './RootSemanticInspector';
 import { RootSemanticContextModal } from './RootSemanticContextModal';
 import { RootObservatoryWorkspace } from './RootObservatoryWorkspace';
 import { FriccionautaConsole } from '@/components/root/friccionauta/FriccionautaConsole';
+import { CognitiveLabConsole } from '@/components/root/cognitive-lab/CognitiveLabConsole';
 import './root-sovereign.css';
 import './root-observatory-scale.css';
 import './root-semantic-context.css';
@@ -121,6 +122,7 @@ export function RootSovereignConsole({ initialState, accessMode = 'sovereign', a
     {selection && richSemantic ? <RootSemanticContextModal selection={selection} onClose={() => setSelection(null)} /> : <RootSemanticInspector value={selection} onClose={() => setSelection(null)} />}
     {!readOnly ? <RootMethodologyWorkbench state={state} launcher={false} /> : null}
     {!readOnly ? <FriccionautaConsole launcher={false} /> : null}
+    {!readOnly ? <CognitiveLabConsole /> : null}
     {events.length ? <div className="rs-root-events" aria-live="polite">{events.slice(0, 3).map((event) => <div key={event.id} data-status={event.status}><strong>{event.label}</strong><span>{event.detail}</span></div>)}</div> : null}
     {!readOnly && pending ? <div className="rs-dialog-backdrop" role="presentation"><section className="rs-dialog" role="dialog" aria-modal="true" aria-labelledby="rs-dialog-title"><span>REVISAR ANTES DE EJECUTAR</span><h2 id="rs-dialog-title">{pending.label}</h2><dl><div><dt>QUÉ HARÁ</dt><dd>{pending.effect}</dd></div><div><dt>SOBRE QUÉ</dt><dd>{pending.target}</dd></div></dl><label className="rs-confirm"><input type="checkbox" checked={confirmed} onChange={(event) => setConfirmed(event.target.checked)} />Confirmo esta acción y comprendo su objetivo.</label><div className="rs-dialog-actions"><button type="button" onClick={() => { setPending(null); setConfirmed(false); }} disabled={running}>CANCELAR</button><button type="button" onClick={() => void execute()} disabled={!confirmed || running}>{running ? 'EJECUTANDO' : 'CONFIRMAR Y EJECUTAR'}</button></div></section></div> : null}
   </div>;

--- a/src/components/root/sovereign/RootSovereignConsole.tsx
+++ b/src/components/root/sovereign/RootSovereignConsole.tsx
@@ -8,7 +8,6 @@ import { RootSemanticInspector } from './RootSemanticInspector';
 import { RootSemanticContextModal } from './RootSemanticContextModal';
 import { RootObservatoryWorkspace } from './RootObservatoryWorkspace';
 import { FriccionautaConsole } from '@/components/root/friccionauta/FriccionautaConsole';
-import { CognitiveLabConsole } from '@/components/root/cognitive-lab/CognitiveLabConsole';
 import './root-sovereign.css';
 import './root-observatory-scale.css';
 import './root-semantic-context.css';
@@ -24,6 +23,8 @@ function usesRichSemanticContext(selection: RootSelection | null) {
 }
 
 type RootAccessMode = 'sovereign' | 'observer';
+
+const ROOT_BACKGROUND_REFRESH_MS = 60 * 60 * 1000;
 
 export function RootSovereignConsole({ initialState, accessMode = 'sovereign', actorLabel = 'ROOT' }: {
   initialState: RootSovereignState;
@@ -70,7 +71,7 @@ export function RootSovereignConsole({ initialState, accessMode = 'sovereign', a
   }, []);
 
   useEffect(() => {
-    const interval = window.setInterval(() => { if (!document.hidden) void refresh(true); }, 60000);
+    const interval = window.setInterval(() => { if (!document.hidden) void refresh(true); }, ROOT_BACKGROUND_REFRESH_MS);
     const visible = () => { if (!document.hidden) void refresh(true); };
     document.addEventListener('visibilitychange', visible);
     return () => { window.clearInterval(interval); document.removeEventListener('visibilitychange', visible); refreshSequence.current += 1; controller.current?.abort('unmount'); };
@@ -119,10 +120,10 @@ export function RootSovereignConsole({ initialState, accessMode = 'sovereign', a
 
   return <div className={`rs-console-host ${selection ? 'has-semantic-selection' : ''}`}>
     <RootObservatoryWorkspace state={state} accessMode={accessMode} actorLabel={actorLabel} refreshing={refreshing} warning={refreshWarning} onRefresh={() => void refresh(false)} onSelect={setSelection} onAction={requestAction} />
+    <a href="/root/method-lab" title="Abrir Method Lab" style={{ position: 'fixed', right: 18, bottom: readOnly ? 18 : 62, zIndex: 35, border: '1px solid rgba(191,160,78,.38)', background: '#080807', color: '#c6ad69', padding: '8px 10px', textDecoration: 'none', font: '9px ui-monospace,SFMono-Regular,Menlo,monospace', letterSpacing: '.08em' }}>METHOD LAB</a>
     {selection && richSemantic ? <RootSemanticContextModal selection={selection} onClose={() => setSelection(null)} /> : <RootSemanticInspector value={selection} onClose={() => setSelection(null)} />}
     {!readOnly ? <RootMethodologyWorkbench state={state} launcher={false} /> : null}
     {!readOnly ? <FriccionautaConsole launcher={false} /> : null}
-    {!readOnly ? <CognitiveLabConsole /> : null}
     {events.length ? <div className="rs-root-events" aria-live="polite">{events.slice(0, 3).map((event) => <div key={event.id} data-status={event.status}><strong>{event.label}</strong><span>{event.detail}</span></div>)}</div> : null}
     {!readOnly && pending ? <div className="rs-dialog-backdrop" role="presentation"><section className="rs-dialog" role="dialog" aria-modal="true" aria-labelledby="rs-dialog-title"><span>REVISAR ANTES DE EJECUTAR</span><h2 id="rs-dialog-title">{pending.label}</h2><dl><div><dt>QUÉ HARÁ</dt><dd>{pending.effect}</dd></div><div><dt>SOBRE QUÉ</dt><dd>{pending.target}</dd></div></dl><label className="rs-confirm"><input type="checkbox" checked={confirmed} onChange={(event) => setConfirmed(event.target.checked)} />Confirmo esta acción y comprendo su objetivo.</label><div className="rs-dialog-actions"><button type="button" onClick={() => { setPending(null); setConfirmed(false); }} disabled={running}>CANCELAR</button><button type="button" onClick={() => void execute()} disabled={!confirmed || running}>{running ? 'EJECUTANDO' : 'CONFIRMAR Y EJECUTAR'}</button></div></section></div> : null}
   </div>;

--- a/src/lib/cognitive-lab/interaction.ts
+++ b/src/lib/cognitive-lab/interaction.ts
@@ -1,0 +1,176 @@
+import 'server-only';
+
+import { runLlmTask } from '@/lib/ai/providerRouter';
+import { createCognitiveTwinEnvelope, evaluateCognitiveTwinAuthority } from '@/lib/cognitive-twin/contract';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { appendCognitiveLabEvent, getCognitiveLabSession } from './service';
+
+type Row = Record<string, unknown>;
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
+}
+
+export async function runCognitiveLabInteraction(createdBy: string, sessionId: string, input: {
+  prompt: string;
+  history?: Array<{ role: 'user' | 'assistant'; content: string }>;
+}) {
+  const db = createServiceSupabaseClient();
+  const lab = await getCognitiveLabSession(sessionId);
+  const session = lab.session as Row;
+  const condition = String(session.condition ?? 'OTHER');
+
+  if (!['FOUNDER_MODEL', 'FOUNDER_TWIN'].includes(condition)) {
+    throw new Error('COGNITIVE_LAB_INTERACTION_REQUIRES_MODEL_CONDITION');
+  }
+
+  const promptEvent = await appendCognitiveLabEvent(createdBy, sessionId, {
+    eventKind: 'PROMPT',
+    provenance: 'FOUNDER_ORIGINATED',
+    actorKey: 'FOUNDER',
+    relationFrom: 'FOUNDER',
+    relationTo: condition === 'FOUNDER_TWIN' ? 'COGNITIVE_TWIN' : 'MODEL',
+    payload: { text: input.prompt, interactionMode: condition },
+    evidenceRefs: [],
+    sourceRef: `cognitive-lab:${sessionId}:interaction`,
+  });
+
+  let memory: Row[] = [];
+  let decisions: Row[] = [];
+  const warnings: string[] = [];
+
+  if (condition === 'FOUNDER_TWIN') {
+    const [memoryResult, decisionsResult] = await Promise.all([
+      db.from('sfi_cognitive_twin_memory')
+        .select('memory_key,memory_type,status,content,evidence_refs,source_kind,source_ref,version,updated_at')
+        .in('status', ['VERIFIED', 'CANONICAL'])
+        .order('updated_at', { ascending: false })
+        .limit(80),
+      db.from('sfi_cognitive_twin_decisions')
+        .select('decision_id,situation,rejected_condition,correct_state,general_rule,required_evidence,evidence_refs,status,approved_at')
+        .eq('status', 'APPROVED')
+        .order('approved_at', { ascending: false })
+        .limit(50),
+    ]);
+    if (memoryResult.error) warnings.push(`memory_unavailable:${memoryResult.error.message}`);
+    if (decisionsResult.error) warnings.push(`decisions_unavailable:${decisionsResult.error.message}`);
+    memory = (memoryResult.data ?? []) as Row[];
+    decisions = (decisionsResult.data ?? []) as Row[];
+  }
+
+  const evidenceRefs = Array.from(new Set([
+    `cognitive-lab-event:${String(promptEvent.id)}`,
+    ...memory.flatMap((row) => strings(row.evidence_refs)),
+    ...decisions.flatMap((row) => strings(row.evidence_refs)),
+  ])).slice(0, 100);
+
+  const system = condition === 'FOUNDER_TWIN'
+    ? [
+        'You are the replaceable execution model operating inside a controlled Cognitive Twin laboratory condition.',
+        'Use only the supplied VERIFIED/CANONICAL institutional memory and APPROVED founder decisions as Cognitive Twin context.',
+        'Do not use candidate learning and do not infer that founder authorization means founder origination.',
+        'Respond to the task normally, but preserve uncertainty, provenance and reversibility where material.',
+        'Do not mutate canon or claim verification.',
+      ].join(' ')
+    : [
+        'You are a general model operating inside a controlled human-model laboratory condition.',
+        'You have no Cognitive Twin memory and must not infer a founder-specific method from the prompt alone.',
+        'Solve the task as a capable general assistant. Preserve uncertainty and do not claim hidden knowledge about the founder.',
+      ].join(' ');
+
+  const fallback = `MODEL EXECUTION DEGRADED\nPrompt: ${input.prompt}\nNo provider synthesis was available.`;
+  const llm = await runLlmTask({
+    task: 'context_long',
+    system,
+    prompt: JSON.stringify({
+      prompt: input.prompt,
+      history: (input.history ?? []).slice(-10),
+      condition,
+      cognitiveTwinContext: condition === 'FOUNDER_TWIN' ? { memory, decisions } : null,
+      warnings,
+    }),
+    fallbackResult: fallback,
+    maxTokens: 1800,
+  });
+
+  const outputEvent = await appendCognitiveLabEvent(createdBy, sessionId, {
+    eventKind: 'MODEL_OUTPUT',
+    provenance: 'MODEL_PROPOSED',
+    actorKey: condition === 'FOUNDER_TWIN' ? 'COGNITIVE_TWIN_EXECUTION_MODEL' : 'MODEL',
+    relationFrom: condition === 'FOUNDER_TWIN' ? 'COGNITIVE_TWIN' : 'MODEL',
+    relationTo: 'FOUNDER',
+    payload: {
+      text: llm.result,
+      provider: llm.provider,
+      model: llm.model,
+      providerExecutionSucceeded: llm.ok,
+      interactionMode: condition,
+    },
+    evidenceRefs,
+    sourceRef: `cognitive-lab:${sessionId}:interaction`,
+  });
+
+  let twinRun: Row | null = null;
+  if (condition === 'FOUNDER_TWIN') {
+    const authority = evaluateCognitiveTwinAuthority({
+      action: 'propose',
+      founderAbsent: false,
+      evidencePresent: evidenceRefs.length > 0,
+    });
+    const taskId = `cognitive-lab:interaction:${sessionId}:${Date.now()}`;
+    const envelope = createCognitiveTwinEnvelope({
+      status: llm.ok ? 'PROPOSED' : 'REJECTED',
+      taskId,
+      modelId: `${llm.provider}:${llm.model}`,
+      result: {
+        labSessionId: sessionId,
+        promptEventId: promptEvent.id,
+        outputEventId: outputEvent.id,
+        answer: llm.result,
+        authority,
+        condition,
+      },
+      limitations: [...warnings, ...llm.warnings],
+      missingEvidence: [],
+      actionsExecuted: ['read_verified_canonical_memory', 'read_approved_decisions', 'execute_lab_interaction'],
+      recommendedTransition: 'VERIFYING',
+    });
+
+    const persisted = await db.from('sfi_cognitive_twin_runs').insert({
+      task_id: taskId,
+      contract_version: envelope.contractVersion,
+      provider: llm.provider,
+      model: llm.model,
+      role: 'cognitive_lab_interaction',
+      status: llm.ok ? 'READY' : 'BLOCKED',
+      objective: input.prompt,
+      input_snapshot: {
+        labSessionId: sessionId,
+        promptEventId: promptEvent.id,
+        requestedBy: createdBy,
+        condition,
+      },
+      output_envelope: envelope,
+      evidence_refs: evidenceRefs,
+      limitations: envelope.limitations,
+      started_at: promptEvent.occurred_at,
+      finished_at: outputEvent.occurred_at,
+    }).select('id,task_id,status,provider,model,role,created_at').single();
+
+    if (!persisted.error) twinRun = persisted.data as Row;
+  }
+
+  return {
+    ok: llm.ok,
+    answer: llm.result,
+    provider: llm.provider,
+    model: llm.model,
+    warnings: [...warnings, ...llm.warnings],
+    condition,
+    promptEvent,
+    outputEvent,
+    twinRun,
+  };
+}

--- a/src/lib/cognitive-lab/service.ts
+++ b/src/lib/cognitive-lab/service.ts
@@ -1,0 +1,469 @@
+import 'server-only';
+
+import { runLlmTask } from '@/lib/ai/providerRouter';
+import { createCognitiveTwinEnvelope, evaluateCognitiveTwinAuthority } from '@/lib/cognitive-twin/contract';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+type Row = Record<string, unknown>;
+
+export type CognitiveLabCondition =
+  | 'FOUNDER_SOLO'
+  | 'FOUNDER_MODEL'
+  | 'FOUNDER_TWIN'
+  | 'FOUNDER_HUMAN_TECH'
+  | 'TWIN_ONLY'
+  | 'OTHER';
+
+export type CognitiveLabEventKind =
+  | 'PROMPT'
+  | 'MODEL_OUTPUT'
+  | 'FOUNDER_DECISION'
+  | 'TOOL_EXECUTION'
+  | 'ARTIFACT'
+  | 'OUTCOME'
+  | 'OBSERVATION'
+  | 'FRICTION'
+  | 'OMISSION'
+  | 'OTHER';
+
+export type CognitiveLabProvenance =
+  | 'FOUNDER_ORIGINATED'
+  | 'MODEL_PROPOSED'
+  | 'CO_DEVELOPED'
+  | 'SYSTEM_EMERGENT'
+  | 'EXTERNAL'
+  | 'FOUNDER_AUTHORIZATION'
+  | 'UNKNOWN';
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown, maximum = 12000): string {
+  return typeof value === 'string' ? value.trim().slice(0, maximum) : '';
+}
+
+function textOrNull(value: unknown, maximum = 12000): string | null {
+  const valueText = text(value, maximum);
+  return valueText || null;
+}
+
+function stringArray(value: unknown, maximum = 100): string[] {
+  if (!Array.isArray(value)) return [];
+  return Array.from(new Set(value
+    .filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    .map((item) => item.trim())
+  )).slice(0, maximum);
+}
+
+function jsonArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value.slice(0, 100) : [];
+}
+
+function sessionKey() {
+  const stamp = new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
+  const suffix = Math.random().toString(36).slice(2, 8).toUpperCase();
+  return `CRL-${stamp}-${suffix}`;
+}
+
+function eventEvidenceRefs(events: Row[]) {
+  return Array.from(new Set(events.flatMap((event) => [
+    `cognitive-lab-event:${String(event.id)}`,
+    ...stringArray(event.evidence_refs),
+  ]))).slice(0, 120);
+}
+
+async function requireSession(sessionId: string) {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_cognitive_lab_sessions')
+    .select('*')
+    .eq('id', sessionId)
+    .single();
+  if (result.error || !result.data) throw new Error('COGNITIVE_LAB_SESSION_NOT_FOUND');
+  return result.data as Row;
+}
+
+async function readSessionEvents(sessionId: string) {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_cognitive_lab_events')
+    .select('*')
+    .eq('session_id', sessionId)
+    .order('occurred_at', { ascending: true })
+    .order('created_at', { ascending: true })
+    .limit(500);
+  if (result.error) throw new Error(`COGNITIVE_LAB_EVENTS_READ_FAILED:${result.error.message}`);
+  return (result.data ?? []) as Row[];
+}
+
+export async function createCognitiveLabSession(createdBy: string, input: {
+  title: string;
+  objective: string;
+  condition: CognitiveLabCondition;
+  technologyNodes?: unknown[];
+  humanNodes?: unknown[];
+  baselineSessionId?: string | null;
+  metadata?: Row;
+}) {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_cognitive_lab_sessions').insert({
+    session_key: sessionKey(),
+    title: input.title,
+    objective: input.objective,
+    condition: input.condition,
+    status: 'OPEN',
+    subject_actor: 'FOUNDER',
+    technology_nodes: jsonArray(input.technologyNodes),
+    human_nodes: jsonArray(input.humanNodes),
+    baseline_session_id: input.baselineSessionId ?? null,
+    metadata: record(input.metadata),
+    created_by: createdBy,
+    started_at: new Date().toISOString(),
+  }).select('*').single();
+
+  if (result.error) throw new Error(`COGNITIVE_LAB_SESSION_CREATE_FAILED:${result.error.message}`);
+  return result.data;
+}
+
+export async function listCognitiveLabSessions(limit = 30) {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_cognitive_lab_sessions')
+    .select('*')
+    .order('created_at', { ascending: false })
+    .limit(Math.min(Math.max(limit, 1), 100));
+  if (result.error) throw new Error(`COGNITIVE_LAB_SESSION_LIST_FAILED:${result.error.message}`);
+  return result.data ?? [];
+}
+
+export async function getCognitiveLabSession(sessionId: string) {
+  const db = createServiceSupabaseClient();
+  const [session, events, analyses] = await Promise.all([
+    db.from('sfi_cognitive_lab_sessions').select('*').eq('id', sessionId).single(),
+    db.from('sfi_cognitive_lab_events').select('*').eq('session_id', sessionId).order('occurred_at', { ascending: true }).order('created_at', { ascending: true }),
+    db.from('sfi_cognitive_lab_analyses').select('*').eq('session_id', sessionId).order('created_at', { ascending: true }),
+  ]);
+  if (session.error || !session.data) throw new Error('COGNITIVE_LAB_SESSION_NOT_FOUND');
+  return {
+    session: session.data,
+    events: events.data ?? [],
+    analyses: analyses.data ?? [],
+    warnings: [events.error?.message, analyses.error?.message].filter((item): item is string => Boolean(item)),
+  };
+}
+
+export async function appendCognitiveLabEvent(createdBy: string, sessionId: string, input: {
+  eventKind: CognitiveLabEventKind;
+  provenance: CognitiveLabProvenance;
+  actorKey: string;
+  relationFrom?: string | null;
+  relationTo?: string | null;
+  payload?: Row;
+  evidenceRefs?: string[];
+  sourceRef?: string | null;
+  occurredAt?: string | null;
+}) {
+  const db = createServiceSupabaseClient();
+  const session = await requireSession(sessionId);
+  const status = text(session.status, 80);
+  if (['CLOSED', 'REJECTED'].includes(status)) throw new Error('COGNITIVE_LAB_SESSION_NOT_OPEN');
+
+  const result = await db.from('sfi_cognitive_lab_events').insert({
+    session_id: sessionId,
+    event_kind: input.eventKind,
+    provenance: input.provenance,
+    actor_key: input.actorKey,
+    relation_from: input.relationFrom ?? null,
+    relation_to: input.relationTo ?? null,
+    payload: record(input.payload),
+    evidence_refs: stringArray(input.evidenceRefs),
+    source_ref: input.sourceRef ?? null,
+    occurred_at: input.occurredAt ?? new Date().toISOString(),
+    created_by: createdBy,
+  }).select('*').single();
+  if (result.error) throw new Error(`COGNITIVE_LAB_EVENT_CREATE_FAILED:${result.error.message}`);
+
+  if (status === 'OPEN') {
+    await db.from('sfi_cognitive_lab_sessions')
+      .update({ status: 'READY_FOR_BLIND', updated_at: new Date().toISOString() })
+      .eq('id', sessionId);
+  }
+
+  return result.data;
+}
+
+export async function runCognitiveLabBlindTwin(createdBy: string, sessionId: string) {
+  const db = createServiceSupabaseClient();
+  const session = await requireSession(sessionId);
+  const events = await readSessionEvents(sessionId);
+  if (events.length === 0) throw new Error('COGNITIVE_LAB_BLIND_REQUIRES_EVENTS');
+
+  // Blind analysis deliberately excludes CANDIDATE memory to reduce circular learning.
+  const [memoryResult, decisionsResult] = await Promise.all([
+    db.from('sfi_cognitive_twin_memory')
+      .select('memory_key,memory_type,status,content,evidence_refs,source_kind,source_ref,version,updated_at')
+      .in('status', ['VERIFIED', 'CANONICAL'])
+      .order('updated_at', { ascending: false })
+      .limit(80),
+    db.from('sfi_cognitive_twin_decisions')
+      .select('decision_id,situation,rejected_condition,correct_state,general_rule,required_evidence,evidence_refs,status,approved_at')
+      .eq('status', 'APPROVED')
+      .order('approved_at', { ascending: false })
+      .limit(50),
+  ]);
+
+  const warnings = [memoryResult.error?.message, decisionsResult.error?.message]
+    .filter((item): item is string => Boolean(item));
+  const memory = memoryResult.data ?? [];
+  const decisions = decisionsResult.data ?? [];
+  const evidenceRefs = eventEvidenceRefs(events);
+  const startedAt = new Date().toISOString();
+
+  const fallback = [
+    'Cognitive Lab blind analysis unavailable through an LLM provider.',
+    `Session: ${String(session.session_key)}`,
+    `Events: ${events.length}.`,
+    'No relational conclusion is promoted.',
+  ].join('\n');
+
+  const llm = await runLlmTask({
+    task: 'deep_report',
+    system: [
+      'You are executing a BLIND relational analysis for the System Friction Institute Cognitive Twin.',
+      'Do not assume the founder originated an operation merely because the founder authorized execution.',
+      'Use the event provenance labels as evidence, not as psychological interpretation.',
+      'Do not use candidate learning. Use only the supplied VERIFIED/CANONICAL memory and APPROVED decisions.',
+      'Separate observed interaction from inferred relation.',
+      'Identify: objective reconstruction; founder function; technology function; initiative direction; expansion events; contraction events; induced friction; omissions; material trajectory changes; candidate relational phenomena; uncertainties; and what must not be learned yet.',
+      'Explicitly answer WHO CHANGED WHOM for each material transformation when evidence allows.',
+      'Do not promote anything to canon.',
+    ].join(' '),
+    prompt: JSON.stringify({
+      session,
+      events,
+      verifiedCanonicalMemory: memory,
+      approvedFounderDecisions: decisions,
+      warnings,
+    }),
+    fallbackResult: fallback,
+    maxTokens: 1800,
+  });
+
+  const finishedAt = new Date().toISOString();
+  const analysisStatus = llm.ok ? 'CANDIDATE' : 'BLOCKED';
+  const analysis = await db.from('sfi_cognitive_lab_analyses').insert({
+    session_id: sessionId,
+    analysis_kind: 'BLIND_TWIN',
+    status: analysisStatus,
+    input_event_ids: events.map((event) => String(event.id)),
+    output: {
+      answer: llm.result,
+      providerExecutionSucceeded: llm.ok,
+      corpus: {
+        events: events.length,
+        verifiedCanonicalMemory: memory.length,
+        approvedFounderDecisions: decisions.length,
+      },
+    },
+    provider: llm.provider,
+    model: llm.model,
+    evidence_refs: evidenceRefs,
+    limitations: [...warnings, ...llm.warnings],
+    created_by: createdBy,
+  }).select('*').single();
+  if (analysis.error) throw new Error(`COGNITIVE_LAB_BLIND_PERSIST_FAILED:${analysis.error.message}`);
+
+  const authority = evaluateCognitiveTwinAuthority({
+    action: 'propose',
+    founderAbsent: false,
+    evidencePresent: evidenceRefs.length > 0,
+  });
+  const taskId = `cognitive-lab:blind:${sessionId}:${Date.now()}`;
+  const envelope = createCognitiveTwinEnvelope({
+    status: llm.ok ? 'PROPOSED' : 'REJECTED',
+    taskId,
+    modelId: `${llm.provider}:${llm.model}`,
+    result: {
+      labSessionId: sessionId,
+      labAnalysisId: analysis.data.id,
+      answer: llm.result,
+      authority,
+      providerExecutionSucceeded: llm.ok,
+    },
+    limitations: [...warnings, ...llm.warnings],
+    missingEvidence: [],
+    actionsExecuted: ['read_lab_events', 'read_verified_canonical_memory', 'read_approved_decisions', llm.ok ? 'blind_relational_analysis' : 'blind_relational_analysis_failed'],
+    recommendedTransition: llm.ok ? 'VERIFYING' : 'BLOCKED',
+  });
+
+  await db.from('sfi_cognitive_twin_runs').insert({
+    task_id: taskId,
+    contract_version: envelope.contractVersion,
+    provider: llm.provider,
+    model: llm.model,
+    role: 'cognitive_lab_blind_relational_analysis',
+    status: llm.ok ? 'VERIFYING' : 'BLOCKED',
+    objective: `Blind relational reconstruction for ${String(session.session_key)}`,
+    input_snapshot: {
+      labSessionId: sessionId,
+      eventCount: events.length,
+      requestedBy: createdBy,
+    },
+    output_envelope: envelope,
+    evidence_refs: evidenceRefs,
+    limitations: envelope.limitations,
+    started_at: startedAt,
+    finished_at: finishedAt,
+  });
+
+  await db.from('sfi_cognitive_lab_sessions').update({
+    status: llm.ok ? 'BLIND_COMPLETE' : 'READY_FOR_BLIND',
+    updated_at: new Date().toISOString(),
+  }).eq('id', sessionId);
+
+  return { analysis: analysis.data, envelope, cognitiveExecution: llm.ok ? 'EXECUTED' : 'DEGRADED' };
+}
+
+export async function runCognitiveLabFounderContrast(createdBy: string, sessionId: string, founderReadingInput: unknown) {
+  const db = createServiceSupabaseClient();
+  const session = await requireSession(sessionId);
+  const events = await readSessionEvents(sessionId);
+  if (events.length === 0) throw new Error('COGNITIVE_LAB_CONTRAST_REQUIRES_EVENTS');
+
+  const blindResult = await db.from('sfi_cognitive_lab_analyses')
+    .select('*')
+    .eq('session_id', sessionId)
+    .eq('analysis_kind', 'BLIND_TWIN')
+    .eq('status', 'CANDIDATE')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (blindResult.error || !blindResult.data) throw new Error('COGNITIVE_LAB_BLIND_ANALYSIS_REQUIRED');
+
+  const founderReading = typeof founderReadingInput === 'string'
+    ? { narrative: text(founderReadingInput, 30000) }
+    : record(founderReadingInput);
+  if (Object.keys(founderReading).length === 0) throw new Error('COGNITIVE_LAB_FOUNDER_READING_REQUIRED');
+
+  const evidenceRefs = eventEvidenceRefs(events);
+  const founderAnalysis = await db.from('sfi_cognitive_lab_analyses').insert({
+    session_id: sessionId,
+    analysis_kind: 'FOUNDER_READING',
+    status: 'VERIFIED',
+    input_event_ids: events.map((event) => String(event.id)),
+    output: founderReading,
+    provider: null,
+    model: null,
+    evidence_refs: evidenceRefs,
+    limitations: [],
+    created_by: createdBy,
+  }).select('*').single();
+  if (founderAnalysis.error) throw new Error(`COGNITIVE_LAB_FOUNDER_READING_PERSIST_FAILED:${founderAnalysis.error.message}`);
+
+  const fallback = [
+    'Cognitive Lab divergence analysis unavailable through an LLM provider.',
+    'Blind and founder readings were persisted but no machine divergence claim is made.',
+  ].join('\n');
+
+  const llm = await runLlmTask({
+    task: 'deep_report',
+    system: [
+      'You are comparing a BLIND Cognitive Twin relational reading against a later founder reading.',
+      'The founder reading is contrast evidence, not automatic ground truth for every causal interpretation.',
+      'Separate agreement, divergence, provenance conflicts, omissions, relation errors, and genuinely new founder information.',
+      'Identify which differences imply missing memory, missing relational representation, instrument bias, or legitimate ambiguity.',
+      'Generate learning candidates only for claims supported by interaction evidence plus contrast. Never mark them canonical.',
+      'For each learning candidate state: operation/relation, provenance, evidence basis, transfer boundary, counterexample needed, and reopen condition.',
+    ].join(' '),
+    prompt: JSON.stringify({
+      session,
+      events,
+      blindReading: blindResult.data,
+      founderReading,
+    }),
+    fallbackResult: fallback,
+    maxTokens: 1800,
+  });
+
+  const divergence = await db.from('sfi_cognitive_lab_analyses').insert({
+    session_id: sessionId,
+    analysis_kind: 'DIVERGENCE',
+    status: llm.ok ? 'CANDIDATE' : 'BLOCKED',
+    input_event_ids: events.map((event) => String(event.id)),
+    output: {
+      answer: llm.result,
+      blindAnalysisId: blindResult.data.id,
+      founderAnalysisId: founderAnalysis.data.id,
+      providerExecutionSucceeded: llm.ok,
+    },
+    provider: llm.provider,
+    model: llm.model,
+    evidence_refs: [
+      ...evidenceRefs,
+      `cognitive-lab-analysis:${String(blindResult.data.id)}`,
+      `cognitive-lab-analysis:${String(founderAnalysis.data.id)}`,
+    ],
+    limitations: llm.warnings,
+    created_by: createdBy,
+  }).select('*').single();
+  if (divergence.error) throw new Error(`COGNITIVE_LAB_DIVERGENCE_PERSIST_FAILED:${divergence.error.message}`);
+
+  let learning: Row = { persisted: false, reason: 'divergence_analysis_degraded' };
+  if (llm.ok) {
+    const memoryEvidenceRefs = [
+      ...evidenceRefs,
+      `cognitive-lab-analysis:${String(blindResult.data.id)}`,
+      `cognitive-lab-analysis:${String(founderAnalysis.data.id)}`,
+      `cognitive-lab-analysis:${String(divergence.data.id)}`,
+    ];
+    const authority = evaluateCognitiveTwinAuthority({
+      action: 'persist_memory',
+      founderAbsent: false,
+      evidencePresent: memoryEvidenceRefs.length > 0,
+    });
+
+    if (authority.decision === 'ALLOW') {
+      const memory = await db.from('sfi_cognitive_twin_memory').upsert({
+        memory_key: `cognitive_lab:${sessionId}:relational_contrast`,
+        memory_type: 'STATE',
+        status: 'CANDIDATE',
+        content: {
+          epistemicStatus: 'CANDIDATE',
+          learningClass: 'RELATIONAL_COUPLING_CONTRAST',
+          labSessionId: sessionId,
+          sessionKey: session.session_key,
+          condition: session.condition,
+          blindAnalysisId: blindResult.data.id,
+          founderAnalysisId: founderAnalysis.data.id,
+          divergenceAnalysisId: divergence.data.id,
+          divergence: llm.result,
+          provenanceRule: 'FOUNDER_AUTHORIZATION_IS_NOT_FOUNDER_ORIGIN',
+          promotionRule: 'Requires later replication or explicit verification before VERIFIED/CANONICAL.',
+        },
+        evidence_refs: memoryEvidenceRefs,
+        source_kind: 'COGNITIVE_LAB_CONTRAST',
+        source_ref: String(divergence.data.id),
+        version: 'cognitive-lab-v1',
+        created_by: createdBy,
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'memory_key,version' }).select('id,status,memory_key,version').single();
+
+      learning = memory.error
+        ? { persisted: false, reason: memory.error.message }
+        : { persisted: true, ...record(memory.data) };
+    } else {
+      learning = { persisted: false, reason: authority.reason };
+    }
+  }
+
+  await db.from('sfi_cognitive_lab_sessions').update({
+    status: llm.ok ? 'CLOSED' : 'CONTRAST_PENDING',
+    ended_at: llm.ok ? new Date().toISOString() : null,
+    updated_at: new Date().toISOString(),
+  }).eq('id', sessionId);
+
+  return {
+    founderReading: founderAnalysis.data,
+    divergence: divergence.data,
+    learning,
+    cognitiveExecution: llm.ok ? 'EXECUTED' : 'DEGRADED',
+  };
+}

--- a/supabase/migrations/20260810003000_cognitive_relational_lab_v1.sql
+++ b/supabase/migrations/20260810003000_cognitive_relational_lab_v1.sql
@@ -1,0 +1,115 @@
+-- SFI Cognitive Relational Laboratory v1
+-- Experimental infrastructure for observing human-model-system coupling.
+-- No seed rows. No laboratory output is canonical by default.
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.sfi_cognitive_lab_sessions (
+  id uuid primary key default gen_random_uuid(),
+  session_key text not null unique,
+  title text not null,
+  objective text not null,
+  condition text not null check (condition in (
+    'FOUNDER_SOLO',
+    'FOUNDER_MODEL',
+    'FOUNDER_TWIN',
+    'FOUNDER_HUMAN_TECH',
+    'TWIN_ONLY',
+    'OTHER'
+  )),
+  status text not null default 'OPEN' check (status in (
+    'OPEN',
+    'READY_FOR_BLIND',
+    'BLIND_COMPLETE',
+    'CONTRAST_PENDING',
+    'CLOSED',
+    'REJECTED'
+  )),
+  subject_actor text not null default 'FOUNDER',
+  technology_nodes jsonb not null default '[]'::jsonb,
+  human_nodes jsonb not null default '[]'::jsonb,
+  baseline_session_id uuid references public.sfi_cognitive_lab_sessions(id) on delete set null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_by text not null,
+  started_at timestamptz not null default now(),
+  ended_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.sfi_cognitive_lab_events (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid not null references public.sfi_cognitive_lab_sessions(id) on delete cascade,
+  event_kind text not null check (event_kind in (
+    'PROMPT',
+    'MODEL_OUTPUT',
+    'FOUNDER_DECISION',
+    'TOOL_EXECUTION',
+    'ARTIFACT',
+    'OUTCOME',
+    'OBSERVATION',
+    'FRICTION',
+    'OMISSION',
+    'OTHER'
+  )),
+  provenance text not null check (provenance in (
+    'FOUNDER_ORIGINATED',
+    'MODEL_PROPOSED',
+    'CO_DEVELOPED',
+    'SYSTEM_EMERGENT',
+    'EXTERNAL',
+    'FOUNDER_AUTHORIZATION',
+    'UNKNOWN'
+  )),
+  actor_key text not null,
+  relation_from text,
+  relation_to text,
+  payload jsonb not null default '{}'::jsonb,
+  evidence_refs text[] not null default '{}',
+  source_ref text,
+  occurred_at timestamptz not null default now(),
+  created_by text not null,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.sfi_cognitive_lab_analyses (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid not null references public.sfi_cognitive_lab_sessions(id) on delete cascade,
+  analysis_kind text not null check (analysis_kind in (
+    'BLIND_TWIN',
+    'FOUNDER_READING',
+    'DIVERGENCE',
+    'PPOI',
+    'NEGATIVE_MAP'
+  )),
+  status text not null default 'CANDIDATE' check (status in (
+    'CANDIDATE',
+    'VERIFIED',
+    'REJECTED',
+    'BLOCKED'
+  )),
+  input_event_ids uuid[] not null default '{}',
+  output jsonb not null default '{}'::jsonb,
+  provider text,
+  model text,
+  evidence_refs text[] not null default '{}',
+  limitations text[] not null default '{}',
+  created_by text not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_sfi_cognitive_lab_sessions_status
+  on public.sfi_cognitive_lab_sessions(status, created_at desc);
+create index if not exists idx_sfi_cognitive_lab_events_session_time
+  on public.sfi_cognitive_lab_events(session_id, occurred_at asc, created_at asc);
+create index if not exists idx_sfi_cognitive_lab_events_provenance
+  on public.sfi_cognitive_lab_events(provenance, created_at desc);
+create index if not exists idx_sfi_cognitive_lab_analyses_session_kind
+  on public.sfi_cognitive_lab_analyses(session_id, analysis_kind, created_at desc);
+
+alter table public.sfi_cognitive_lab_sessions enable row level security;
+alter table public.sfi_cognitive_lab_events enable row level security;
+alter table public.sfi_cognitive_lab_analyses enable row level security;
+
+-- ROOT-only infrastructure. Access occurs through governed server routes using service role.
+-- Explicitly no public RLS policies are created.

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in agent/root-runtime-reports-convergence|agent/method-lab-convergence) exit 0 ;; *) exit 1 ;; esac",
   "crons": [
     {
       "path": "/api/cron/continuity-heartbeat",


### PR DESCRIPTION
## Objective
Create the first operational Cognitive Relational Laboratory in ROOT so SFI observes founder–technology coupling instead of treating the founder as an isolated cognitive object.

## What this adds
- ROOT `CRL` launcher and persisted laboratory sessions.
- Controlled `FOUNDER + MODEL` and `FOUNDER + COGNITIVE TWIN` conditions.
- Provenance classes separating founder origin, model proposal, co-development, system emergence, external origin and founder authorization.
- Explicit `REGISTRAR “EJECUTA”` semantics: authorization is not founder origination.
- Blind Cognitive Twin reconstruction before founder interpretation.
- Founder contrast and divergence analysis.
- Evidence-bound `CANDIDATE` relational learning only after contrast; never auto-canonical.
- Dedicated Supabase persistence for sessions, events and analyses.
- Blind analyses exclude CANDIDATE Twin memory to reduce circular learning.

## Activation
After merge/deploy and application of `20260810003000_cognitive_relational_lab_v1.sql`, ROOT exposes the `CRL` launcher. A session is activated from ROOT and persisted before any interaction.

## Truth boundaries
- No seed/synthetic lab rows.
- No canonical promotion from a single laboratory case.
- Missing DB migration fails visibly.
- Missing LLM provider preserves captured evidence but degrades synthesis.

## Verification required
- SFI Verify / typecheck / production build.
- Migration compatibility with current Cognitive Twin core.
- ROOT authorization boundaries.