### PR TITLE
Prevent invalid Tailwind candidate from breaking production build

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,10 @@ module.exports = {
     './src/hooks/**/*.{js,ts,jsx,tsx,mdx}',
     './src/lib/**/*.{js,ts,jsx,tsx,mdx}'
   ],
+  // Tailwind's extractor can interpret regex character classes found in source
+  // as arbitrary-property utilities. `[-:.TZ]` is source syntax, not a CSS
+  // class, and generates invalid PostCSS (`-: .TZ`). Keep it out explicitly.
+  blocklist: ['[-:.TZ]'],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Problem
Vercel production build fails in generated `src/app/globals.css` because Tailwind interprets the source regex character class `[-:.TZ]` as an arbitrary-property utility and emits invalid CSS (`-: .TZ`).

## Fix
- Explicitly block `[-:.TZ]` in `tailwind.config.js`.
- Preserve legitimate arbitrary utilities such as `[animation-delay:1.4s]`.
- No UI behavior or runtime semantics changed.

## Why this is the correct boundary
This is extractor contamination: `[-:.TZ]` is source syntax, not a class name. The fix prevents Tailwind from generating CSS for that token rather than deleting unrelated styles or changing application behavior.

## Verification
Run the full existing SFI Verify workflow, including typecheck and production build.