### PR TITLE
Unify ROOT evidence graph, quarantine malformed rows and classify rebuildable DB data

### DIFF
--- a/scripts/db/prepare-institutional-cleanup.mjs
+++ b/scripts/db/prepare-institutional-cleanup.mjs
@@ -2,62 +2,86 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { createAdminClient, nowStamp } from './sfi-db-client.mjs';
 
-const PROTECTED = [
-  'profiles',
-  'root_evidence_entries',
-  'sfi_evidence_ledger',
-  'epistemic_events',
-  'graph_nodes',
-  'graph_edges',
-  'sfi_graph_nodes',
-  'sfi_graph_edges',
-  'world_source_observations',
-  'world_friction_readings',
-  'world_hypotheses',
-  'world_hypothesis_outcomes',
-  'world_learning_events',
-  'worldspect_snapshots',
-  'sfi_reference_cases',
-  'sfi_cognitive_twin_memory',
-  'sfi_cognitive_twin_decisions',
-  'sfi_cognitive_twin_models',
-  'sfi_cognitive_twin_model_evaluations',
-  'sfi_cognitive_twin_runs',
-  'sfi_continuity_state',
-  'sfi_continuity_runs',
-  'sfi_capability_health_checks',
-  'sfi_institutional_incidents',
-  'sfi_founder_decision_queue',
-  'sfi_continuity_reports',
-  'root_audit_events',
-];
+// Cleanup policy is based on epistemic function, not fear of dependencies.
+// A derived index can be rebuilt. A source-of-truth record cannot.
+const TABLE_POLICY = {
+  SOURCE_OF_TRUTH: [
+    'profiles',
+    'root_evidence_entries',
+    'sfi_evidence_ledger',
+    'world_source_observations',
+    'world_hypotheses',
+    'world_hypothesis_outcomes',
+    'world_learning_events',
+    'sfi_reference_cases',
+    'sfi_cognitive_twin_decisions',
+    'sfi_cognitive_twin_models',
+    'sfi_cognitive_twin_model_evaluations',
+    'sfi_continuity_state',
+    'sfi_institutional_incidents',
+    'sfi_founder_decision_queue',
+  ],
+  REVIEW_BY_ROW_STATUS: [
+    // These tables contain a mix of durable knowledge and disposable candidates/runs.
+    'sfi_cognitive_twin_memory',
+    'sfi_cognitive_twin_runs',
+    'epistemic_events',
+    'world_friction_readings',
+    'worldspect_snapshots',
+    'sfi_continuity_runs',
+    'sfi_capability_health_checks',
+    'sfi_continuity_reports',
+    'root_audit_events',
+  ],
+  REBUILDABLE_INDEX: [
+    // These are projections/indices over evidence and institutional state. They are
+    // allowed to disappear and be rebuilt from primary records after cleanup.
+    'graph_nodes',
+    'graph_edges',
+    'sfi_graph_nodes',
+    'sfi_graph_edges',
+    'root_neural_nodes',
+    'root_neural_edges',
+  ],
+  LEGACY_OR_EPHEMERAL_REVIEW: [
+    'action_proposals',
+    'logbook_mutations',
+    'logbook_visible',
+    'logbook_events',
+    'logbook_signals',
+    'logbook_regime',
+    'logbook_knowledge',
+    'logbook_frictions',
+    'amv_learning',
+    'evidence_ledger',
+    'scorefriction_sources',
+    'scorefriction_observations',
+    'scorefriction_vectors',
+    'scorefriction_evidence',
+  ],
+};
 
-const REVIEW = [
-  'action_proposals',
-  'logbook_mutations',
-  'logbook_visible',
-  'logbook_events',
-  'logbook_signals',
-  'logbook_regime',
-  'logbook_knowledge',
-  'logbook_frictions',
-  'amv_learning',
-  'evidence_ledger',
-  'root_neural_nodes',
-  'root_neural_edges',
-  'scorefriction_sources',
-  'scorefriction_observations',
-  'scorefriction_vectors',
-  'scorefriction_evidence',
-];
+const ACTION = {
+  SOURCE_OF_TRUTH: 'PRESERVE_UNLESS_EXPLICITLY_INVALID_WITH_PROVENANCE',
+  REVIEW_BY_ROW_STATUS: 'PRESERVE_VERIFIED_CANONICAL_OR_AUDIT_VALUE_PURGE_REDUNDANT_CANDIDATE_NOISE',
+  REBUILDABLE_INDEX: 'EXPORT_OPTIONAL_PURGE_ALLOWED_REBUILD_FROM_PRIMARY_EVIDENCE',
+  LEGACY_OR_EPHEMERAL_REVIEW: 'PURGE_OR_MIGRATE_IF_NOT_REFERENCED_BY_CURRENT_RUNTIME',
+};
+
+const policyByTable = new Map();
+for (const [policy, tables] of Object.entries(TABLE_POLICY)) {
+  for (const table of tables) policyByTable.set(table, policy);
+}
 
 const db = createAdminClient();
 const rows = [];
