### PR TITLE
Repair Groq GPT-OSS execution and Hugging Face fallback

### DIFF
--- a/src/app/api/root/llm/groq/health/route.ts
+++ b/src/app/api/root/llm/groq/health/route.ts
@@ -1,34 +1,109 @@
 import { NextResponse } from 'next/server';
-import { getLlmProviderStatus, runLlmTask } from '@/lib/ai/providerRouter';
+import { getLlmProviderStatus } from '@/lib/ai/providerRouter';
 import { requireRootActor } from '@/lib/root/server';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 export const maxDuration = 30;
 
+function compactError(value: unknown) {
+  if (!value) return 'unknown_error';
+  if (typeof value === 'string') return value.slice(0, 500);
+  try { return JSON.stringify(value).slice(0, 500); } catch { return 'unserializable_error'; }
+}
+
 export async function GET() {
   const gate = await requireRootActor('llm.groq.health');
   if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
 
   const configured = getLlmProviderStatus().find((provider) => provider.id === 'groq') ?? null;
-  const probe = await runLlmTask({
-    task: 'fast_classification',
-    preferredProvider: 'groq',
-    system: 'Return exactly GROQ_OK. No additional text.',
-    prompt: 'health probe',
-    fallbackResult: 'GROQ_UNAVAILABLE',
-    maxTokens: 12,
-  });
+  const apiKey = process.env.GROQ_API_KEY;
+  const model = process.env.GROQ_MODEL ?? configured?.model ?? 'openai/gpt-oss-20b';
+  const started = Date.now();
 
-  const groqExecuted = probe.ok && probe.provider === 'groq';
-  return NextResponse.json({
-    ok: groqExecuted,
-    configured: configured?.available === true,
-    configuredModel: configured?.model ?? null,
-    executedProvider: probe.provider,
-    executedModel: probe.model,
-    result: probe.result,
-    warnings: probe.warnings,
-    latencyMs: probe.latency_ms,
-  }, { status: groqExecuted ? 200 : 503, headers: { 'Cache-Control': 'no-store' } });
+  if (!apiKey) {
+    return NextResponse.json({
+      ok: false,
+      configured: false,
+      configuredModel: model,
+      executedProvider: null,
+      executedModel: null,
+      result: 'GROQ_API_KEY_MISSING',
+      finishReason: null,
+      usage: null,
+      warnings: ['groq_key_missing'],
+      latencyMs: Date.now() - started,
+    }, { status: 503, headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  try {
+    const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: 'Return exactly GROQ_OK. No additional text.' },
+          { role: 'user', content: 'health probe' },
+        ],
+        temperature: 0,
+        max_completion_tokens: 128,
+        ...(model.startsWith('openai/gpt-oss-') ? { include_reasoning: false, reasoning_effort: 'low' } : {}),
+      }),
+      cache: 'no-store',
+    });
+
+    const body = await response.json().catch(() => null) as Record<string, unknown> | null;
+    if (!response.ok) {
+      const error = body && typeof body === 'object' ? body.error : null;
+      return NextResponse.json({
+        ok: false,
+        configured: true,
+        configuredModel: model,
+        executedProvider: 'groq',
+        executedModel: model,
+        result: 'GROQ_REQUEST_FAILED',
+        finishReason: null,
+        usage: null,
+        httpStatus: response.status,
+        warnings: [`groq_failed:${compactError(error ?? body ?? `http_${response.status}`)}`],
+        latencyMs: Date.now() - started,
+      }, { status: 503, headers: { 'Cache-Control': 'no-store' } });
+    }
+
+    const choices = Array.isArray(body?.choices) ? body.choices as Array<Record<string, unknown>> : [];
+    const message = choices[0]?.message as Record<string, unknown> | undefined;
+    const content = typeof message?.content === 'string' ? message.content.trim() : '';
+    const finishReason = typeof choices[0]?.finish_reason === 'string' ? choices[0].finish_reason : null;
+    const ok = content === 'GROQ_OK';
+
+    return NextResponse.json({
+      ok,
+      configured: true,
+      configuredModel: model,
+      executedProvider: 'groq',
+      executedModel: typeof body?.model === 'string' ? body.model : model,
+      result: content || 'GROQ_EMPTY_CONTENT',
+      finishReason,
+      usage: body?.usage ?? null,
+      warnings: ok ? [] : [content ? 'groq_unexpected_probe_result' : 'groq_empty_content'],
+      latencyMs: Date.now() - started,
+    }, { status: ok ? 200 : 503, headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      configured: true,
+      configuredModel: model,
+      executedProvider: 'groq',
+      executedModel: model,
+      result: 'GROQ_FETCH_FAILED',
+      finishReason: null,
+      usage: null,
+      warnings: [`groq_fetch_failed:${error instanceof Error ? error.message : 'unknown'}`],
+      latencyMs: Date.now() - started,
+    }, { status: 503, headers: { 'Cache-Control': 'no-store' } });
+  }
 }

