### PR TITLE
Hotfix ROOT stability and Friccionauta/Groq interaction

### DIFF
--- a/src/app/api/root/friccionauta/route.ts
+++ b/src/app/api/root/friccionauta/route.ts
@@ -30,13 +30,20 @@ function compact(value: unknown, max = 6000) {
 function recentConversation(value: unknown) {
   return rows(value).slice(-8).map((item) => ({ role: text(item.role, 'user'), content: text(item.content).slice(0, 2200) }));
 }
+function rejectedWarning(label: string, result: PromiseSettledResult<unknown>) {
+  return result.status === 'rejected'
+    ? `${label}_unavailable:${result.reason instanceof Error ? result.reason.message : String(result.reason)}`
+    : null;
+}
 
 async function ask(request: Request, gate: RootActorGate, body: Row) {
   const question = text(body.question);
   if (!question) return NextResponse.json({ ok: false, error: 'question_required' }, { status: 400 });
   const startedAt = new Date().toISOString();
 
-  const [root, twin, world, graph, amv] = await Promise.all([
+  // A conversational surface must not collapse because one observational reader is degraded.
+  // Each source is independently optional; the LLM still receives the context that is actually available.
+  const [rootResult, twinResult, worldResult, graphResult, amvResult] = await Promise.allSettled([
     readRootSovereignState(),
     readCognitiveTwinState(),
     buildWorldVectorOperationalState(),
@@ -44,63 +51,79 @@ async function ask(request: Request, gate: RootActorGate, body: Row) {
     readAmvOperationalMemory({ query: question, limit: 14 }),
   ]);
 
+  const root = rootResult.status === 'fulfilled' ? rootResult.value : null;
+  const twin = twinResult.status === 'fulfilled' ? twinResult.value : null;
+  const world = worldResult.status === 'fulfilled' ? worldResult.value : null;
+  const graph = graphResult.status === 'fulfilled' ? graphResult.value : null;
+  const amv = amvResult.status === 'fulfilled' ? amvResult.value : null;
+  const retrievalWarnings = [
+    rejectedWarning('root', rootResult),
+    rejectedWarning('cognitive_twin', twinResult),
+    rejectedWarning('world_vector', worldResult),
+    rejectedWarning('neural_graph', graphResult),
+    rejectedWarning('amv', amvResult),
+  ].filter((item): item is string => Boolean(item));
+
   const evidenceRefs = Array.from(new Set([
-    ...graph.evidence.map((item) => item.id),
-    ...amv.items.map((item) => item.id),
-    ...root.interpretation.facts.flatMap((fact) => fact.evidenceIds),
-    ...root.predictions.data.runs.flatMap((row) => strings(row.evidence_refs)),
+    ...(graph?.evidence ?? []).map((item) => item.id),
+    ...(amv?.items ?? []).map((item) => item.id),
+    ...(root?.interpretation.facts ?? []).flatMap((fact) => fact.evidenceIds),
+    ...(root?.predictions.data.runs ?? []).flatMap((row) => strings(row.evidence_refs)),
   ])).slice(0, 80);
 
   const context = {
-    generatedAt: root.generatedAt,
-    institutionalInterpretation: root.interpretation,
-    systemMatrix: root.system.data.matrix,
-    warnings: root.warnings,
-    governance: {
+    generatedAt: root?.generatedAt ?? new Date().toISOString(),
+    retrievalWarnings,
+    institutionalInterpretation: root?.interpretation ?? null,
+    systemMatrix: root?.system.data.matrix ?? [],
+    warnings: root?.warnings ?? [],
+    governance: root ? {
       proposals: root.governance.data.proposals.slice(0, 18),
       mutations: root.governance.data.mutations.slice(0, 12),
-    },
-    cognitiveRuntime: {
+    } : null,
+    cognitiveRuntime: root ? {
       status: root.cognitiveRuntime.data.status,
       contract: root.cognitiveRuntime.data.contract,
       agents: root.cognitiveRuntime.data.agents,
       recentEvents: root.cognitiveRuntime.data.eventGraph.recentEvents.slice(0, 24),
-    },
-    predictions: {
+    } : null,
+    predictions: root ? {
       runs: root.predictions.data.runs.slice(0, 16),
       outcomes: root.predictions.data.outcomes.slice(0, 16),
       legacy: root.predictions.data.legacyEntries.slice(0, 12),
-    },
-    attractors: root.amv.data.attractors.slice(0, 18),
-    executionCapabilities: root.execution.data.capabilities,
-    worldVector: world.today.observation,
-    cognitiveTwin: {
+    } : null,
+    attractors: root?.amv.data.attractors.slice(0, 18) ?? [],
+    executionCapabilities: root?.execution.data.capabilities ?? [],
+    worldVector: world?.today.observation ?? null,
+    cognitiveTwin: twin ? {
       implementation: twin.implementation,
       counts: twin.counts,
       recentDecisions: twin.recentDecisions.slice(0, 12),
       recentRuns: twin.recentRuns.slice(0, 12),
       errors: twin.errors,
-    },
-    targetedRetrieval: {
+    } : null,
+    targetedRetrieval: graph ? {
       interpretation: graph.interpretation,
       evidence: graph.evidence.slice(0, 16),
       nodes: graph.nodes.slice(0, 22),
       predictions: graph.related_predictions.slice(0, 12),
       reports: graph.related_reports.slice(0, 10),
       missingContext: graph.missing_context,
-      amvItems: amv.items.slice(0, 14),
+    } : null,
+    amv: amv ? {
+      items: amv.items.slice(0, 14),
       recurrentPatterns: amv.recurrent_patterns,
-    },
+      warnings: amv.warnings,
+    } : null,
     conversation: recentConversation(body.history),
   };
 
   const fallback = [
     'FRICCIONAUTA · DEGRADED',
     `Pregunta: ${question}`,
-    `Estado ROOT generado: ${root.generatedAt}`,
-    `Divergencias: ${root.interpretation.divergences.length}`,
-    `Evidencia recuperada: ${graph.evidence.length}`,
-    'No hubo proveedor LLM disponible. La información institucional fue recuperada pero no sintetizada por modelo.',
+    `Fuentes degradadas: ${retrievalWarnings.length}.`,
+    `Evidencia recuperada: ${graph?.evidence.length ?? 0}.`,
+    'No hubo proveedor LLM disponible para sintetizar una respuesta. La conversación permanece registrada como intento degradado.',
   ].join('\n');
 
   const llm = await runLlmTask({
@@ -110,6 +133,7 @@ async function ask(request: Request, gate: RootActorGate, body: Row) {
       'You are FRICCIONAUTA, the read-only conversational interface of System Friction Institute ROOT.',
       'You operate through the Cognitive Twin contract. You are not the Cognitive Twin itself and you do not own institutional memory.',
       'Answer questions about SFI using the supplied current institutional state and targeted retrieval.',
+      'Some readers may be explicitly unavailable. Missing readers are not a reason to refuse the whole conversation; name the missing context and continue with what is available.',
       'You may interpret, compare, diagnose gaps and propose next observations. You may NOT execute endpoints, approve, publish, mutate canon, alter formulas, grant access, contact anyone or represent a proposal as executed.',
       'Evidence before inference. Distinguish OBSERVED, IMPORTED, DERIVED, INFERRED, PROPOSED and MISSING.',
       'When asked what something means, explain the operational consequence rather than restating database fields.',
@@ -124,8 +148,16 @@ async function ask(request: Request, gate: RootActorGate, body: Row) {
 
   const authority = evaluateCognitiveTwinAuthority({ action: 'propose', founderAbsent: false, evidencePresent: evidenceRefs.length > 0 });
   const taskId = `friccionauta:${Date.now()}`;
+  const allWarnings = [
+    ...retrievalWarnings,
+    ...llm.warnings,
+    ...(root?.warnings ?? []),
+    ...(graph?.warnings ?? []),
+    ...(amv?.warnings ?? []),
+  ];
+  const missingEvidence = graph?.missing_context ?? (graph ? [] : ['neural_graph_context_unavailable']);
   const envelope = createCognitiveTwinEnvelope({
-    status: 'PROPOSED',
+    status: llm.ok ? 'PROPOSED' : 'REJECTED',
     taskId,
     modelId: `${llm.provider}:${llm.model}`,
     result: {
@@ -134,13 +166,22 @@ async function ask(request: Request, gate: RootActorGate, body: Row) {
       provider: llm.provider,
       model: llm.model,
       authority,
-      rootGeneratedAt: root.generatedAt,
+      rootGeneratedAt: root?.generatedAt ?? null,
       evidenceRefCount: evidenceRefs.length,
+      retrievalDegradationCount: retrievalWarnings.length,
+      providerExecutionSucceeded: llm.ok,
     },
-    limitations: [...llm.warnings, ...root.warnings, ...graph.warnings, ...amv.warnings],
-    missingEvidence: graph.missing_context,
-    actionsExecuted: ['read_root_state', 'read_cognitive_twin', 'read_world_vector', 'retrieve_neural_graph', 'read_amv', 'llm_synthesis'],
-    recommendedTransition: 'VERIFYING',
+    limitations: allWarnings,
+    missingEvidence,
+    actionsExecuted: [
+      root ? 'read_root_state' : 'read_root_state_failed',
+      twin ? 'read_cognitive_twin' : 'read_cognitive_twin_failed',
+      world ? 'read_world_vector' : 'read_world_vector_failed',
+      graph ? 'retrieve_neural_graph' : 'retrieve_neural_graph_failed',
+      amv ? 'read_amv' : 'read_amv_failed',
+      llm.ok ? 'llm_synthesis' : 'llm_synthesis_failed',
+    ],
+    recommendedTransition: llm.ok ? 'VERIFYING' : 'BLOCKED',
   });
   const finishedAt = new Date().toISOString();
 
@@ -150,9 +191,15 @@ async function ask(request: Request, gate: RootActorGate, body: Row) {
     provider: llm.provider,
     model: llm.model,
     role: 'friccionauta',
-    status: 'READY',
+    status: llm.ok ? 'READY' : 'BLOCKED',
     objective: question,
-    input_snapshot: { question, requestedBy: gate.ctx.user.id, rootGeneratedAt: root.generatedAt },
+    input_snapshot: {
+      question,
+      requestedBy: gate.ctx.user.id,
+      rootGeneratedAt: root?.generatedAt ?? null,
+      retrievalWarnings,
+      providerExecutionSucceeded: llm.ok,
+    },
     output_envelope: envelope,
     evidence_refs: evidenceRefs,
     limitations: envelope.limitations,
@@ -161,10 +208,35 @@ async function ask(request: Request, gate: RootActorGate, body: Row) {
   }).select('id,task_id,status,provider,model,role,objective,evidence_refs,limitations,created_at').single();
 
   if (persisted.error) return NextResponse.json({ ok: false, error: 'friccionauta_run_persistence_failed', details: persisted.error.message, envelope }, { status: 500 });
-  const audit = await auditRootAction({ actorId: gate.ctx.user.id, action: 'friccionauta.ask', target: taskId, payload: { runId: persisted.data.id, provider: llm.provider, model: llm.model, evidenceRefs: evidenceRefs.length }, request });
+  const audit = await auditRootAction({
+    actorId: gate.ctx.user.id,
+    action: 'friccionauta.ask',
+    target: taskId,
+    payload: {
+      runId: persisted.data.id,
+      provider: llm.provider,
+      model: llm.model,
+      providerExecutionSucceeded: llm.ok,
+      evidenceRefs: evidenceRefs.length,
+      retrievalDegradationCount: retrievalWarnings.length,
+    },
+    request,
+  });
   if (!audit.ok) return NextResponse.json(audit, { status: 500 });
 
-  return NextResponse.json({ ok: true, answer: llm.result, provider: llm.provider, model: llm.model, evidenceRefs, warnings: envelope.limitations, run: persisted.data, envelope, audit });
+  return NextResponse.json({
+    ok: true,
+    cognitiveExecution: llm.ok ? 'EXECUTED' : 'DEGRADED',
+    answer: llm.result,
+    provider: llm.provider,
+    model: llm.model,
+    evidenceRefs,
+    warnings: envelope.limitations,
+    retrievalWarnings,
+    run: persisted.data,
+    envelope,
+    audit,
+  });
 }
 
 async function saveFinding(request: Request, gate: RootActorGate, body: Row) {
@@ -176,7 +248,7 @@ async function saveFinding(request: Request, gate: RootActorGate, body: Row) {
   const memoryKey = `FRICCIONAUTA:FINDING:${new Date().toISOString()}:${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
   const write = await gate.ctx.service.from('sfi_cognitive_twin_memory').insert({
     memory_key: memoryKey,
-    memory_type: 'OBSERVATION',
+    memory_type: 'EVIDENCE',
     status: 'CANDIDATE',
     content: {
       finding,

--- a/src/app/api/root/llm/groq/health/route.ts
+++ b/src/app/api/root/llm/groq/health/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { getLlmProviderStatus, runLlmTask } from '@/lib/ai/providerRouter';
+import { requireRootActor } from '@/lib/root/server';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
+export async function GET() {
+  const gate = await requireRootActor('llm.groq.health');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  const configured = getLlmProviderStatus().find((provider) => provider.id === 'groq') ?? null;
+  const probe = await runLlmTask({
+    task: 'fast_classification',
+    preferredProvider: 'groq',
+    system: 'Return exactly GROQ_OK. No additional text.',
+    prompt: 'health probe',
+    fallbackResult: 'GROQ_UNAVAILABLE',
+    maxTokens: 12,
+  });
+
+  const groqExecuted = probe.ok && probe.provider === 'groq';
+  return NextResponse.json({
+    ok: groqExecuted,
+    configured: configured?.available === true,
+    configuredModel: configured?.model ?? null,
+    executedProvider: probe.provider,
+    executedModel: probe.model,
+    result: probe.result,
+    warnings: probe.warnings,
+    latencyMs: probe.latency_ms,
+  }, { status: groqExecuted ? 200 : 503, headers: { 'Cache-Control': 'no-store' } });
+}

--- a/src/components/root/sovereign/RootSovereignConsole.tsx
+++ b/src/components/root/sovereign/RootSovereignConsole.tsx
@@ -24,6 +24,8 @@ function usesRichSemanticContext(selection: RootSelection | null) {
 
 type RootAccessMode = 'sovereign' | 'observer';
 
+const ROOT_BACKGROUND_REFRESH_MS = 60 * 60 * 1000;
+
 export function RootSovereignConsole({ initialState, accessMode = 'sovereign', actorLabel = 'ROOT' }: {
   initialState: RootSovereignState;
   accessMode?: RootAccessMode;
@@ -69,7 +71,9 @@ export function RootSovereignConsole({ initialState, accessMode = 'sovereign', a
   }, []);
 
   useEffect(() => {
-    const interval = window.setInterval(() => { if (!document.hidden) void refresh(true); }, 60000);
+    // ROOT is server-rendered on entry. After that, refresh only once per hour,
+    // plus an explicit refresh whenever the user returns to the page/tab.
+    const interval = window.setInterval(() => { if (!document.hidden) void refresh(true); }, ROOT_BACKGROUND_REFRESH_MS);
     const visible = () => { if (!document.hidden) void refresh(true); };
     document.addEventListener('visibilitychange', visible);
     return () => { window.clearInterval(interval); document.removeEventListener('visibilitychange', visible); refreshSequence.current += 1; controller.current?.abort('unmount'); };


### PR DESCRIPTION
## Fixes

1. ROOT background polling changes from every 60 seconds to every 60 minutes.
   - Initial state still loads server-side on page entry/login.
   - Returning to the page/tab still refreshes once.
   - Manual refresh remains available.
   - Explicit actions may refresh immediately after execution.

2. Friccionauta no longer collapses if one ROOT reader fails.
   - ROOT, Cognitive Twin, World Vector, Neural Graph and AMV are read with independent failure boundaries.
   - Partial context is passed to the LLM with explicit retrieval warnings.
   - Groq can still answer when a non-essential observational reader is degraded.

3. Fix invalid Cognitive Twin memory write.
   - `save_finding` used `memory_type='OBSERVATION'`, which is not allowed by the current Cognitive Twin schema.
   - It now persists as `EVIDENCE` with `CANDIDATE` status.

4. Add a real ROOT-only Groq probe.
   - `GET /api/root/llm/groq/health`
   - Reports whether GROQ_API_KEY is configured, which model is configured, whether Groq actually executed, latency and provider warnings.

## Important
The current default Groq model in code is `llama-3.1-8b-instant`. Groq's official deprecation schedule currently lists shutdown for free/developer usage on 2026-08-16, so model migration should follow separately; this PR first restores interaction and observability without silently changing model behavior.