-for (const table of [...new Set([...PROTECTED, ...REVIEW])]) {
+for (const table of policyByTable.keys()) {
   const result = await db.from(table).select('*', { count: 'exact', head: true });
+  const policy = policyByTable.get(table);
   rows.push({
     table,
-    policy: PROTECTED.includes(table) ? 'PROTECT_BY_DEFAULT' : 'REVIEW_BEFORE_PURGE',
+    policy,
+    recommended_action: ACTION[policy],
     available: !result.error,
     count: result.error ? null : result.count ?? 0,
     error: result.error?.message ?? null,
@@ -68,8 +92,9 @@ const report = {
   ok: true,
   destructive: false,
   generatedAt: new Date().toISOString(),
-  rule: 'This command never deletes data. It inventories preservation and review candidates before any purge.',
-  nextGate: 'A purge plan must name exact tables/row predicates and reference a completed export before deletion is allowed.',
+  rule: 'Preserve primary evidence and validated institutional knowledge; derived indices are rebuildable and must never be protected merely because code currently depends on them.',
+  classifications: TABLE_POLICY,
+  nextGate: 'Destructive cleanup should target exact row predicates for mixed tables and may whole-table purge REBUILDABLE_INDEX only after confirming a rebuild path from primary evidence.',
   rows,
 };
 

--- a/src/app/api/root/semantic-context/route.ts
+++ b/src/app/api/root/semantic-context/route.ts
@@ -12,7 +12,17 @@ function text(value: unknown, fallback = '') { return typeof value === 'string' 
 function rec(value: unknown): Row { return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {}; }
 function strings(value: unknown) { return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && Boolean(item.trim())) : []; }
 function uniqueRows(items: any[], key: string) {
-  return Array.from(new Map(items.filter(Boolean).map((item) => [text(item?.[key], JSON.stringify(item)), item])).values());
+  const unique = new Map<string, any>();
+  let anonymous = 0;
+  for (const item of items.filter(Boolean)) {
+    const stableKey = text(item?.[key]);
+    // Never stringify an arbitrary persisted payload just to obtain a map key.
+    // Legacy rows can contain unusually large or malformed nested structures;
+    // they must not be able to crash the whole semantic context route.
+    const resolvedKey = stableKey || `anonymous:${anonymous++}`;
+    if (!unique.has(resolvedKey)) unique.set(resolvedKey, item);
+  }
+  return [...unique.values()];
 }
 function connectedNodeIds(edges: any[], excluded: string[]) {
   return Array.from(new Set<string>(edges.flatMap((edge) => [text(edge?.source_node_id), text(edge?.target_node_id)]).filter((nodeId): nodeId is string => Boolean(nodeId) && !excluded.includes(nodeId))));
@@ -74,25 +84,12 @@ async function predictionContext(service: any, id: string) {
       : null;
   const origin = rec(attractors.data?.[0]?.vector).origin ?? (legacy ? 'LEGACY_REGISTRY' : 'UNKNOWN');
   return {
-    kind: 'prediction_case',
-    prediction,
-    confidence,
+    kind: 'prediction_case', prediction, confidence,
     status: text(run.data?.status ?? legacy?.estado_observacion ?? legacy?.evidence_state, 'MISSING'),
-    createdAt: at,
-    dueAt: run.data?.due_at ?? null,
-    interpretation: run.data?.interpretation ?? null,
+    createdAt: at, dueAt: run.data?.due_at ?? null, interpretation: run.data?.interpretation ?? null,
     verificationRule: run.data?.verification_rule ?? verification.data?.[0]?.verification_rule ?? null,
-    evidenceRefs: strings(run.data?.evidence_refs),
-    missingEvidence: strings(run.data?.missing_evidence),
-    origin,
-    run: run.data ?? null,
-    legacy,
-    outcomes: outcomes.data ?? [],
-    evidenceRequests: requests.data ?? [],
-    learningEvents: learning.data ?? [],
-    verifications: verification.data ?? [],
-    attractors: attractors.data ?? [],
-    world,
+    evidenceRefs: strings(run.data?.evidence_refs), missingEvidence: strings(run.data?.missing_evidence), origin,
+    run: run.data ?? null, legacy, outcomes: outcomes.data ?? [], evidenceRequests: requests.data ?? [], learningEvents: learning.data ?? [], verifications: verification.data ?? [], attractors: attractors.data ?? [], world,
   };
 }
 
@@ -128,37 +125,22 @@ async function evidenceContext(service: any, id: string) {
   const evidenceKey = text(metadata.evidenceKey ?? summary.evidenceKey);
   const caseId = text(metadata.caseId ?? row.case_id);
   const nodeCandidates = Array.from(new Set<string>([
-    text(resolved.node?.node_id),
-    hash ? `root_evidence:${hash.slice(0, 24)}` : '',
-    hash ? `ledger_evidence:${hash.slice(0, 24)}` : '',
+    text(resolved.node?.node_id), hash ? `root_evidence:${hash.slice(0, 24)}` : '', hash ? `ledger_evidence:${hash.slice(0, 24)}` : '',
   ].filter((value): value is string => Boolean(value))));
   const nodes = nodeCandidates.length ? await service.from('graph_nodes').select('*').in('node_id', nodeCandidates) : { data: [] };
   const nodeIds = (nodes.data ?? []).map((node: any) => text(node?.node_id)).filter((nodeId: string): nodeId is string => Boolean(nodeId));
   const directEdges = nodeIds.length ? await service.from('graph_edges').select('*').or(edgeFilterFor(nodeIds)) : { data: [] };
   const firstHopIds = connectedNodeIds(directEdges.data ?? [], nodeIds);
-
-  // Two hops are intentional: enough to get beyond the root/ledger mirror and expose
-  // case/module/source relations, without performing an unbounded graph crawl.
   const secondEdges = firstHopIds.length ? await service.from('graph_edges').select('*').or(edgeFilterFor(firstHopIds)) : { data: [] };
   const allEdges = uniqueRows([...(directEdges.data ?? []), ...(secondEdges.data ?? [])], 'edge_id');
   const relatedIds = connectedNodeIds(allEdges, nodeIds);
   const relatedNodes = relatedIds.length ? await service.from('graph_nodes').select('*').in('node_id', relatedIds) : { data: [] };
-
   const attractors = await service.from('sfi_attractors').select('*').order('updated_at', { ascending: false }).limit(250);
   const linkedAttractors = (attractors.data ?? []).filter((attractor: any) => {
-    const vector = rec(attractor.vector);
-    const refs = strings(vector.evidenceRefs);
+    const vector = rec(attractor.vector); const refs = strings(vector.evidenceRefs);
     return refs.some((ref) => [id, hash, evidenceKey].filter(Boolean).includes(ref)) || (caseId && text(vector.caseId) === caseId);
   });
-  return {
-    kind: 'evidence_context',
-    missing: false,
-    record: row,
-    graphNodes: nodes.data ?? [],
-    graphEdges: allEdges,
-    relatedNodes: relatedNodes.data ?? [],
-    attractors: linkedAttractors,
-  };
+  return { kind: 'evidence_context', missing: false, record: row, graphNodes: nodes.data ?? [], graphEdges: allEdges, relatedNodes: relatedNodes.data ?? [], attractors: linkedAttractors };
 }
 
 async function attractorContext(service: any, id: string) {
@@ -166,15 +148,10 @@ async function attractorContext(service: any, id: string) {
   if (!attractor.data) attractor = await service.from('sfi_attractors').select('*').eq('attractor_key', id.replace(/^attractor:/, '')).maybeSingle();
   const row = attractor.data;
   if (!row) return { kind: 'attractor_context', missing: true };
-  const vector = rec(row.vector);
-  const refs = strings(vector.evidenceRefs);
-  let evidence: any[] = [];
+  const vector = rec(row.vector); const refs = strings(vector.evidenceRefs); let evidence: any[] = [];
   if (refs.length) {
     const [rootByHash, ledgerByHash, rootById, ledgerById] = await Promise.all([
-      service.from('root_evidence_entries').select('*').in('evidence_hash', refs),
-      service.from('sfi_evidence_ledger').select('*').in('evidence_hash', refs),
-      service.from('root_evidence_entries').select('*').in('id', refs),
-      service.from('sfi_evidence_ledger').select('*').in('id', refs),
+      service.from('root_evidence_entries').select('*').in('evidence_hash', refs), service.from('sfi_evidence_ledger').select('*').in('evidence_hash', refs), service.from('root_evidence_entries').select('*').in('id', refs), service.from('sfi_evidence_ledger').select('*').in('id', refs),
     ]);
     evidence = uniqueRows([...(rootByHash.data ?? []), ...(ledgerByHash.data ?? []), ...(rootById.data ?? []), ...(ledgerById.data ?? [])], 'id');
   }
@@ -186,17 +163,18 @@ async function attractorContext(service: any, id: string) {
 export async function GET(request: Request) {
   const gate = await requireRootViewer('root.semantic_context.read');
   if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
-  const url = new URL(request.url);
-  const kind = text(url.searchParams.get('kind'));
-  const id = text(url.searchParams.get('id'));
+  const url = new URL(request.url); const kind = text(url.searchParams.get('kind')); const id = text(url.searchParams.get('id'));
   if (!kind || !id) return NextResponse.json({ ok: false, error: 'kind_and_id_required' }, { status: 400 });
   const normalized = kind.toLowerCase();
-  const context = normalized.includes('hypothesis') || normalized.includes('prediction') || normalized === 'outcome'
-    ? await predictionContext(gate.ctx.service, id)
-    : normalized.includes('evidence') || normalized.includes('ledger')
-      ? await evidenceContext(gate.ctx.service, id)
-      : normalized.includes('attractor')
-        ? await attractorContext(gate.ctx.service, id)
-        : null;
-  return NextResponse.json({ ok: true, context }, { headers: { 'Cache-Control': 'no-store' } });
+  try {
+    const context = normalized.includes('hypothesis') || normalized.includes('prediction') || normalized === 'outcome'
+      ? await predictionContext(gate.ctx.service, id)
+      : normalized.includes('evidence') || normalized.includes('ledger')
+        ? await evidenceContext(gate.ctx.service, id)
+        : normalized.includes('attractor') ? await attractorContext(gate.ctx.service, id) : null;
+    return NextResponse.json({ ok: true, context }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : 'malformed_or_unresolvable_record';
+    return NextResponse.json({ ok: false, error: 'semantic_context_record_quarantined', details: detail }, { status: 422, headers: { 'Cache-Control': 'no-store' } });
+  }
 }

--- a/src/components/root/sovereign/visual/EvidenceGraph.tsx
+++ b/src/components/root/sovereign/visual/EvidenceGraph.tsx
@@ -1,14 +1,176 @@
+'use client';
+
+import { useMemo, useState } from 'react';
 import type { RootEvidenceEdge, RootEvidenceNode } from '@/lib/root/sovereign/rootSovereignState';
 import type { RootSelection } from '../sovereignTypes';
 
-function position(index: number, total: number) {
-  const angle = (index / Math.max(total, 1)) * Math.PI * 2 - Math.PI / 2;
-  const ring = index % 3 === 0 ? 108 : index % 3 === 1 ? 176 : 236;
-  return { x: 320 + Math.cos(angle) * ring, y: 250 + Math.sin(angle) * ring };
+type Depth = 1 | 2 | 3 | 'all';
+
+function finite(value: unknown, fallback = 0) {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function validNode(node: RootEvidenceNode) {
+  return Boolean(node?.id?.trim() && node?.label?.trim());
+}
+
+function dedupeNodes(nodes: RootEvidenceNode[]) {
+  const map = new Map<string, RootEvidenceNode>();
+  for (const node of nodes) {
+    if (!validNode(node) || map.has(node.id)) continue;
+    map.set(node.id, node);
+  }
+  return [...map.values()];
+}
+
+function validEdges(edges: RootEvidenceEdge[], ids: Set<string>) {
+  const map = new Map<string, RootEvidenceEdge>();
+  for (const edge of edges) {
+    if (!edge?.id?.trim() || !edge.from?.trim() || !edge.to?.trim()) continue;
+    if (!ids.has(edge.from) || !ids.has(edge.to) || map.has(edge.id)) continue;
+    map.set(edge.id, edge);
+  }
+  return [...map.values()];
+}
+
+function degrees(nodes: RootEvidenceNode[], edges: RootEvidenceEdge[]) {
+  const result = new Map(nodes.map((node) => [node.id, 0]));
+  for (const edge of edges) {
+    result.set(edge.from, (result.get(edge.from) ?? 0) + 1);
+    result.set(edge.to, (result.get(edge.to) ?? 0) + 1);
+  }
+  return result;
+}
+
+function levels(anchor: string | null, nodes: RootEvidenceNode[], edges: RootEvidenceEdge[]) {
+  const result = new Map<string, number>();
+  if (!anchor) return result;
+  const adjacency = new Map<string, string[]>();
+  for (const edge of edges) {
+    adjacency.set(edge.from, [...(adjacency.get(edge.from) ?? []), edge.to]);
+    adjacency.set(edge.to, [...(adjacency.get(edge.to) ?? []), edge.from]);
+  }
+  const queue = [anchor];
+  result.set(anchor, 0);
+  while (queue.length) {
+    const current = queue.shift()!;
+    const next = (result.get(current) ?? 0) + 1;
+    for (const neighbor of adjacency.get(current) ?? []) {
+      if (result.has(neighbor)) continue;
+      result.set(neighbor, next);
+      queue.push(neighbor);
+    }
+  }
+  const detached = Math.max(0, ...result.values()) + 1;
+  for (const node of nodes) if (!result.has(node.id)) result.set(node.id, detached);
+  return result;
+}
+
+function safeSelection(node: RootEvidenceNode, degree: number): RootSelection {
+  return {
+    kind: 'evidence-node',
+    id: node.id,
+    title: node.label,
+    source: node.source,
+    observedAt: node.observedAt,
+    confidence: node.confidence,
+    evidenceIds: Array.isArray(node.evidenceIds) ? node.evidenceIds.filter((item) => typeof item === 'string') : [],
+    warning: null,
+    // Do not push arbitrary historical payloads into client selection state. The
+    // semantic-context route reconstructs detail from persisted source records.
+    data: {
+      nodeType: node.type,
+      epistemicClass: node.epistemicClass,
+      confidence: node.confidence,
+      lineage: Array.isArray(node.lineage) ? node.lineage.filter((item) => typeof item === 'string') : [],
+      degree,
+    },
+  };
 }
 
 export function EvidenceGraph({ nodes, edges, onSelect }: { nodes: RootEvidenceNode[]; edges: RootEvidenceEdge[]; onSelect: (selection: RootSelection) => void }) {
-  const visibleNodes = nodes.slice(0, 36); const positions = new Map(visibleNodes.map((node, index) => [node.id, position(index, visibleNodes.length)]));
-  if (!visibleNodes.length) return <div className="rs-empty"><b>SIN EVIDENCIA</b><p>No hay nodos persistidos. El atlas no genera sustitutos.</p></div>;
-  return <div className="rs-graph"><div className="rs-graph-legend"><span>LAYOUT DERIVED</span><strong>RELATIONSHIPS OBSERVED</strong></div><svg viewBox="0 0 640 500" role="img" aria-label="Persisted evidence graph">{edges.slice(0, 80).map((edge) => { const from = positions.get(edge.from); const to = positions.get(edge.to); return from && to ? <line key={edge.id} x1={from.x} y1={from.y} x2={to.x} y2={to.y} data-relation={edge.relation} opacity={edge.weight ?? 0.45} /> : null; })}{visibleNodes.map((node) => { const point = positions.get(node.id)!; return <g key={node.id} role="button" tabIndex={0} transform={`translate(${point.x} ${point.y})`} onClick={() => onSelect({ kind: 'evidence node', id: node.id, title: node.label, source: node.source, observedAt: node.observedAt, confidence: node.confidence, evidenceIds: node.evidenceIds, warning: null, data: node })} onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') event.currentTarget.dispatchEvent(new MouseEvent('click', { bubbles: true })); }}><circle r={Math.max(5, 6 + Math.min(node.evidenceIds.length, 6))} /><text y="-12">{node.label.slice(0, 18)}</text></g>; })}</svg></div>;
+  const cleanNodes = useMemo(() => dedupeNodes(nodes), [nodes]);
+  const nodeIds = useMemo(() => new Set(cleanNodes.map((node) => node.id)), [cleanNodes]);
+  const cleanEdges = useMemo(() => validEdges(edges, nodeIds), [edges, nodeIds]);
+  const nodeDegrees = useMemo(() => degrees(cleanNodes, cleanEdges), [cleanNodes, cleanEdges]);
+  const [focusId, setFocusId] = useState<string | null>(null);
+  const [depth, setDepth] = useState<Depth>(2);
+  const [zoom, setZoom] = useState(1);
+  const [expanded, setExpanded] = useState(false);
+
+  const autoAnchor = useMemo(() => [...cleanNodes].sort((a, b) => (nodeDegrees.get(b.id) ?? 0) - (nodeDegrees.get(a.id) ?? 0))[0]?.id ?? null, [cleanNodes, nodeDegrees]);
+  const anchor = focusId && nodeIds.has(focusId) ? focusId : autoAnchor;
+  const nodeLevels = useMemo(() => levels(anchor, cleanNodes, cleanEdges), [anchor, cleanNodes, cleanEdges]);
+  const maxDepth = depth === 'all' ? Number.POSITIVE_INFINITY : depth;
+  const visibleNodes = useMemo(() => cleanNodes
+    .filter((node) => (nodeLevels.get(node.id) ?? Number.POSITIVE_INFINITY) <= maxDepth)
+    .sort((a, b) => (nodeLevels.get(a.id) ?? 99) - (nodeLevels.get(b.id) ?? 99) || (nodeDegrees.get(b.id) ?? 0) - (nodeDegrees.get(a.id) ?? 0)), [cleanNodes, nodeLevels, maxDepth, nodeDegrees]);
+  const visibleIds = useMemo(() => new Set(visibleNodes.map((node) => node.id)), [visibleNodes]);
+  const visibleEdges = useMemo(() => cleanEdges.filter((edge) => visibleIds.has(edge.from) && visibleIds.has(edge.to)), [cleanEdges, visibleIds]);
+
+  const points = useMemo(() => {
+    const byLevel = new Map<number, RootEvidenceNode[]>();
+    for (const node of visibleNodes) {
+      const level = nodeLevels.get(node.id) ?? 0;
+      byLevel.set(level, [...(byLevel.get(level) ?? []), node]);
+    }
+    const result = new Map<string, { x: number; y: number }>();
+    for (const [level, group] of byLevel.entries()) {
+      if (level === 0) {
+        group.forEach((node) => result.set(node.id, { x: 500, y: 350 }));
+        continue;
+      }
+      const radius = Math.min(300, 90 + level * 80);
+      group.sort((a, b) => (nodeDegrees.get(b.id) ?? 0) - (nodeDegrees.get(a.id) ?? 0) || a.label.localeCompare(b.label));
+      group.forEach((node, index) => {
+        const angle = -Math.PI / 2 + (index / Math.max(1, group.length)) * Math.PI * 2 + level * 0.23;
+        result.set(node.id, { x: 500 + Math.cos(angle) * radius, y: 350 + Math.sin(angle) * radius });
+      });
+    }
+    return result;
+  }, [visibleNodes, nodeLevels, nodeDegrees]);
+
+  if (!cleanNodes.length) return <div className="rs-empty"><b>SIN EVIDENCIA</b><p>No hay nodos persistidos válidos. El atlas no genera sustitutos.</p></div>;
+
+  const quarantinedNodes = Math.max(0, nodes.length - cleanNodes.length);
+  const quarantinedEdges = Math.max(0, edges.length - cleanEdges.length);
+  const anchorNode = cleanNodes.find((node) => node.id === anchor) ?? null;
+
+  return <div className={`rs-graph rs-graph-v2 ${expanded ? 'is-expanded' : ''}`}>
+    <div className="rs-graph-toolbar">
+      <div><span>GRAFO RELACIONAL</span><strong>{visibleNodes.length}/{cleanNodes.length} N · {visibleEdges.length}/{cleanEdges.length} E</strong></div>
+      <div className="rs-graph-actions">
+        {([1, 2, 3, 'all'] as const).map((value) => <button type="button" key={String(value)} className={depth === value ? 'active' : ''} onClick={() => setDepth(value)}>{value === 'all' ? 'TODO' : `${value}S`}</button>)}
+        <button type="button" onClick={() => setFocusId(null)}>AUTO</button>
+        <button type="button" onClick={() => setZoom((value) => Math.max(.55, Number((value - .15).toFixed(2))))}>−</button>
+        <button type="button" onClick={() => setZoom((value) => Math.min(2.4, Number((value + .15).toFixed(2))))}>+</button>
+        <button type="button" onClick={() => setExpanded((value) => !value)}>{expanded ? 'CERRAR' : 'AMPLIAR'}</button>
+      </div>
+    </div>
+    {(quarantinedNodes || quarantinedEdges) ? <div className="rs-graph-quarantine">CUARENTENA DE LECTURA · {quarantinedNodes} N · {quarantinedEdges} E inválidos/duplicados fuera del grafo activo</div> : null}
+    <div className="rs-graph-stage">
+      <svg viewBox="0 0 1000 700" role="img" aria-label="Persisted evidence graph">
+        <defs><marker id="atlas-evidence-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto"><path d="M0,0 L7,3.5 L0,7 z" /></marker></defs>
+        <g transform={`translate(${500 * (1 - zoom)} ${350 * (1 - zoom)}) scale(${zoom})`}>
+          {visibleEdges.map((edge) => {
+            const from = points.get(edge.from); const to = points.get(edge.to);
+            if (!from || !to) return null;
+            const focused = edge.from === anchor || edge.to === anchor;
+            return <g key={edge.id} className={focused ? 'edge-focused' : ''}><line x1={from.x} y1={from.y} x2={to.x} y2={to.y} opacity={Math.max(.12, Math.min(1, finite(edge.weight, .45)))} markerEnd="url(#atlas-evidence-arrow)" />{focused ? <text x={(from.x + to.x) / 2} y={(from.y + to.y) / 2 - 8}>{edge.relation.slice(0, 42)}</text> : null}</g>;
+          })}
+          {visibleNodes.map((node) => {
+            const point = points.get(node.id); if (!point) return null;
+            const focused = node.id === anchor;
+            const degree = nodeDegrees.get(node.id) ?? 0;
+            return <g key={node.id} role="button" tabIndex={0} className={focused ? 'node-focused' : ''} transform={`translate(${point.x} ${point.y})`} onClick={() => { setFocusId(node.id); onSelect(safeSelection(node, degree)); }} onKeyDown={(event) => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); setFocusId(node.id); onSelect(safeSelection(node, degree)); } }}><circle r={focused ? 10 : Math.min(8, 5 + degree * .35)} /><text y={focused ? -16 : -12}>{node.label.slice(0, focused ? 34 : 20)}</text><title>{`${node.label}\n${node.type} · ${node.epistemicClass}\n${degree} relaciones`}</title></g>;
+          })}
+        </g>
+      </svg>
+    </div>
+    <div className="rs-graph-footer"><span>FOCO · {anchorNode?.label ?? 'MISSING'}</span><span>ZOOM · {Math.round(zoom * 100)}%</span><span>LAYOUT DERIVED · RELACIONES PERSISTIDAS</span></div>
+    <style jsx>{`
+      .rs-graph-v2{position:relative;min-height:620px;border:1px solid rgba(200,169,81,.18);background:#050504;overflow:hidden}.rs-graph-v2.is-expanded{position:fixed;z-index:180;inset:16px;min-height:0;background:#050504;box-shadow:0 24px 100px rgba(0,0,0,.85)}.rs-graph-toolbar{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-bottom:1px solid rgba(200,169,81,.12)}.rs-graph-toolbar span,.rs-graph-footer,.rs-graph-quarantine{font-size:8px;letter-spacing:.12em;color:#777064}.rs-graph-toolbar strong{display:block;margin-top:4px;color:#cbb675;font-size:10px}.rs-graph-actions{display:flex;gap:5px;flex-wrap:wrap;justify-content:flex-end}.rs-graph-actions button{border:1px solid rgba(200,169,81,.2);background:#090908;color:#9c8d69;padding:6px 8px;font-size:8px;cursor:pointer}.rs-graph-actions button.active,.rs-graph-actions button:hover{border-color:#8d7540;color:#e0c674}.rs-graph-quarantine{padding:7px 12px;border-bottom:1px solid rgba(184,80,80,.2);color:#b18472}.rs-graph-stage{height:540px;overflow:hidden}.is-expanded .rs-graph-stage{height:calc(100vh - 130px)}.rs-graph-stage svg{width:100%;height:100%}.rs-graph-stage line{stroke:#8d7540;stroke-width:1}.rs-graph-stage path{fill:#8d7540}.rs-graph-stage .edge-focused line{stroke:#d9bd70;stroke-width:1.5}.rs-graph-stage g>text{fill:#8b816e;font-size:9px;text-anchor:middle;pointer-events:none}.rs-graph-stage .edge-focused text{fill:#a99665;font-size:8px}.rs-graph-stage circle{fill:#070706;stroke:#9b844b;stroke-width:1.2;cursor:pointer}.rs-graph-stage .node-focused circle{fill:#b89d58;stroke:#ead080;stroke-width:2}.rs-graph-stage .node-focused text{fill:#ead080}.rs-graph-footer{display:flex;justify-content:space-between;gap:12px;padding:8px 12px;border-top:1px solid rgba(200,169,81,.12)}@media(max-width:760px){.rs-graph-toolbar{align-items:flex-start;flex-direction:column}.rs-graph-stage{height:480px}.rs-graph-footer{flex-direction:column}.rs-graph-v2.is-expanded{inset:4px}}
+    `}</style>
+  </div>;
 }

--- a/src/lib/root/sovereign/readers/readRootEvidenceGraph.ts
+++ b/src/lib/root/sovereign/readers/readRootEvidenceGraph.ts
@@ -3,7 +3,7 @@ import type { RootEvidenceEdge, RootEvidenceNode, RootRow } from '../rootSoverei
 import { dateValue, numberValue, selectRows, source, text } from './readerSupport';
 
 function strings(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && Boolean(item.trim())) : [];
 }
 function record(value: unknown): RootRow {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as RootRow : {};
@@ -43,6 +43,30 @@ function edgeFrom(row: RootRow, table: string): RootEvidenceEdge {
   };
 }
 
+function dedupeNodes(primary: RootEvidenceNode[], secondary: RootEvidenceNode[]) {
+  const nodes = new Map<string, RootEvidenceNode>();
+  // graph_nodes is the canonical evidence relation index. sfi_graph_nodes is a
+  // secondary institutional topology source. A duplicate must never overwrite
+  // the primary record simply because it was read later.
+  for (const node of [...primary, ...secondary]) {
+    if (!node.id.trim() || !node.label.trim() || nodes.has(node.id)) continue;
+    nodes.set(node.id, node);
+  }
+  return [...nodes.values()];
+}
+
+function dedupeEdges(primary: RootEvidenceEdge[], secondary: RootEvidenceEdge[], nodeIds: Set<string>) {
+  const edges = new Map<string, RootEvidenceEdge>();
+  for (const edge of [...primary, ...secondary]) {
+    if (!edge.id.trim() || !edge.from.trim() || !edge.to.trim()) continue;
+    // Orphan relations are not evidence graph edges. Keep them in persistence
+    // for forensic cleanup, but never let them enter the active ROOT topology.
+    if (!nodeIds.has(edge.from) || !nodeIds.has(edge.to) || edges.has(edge.id)) continue;
+    edges.set(edge.id, edge);
+  }
+  return [...edges.values()];
+}
+
 export async function readRootEvidenceGraph() {
   const [rootEntries, ledger, graphNodes, graphEdges, sfiNodes, sfiEdges] = await Promise.all([
     selectRows({ table: 'root_evidence_entries', select: 'id,evidence_hash,actor_id,title,content,evidence_type,target_node_id,payload,epistemic_event_id,created_at', order: 'created_at', limit: 60 }),
@@ -52,8 +76,15 @@ export async function readRootEvidenceGraph() {
     selectRows({ table: 'sfi_graph_nodes', select: 'id,node_key,label,module,node_type,layer,parent_key,description,metrics,evidence_count,private_evidence_count,density,weight,degradation,status,position,visual,created_at,updated_at', order: 'created_at', limit: 220 }),
     selectRows({ table: 'sfi_graph_edges', select: 'id,from_key,to_key,edge_type,weight,evidence_count,degradation,metadata,created_at,updated_at', order: 'created_at', limit: 420 }),
   ]);
-  const nodes = [...graphNodes.rows.map((item) => nodeFrom(item, 'graph_nodes')), ...sfiNodes.rows.map((item) => nodeFrom(item, 'sfi_graph_nodes'))].filter((item) => item.id);
-  const edges = [...graphEdges.rows.map((item) => edgeFrom(item, 'graph_edges')), ...sfiEdges.rows.map((item) => edgeFrom(item, 'sfi_graph_edges'))].filter((item) => item.id && item.from && item.to);
+
+  const primaryNodes = graphNodes.rows.map((item) => nodeFrom(item, 'graph_nodes'));
+  const secondaryNodes = sfiNodes.rows.map((item) => nodeFrom(item, 'sfi_graph_nodes'));
+  const nodes = dedupeNodes(primaryNodes, secondaryNodes);
+  const nodeIds = new Set(nodes.map((item) => item.id));
+  const primaryEdges = graphEdges.rows.map((item) => edgeFrom(item, 'graph_edges'));
+  const secondaryEdges = sfiEdges.rows.map((item) => edgeFrom(item, 'sfi_graph_edges'));
+  const edges = dedupeEdges(primaryEdges, secondaryEdges, nodeIds);
+
   return source(
     { nodes, edges, entries: rootEntries.rows, ledger: ledger.rows },
     'persisted evidence graphs',


### PR DESCRIPTION
## Observed defects
- ROOT currently contains two evidence-graph implementations. `Evidence / Atlas` still uses the legacy fixed three-ring graph with hard `36 node / 80 edge` truncation while the main ROOT workspace uses the newer relational/BFS graph.
- The graph reader merges `graph_*` and `sfi_graph_*` without deduplicating IDs or rejecting orphan relations.
- The legacy graph pushes the entire arbitrary persisted node payload into client selection state.
- Semantic-context deduplication eagerly stringifies arbitrary persisted rows.
- The DB cleanup planner protects derived graph indices by default, conflating rebuildable projections with sources of truth.

## Changes
- Replace the legacy Atlas graph with a focusable BFS/depth graph, zoom controls and an `AMPLIAR` full-screen mode.
- Remove low fixed 36/80 truncation from the Atlas graph.
- Quarantine invalid/duplicate nodes and orphan/duplicate edges from active rendering.
- Keep primary `graph_nodes/graph_edges` precedence when IDs collide with `sfi_graph_*`.
- Stop passing raw arbitrary payloads through graph selection state; semantic detail is reconstructed server-side.
- Make semantic-context row dedupe non-stringifying and return a bounded 422 quarantine response for malformed/unresolvable records instead of allowing one row to crash the route.
- Reclassify DB cleanup policy into SOURCE_OF_TRUTH, REVIEW_BY_ROW_STATUS, REBUILDABLE_INDEX and LEGACY_OR_EPHEMERAL_REVIEW. Graph/neural indices are explicitly rebuildable rather than protected institutional truth.

## Epistemic boundary
This PR does not delete live Supabase rows and does not claim the current live DB inventory is known. It changes the active-system boundary so malformed/duplicate derived rows stop controlling ROOT and prepares destructive cleanup according to evidence value rather than dependency fear.

## Verification
Run full SFI Verify including ROOT graph/navigation checks, typecheck and production build.