--- a/src/lib/ai/providerRouter.ts
+++ b/src/lib/ai/providerRouter.ts
@@ -50,7 +50,7 @@ const DEFAULTS = {
   openai: process.env.OPENAI_MODEL ?? 'gpt-4o-mini',
   anthropic: process.env.ANTHROPIC_MODEL ?? process.env.CLAUDE_MODEL ?? 'claude-3-5-sonnet-latest',
   gemini: process.env.GEMINI_MODEL ?? process.env.GOOGLE_MODEL ?? 'gemini-1.5-flash',
-  groq: process.env.GROQ_MODEL ?? 'llama-3.1-8b-instant',
+  groq: process.env.GROQ_MODEL ?? 'openai/gpt-oss-20b',
   ollama: process.env.OLLAMA_MODEL ?? 'llama3.1',
   huggingface: process.env.HUGGINGFACE_TEXT_MODEL ?? process.env.HF_TEXT_MODEL ?? 'mistralai/Mistral-7B-Instruct-v0.3',
   openaiEmbedding: process.env.OPENAI_EMBEDDING_MODEL ?? 'text-embedding-3-small',
@@ -96,7 +96,7 @@ function providerConfigs(): ProviderConfig[] {
       available: Boolean(groqKey),
       apiKey: groqKey,
       model: DEFAULTS.groq,
-      role: 'fast classification and drafts',
+      role: 'fast inference, reasoning, classification and drafts',
       configuredBy: ['GROQ_API_KEY', 'GROQ_MODEL'],
     },
     {
@@ -224,6 +224,7 @@ async function callProvider(config: ProviderConfig, input: {
   }
 
   if (config.id === 'groq') {
+    const isGptOss = config.model.startsWith('openai/gpt-oss-');
     const json = await fetchJson('https://api.groq.com/openai/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -237,7 +238,11 @@ async function callProvider(config: ProviderConfig, input: {
           { role: 'user', content: input.prompt },
         ],
         temperature: 0.2,
-        max_tokens: input.maxTokens,
+        max_completion_tokens: input.maxTokens,
+        ...(isGptOss ? {
+          include_reasoning: false,
+          reasoning_effort: input.task === 'fast_classification' ? 'low' : 'medium',
+        } : {}),
       }),
     }, 12_000);
     const record = json as Record<string, unknown>;
@@ -266,21 +271,27 @@ async function callProvider(config: ProviderConfig, input: {
   }
 
   if (config.id === 'huggingface') {
-    const json = await fetchJson(`https://api-inference.huggingface.co/models/${config.model}`, {
+    const json = await fetchJson('https://router.huggingface.co/v1/chat/completions', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${config.apiKey}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        inputs: `${input.system}\n\n${input.prompt}`,
-        parameters: { max_new_tokens: input.maxTokens, temperature: 0.2, return_full_text: false },
+        model: config.model,
+        messages: [
+          { role: 'system', content: input.system },
+          { role: 'user', content: input.prompt },
+        ],
+        temperature: 0.2,
+        max_tokens: input.maxTokens,
+        stream: false,
       }),
     }, 20_000);
-    const generated = Array.isArray(json)
-      ? (json[0] as Record<string, unknown> | undefined)?.generated_text
-      : (json as Record<string, unknown>).generated_text;
-    return { result: typeof generated === 'string' ? generated : '', usage: null };
+    const record = json as Record<string, unknown>;
+    const choices = Array.isArray(record.choices) ? record.choices as Array<Record<string, unknown>> : [];
+    const message = choices[0]?.message as Record<string, unknown> | undefined;
+    return { result: typeof message?.content === 'string' ? message.content : '', usage: record.usage as Record<string, unknown> | null ?? null };
   }
 
   return { result: '', usage: null };


### PR DESCRIPTION
## Observed production evidence
`/api/root/llm/groq/health` reports Groq configured with `openai/gpt-oss-20b`, but the router returns `groq_empty_result` and then falls through to exhausted OpenAI/Anthropic/Gemini providers. Hugging Face also fails through the legacy `api-inference.huggingface.co/models/...` text-generation path.

## Fix
- Make the ROOT Groq health probe call Groq directly, with no unrelated provider fallbacks.
- For GPT-OSS, use `max_completion_tokens`, `include_reasoning: false`, and bounded `reasoning_effort` so reasoning does not consume a tiny probe budget without a final answer.
- Increase the health-probe completion budget from the previous effective 12-token router call to 128 tokens.
- Update the shared Groq router to use GPT-OSS-aware parameters.
- Change the shared Hugging Face chat fallback to the current OpenAI-compatible `router.huggingface.co/v1/chat/completions` endpoint.
- Change the code default Groq model to `openai/gpt-oss-20b`; the Vercel `GROQ_MODEL` override remains authoritative.

## Boundaries
No secrets are logged. No provider is claimed healthy until a real provider response is observed. Existing OpenAI/Anthropic/Gemini configuration is not removed.