### PR TITLE
Converge Groq execution across ROOT and Observatory

### DIFF
--- a/src/app/api/root/friccionauta/route.ts
+++ b/src/app/api/root/friccionauta/route.ts
@@ -41,8 +41,6 @@ async function ask(request: Request, gate: RootActorGate, body: Row) {
   if (!question) return NextResponse.json({ ok: false, error: 'question_required' }, { status: 400 });
   const startedAt = new Date().toISOString();
 
-  // A conversational surface must not collapse because one observational reader is degraded.
-  // Each source is independently optional; the LLM still receives the context that is actually available.
   const [rootResult, twinResult, worldResult, graphResult, amvResult] = await Promise.allSettled([
     readRootSovereignState(),
     readCognitiveTwinState(),
@@ -126,25 +124,48 @@ async function ask(request: Request, gate: RootActorGate, body: Row) {
     'No hubo proveedor LLM disponible para sintetizar una respuesta. La conversación permanece registrada como intento degradado.',
   ].join('\n');
 
-  const llm = await runLlmTask({
+  const system = [
+    'You are FRICCIONAUTA, the read-only conversational interface of System Friction Institute ROOT.',
+    'You operate through the Cognitive Twin contract. You are not the Cognitive Twin itself and you do not own institutional memory.',
+    'Answer questions about SFI using the supplied current institutional state and targeted retrieval.',
+    'Some readers may be explicitly unavailable. Missing readers are not a reason to refuse the whole conversation; name the missing context and continue with what is available.',
+    'You may interpret, compare, diagnose gaps and propose next observations. You may NOT execute endpoints, approve, publish, mutate canon, alter formulas, grant access, contact anyone or represent a proposal as executed.',
+    'Evidence before inference. Distinguish OBSERVED, IMPORTED, DERIVED, INFERRED, PROPOSED and MISSING.',
+    'When asked what something means, explain the operational consequence rather than restating database fields.',
+    'When dates matter, reconstruct the temporal context from the supplied records and say when the context is incomplete.',
+    'If the user asks about something not present in SFI context, say that it is not currently observable from ROOT rather than inventing it.',
+    'Be concise but sufficiently diagnostic. Prefer: answer, evidence/context, contradiction or uncertainty, next useful observation.',
+  ].join(' ');
+
+  const firstAttempt = await runLlmTask({
     task: 'context_long',
     preferredProvider: 'groq',
-    system: [
-      'You are FRICCIONAUTA, the read-only conversational interface of System Friction Institute ROOT.',
-      'You operate through the Cognitive Twin contract. You are not the Cognitive Twin itself and you do not own institutional memory.',
-      'Answer questions about SFI using the supplied current institutional state and targeted retrieval.',
-      'Some readers may be explicitly unavailable. Missing readers are not a reason to refuse the whole conversation; name the missing context and continue with what is available.',
-      'You may interpret, compare, diagnose gaps and propose next observations. You may NOT execute endpoints, approve, publish, mutate canon, alter formulas, grant access, contact anyone or represent a proposal as executed.',
-      'Evidence before inference. Distinguish OBSERVED, IMPORTED, DERIVED, INFERRED, PROPOSED and MISSING.',
-      'When asked what something means, explain the operational consequence rather than restating database fields.',
-      'When dates matter, reconstruct the temporal context from the supplied records and say when the context is incomplete.',
-      'If the user asks about something not present in SFI context, say that it is not currently observable from ROOT rather than inventing it.',
-      'Be concise but sufficiently diagnostic. Prefer: answer, evidence/context, contradiction or uncertainty, next useful observation.',
-    ].join(' '),
+    system,
     prompt: `QUESTION\n${question}\n\nSFI_CONTEXT\n${compact(context, 52000)}`,
     fallbackResult: fallback,
     maxTokens: 1500,
   });
+
+  let llm = firstAttempt;
+  if (!firstAttempt.ok) {
+    const retry = await runLlmTask({
+      task: 'context_long',
+      preferredProvider: 'groq',
+      system,
+      prompt: `QUESTION\n${question}\n\nSFI_CONTEXT_COMPACT_RETRY\n${compact(context, 18000)}`,
+      fallbackResult: fallback,
+      maxTokens: 900,
+    });
+    llm = {
+      ...retry,
+      warnings: [
+        ...firstAttempt.warnings,
+        retry.ok ? 'friccionauta_compact_retry_succeeded' : 'friccionauta_compact_retry_failed',
+        ...retry.warnings,
+      ],
+      latency_ms: firstAttempt.latency_ms + retry.latency_ms,
+    };
+  }
 
   const authority = evaluateCognitiveTwinAuthority({ action: 'propose', founderAbsent: false, evidencePresent: evidenceRefs.length > 0 });
   const taskId = `friccionauta:${Date.now()}`;
@@ -232,6 +253,7 @@ async function ask(request: Request, gate: RootActorGate, body: Row) {
     model: llm.model,
     evidenceRefs,
     warnings: envelope.limitations,
+    providerWarnings: llm.warnings,
     retrievalWarnings,
     run: persisted.data,
     envelope,

--- a/src/observatory/ai/aiProviderRouter.ts
+++ b/src/observatory/ai/aiProviderRouter.ts
@@ -1,3 +1,4 @@
+import { runLlmTask, type LlmTask } from '@/lib/ai/providerRouter';
 import type { AiProvider, AiProviderConfig, AiProviderRequest, AiProviderResponse } from './aiProviderTypes';
 
 const providerEnv: Record<Exclude<AiProvider, 'local_stub'>, string> = {
@@ -40,6 +41,12 @@ function systemInstruction(request: AiProviderRequest) {
       : `Tarea: ${request.task}.`,
     context ? `Contexto visible:\n${context}` : '',
   ].filter(Boolean).join('\n\n');
+}
+
+function centralTask(request: AiProviderRequest): LlmTask {
+  if (request.task === 'audit' || request.task === 'simulate') return 'deep_report';
+  if (request.task === 'route') return 'fast_classification';
+  return 'draft';
 }
 
 async function parseJsonResponse(response: Response) {
@@ -105,19 +112,15 @@ async function callAnthropic(request: AiProviderRequest, apiKey: string) {
   };
 }
 
-async function callGroqCompatible(request: AiProviderRequest, apiKey: string, provider: 'groq' | 'deepseek') {
-  const endpoint = provider === 'groq' ? 'https://api.groq.com/openai/v1/chat/completions' : 'https://api.deepseek.com/chat/completions';
-  const model = provider === 'groq'
-    ? process.env.GROQ_MODEL || 'llama-3.1-8b-instant'
-    : process.env.DEEPSEEK_MODEL || 'deepseek-chat';
-  const response = await fetch(endpoint, {
+async function callDeepseek(request: AiProviderRequest, apiKey: string) {
+  const response = await fetch('https://api.deepseek.com/chat/completions', {
     method: 'POST',
     headers: {
       authorization: `Bearer ${apiKey}`,
       'content-type': 'application/json',
     },
     body: JSON.stringify({
-      model,
+      model: process.env.DEEPSEEK_MODEL || 'deepseek-chat',
       messages: [
         { role: 'system', content: systemInstruction(request) },
         { role: 'user', content: request.input },
@@ -167,12 +170,34 @@ export async function runAiTask(request: AiProviderRequest): Promise<AiProviderR
     };
   }
 
+  if (provider === 'groq') {
+    const central = await runLlmTask({
+      task: centralTask(request),
+      preferredProvider: 'groq',
+      system: systemInstruction(request),
+      prompt: request.input,
+      fallbackResult: 'Motor Groq degradado.',
+      maxTokens: request.task === 'route' ? 320 : 1100,
+    });
+    return {
+      ok: central.ok,
+      provider: central.ok ? 'groq' : 'groq',
+      task: request.task,
+      output: central.result,
+      text: central.result,
+      external: true,
+      usage: central.usage ?? undefined,
+      reason: central.ok ? undefined : 'provider_request_failed',
+      error: central.ok ? undefined : central.warnings.join(' | '),
+    };
+  }
+
   try {
     const result = provider === 'openai'
       ? await callOpenAi(request, apiKey)
       : provider === 'anthropic'
         ? await callAnthropic(request, apiKey)
-        : await callGroqCompatible(request, apiKey, provider);
+        : await callDeepseek(request, apiKey);
     const output = result.text.trim();
     if (!output) throw new Error('empty_provider_response');
     return {


### PR DESCRIPTION
## Observed live defect
ROOT Friccionauta returned `DEGRADED · manual_fallback` while the authenticated Groq health probe returned `GROQ_OK` with `openai/gpt-oss-20b`.

## Root cause boundary
The health probe only verifies a tiny 12-token request. Friccionauta sends a much larger institutional context and can fail independently. Observatory also maintained a separate Groq implementation instead of the repaired central provider router.

## Changes
- Friccionauta keeps Groq preferred but retries once with a bounded 18k-character context and 900 completion tokens if the full-context call fails.
- Provider warnings from both attempts are retained and returned explicitly as `providerWarnings` for diagnosis.
- Observatory Groq execution now delegates to the central `runLlmTask` router, so GPT-OSS request semantics are no longer duplicated in a legacy router.
- DeepSeek legacy handling remains isolated; OpenAI/Anthropic behavior remains unchanged in Observatory.

## Scope
This does not claim Studio/Field/Map live execution is already proven. Studio and Field/Map already use the central router; their actual execution remains observable per-run. This PR removes one known duplicate Groq path and makes ROOT failure behavior diagnosable/resilient.