### PR TITLE
Canonical evidence graph rebuild and truthful ROOT state

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Verify ROOT graph and navigation convergence
         run: npx tsx scripts/qa-sfi-root-graph-navigation.ts
 
+      - name: Verify canonical evidence identity
+        run: node --import tsx --test src/lib/evidence/canonicalEvidence.test.ts
+
+      - name: Verify canonical evidence QA
+        run: npx tsx scripts/qa-sfi-canonical-evidence.ts
+
       - name: Verify Studio Field surface
         run: npm run qa:sfi-studio-workspace
 

--- a/docs/db/SFI_CANONICAL_EVIDENCE_CHANGELOG_2026-08-10.md
+++ b/docs/db/SFI_CANONICAL_EVIDENCE_CHANGELOG_2026-08-10.md
@@ -1,0 +1,17 @@
+# SFI Canonical Evidence Graph Changelog — 2026-08-10
+
+This change removes a structural ambiguity in ROOT: persistence rows are no longer treated as independent epistemic objects merely because they live in different tables.
+
+Implemented scope:
+
+- canonical evidence identity by hash;
+- rebuildable graph projection;
+- module/case context nodes instead of storage-surface nodes;
+- explicit graph health when relations are missing;
+- canonical evidence counting in ROOT institutional interpretation;
+- actual Cognitive Twin state in the Cognitive Twin panel;
+- qualified legacy prediction display;
+- reconciliation audit metadata;
+- focused invariant tests and QA documentation.
+
+No source evidence is deleted by this code change.

--- a/docs/db/SFI_CANONICAL_EVIDENCE_GRAPH_2026-08-10.md
+++ b/docs/db/SFI_CANONICAL_EVIDENCE_GRAPH_2026-08-10.md
@@ -1,0 +1,68 @@
+# SFI Canonical Evidence Graph — 2026-08-10
+
+## Invariant
+
+One evidence object is represented once in the active graph, independently of how many persistence tables reference it.
+
+Primary identity rule:
+
+```text
+1 evidence_hash = 1 canonical evidence object = 1 canonical evidence node
+```
+
+`root_evidence_entries` and `sfi_evidence_ledger` are provenance surfaces. They do not create separate epistemic objects when they share the same evidence hash.
+
+## Source of truth vs projection
+
+Preserved source-of-truth surfaces:
+
+- `root_evidence_entries`
+- `sfi_evidence_ledger`
+- Cognitive Twin canonical tables
+- domain-specific primary records
+
+Rebuildable projection:
+
+- `graph_nodes`
+- `graph_edges`
+
+The reconciler may remove its own previously managed projection and rebuild it from primary evidence. It must not delete source evidence.
+
+## Graph node classes
+
+- `evidence`: one canonical evidence object.
+- `module`: declared taxonomy/context node; not additional evidence.
+- `case`: declared case/context node; not additional evidence.
+- `attractor`: declared attractor state; does not prove convergence.
+
+Source URLs and database table names remain provenance attributes. They are not emitted as cognitive nodes solely because they exist in storage.
+
+## Display contract
+
+ROOT distinguishes:
+
+- `OBJ`: canonical evidence objects.
+- `N`: graph nodes, including context nodes.
+- `E`: explicit graph relations.
+
+Therefore `OBJ`, `N`, and `E` are intentionally different quantities.
+
+The Cognitive Twin panel reads `sfi_cognitive_twin_*` state. Predictive hypotheses remain in the Predictive Engine and are not relabeled as Cognitive Twin memory.
+
+## Predictive legacy boundary
+
+Legacy prediction rows that are placeholders or structurally empty are retained in storage for forensic continuity but are excluded from the active ROOT predictive view. Current filtering excludes short placeholder records such as `x`, `test`, `prueba`, `placeholder`, `n/a`, and exact textual duplicates.
+
+## Reconciliation behavior
+
+`POST /api/root/evidence/reconcile` is explicit, auditable and idempotent at the canonical-object level. It:
+
+1. reads primary ROOT and SFI evidence rows;
+2. resolves canonical evidence objects;
+3. removes the reconciler-managed graph projection;
+4. writes one evidence node per canonical object;
+5. creates declared module/case context relations;
+6. links explicit evidence references to attractors where present;
+7. reports object, node, edge, removal and warning counts to ROOT audit.
+
+Reading ROOT alone does not mutate the graph.

--- a/docs/db/SFI_CANONICAL_EVIDENCE_QA_2026-08-10.md
+++ b/docs/db/SFI_CANONICAL_EVIDENCE_QA_2026-08-10.md
@@ -1,0 +1,13 @@
+# SFI Canonical Evidence QA — Acceptance Criteria
+
+The change is acceptable only if all of the following remain true:
+
+- One shared `evidence_hash` across ROOT and ledger resolves to one canonical evidence object.
+- Provenance retains both persistence surfaces without representing them as duplicate evidence nodes.
+- Reconciliation never deletes source rows from `root_evidence_entries` or `sfi_evidence_ledger`.
+- Reconciliation produces explicit relations for declared module/case context instead of arbitrary evidence-to-evidence same-module links.
+- ROOT reports canonical evidence objects separately from graph nodes and graph edges.
+- Cognitive Twin UI reads `sfi_cognitive_twin_*` state.
+- Predictive legacy placeholders are excluded from active prediction display without deleting forensic history.
+- Nodes without relations are not reported as a healthy functional graph.
+- ROOT read remains non-mutating; reconciliation remains an explicit sovereign POST action.

--- a/docs/db/SFI_POST_MERGE_RECONCILIATION_2026-08-10.md
+++ b/docs/db/SFI_POST_MERGE_RECONCILIATION_2026-08-10.md
@@ -1,0 +1,19 @@
+# SFI Post-merge Reconciliation — 2026-08-10
+
+The live database currently has an intentionally empty derived graph after cleanup. Do not run the legacy whole-table reset.
+
+After this branch is merged and deployed:
+
+1. Open ROOT as a sovereign actor.
+2. Verify `EVIDENCIA` reports canonical object count independently from graph `N/E`.
+3. Execute `RECONCILIAR GRAFO PERSISTIDO` once.
+4. Verify the reconciliation response reports `canonicalEvidenceObjects > 0`, `nodesCreated > 0`, `edgesCreated > 0`, and no unexpected warnings.
+5. Refresh ROOT and verify:
+   - `EVIDENCIA` remains the canonical object count;
+   - `GRAFO` has nodes and relations;
+   - duplicate ROOT/ledger representations do not double the object count;
+   - source URLs do not appear as graph nodes merely because they are provenance;
+   - the Cognitive Twin panel shows Cognitive Twin memory/decisions/runs rather than Predictive Engine hypotheses;
+   - placeholder prediction rows such as `x` are absent from the active predictive view.
+
+Do not use `npm run db:reset:sfi` for this transition. The graph is a rebuildable projection; source-of-truth evidence remains preserved.

--- a/scripts/qa-sfi-canonical-evidence.ts
+++ b/scripts/qa-sfi-canonical-evidence.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { canonicalizeEvidenceRows } from '../src/lib/evidence/canonicalEvidence';
+
+const hash = 'a'.repeat(64);
+const canonical = canonicalizeEvidenceRows([
+  {
+    id: 'root-1',
+    evidence_hash: hash,
+    title: 'Evidence A',
+    evidence_type: 'document',
+    payload: { metadata: { module: 'atlas', evidenceKey: 'evidence-a', epistemicClass: 'IMPORTED_PROVENANCE' } },
+    created_at: '2026-08-09T00:00:00Z',
+  },
+], [
+  {
+    id: 'ledger-1',
+    evidence_hash: hash,
+    module: 'atlas',
+    evidence_kind: 'longitudinal_report',
+    source_name: 'Evidence A',
+    public_summary: { title: 'Evidence A', evidenceKey: 'evidence-a', epistemicClass: 'IMPORTED_PROVENANCE' },
+    trust_level: 'provenance_observed',
+    trust_score: 1,
+    observed_at: '2026-08-09T00:00:00Z',
+    created_at: '2026-08-09T00:00:01Z',
+  },
+]);
+
+assert.equal(canonical.length, 1, 'ROOT + ledger persistence must resolve to one evidence object');
+assert.equal(canonical[0].nodeId, `evidence:${hash.slice(0, 24)}`);
+assert.ok(canonical[0].provenance.includes('root_evidence_entries'));
+assert.ok(canonical[0].provenance.includes('sfi_evidence_ledger'));
+assert.equal(canonical[0].module, 'atlas');
+
+console.log(JSON.stringify({
+  ok: true,
+  invariant: 'one evidence hash = one canonical evidence object',
+  canonicalObjects: canonical.length,
+  nodeId: canonical[0].nodeId,
+  provenance: canonical[0].provenance,
+}, null, 2));

--- a/src/app/api/root/evidence/reconcile/route.ts
+++ b/src/app/api/root/evidence/reconcile/route.ts
@@ -16,9 +16,12 @@ export async function POST(request: Request) {
     action: 'evidence.graph.reconcile',
     target: 'graph_nodes+graph_edges',
     payload: {
+      projectionVersion: result.projectionVersion,
       rootEvidenceRows: result.rootEvidenceRows,
       ledgerRows: result.ledgerRows,
-      evidenceDescriptors: result.evidenceDescriptors,
+      canonicalEvidenceObjects: result.canonicalEvidenceObjects,
+      nodesRemoved: result.nodesRemoved,
+      edgesRemoved: result.edgesRemoved,
       nodesCreated: result.nodesCreated,
       nodesUpdated: result.nodesUpdated,
       edgesCreated: result.edgesCreated,

--- a/src/components/root/sovereign/RootObservatoryWorkspace.tsx
+++ b/src/components/root/sovereign/RootObservatoryWorkspace.tsx
@@ -111,10 +111,10 @@ function strings(value: unknown) {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
 }
 function rowDate(row: RootRow) {
-  return text(row.observed_at ?? row.occurred_at ?? row.executed_at ?? row.updated_at ?? row.created_at ?? row.timestamp, '') || null;
+  return text(row.observed_at ?? row.occurred_at ?? row.executed_at ?? row.finished_at ?? row.updated_at ?? row.created_at ?? row.timestamp, '') || null;
 }
 function rid(row: RootRow, fallback: string) {
-  return text(row.id ?? row.event_id ?? row.run_id ?? row.node_key ?? row.node_id ?? row.attractor_key ?? row.hypothesis_id, fallback);
+  return text(row.id ?? row.event_id ?? row.run_id ?? row.task_id ?? row.decision_id ?? row.memory_key ?? row.node_key ?? row.node_id ?? row.attractor_key ?? row.hypothesis_id, fallback);
 }
 function when(value: string | null | undefined) {
   if (!value) return 'SIN FECHA';
@@ -127,8 +127,8 @@ function millis(value: string | null | undefined) {
 }
 function tone(value: string | null | undefined) {
   const status = (value ?? '').toLowerCase();
-  if (['observed', 'imported', 'operational', 'available', 'accepted', 'verified', 'active', 'canonical', 'win'].includes(status)) return 'ok';
-  if (['derived', 'thin', 'declared', 'proposed', 'waiting_evidence', 'inferred', 'extracted', 'inconclusive', 'pending'].includes(status)) return 'warn';
+  if (['observed', 'imported', 'operational', 'available', 'accepted', 'verified', 'active', 'canonical', 'approved', 'released', 'closed', 'win'].includes(status)) return 'ok';
+  if (['derived', 'thin', 'declared', 'candidate', 'registered', 'ready', 'planning', 'policy_check', 'executing', 'evidence_pending', 'verifying', 'proposed', 'waiting_evidence', 'inferred', 'extracted', 'inconclusive', 'pending'].includes(status)) return 'warn';
   if (['degraded', 'conflicted', 'blocked', 'error', 'blocking', 'rejected', 'loss'].includes(status)) return 'bad';
   return 'idle';
 }
@@ -265,7 +265,7 @@ function EvidenceGraph({ state, onSelect }: { state: RootSovereignState; onSelec
 
   return <div className="evidence-graph-live" onClick={(event) => event.stopPropagation()}>
     <div className="graph-controls">
-      <span>{displayNodes.length}/{timeNodes.length} N · {displayEdges.length}/{timeEdges.length} E</span>
+      <span>{state.evidence.data.objects.length} OBJ · {displayNodes.length}/{timeNodes.length} N · {displayEdges.length}/{timeEdges.length} E</span>
       <div>{([1, 2, 3, 'all'] as const).map((value) => <button type="button" key={String(value)} className={depth === value ? 'active' : ''} onClick={() => setDepth(value)}>{value === 'all' ? 'TODO' : `${value} SALTO${value > 1 ? 'S' : ''}`}</button>)}</div>
       <button type="button" onClick={() => setFocusId(null)}>AUTOFOCO</button>
     </div>
@@ -328,16 +328,21 @@ export function RootObservatoryWorkspace({ state, accessMode, actorLabel, refres
   const executed = agents.filter((agent) => agent.status === 'operational').length;
   const capabilities = state.execution.data.capabilities;
   const available = capabilities.filter((capability) => capability.state === 'available').length;
-  const evidenceCount = state.evidence.data.entries.length + state.evidence.data.ledger.length;
-  const graphStatus = state.evidence.error ? 'DEGRADED' : state.evidence.data.nodes.length ? 'OBSERVED' : 'MISSING';
+  const evidenceCount = state.evidence.data.objects.length;
+  const graphStatus = state.evidence.error ? 'DEGRADED' : state.evidence.data.nodes.length ? (state.evidence.data.nodes.length > 1 && !state.evidence.data.edges.length ? 'DEGRADED' : 'OBSERVED') : 'MISSING';
   const attractor = state.amv.data.attractors[0] ?? null;
   const divergenceCount = state.interpretation.divergences.length;
-  const sources = [state.system, state.governance, state.agents, state.predictions, state.amv, state.evidence, state.execution, state.telemetry, state.cognitiveRuntime];
+  const sources = [state.system, state.governance, state.agents, state.predictions, state.amv, state.evidence, state.execution, state.telemetry, state.cognitiveRuntime, state.cognitiveTwin];
   const sourceOk = sources.filter((source) => !source.error).length;
   const hypotheses = [...state.predictions.data.runs, ...state.predictions.data.legacyEntries];
   const recentEvents = state.cognitiveRuntime.data.eventGraph.recentEvents.slice(0, 30);
+  const cognitiveTwinRows = [
+    ...state.cognitiveTwin.data.memory.map((row) => ({ kind: 'memory', row })),
+    ...state.cognitiveTwin.data.decisions.map((row) => ({ kind: 'decision', row })),
+    ...state.cognitiveTwin.data.runs.map((row) => ({ kind: 'run', row })),
+  ].sort((a, b) => millis(rowDate(b.row)) - millis(rowDate(a.row)));
   const trajectory = [
-    ...state.evidence.data.entries.map((row) => ({ kind: 'evidence', row })),
+    ...state.evidence.data.objects.map((row) => ({ kind: 'evidence', row })),
     ...hypotheses.map((row) => ({ kind: 'prediction', row })),
     ...state.predictions.data.outcomes.map((row) => ({ kind: 'outcome', row })),
     ...state.predictions.data.learningEvents.map((row) => ({ kind: 'learning', row })),
@@ -348,7 +353,7 @@ export function RootObservatoryWorkspace({ state, accessMode, actorLabel, refres
     + state.governance.data.mutations.filter((row) => !['executed', 'closed', 'rejected'].includes(text(row.status, '').toLowerCase())).length;
   const predictionOpen = state.predictions.data.runs.filter((row) => ['OPEN', 'WAITING_EVIDENCE', 'DUE', 'PROPOSED'].includes(text(row.status, '').toUpperCase())).length
     + state.predictions.data.legacyEntries.filter((row) => !['verified', 'closed', 'falsified'].includes(text(row.estado_observacion, '').toLowerCase())).length;
-  const latestEvidenceAt = [...state.evidence.data.entries, ...state.evidence.data.ledger].map(rowDate).filter((value): value is string => Boolean(value)).sort((a, b) => millis(b) - millis(a))[0] ?? null;
+  const latestEvidenceAt = state.evidence.data.objects.map(rowDate).filter((value): value is string => Boolean(value)).sort((a, b) => millis(b) - millis(a))[0] ?? null;
   const activeAttractors = state.amv.data.attractors.filter((row) => !['archived', 'retired', 'closed'].includes(text(row.status, '').toLowerCase())).length;
 
   const byFamily = new Map<string, typeof capabilities>();
@@ -380,7 +385,7 @@ export function RootObservatoryWorkspace({ state, accessMode, actorLabel, refres
       const body = await response.json().catch(() => null) as Record<string, unknown> | null;
       if (!response.ok || !body?.ok) throw new Error(text(body?.error, `HTTP ${response.status}`));
       const reconciliation = rec(body.reconciliation);
-      setToolStatus({ text: `${tool.label} · ${text(reconciliation.nodesCreated, '0')} nodos nuevos · ${text(reconciliation.nodesUpdated, '0')} actualizados · ${text(reconciliation.edgesCreated, '0')} edges nuevos · ${Array.isArray(reconciliation.warnings) ? reconciliation.warnings.length : 0} warnings`, tone: Array.isArray(reconciliation.warnings) && reconciliation.warnings.length ? 'idle' : 'ok' });
+      setToolStatus({ text: `${tool.label} · ${text(reconciliation.canonicalEvidenceObjects, '0')} objetos · ${text(reconciliation.nodesCreated, '0')} nodos · ${text(reconciliation.edgesCreated, '0')} relaciones · ${text(reconciliation.nodesRemoved, '0')} nodos previos retirados · ${Array.isArray(reconciliation.warnings) ? reconciliation.warnings.length : 0} warnings`, tone: Array.isArray(reconciliation.warnings) && reconciliation.warnings.length ? 'idle' : 'ok' });
       onRefresh();
     } catch (error) {
       setToolStatus({ text: error instanceof Error ? error.message : 'No fue posible ejecutar la acción.', tone: 'bad' });
@@ -391,7 +396,7 @@ export function RootObservatoryWorkspace({ state, accessMode, actorLabel, refres
     <header className="root-hdr">
       <strong>SFI · ROOT</strong><b>ΦSFI <em>{phi}</em></b>
       <span className="hdr-health" data-tone={sourceOk === sources.length ? 'ok' : 'bad'}>FUENTES <i>{sourceOk}/{sources.length}</i></span>
-      <span>GRAFO <i data-tone={tone(graphStatus)}>{state.evidence.data.nodes.length}N/{state.evidence.data.edges.length}E · {graphStatus}</i></span>
+      <span>EVIDENCIA <i>{evidenceCount} OBJ</i></span><span>GRAFO <i data-tone={tone(graphStatus)}>{state.evidence.data.nodes.length}N/{state.evidence.data.edges.length}E · {graphStatus}</i></span>
       <span>COLA <i>{governanceOpen}</i></span><span>PRED <i>{predictionOpen} abiertas · {state.predictions.data.outcomes.length} outcomes</i></span>
       <span>AGENTES <i>{executed}/{agents.length || '—'}</i></span><span>ATR <i>{activeAttractors}</i></span>
       <span className="hdr-evidence-time">ÚLTIMA EVIDENCIA <i>{when(latestEvidenceAt)}</i></span>
@@ -432,7 +437,7 @@ export function RootObservatoryWorkspace({ state, accessMode, actorLabel, refres
 
           <Panel id="mod-institution" module="01a · INSTITUCIONALIZACIÓN" label="Founder dependency / transferencia" status="declared" statusContext="CLASE" source="FEP-01 + Cognitive Twin memory" width="l"><div className="intake-live"><p>Observa dónde SFI todavía depende del fundador, separa criterio transferible de autoridad reservada y exige reproducción antes de declarar capacidad institucional.</p><button type="button" onClick={() => setSurface({ title: 'INSTITUCIONALIZACIÓN', href: '/root/institutionalization' })}>ABRIR INSTITUTIONALIZATION →</button><button type="button" onClick={() => setSurface({ title: 'REPORTES DE AGENTES', href: '/root/reports' })}>LEER REPORTES DE AGENTES →</button></div></Panel>
 
-          <Panel id="mod-04-chat" module="04a · SFI" label="Chat / mantenimiento contextual" status="available" statusContext="ESTADO" source="Friccionauta + Cognitive Twin" width="l"><div className="chat-root-panel"><p>El chat con SFI permanece disponible. La evidencia se agrega desde el nodo/hipótesis/atractor seleccionado; el intake global deja de ocupar este espacio.</p><button type="button" onClick={() => window.dispatchEvent(new Event('sfi:open-friccionauta'))}>ABRIR CHAT CON SFI →</button>{accessMode === 'sovereign' ? <button type="button" onClick={() => void openTool({ label: 'RECONCILIAR GRAFO', kind: 'api', target: '/api/root/evidence/reconcile' })}>RECONCILIAR GRAFO PERSISTIDO →</button> : null}<small>Leer ROOT no ejecuta reconciliación. La reconciliación es explícita, auditable e idempotente.</small></div></Panel>
+          <Panel id="mod-04-chat" module="04a · SFI" label="Chat / mantenimiento contextual" status="available" statusContext="ESTADO" source="Friccionauta + Cognitive Twin" width="l"><div className="chat-root-panel"><p>El chat con SFI permanece disponible. La evidencia se agrega desde el nodo/hipótesis/atractor seleccionado; el intake global deja de ocupar este espacio.</p><button type="button" onClick={() => window.dispatchEvent(new Event('sfi:open-friccionauta'))}>ABRIR CHAT CON SFI →</button>{accessMode === 'sovereign' ? <button type="button" onClick={() => void openTool({ label: 'RECONCILIAR GRAFO', kind: 'api', target: '/api/root/evidence/reconcile' })}>RECONCILIAR GRAFO PERSISTIDO →</button> : null}<small>Leer ROOT no ejecuta reconciliación. La reconciliación reconstruye una proyección canónica; no duplica una evidencia por cada tabla que la persiste.</small></div></Panel>
 
           <Panel id="mod-10" module="10 · GOBERNANZA" label="Capacidades ejecutables" status={state.execution.error ? 'degraded' : state.execution.dataClass} statusContext="SALUD" source={state.execution.source} width="l"><div className="cap-groups">{[...byFamily.entries()].map(([family, items]) => <div key={family}><b>{family}</b>{items.map((capability) => <button key={capability.id} type="button" data-tone={tone(capability.state)} onClick={(event) => { event.stopPropagation(); onAction({ id: capability.id, label: capability.label, effect: capability.description, target: capability.endpoint ?? capability.id, endpoint: capability.endpoint, method: 'POST' }); }}>{capability.label}<i>{statusLabel(capability.state, 'ESTADO')}</i></button>)}</div>)}</div></Panel>
         </div>
@@ -441,9 +446,13 @@ export function RootObservatoryWorkspace({ state, accessMode, actorLabel, refres
       <section className={`topology-row ${focus('II') ? '' : 'dim'}`}>
         <header><b>II</b><strong>{TOPOLOGIES.II.title}</strong><em>{TOPOLOGIES.II.question}</em></header>
         <div className="panel-strip">
-          <Panel id="mod-04" module="04 · EVIDENCIA" label="Grafo relacional / longitudinal" status={graphStatus} statusContext="SALUD" source={state.evidence.source} width="xl"><EvidenceGraph state={state} onSelect={onSelect} /></Panel>
+          <Panel id="mod-04" module="04 · EVIDENCIA" label="Grafo canónico relacional / longitudinal" status={graphStatus} statusContext="SALUD" source={state.evidence.source} width="xl"><EvidenceGraph state={state} onSelect={onSelect} /></Panel>
           <Panel id="mod-05" module="05 · RUNTIME" label={`${agents.length} agentes`} status={state.cognitiveRuntime.data.status} statusContext="SALUD" source={state.cognitiveRuntime.source} width="l"><Rows rows={agents.map((agent) => ({ name: agent.name, sub: `${agent.layer} · ${agent.domain}`, status: agent.status, statusContext: 'ESTADO', onClick: () => onSelect(sel({ kind: 'agent', id: agent.id, title: agent.name, source: state.cognitiveRuntime.source, observedAt: state.cognitiveRuntime.observedAt, evidenceIds: agentEvidenceIds(agent.id), data: agent })) }))} /></Panel>
-          <Panel id="mod-06" module="06 · COGNITIVE TWIN" label="Hipótesis persistidas / contradicciones" status={state.predictions.error ? 'degraded' : hypotheses.length ? 'observed' : 'missing'} statusContext="ESTADO" source={state.predictions.source}><Rows rows={hypotheses.slice(0, 20).map((row, index) => ({ name: text(row.title ?? row.hypothesis ?? row.interpretation ?? row.prediccion_explicita ?? row.status, `Hipótesis ${index + 1}`), sub: text(row.learning_state ?? row.status, ''), status: text(row.epistemic_class ?? row.status, 'inferred'), statusContext: 'CLASE', onClick: () => onSelect(sel({ kind: 'hypothesis', id: rid(row, `hyp-${index}`), title: text(row.title ?? row.hypothesis ?? row.interpretation ?? row.prediccion_explicita, `Hipótesis ${index + 1}`), source: state.predictions.source, observedAt: rowDate(row), evidenceIds: strings(row.evidence_refs), data: row })) }))} /></Panel>
+          <Panel id="mod-06" module="06 · COGNITIVE TWIN" label="Memoria / decisiones / ejecuciones" status={state.cognitiveTwin.error ? 'degraded' : state.cognitiveTwin.dataClass} statusContext="ESTADO" source={state.cognitiveTwin.source}><Rows rows={cognitiveTwinRows.slice(0, 20).map((item, index) => {
+            const content = rec(item.row.content);
+            const title = text(content.title ?? content.statement ?? content.summary ?? item.row.general_rule ?? item.row.situation ?? item.row.objective ?? item.row.memory_key ?? item.row.decision_id ?? item.row.task_id, `${item.kind} ${index + 1}`);
+            return { name: title, sub: `${item.kind.toUpperCase()} · ${when(rowDate(item.row))}`, status: text(item.row.status, item.kind === 'memory' ? 'candidate' : 'observed'), statusContext: item.kind === 'run' ? 'ESTADO' as const : 'CLASE' as const, onClick: () => onSelect(sel({ kind: `cognitive-twin-${item.kind}`, id: rid(item.row, `ct-${item.kind}-${index}`), title, source: state.cognitiveTwin.source, observedAt: rowDate(item.row), evidenceIds: strings(item.row.evidence_refs), data: item.row })) };
+          })} /></Panel>
           <Panel id="mod-07" module="07 · PROYECCIÓN" label="Prediction Outcome · ramas longitudinales" status={state.predictions.error ? 'degraded' : state.predictions.dataClass} statusContext="SALUD" source={state.predictions.source} width="xl"><PredictionOutcomeTree state={state} onSelect={onSelect} /></Panel>
           <Panel id="mod-08" module="08 · ATRACTORES" label="Campo dinámico / longitudinal" status={attractor ? text(attractor.status, 'declared') : 'missing'} statusContext="CLASE" source={state.amv.source} width="xl"><DynamicAttractorField state={state} onSelect={onSelect} /></Panel>
         </div>
@@ -452,8 +461,8 @@ export function RootObservatoryWorkspace({ state, accessMode, actorLabel, refres
       <section className={`topology-row ${focus('III') ? '' : 'dim'}`}>
         <header><b>III</b><strong>{TOPOLOGIES.III.title}</strong><em>{TOPOLOGIES.III.question}</em></header>
         <div className="panel-strip">
-          <Panel id="mod-09" module="09 · TRAYECTORIA" label="Evidencia → aprendizaje" status={trajectory.length ? 'derived' : 'missing'} statusContext="MODO" source="evidence + prediction + outcome + learning + audit" width="xl"><div className="trajectory-live">{trajectory.map((item, index) => <button key={`${item.kind}-${rid(item.row, String(index))}`} type="button" onClick={(event) => { event.stopPropagation(); onSelect(sel({ kind: item.kind, id: rid(item.row, `${item.kind}-${index}`), title: text(item.row.title ?? item.row.event_name ?? item.row.action ?? item.row.status, item.kind), source: item.kind, observedAt: rowDate(item.row), evidenceIds: strings(item.row.evidence_refs), data: item.row })); }}><time>{when(rowDate(item.row))}</time><i>{item.kind}</i><span>{text(item.row.title ?? item.row.event_name ?? item.row.action ?? item.row.status ?? item.row.learning_state, item.kind)}</span></button>)}</div></Panel>
-          <Panel id="mod-09-memory" module="09 · MEMORIA" label="AMV / MIHM" status={state.amv.error ? 'degraded' : state.amv.dataClass} statusContext="SALUD" source={state.amv.source}><div className="metric-cluster"><b>{state.amv.data.memories.length}<small>AMV MEMORY</small></b><b>{state.predictions.data.learningEvents.length}<small>LEARNING EVENTS</small></b><b>{state.governance.data.audits.length}<small>AUDITED ACTIONS</small></b></div></Panel>
+          <Panel id="mod-09" module="09 · TRAYECTORIA" label="Evidencia → aprendizaje" status={trajectory.length ? 'derived' : 'missing'} statusContext="MODO" source="canonical evidence + prediction + outcome + learning + audit" width="xl"><div className="trajectory-live">{trajectory.map((item, index) => <button key={`${item.kind}-${rid(item.row, String(index))}`} type="button" onClick={(event) => { event.stopPropagation(); onSelect(sel({ kind: item.kind, id: rid(item.row, `${item.kind}-${index}`), title: text(item.row.title ?? item.row.event_name ?? item.row.action ?? item.row.status, item.kind), source: item.kind, observedAt: rowDate(item.row), evidenceIds: strings(item.row.evidence_refs), data: item.row })); }}><time>{when(rowDate(item.row))}</time><i>{item.kind}</i><span>{text(item.row.title ?? item.row.event_name ?? item.row.action ?? item.row.status ?? item.row.learning_state, item.kind)}</span></button>)}</div></Panel>
+          <Panel id="mod-09-memory" module="09 · MEMORIA" label="AMV / Cognitive Twin / MIHM" status={state.amv.error || state.cognitiveTwin.error ? 'degraded' : 'observed'} statusContext="SALUD" source="AMV + Cognitive Twin"><div className="metric-cluster"><b>{state.amv.data.memories.length}<small>AMV MEMORY</small></b><b>{text(state.cognitiveTwin.data.counts.memory, '0')}<small>COGNITIVE TWIN</small></b><b>{state.predictions.data.learningEvents.length}<small>LEARNING EVENTS</small></b><b>{state.governance.data.audits.length}<small>AUDITED ACTIONS</small></b></div></Panel>
           <Panel id="mod-10-log" module="10 · GOBERNANZA" label="Bitácora / eventos cognitivos" status={state.governance.error ? 'degraded' : state.governance.dataClass} statusContext="SALUD" source={state.governance.source} width="l"><Rows rows={[
             ...recentEvents.map((event) => ({ name: event.eventName, sub: `${when(event.occurredAt)} · ${event.sourceId ?? 'runtime'}`, status: event.epistemicClass, statusContext: 'CLASE' as const, onClick: () => onSelect(sel({ kind: 'cognitive-event', id: event.eventId, title: event.eventName, source: event.sourceId ?? state.cognitiveRuntime.source, observedAt: event.occurredAt, data: event })) })),
             ...state.governance.data.audits.slice(0, 10).map((row, index) => ({ name: text(row.action, `audit ${index + 1}`), sub: when(rowDate(row)), status: 'observed', statusContext: 'ESTADO' as const, onClick: () => onSelect(sel({ kind: 'audit', id: rid(row, `audit-${index}`), title: text(row.action, 'Audit'), source: state.governance.source, observedAt: rowDate(row), data: row })) })),

--- a/src/components/root/sovereign/RootObservatoryWorkspace.tsx
+++ b/src/components/root/sovereign/RootObservatoryWorkspace.tsx
@@ -102,7 +102,9 @@ const DIVERGENCE_FACT: Record<string, string> = {
 };
 
 function text(value: unknown, fallback = '—') {
-  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return fallback;
 }
 function rec(value: unknown): RootRow {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as RootRow : {};
@@ -138,6 +140,16 @@ function statusLabel(status: string, context: StatusContext = 'ESTADO') {
 function systemStatusContext(id: string): StatusContext {
   if (id.startsWith('mihm-') && id !== 'mihm-llm-providers') return 'CLASE';
   return 'SALUD';
+}
+function systemCountLabel(id: string, value: number | null) {
+  if (value === null) return undefined;
+  if (id === 'governance' || id === 'predictive') return `${value} abiertos`;
+  if (id === 'neural-graph') return `${value} nodos`;
+  if (id === 'cognitive-runtime') return `${value} agentes`;
+  if (id === 'cognitive-twin') return `${value} registros`;
+  if (id === 'evidence') return `${value} objetos`;
+  if (id === 'amv') return `${value} registros`;
+  return `${value} registros`;
 }
 function sel(input: {
   kind: string;
@@ -430,7 +442,7 @@ export function RootObservatoryWorkspace({ state, accessMode, actorLabel, refres
           </Panel>
 
           <Panel id="mod-02" module="02 · SISTEMA" label="Salud de superficies" status={state.system.error ? 'degraded' : state.system.dataClass} statusContext="SALUD" source={state.system.source}>
-            <Rows rows={state.system.data.matrix.map((item) => ({ name: item.label, sub: item.openItems.value === null ? undefined : `${item.openItems.value} abiertos`, status: item.state.status, statusContext: systemStatusContext(item.id), onClick: () => onSelect(sel({ kind: 'system-item', id: item.id, title: item.label, source: item.state.source, observedAt: item.state.observedAt, evidenceIds: item.state.evidenceIds, warning: item.state.warning, data: item })) }))} />
+            <Rows rows={state.system.data.matrix.map((item) => ({ name: item.label, sub: systemCountLabel(item.id, item.openItems.value), status: item.state.status, statusContext: systemStatusContext(item.id), onClick: () => onSelect(sel({ kind: 'system-item', id: item.id, title: item.label, source: item.state.source, observedAt: item.state.observedAt, evidenceIds: item.state.evidenceIds, warning: item.state.warning, data: item })) }))} />
           </Panel>
 
           <Panel id="mod-03" module="03 · IDENTIDAD" label="Sesión / autoridad" status="observed" statusContext="ESTADO" source="server user context"><Rows rows={[{ name: actorLabel, sub: accessMode === 'sovereign' ? 'ROOT · SOVEREIGN' : 'ROOT · OBSERVER', status: 'observed', statusContext: 'ESTADO' }]} /></Panel>

--- a/src/lib/cognitive-twin/readState.ts
+++ b/src/lib/cognitive-twin/readState.ts
@@ -45,13 +45,14 @@ export async function readCognitiveTwinState() {
   const tableMap = new Map(tableResults.map((item) => [item.table, item]));
   const databaseReady = tableResults.every((item) => item.available);
 
-  const [recentDecisions, recentRuns, recentEvaluations] = databaseReady
+  const [recentMemory, recentDecisions, recentRuns, recentEvaluations] = databaseReady
     ? await Promise.all([
+        db.from('sfi_cognitive_twin_memory').select('*').order('updated_at', { ascending: false }).limit(24),
         db.from('sfi_cognitive_twin_decisions').select('*').order('created_at', { ascending: false }).limit(12),
         db.from('sfi_cognitive_twin_runs').select('*').order('created_at', { ascending: false }).limit(24),
         db.from('sfi_cognitive_twin_evaluations').select('*').order('executed_at', { ascending: false }).limit(20),
       ])
-    : [null, null, null];
+    : [null, null, null, null];
 
   const providers = getLlmProviderStatus();
   const configuredProviders = providers.filter((item) => item.available);
@@ -92,11 +93,13 @@ export async function readCognitiveTwinState() {
       evaluations: tableMap.get('sfi_cognitive_twin_evaluations')?.count ?? null,
       runs: tableMap.get('sfi_cognitive_twin_runs')?.count ?? null,
     },
+    recentMemory: recentMemory?.data ?? [],
     recentDecisions: recentDecisions?.data ?? [],
     recentRuns: recentRuns?.data ?? [],
     recentEvaluations: recentEvaluations?.data ?? [],
     errors: [
       ...tableResults.filter((item) => item.error).map((item) => `${item.table}: ${item.error}`),
+      ...(recentMemory?.error ? [`memory: ${recentMemory.error.message}`] : []),
       ...(recentDecisions?.error ? [`decisions: ${recentDecisions.error.message}`] : []),
       ...(recentRuns?.error ? [`runs: ${recentRuns.error.message}`] : []),
       ...(recentEvaluations?.error ? [`evaluations: ${recentEvaluations.error.message}`] : []),

--- a/src/lib/evidence/canonicalEvidence.test.ts
+++ b/src/lib/evidence/canonicalEvidence.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { canonicalizeEvidenceRows } from './canonicalEvidence';
+
+test('same evidence hash across ROOT and ledger becomes one canonical object', () => {
+  const hash = 'a'.repeat(64);
+  const objects = canonicalizeEvidenceRows([
+    {
+      id: 'root-1',
+      evidence_hash: hash,
+      title: 'Canonical object',
+      evidence_type: 'document',
+      payload: { metadata: { module: 'atlas', evidenceKey: 'atlas-1', epistemicClass: 'IMPORTED_PROVENANCE' } },
+      created_at: '2026-08-09T00:00:00Z',
+    },
+  ], [
+    {
+      id: 'ledger-1',
+      evidence_hash: hash,
+      module: 'atlas',
+      evidence_kind: 'longitudinal_report',
+      source_name: 'SFI',
+      public_summary: { title: 'Canonical object', evidenceKey: 'atlas-1', epistemicClass: 'IMPORTED_PROVENANCE' },
+      trust_level: 'provenance_observed',
+      trust_score: 1,
+      observed_at: '2026-08-09T00:00:00Z',
+      created_at: '2026-08-09T00:00:01Z',
+    },
+  ]);
+
+  assert.equal(objects.length, 1);
+  assert.equal(objects[0].nodeId, `evidence:${hash.slice(0, 24)}`);
+  assert.deepEqual(objects[0].rootEvidenceIds, ['root-1']);
+  assert.deepEqual(objects[0].ledgerEvidenceIds, ['ledger-1']);
+  assert.deepEqual(objects[0].provenance.sort(), ['root_evidence_entries', 'sfi_evidence_ledger'].sort());
+  assert.equal(objects[0].module, 'atlas');
+});
+
+test('different evidence hashes remain distinct canonical objects', () => {
+  const objects = canonicalizeEvidenceRows([
+    { id: 'root-1', evidence_hash: '1'.repeat(64), title: 'One', payload: {}, created_at: '2026-08-01T00:00:00Z' },
+    { id: 'root-2', evidence_hash: '2'.repeat(64), title: 'Two', payload: {}, created_at: '2026-08-02T00:00:00Z' },
+  ], []);
+  assert.equal(objects.length, 2);
+  assert.notEqual(objects[0].nodeId, objects[1].nodeId);
+});
+
+test('persistence duplication does not increase evidence object count', () => {
+  const hash = 'f'.repeat(64);
+  const objects = canonicalizeEvidenceRows(
+    [
+      { id: 'root-1', evidence_hash: hash, title: 'Object', payload: {}, created_at: '2026-08-01T00:00:00Z' },
+      { id: 'root-2', evidence_hash: hash, title: 'Object', payload: {}, created_at: '2026-08-01T00:00:00Z' },
+    ],
+    [
+      { id: 'ledger-1', evidence_hash: hash, source_name: 'Object', public_summary: {}, trust_score: 1, created_at: '2026-08-01T00:00:00Z' },
+    ],
+  );
+  assert.equal(objects.length, 1);
+  assert.equal(objects[0].rootEvidenceIds.length, 2);
+  assert.equal(objects[0].ledgerEvidenceIds.length, 1);
+});

--- a/src/lib/evidence/canonicalEvidence.ts
+++ b/src/lib/evidence/canonicalEvidence.ts
@@ -1,0 +1,216 @@
+import { createHash } from 'node:crypto';
+import { isEpistemicClass, type EpistemicClass } from '../../../packages/events/src/schema';
+
+export type EvidenceRow = Record<string, unknown>;
+
+export type CanonicalEvidenceObject = {
+  key: string;
+  nodeId: string;
+  evidenceHash: string | null;
+  label: string;
+  module: string | null;
+  caseId: string | null;
+  evidenceKind: string | null;
+  evidenceType: string | null;
+  evidenceKey: string | null;
+  sourceUrls: string[];
+  privateRefs: string[];
+  rootEvidenceIds: string[];
+  ledgerEvidenceIds: string[];
+  epistemicEventIds: string[];
+  targetNodeIds: string[];
+  observedAt: string | null;
+  epistemicClass: EpistemicClass;
+  confidence: number;
+  provenance: Array<'root_evidence_entries' | 'sfi_evidence_ledger'>;
+  metadata: EvidenceRow;
+};
+
+function text(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function record(value: unknown): EvidenceRow {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as EvidenceRow : {};
+}
+
+function unique(values: Array<string | null | undefined>) {
+  return [...new Set(values.filter((value): value is string => Boolean(value && value.trim())))];
+}
+
+function number01(value: unknown, fallback = 1) {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' && value.trim() ? Number(value) : Number.NaN;
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(0, Math.min(1, parsed));
+}
+
+function normalizeEpistemicClass(value: unknown, fallback: EpistemicClass): EpistemicClass {
+  const raw = text(value)?.toLowerCase();
+  if (!raw) return fallback;
+  if (isEpistemicClass(raw)) return raw as EpistemicClass;
+  if (['imported_provenance', 'persisted_reference', 'provenance_observed'].includes(raw)) return 'imported';
+  return fallback;
+}
+
+const EPISTEMIC_RANK: Record<EpistemicClass, number> = {
+  canonical: 12,
+  observed: 11,
+  imported: 10,
+  extracted: 9,
+  derived: 8,
+  declared: 7,
+  inferred: 6,
+  simulated: 5,
+  proposed: 4,
+  degraded: 3,
+  conflicted: 2,
+  missing: 1,
+  rejected: 0,
+};
+
+function strongerEpistemicClass(a: EpistemicClass, b: EpistemicClass) {
+  return EPISTEMIC_RANK[b] > EPISTEMIC_RANK[a] ? b : a;
+}
+
+function earlierDate(a: string | null, b: string | null) {
+  const left = a ? Date.parse(a) : Number.NaN;
+  const right = b ? Date.parse(b) : Number.NaN;
+  if (Number.isFinite(left) && Number.isFinite(right)) return left <= right ? a : b;
+  return Number.isFinite(left) ? a : Number.isFinite(right) ? b : null;
+}
+
+function shortHash(value: string) {
+  return createHash('sha256').update(value).digest('hex').slice(0, 24);
+}
+
+function canonicalKey(source: 'root' | 'ledger', id: string, hash: string | null) {
+  return hash ? `hash:${hash}` : `${source}:${id}`;
+}
+
+function nodeIdFor(key: string, hash: string | null) {
+  return hash ? `evidence:${hash.slice(0, 24)}` : `evidence:${shortHash(key)}`;
+}
+
+function blank(key: string, hash: string | null): CanonicalEvidenceObject {
+  return {
+    key,
+    nodeId: nodeIdFor(key, hash),
+    evidenceHash: hash,
+    label: 'Evidencia sin etiqueta',
+    module: null,
+    caseId: null,
+    evidenceKind: null,
+    evidenceType: null,
+    evidenceKey: null,
+    sourceUrls: [],
+    privateRefs: [],
+    rootEvidenceIds: [],
+    ledgerEvidenceIds: [],
+    epistemicEventIds: [],
+    targetNodeIds: [],
+    observedAt: null,
+    epistemicClass: 'imported',
+    confidence: 0,
+    provenance: [],
+    metadata: {},
+  };
+}
+
+export function canonicalizeEvidenceRows(rootRows: EvidenceRow[], ledgerRows: EvidenceRow[]): CanonicalEvidenceObject[] {
+  const objects = new Map<string, CanonicalEvidenceObject>();
+
+  for (const row of rootRows) {
+    const id = text(row.id);
+    if (!id) continue;
+    const hash = text(row.evidence_hash);
+    const key = canonicalKey('root', id, hash);
+    const payload = record(row.payload);
+    const metadata = record(payload.metadata);
+    const current = objects.get(key) ?? blank(key, hash);
+    const epistemicClass = normalizeEpistemicClass(metadata.epistemicClass ?? payload.epistemicClass, 'observed');
+    const observedAt = text(metadata.sourceObservedAt ?? payload.sourceObservedAt ?? row.created_at);
+    const label = text(row.title) ?? current.label;
+
+    objects.set(key, {
+      ...current,
+      evidenceHash: current.evidenceHash ?? hash,
+      label,
+      module: current.module ?? text(metadata.module),
+      caseId: current.caseId ?? text(metadata.caseId),
+      evidenceKind: current.evidenceKind ?? text(metadata.evidenceKind),
+      evidenceType: current.evidenceType ?? text(row.evidence_type),
+      evidenceKey: current.evidenceKey ?? text(metadata.evidenceKey),
+      sourceUrls: unique([...current.sourceUrls, text(metadata.sourceUrl), text(payload.sourceUrl)]),
+      privateRefs: unique([...current.privateRefs, text(metadata.privateRef), text(payload.privateRef)]),
+      rootEvidenceIds: unique([...current.rootEvidenceIds, id]),
+      epistemicEventIds: unique([...current.epistemicEventIds, text(row.epistemic_event_id)]),
+      targetNodeIds: unique([...current.targetNodeIds, text(row.target_node_id)]),
+      observedAt: earlierDate(current.observedAt, observedAt),
+      epistemicClass: strongerEpistemicClass(current.epistemicClass, epistemicClass),
+      confidence: Math.max(current.confidence, 1),
+      provenance: current.provenance.includes('root_evidence_entries') ? current.provenance : [...current.provenance, 'root_evidence_entries'],
+      metadata: { ...current.metadata, ...metadata },
+    });
+  }
+
+  for (const row of ledgerRows) {
+    const id = text(row.id);
+    if (!id) continue;
+    const hash = text(row.evidence_hash);
+    const key = canonicalKey('ledger', id, hash);
+    const summary = record(row.public_summary);
+    const current = objects.get(key) ?? blank(key, hash);
+    const epistemicClass = normalizeEpistemicClass(summary.epistemicClass ?? row.trust_level, 'imported');
+    const observedAt = text(row.observed_at ?? row.created_at);
+    const label = text(summary.title) ?? text(row.source_name) ?? text(row.evidence_kind) ?? current.label;
+
+    objects.set(key, {
+      ...current,
+      evidenceHash: current.evidenceHash ?? hash,
+      label: current.label === 'Evidencia sin etiqueta' ? label : current.label,
+      module: current.module ?? text(row.module),
+      caseId: current.caseId ?? text(row.case_id),
+      evidenceKind: current.evidenceKind ?? text(row.evidence_kind),
+      evidenceType: current.evidenceType,
+      evidenceKey: current.evidenceKey ?? text(summary.evidenceKey),
+      sourceUrls: unique([...current.sourceUrls, text(row.source_url)]),
+      privateRefs: unique([...current.privateRefs, text(row.private_ref)]),
+      ledgerEvidenceIds: unique([...current.ledgerEvidenceIds, id]),
+      observedAt: earlierDate(current.observedAt, observedAt),
+      epistemicClass: strongerEpistemicClass(current.epistemicClass, epistemicClass),
+      confidence: Math.max(current.confidence, number01(row.trust_score, 1)),
+      provenance: current.provenance.includes('sfi_evidence_ledger') ? current.provenance : [...current.provenance, 'sfi_evidence_ledger'],
+      metadata: { ...current.metadata, publicSummary: summary },
+    });
+  }
+
+  return [...objects.values()].sort((a, b) => {
+    const left = a.observedAt ? Date.parse(a.observedAt) : Number.POSITIVE_INFINITY;
+    const right = b.observedAt ? Date.parse(b.observedAt) : Number.POSITIVE_INFINITY;
+    if (left !== right) return left - right;
+    return a.label.localeCompare(b.label);
+  });
+}
+
+export function canonicalEvidenceRow(object: CanonicalEvidenceObject): EvidenceRow {
+  return {
+    id: object.nodeId,
+    evidence_hash: object.evidenceHash,
+    title: object.label,
+    module: object.module,
+    case_id: object.caseId,
+    evidence_kind: object.evidenceKind,
+    evidence_type: object.evidenceType,
+    evidence_key: object.evidenceKey,
+    observed_at: object.observedAt,
+    epistemic_class: object.epistemicClass,
+    confidence: object.confidence,
+    provenance: object.provenance,
+    source_urls: object.sourceUrls,
+    private_refs: object.privateRefs,
+    root_evidence_ids: object.rootEvidenceIds,
+    ledger_evidence_ids: object.ledgerEvidenceIds,
+    epistemic_event_ids: object.epistemicEventIds,
+    target_node_ids: object.targetNodeIds,
+  };
+}

--- a/src/lib/evidence/reconcileEvidenceGraph.ts
+++ b/src/lib/evidence/reconcileEvidenceGraph.ts
@@ -2,78 +2,71 @@ import 'server-only';
 
 import { createHash } from 'node:crypto';
 import { createServiceSupabaseClient } from '@/runtime/supabase/server';
-import { isEpistemicClass, type EpistemicClass } from '../../../packages/events/src/schema';
+import { canonicalizeEvidenceRows, type CanonicalEvidenceObject, type EvidenceRow } from './canonicalEvidence';
 
 type Row = Record<string, unknown>;
-type FetchResult = { data: Row[]; error: string | null };
-type EvidenceDescriptor = {
-  id: string;
-  hash: string | null;
-  nodeId: string;
-  label: string;
-  caseId: string | null;
-  module: string | null;
-  evidenceKey: string | null;
-  sourceUrl: string | null;
-  observedAt: string | null;
-};
+type FetchResult = { data: EvidenceRow[]; error: string | null };
 
 const PAGE_SIZE = 500;
 const LEGACY_NODE_STORAGE_TYPE = 'INF';
 const LEGACY_EDGE_STORAGE_TYPE = 'structural_inferred';
 const EDGE_CONFLICT = 'source_node_key,target_node_key,relation_type';
+const PROJECTION_VERSION = 'canonical-evidence-v2';
+const MANAGED_NODE_ORIGINS = [
+  'root_evidence',
+  'evidence_ledger',
+  'evidence_provenance',
+  'sfi_attractors',
+  'evidence_canonical',
+  'evidence_context',
+  'evidence_context_attractor',
+];
 
 function rows(value: unknown): Row[] {
   return Array.isArray(value) ? value.filter((item): item is Row => Boolean(item) && typeof item === 'object' && !Array.isArray(item)) : [];
 }
+
 function text(value: unknown) {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
+
 function record(value: unknown): Row {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
 }
+
 function strings(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && Boolean(item.trim())) : [];
 }
+
 function uniqueStrings(...groups: Array<Array<string | null | undefined>>) {
   return [...new Set(groups.flat().filter((item): item is string => Boolean(item && item.trim())))];
 }
+
 function number01(value: unknown, fallback = 1) {
   if (value === null || typeof value === 'undefined' || value === '') return fallback;
   const parsed = typeof value === 'number' ? value : Number(value);
   if (!Number.isFinite(parsed)) return fallback;
   return Math.max(0, Math.min(1, parsed));
 }
-function normalizeEpistemicClass(value: unknown, fallback: EpistemicClass): EpistemicClass {
-  const raw = text(value)?.toLowerCase();
-  if (!raw) return fallback;
-  if (isEpistemicClass(raw)) return raw as EpistemicClass;
-  if (raw === 'imported_provenance' || raw === 'persisted_reference' || raw === 'provenance_observed') return 'imported';
-  return fallback;
+
+function shortHash(value: string) {
+  return createHash('sha256').update(value).digest('hex').slice(0, 24);
 }
-function sourceEpistemicClass(value: unknown) { return text(value) ?? null; }
-function shortHash(value: string) { return createHash('sha256').update(value).digest('hex').slice(0, 24); }
-function urlLabel(value: string) {
-  try {
-    const url = new URL(value);
-    return `${url.hostname}${url.pathname === '/' ? '' : url.pathname}`.slice(0, 140);
-  } catch {
-    return value.slice(0, 140);
-  }
-}
+
 function laterDate(a: string | null, b: string | null) {
   const left = a ? Date.parse(a) : Number.NaN;
   const right = b ? Date.parse(b) : Number.NaN;
   if (Number.isFinite(left) && Number.isFinite(right)) return left >= right ? a : b;
   return Number.isFinite(left) ? a : Number.isFinite(right) ? b : null;
 }
+
 function compactWarnings(input: string[]) {
   const unique = [...new Set(input.filter(Boolean))];
   const buckets = new Map<string, { count: number; sample: string }>();
   for (const warning of unique) {
     const constraint = warning.match(/(?:violates|unique constraint) "([^"]+)"/)?.[1];
     const family = warning.startsWith('evidence_edge:') ? 'graph_edges'
-      : warning.startsWith('source_surface:') || warning.startsWith('attractor_node:') || warning.includes('_evidence_graph:') ? 'graph_nodes'
+      : warning.startsWith('evidence_node:') || warning.startsWith('context_node:') || warning.startsWith('attractor_node:') ? 'graph_nodes'
         : warning.split(':', 1)[0] || 'graph';
     const key = constraint ? `${family}:${constraint}` : warning;
     const current = buckets.get(key);
@@ -82,15 +75,21 @@ function compactWarnings(input: string[]) {
   return [...buckets.entries()].map(([key, value]) => value.count > 1 ? `${key} · ${value.count} reconciliaciones rechazadas` : value.sample);
 }
 
+function chunks<T>(items: T[], size = 180) {
+  const result: T[][] = [];
+  for (let index = 0; index < items.length; index += size) result.push(items.slice(index, index + size));
+  return result;
+}
+
 export async function reconcilePersistedEvidenceGraph() {
   const db = createServiceSupabaseClient();
 
   async function fetchAllRows(table: 'root_evidence_entries' | 'sfi_evidence_ledger', select: string): Promise<FetchResult> {
-    const collected: Row[] = [];
+    const collected: EvidenceRow[] = [];
     for (let offset = 0; ; offset += PAGE_SIZE) {
       const page = await db.from(table).select(select).order('created_at', { ascending: true }).order('id', { ascending: true }).range(offset, offset + PAGE_SIZE - 1);
       if (page.error) return { data: [], error: page.error.message };
-      const pageRows = rows(page.data);
+      const pageRows = rows(page.data) as EvidenceRow[];
       collected.push(...pageRows);
       if (pageRows.length < PAGE_SIZE) return { data: collected, error: null };
     }
@@ -102,17 +101,50 @@ export async function reconcilePersistedEvidenceGraph() {
   ]);
 
   const warnings = [rootEvidence.error, ledger.error].filter((value): value is string => Boolean(value));
+  const canonicalObjects = canonicalizeEvidenceRows(rootEvidence.data, ledger.data);
   let nodesCreated = 0;
   let nodesUpdated = 0;
   let edgesCreated = 0;
-  const descriptors: EvidenceDescriptor[] = [];
+  let nodesRemoved = 0;
+  let edgesRemoved = 0;
+  const writtenNodes = new Set<string>();
+
+  async function pruneManagedProjection() {
+    const managed = await db.from('graph_nodes').select('node_id').in('origin', MANAGED_NODE_ORIGINS).limit(5000);
+    if (managed.error) {
+      warnings.push(`projection_prune_nodes:${managed.error.message}`);
+      return;
+    }
+    const nodeIds = rows(managed.data).map((row) => text(row.node_id)).filter((value): value is string => Boolean(value));
+    for (const batch of chunks(nodeIds)) {
+      const outgoing = await db.from('graph_edges').delete().in('source_node_id', batch).select('id');
+      if (outgoing.error) warnings.push(`projection_prune_edges_source:${outgoing.error.message}`);
+      else edgesRemoved += rows(outgoing.data).length;
+
+      const incoming = await db.from('graph_edges').delete().in('target_node_id', batch).select('id');
+      if (incoming.error) warnings.push(`projection_prune_edges_target:${incoming.error.message}`);
+      else edgesRemoved += rows(incoming.data).length;
+
+      const removed = await db.from('graph_nodes').delete().in('node_id', batch).select('id');
+      if (removed.error) warnings.push(`projection_prune_nodes_delete:${removed.error.message}`);
+      else nodesRemoved += rows(removed.data).length;
+    }
+  }
+
+  await pruneManagedProjection();
 
   async function upsertNode(nodeId: string, value: Row, warningPrefix: string) {
-    const existing = await db.from('graph_nodes').select('id').eq('node_id', nodeId).maybeSingle();
+    const alreadyWritten = writtenNodes.has(nodeId);
+    const existing = alreadyWritten ? { data: { id: nodeId }, error: null } : await db.from('graph_nodes').select('id').eq('node_id', nodeId).maybeSingle();
     if (existing.error) warnings.push(`${warningPrefix}:lookup:${existing.error.message}`);
     const write = await db.from('graph_nodes').upsert(value, { onConflict: 'node_id' });
-    if (write.error) { warnings.push(`${warningPrefix}:${write.error.message}`); return false; }
-    if (existing.data) nodesUpdated += 1; else nodesCreated += 1;
+    if (write.error) {
+      warnings.push(`${warningPrefix}:${write.error.message}`);
+      return false;
+    }
+    writtenNodes.add(nodeId);
+    if (existing.data) nodesUpdated += 1;
+    else nodesCreated += 1;
     return true;
   }
 
@@ -154,6 +186,8 @@ export async function reconcilePersistedEvidenceGraph() {
     const attributes = {
       ...prior,
       ...(input.attributes ?? {}),
+      managedBy: 'canonical_evidence_reconciler',
+      projectionVersion: PROJECTION_VERSION,
       epistemicClass: 'DECLARED',
       relationStrength: weight > 0 ? 'WEIGHTED' : 'UNMEASURED',
       declaredRelation: input.relation,
@@ -185,106 +219,133 @@ export async function reconcilePersistedEvidenceGraph() {
     else if (!existing.data) edgesCreated += 1;
   }
 
-  for (const item of rootEvidence.data) {
-    const id = text(item.id);
-    const hash = text(item.evidence_hash);
-    if (!id || !hash) continue;
-    const nodeId = `root_evidence:${hash.slice(0, 24)}`;
-    const eventId = text(item.epistemic_event_id);
-    const payload = record(item.payload);
-    const metadata = record(payload.metadata);
-    const declaredEpistemicClass = metadata.epistemicClass ?? payload.epistemicClass;
-    const epistemicClass = normalizeEpistemicClass(declaredEpistemicClass, 'observed');
-    const observedAt = text(metadata.sourceObservedAt ?? item.created_at);
-    const nodePayload = {
-      evidenceHash: hash,
-      evidenceType: text(item.evidence_type) ?? 'root_evidence',
-      rootEvidenceId: id,
-      targetNodeId: text(item.target_node_id),
+  async function ensureContextNode(kind: 'module' | 'case', value: string, observedAt: string | null) {
+    const nodeId = `context:${kind}:${shortHash(value.toLowerCase())}`;
+    const payload = {
+      managedBy: 'canonical_evidence_reconciler',
+      projectionVersion: PROJECTION_VERSION,
+      contextKind: kind,
+      contextValue: value,
       sourceObservedAt: observedAt,
-      epistemicClass: epistemicClass.toUpperCase(),
-      sourceEpistemicClass: sourceEpistemicClass(declaredEpistemicClass),
-      observedObject: epistemicClass === 'imported' ? 'imported_evidence_record_existence_and_provenance' : 'evidence_record_existence_and_provenance',
+      observedObject: `${kind}_classification_context`,
       storageNodeType: LEGACY_NODE_STORAGE_TYPE,
-      sourcePayloadMetadata: metadata,
+      claimBoundary: `This node groups canonical evidence by declared ${kind}; it does not assert causal relation.`,
     };
     const ok = await upsertNode(nodeId, {
-      node_id: nodeId, node_key: nodeId, label: text(item.title) ?? `Evidence ${id.slice(0, 8)}`,
-      node_type: LEGACY_NODE_STORAGE_TYPE, ontology_type: 'evidence', origin: 'root_evidence', epistemic_class: epistemicClass,
-      confidence: 1, payload: nodePayload, lineage: eventId ? [eventId] : [], attributes: nodePayload, updated_at: new Date().toISOString(),
-    }, `root_evidence_graph:${id}`);
-    if (!ok) continue;
-
-    descriptors.push({ id, hash, nodeId, label: text(item.title) ?? `Evidence ${id.slice(0, 8)}`, caseId: text(metadata.caseId), module: text(metadata.module), evidenceKey: text(metadata.evidenceKey), sourceUrl: text(metadata.sourceUrl ?? payload.sourceUrl), observedAt });
-    const targetNodeId = text(item.target_node_id);
-    if (targetNodeId) {
-      const target = await db.from('graph_nodes').select('node_id,node_key').or(`node_id.eq.${targetNodeId},node_key.eq.${targetNodeId}`).maybeSingle();
-      const resolvedTarget = target.data && !target.error ? text(target.data.node_id ?? target.data.node_key) : null;
-      if (resolvedTarget) await upsertEdge({ from: nodeId, to: resolvedTarget, relation: text(payload.relationType) ?? 'contextualizes', relationType: 'structural_declared', confidence: 1, observedAt, evidenceIds: eventId ? [eventId] : [], attributes: { evidenceHash: hash, verified: false, explicitTargetNode: true } });
-    }
+      node_id: nodeId,
+      node_key: nodeId,
+      label: kind === 'module' ? value.toUpperCase() : value,
+      node_type: LEGACY_NODE_STORAGE_TYPE,
+      ontology_type: kind,
+      origin: 'evidence_context',
+      epistemic_class: 'declared',
+      confidence: 1,
+      payload,
+      attributes: payload,
+      lineage: [],
+      updated_at: new Date().toISOString(),
+    }, `context_node:${kind}:${value}`);
+    return ok ? nodeId : null;
   }
 
-  for (const item of ledger.data) {
-    const id = text(item.id);
-    if (!id) continue;
-    const hash = text(item.evidence_hash);
-    const nodeId = `ledger_evidence:${hash ? hash.slice(0, 24) : id}`;
-    const publicSummary = record(item.public_summary);
-    const declaredEpistemicClass = publicSummary.epistemicClass ?? item.trust_level;
-    const epistemicClass = normalizeEpistemicClass(declaredEpistemicClass, 'imported');
-    const confidence = number01(item.trust_score, 1);
-    const observedAt = text(item.observed_at ?? item.created_at);
+  const byReference = new Map<string, CanonicalEvidenceObject>();
+
+  for (const object of canonicalObjects) {
     const nodePayload = {
-      evidenceHash: hash, ledgerEvidenceId: id, caseId: text(item.case_id), module: text(item.module), evidenceKind: text(item.evidence_kind),
-      sourceUrl: text(item.source_url), privateRef: text(item.private_ref), sourceObservedAt: observedAt,
-      epistemicClass: epistemicClass.toUpperCase(), sourceEpistemicClass: sourceEpistemicClass(declaredEpistemicClass),
-      observedObject: epistemicClass === 'imported' ? 'imported_ledger_record_existence_and_provenance' : 'ledger_record_existence_and_provenance',
+      managedBy: 'canonical_evidence_reconciler',
+      projectionVersion: PROJECTION_VERSION,
+      canonicalEvidenceObject: true,
+      evidenceHash: object.evidenceHash,
+      evidenceKind: object.evidenceKind,
+      evidenceType: object.evidenceType,
+      evidenceKey: object.evidenceKey,
+      caseId: object.caseId,
+      module: object.module,
+      sourceUrls: object.sourceUrls,
+      privateRefs: object.privateRefs,
+      rootEvidenceIds: object.rootEvidenceIds,
+      ledgerEvidenceIds: object.ledgerEvidenceIds,
+      provenance: object.provenance,
+      sourceObservedAt: object.observedAt,
+      epistemicClass: object.epistemicClass.toUpperCase(),
+      sourcePayloadMetadata: object.metadata,
+      observedObject: 'canonical_evidence_object_existence_and_provenance',
       storageNodeType: LEGACY_NODE_STORAGE_TYPE,
+      claimBoundary: 'One graph node represents one evidence object. Multiple persistence records are provenance, not additional evidence objects.',
     };
-    const label = text(publicSummary.title) ?? text(item.source_name) ?? text(item.evidence_kind) ?? `Ledger evidence ${id.slice(0, 8)}`;
-    const ok = await upsertNode(nodeId, {
-      node_id: nodeId, node_key: nodeId, label, node_type: LEGACY_NODE_STORAGE_TYPE, ontology_type: 'evidence', origin: 'evidence_ledger',
-      epistemic_class: epistemicClass, confidence, payload: nodePayload, lineage: [], attributes: nodePayload, updated_at: new Date().toISOString(),
-    }, `ledger_evidence_graph:${id}`);
+
+    const ok = await upsertNode(object.nodeId, {
+      node_id: object.nodeId,
+      node_key: object.nodeId,
+      label: object.label,
+      node_type: LEGACY_NODE_STORAGE_TYPE,
+      ontology_type: 'evidence',
+      origin: 'evidence_canonical',
+      epistemic_class: object.epistemicClass,
+      confidence: object.confidence,
+      payload: nodePayload,
+      lineage: object.epistemicEventIds,
+      attributes: nodePayload,
+      updated_at: new Date().toISOString(),
+    }, `evidence_node:${object.nodeId}`);
     if (!ok) continue;
-    descriptors.push({ id, hash, nodeId, label, caseId: text(item.case_id), module: text(item.module), evidenceKey: text(publicSummary.evidenceKey), sourceUrl: text(item.source_url), observedAt });
-  }
 
-  const byHash = new Map<string, EvidenceDescriptor[]>();
-  descriptors.forEach((item) => { if (item.hash) byHash.set(item.hash, [...(byHash.get(item.hash) ?? []), item]); });
-  for (const [hash, items] of byHash.entries()) {
-    if (items.length < 2) continue;
-    const [first, ...rest] = items;
-    for (const other of rest) await upsertEdge({ from: first.nodeId, to: other.nodeId, relation: 'same_evidence_object', relationType: 'identity_reference', confidence: 1, observedAt: laterDate(first.observedAt, other.observedAt), attributes: { evidenceHash: hash } });
-  }
+    const refs = uniqueStrings(
+      [object.nodeId, object.evidenceHash, object.evidenceKey],
+      object.rootEvidenceIds,
+      object.ledgerEvidenceIds,
+    );
+    refs.forEach((ref) => byReference.set(ref, object));
 
-  async function linkShared(field: 'caseId' | 'module', relation: string) {
-    const groups = new Map<string, EvidenceDescriptor[]>();
-    descriptors.forEach((item) => {
-      const value = item[field];
-      if (value) groups.set(value, [...(groups.get(value) ?? []), item]);
-    });
-    for (const [value, items] of groups.entries()) {
-      const unique = Array.from(new Map(items.map((item) => [item.hash ?? item.id, item])).values());
-      if (unique.length < 2) continue;
-      for (let index = 1; index < unique.length; index += 1) {
-        await upsertEdge({ from: unique[0].nodeId, to: unique[index].nodeId, relation, relationType: 'contextual_declared', confidence: 1, observedAt: laterDate(unique[0].observedAt, unique[index].observedAt), attributes: { sharedField: field, sharedValue: value, doesNotImplyValidation: true } });
-      }
+    if (object.module) {
+      const moduleNodeId = await ensureContextNode('module', object.module, object.observedAt);
+      if (moduleNodeId) await upsertEdge({
+        from: object.nodeId,
+        to: moduleNodeId,
+        relation: 'classified_in_module',
+        relationType: 'taxonomy_declared',
+        confidence: 1,
+        observedAt: object.observedAt,
+        evidenceIds: object.evidenceHash ? [object.evidenceHash] : [],
+        attributes: { module: object.module, doesNotImplyValidation: true },
+      });
+    }
+
+    if (object.caseId) {
+      const caseNodeId = await ensureContextNode('case', object.caseId, object.observedAt);
+      if (caseNodeId) await upsertEdge({
+        from: object.nodeId,
+        to: caseNodeId,
+        relation: 'belongs_to_case',
+        relationType: 'case_membership_declared',
+        confidence: 1,
+        observedAt: object.observedAt,
+        evidenceIds: object.evidenceHash ? [object.evidenceHash] : [],
+        attributes: { caseId: object.caseId, doesNotImplyValidation: true },
+      });
     }
   }
-  await linkShared('caseId', 'same_case_context');
-  await linkShared('module', 'same_module_context');
 
-  for (const descriptor of descriptors) {
-    if (!descriptor.sourceUrl) continue;
-    const sourceNodeId = `source_surface:${shortHash(descriptor.sourceUrl)}`;
-    const surfacePayload = { url: descriptor.sourceUrl, sourceObservedAt: descriptor.observedAt, observedObject: 'declared_source_surface_reference', storageNodeType: LEGACY_NODE_STORAGE_TYPE, claimBoundary: 'The URL is persisted as provenance. Its current availability/content is not asserted by this graph node.' };
-    const ok = await upsertNode(sourceNodeId, {
-      node_id: sourceNodeId, node_key: sourceNodeId, label: urlLabel(descriptor.sourceUrl), node_type: LEGACY_NODE_STORAGE_TYPE,
-      ontology_type: 'source_surface', origin: 'evidence_provenance', epistemic_class: 'imported', confidence: 1,
-      payload: surfacePayload, attributes: surfacePayload, lineage: [], updated_at: new Date().toISOString(),
-    }, `source_surface:${descriptor.sourceUrl}`);
-    if (ok) await upsertEdge({ from: descriptor.nodeId, to: sourceNodeId, relation: 'declares_source_surface', relationType: 'provenance_declared', confidence: 1, observedAt: descriptor.observedAt, attributes: { sourceUrl: descriptor.sourceUrl } });
+  for (const object of canonicalObjects) {
+    for (const targetNodeId of object.targetNodeIds) {
+      const canonicalTarget = byReference.get(targetNodeId)?.nodeId;
+      let resolvedTarget = canonicalTarget ?? null;
+      if (!resolvedTarget) {
+        const target = await db.from('graph_nodes').select('node_id,node_key').or(`node_id.eq.${targetNodeId},node_key.eq.${targetNodeId}`).maybeSingle();
+        resolvedTarget = target.data && !target.error ? text(target.data.node_id ?? target.data.node_key) : null;
+      }
+      if (!resolvedTarget || resolvedTarget === object.nodeId) continue;
+      await upsertEdge({
+        from: object.nodeId,
+        to: resolvedTarget,
+        relation: 'contextualizes',
+        relationType: 'structural_declared',
+        confidence: 1,
+        observedAt: object.observedAt,
+        evidenceIds: object.epistemicEventIds,
+        attributes: { evidenceHash: object.evidenceHash, explicitTargetNode: true },
+      });
+    }
   }
 
   const attractorRead = await db.from('sfi_attractors').select('id,attractor_key,label,module,owner_node_key,attractor_type,confidence,persistence,trust,weight,evidence_count,status,vector,first_seen,last_seen,created_at,updated_at').order('updated_at', { ascending: false }).limit(250);
@@ -295,25 +356,57 @@ export async function reconcilePersistedEvidenceGraph() {
     const attractorNodeId = `attractor:${attractorKey}`;
     const vector = record(attractor.vector);
     const observedAt = text(attractor.first_seen ?? attractor.created_at);
-    const attractorPayload = { ...attractor, sourceObservedAt: observedAt, observedObject: 'declared_attractor', storageNodeType: LEGACY_NODE_STORAGE_TYPE, claimBoundary: 'An attractor records a declared direction. It does not prove convergence or outcome.' };
+    const attractorPayload = {
+      ...attractor,
+      managedBy: 'canonical_evidence_reconciler',
+      projectionVersion: PROJECTION_VERSION,
+      sourceObservedAt: observedAt,
+      observedObject: 'declared_attractor',
+      storageNodeType: LEGACY_NODE_STORAGE_TYPE,
+      claimBoundary: 'An attractor records a declared direction. It does not prove convergence or outcome.',
+    };
     const ok = await upsertNode(attractorNodeId, {
-      node_id: attractorNodeId, node_key: attractorNodeId, label: text(attractor.label) ?? attractorKey, node_type: LEGACY_NODE_STORAGE_TYPE,
-      ontology_type: 'attractor', origin: 'sfi_attractors', epistemic_class: 'declared', confidence: number01(attractor.confidence, 0),
-      payload: attractorPayload, attributes: attractorPayload, lineage: [], updated_at: new Date().toISOString(),
+      node_id: attractorNodeId,
+      node_key: attractorNodeId,
+      label: text(attractor.label) ?? attractorKey,
+      node_type: LEGACY_NODE_STORAGE_TYPE,
+      ontology_type: 'attractor',
+      origin: 'evidence_context_attractor',
+      epistemic_class: 'declared',
+      confidence: number01(attractor.confidence, 0),
+      payload: attractorPayload,
+      attributes: attractorPayload,
+      lineage: [],
+      updated_at: new Date().toISOString(),
     }, `attractor_node:${attractorKey}`);
     if (!ok) continue;
+
     for (const ref of strings(vector.evidenceRefs)) {
-      const evidence = descriptors.find((item) => item.id === ref || item.hash === ref || item.evidenceKey === ref);
+      const evidence = byReference.get(ref);
       if (!evidence) continue;
-      await upsertEdge({ from: evidence.nodeId, to: attractorNodeId, relation: 'supports_attractor', relationType: 'evidence_declared', confidence: number01(attractor.trust ?? attractor.confidence, 0), observedAt: laterDate(evidence.observedAt, observedAt), weight: number01(attractor.weight, 0), evidenceIds: evidence.hash ? [evidence.hash] : [], attributes: { attractorKey, explicitEvidenceReference: ref } });
+      await upsertEdge({
+        from: evidence.nodeId,
+        to: attractorNodeId,
+        relation: 'supports_attractor',
+        relationType: 'evidence_declared',
+        confidence: number01(attractor.trust ?? attractor.confidence, 0),
+        observedAt: laterDate(evidence.observedAt, observedAt),
+        weight: number01(attractor.weight, 0),
+        evidenceIds: evidence.evidenceHash ? [evidence.evidenceHash] : [],
+        attributes: { attractorKey, explicitEvidenceReference: ref },
+      });
     }
   }
 
   return {
     ok: warnings.length === 0,
+    projectionVersion: PROJECTION_VERSION,
     rootEvidenceRows: rootEvidence.data.length,
     ledgerRows: ledger.data.length,
-    evidenceDescriptors: descriptors.length,
+    canonicalEvidenceObjects: canonicalObjects.length,
+    evidenceDescriptors: canonicalObjects.length,
+    nodesRemoved,
+    edgesRemoved,
     nodesCreated,
     nodesUpdated,
     edgesCreated,

--- a/src/lib/root/sovereign/institutionalInterpretation.ts
+++ b/src/lib/root/sovereign/institutionalInterpretation.ts
@@ -48,12 +48,15 @@ function matrixValue(state: RootStateInput, ids: string[]) {
 function traceability(state: RootStateInput) {
   const nodes = state.evidence.data.nodes;
   const edges = state.evidence.data.edges;
-  const tracedNodes = nodes.filter((node) => node.evidenceIds.length > 0 || node.lineage.length > 0).length;
+  // Taxonomy/context nodes are graph infrastructure, not additional evidence objects.
+  // Traceability is evaluated over evidence/attractor nodes plus explicit relations.
+  const semanticNodes = nodes.filter((node) => ['evidence', 'attractor'].includes(node.type));
+  const tracedNodes = semanticNodes.filter((node) => node.evidenceIds.length > 0 || node.lineage.length > 0).length;
   const tracedEdges = edges.filter((edge) => edge.evidenceIds.length > 0).length;
-  const total = nodes.length + edges.length;
+  const total = semanticNodes.length + edges.length;
   const traced = tracedNodes + tracedEdges;
   const status: RootDataStatus = total === 0 ? 'missing' : traced === total ? 'observed' : traced > 0 ? 'degraded' : 'missing';
-  return { nodes: nodes.length, edges: edges.length, tracedNodes, tracedEdges, total, traced, status };
+  return { nodes: semanticNodes.length, graphNodes: nodes.length, edges: edges.length, tracedNodes, tracedEdges, total, traced, status };
 }
 function capabilityState(state: RootStateInput) {
   const rows = state.execution.data.capabilities;
@@ -65,7 +68,7 @@ function capabilityState(state: RootStateInput) {
 }
 
 export function interpretRootInstitution(state: RootStateInput): RootInstitutionalInterpretation {
-  const sources: SourceLike[] = [state.system, state.governance, state.agents, state.predictions, state.amv, state.evidence, state.execution, state.telemetry, state.cognitiveRuntime];
+  const sources: SourceLike[] = [state.system, state.governance, state.agents, state.predictions, state.amv, state.evidence, state.execution, state.telemetry, state.cognitiveRuntime, state.cognitiveTwin];
   const healthySources = sources.filter((source) => !source.error);
   const failedSources = sources.filter((source) => Boolean(source.error));
   const trace = traceability(state);
@@ -76,18 +79,22 @@ export function interpretRootInstitution(state: RootStateInput): RootInstitution
   const runtimeDegraded = runtime.agents.filter((agent) => agent.status === 'degraded').length;
   const runtimeMissing = runtime.agents.filter((agent) => agent.status === 'missing').length;
   const phi = matrixValue(state, ['mihm-phi-sfi']);
-  const evidenceCount = state.evidence.data.entries.length + state.evidence.data.ledger.length;
+  const evidenceCount = state.evidence.data.objects.length;
   const attractorCount = state.amv.data.attractors.length;
   const governanceRows = state.governance.data.audits.length + state.governance.data.events.length + state.governance.data.mutations.length;
+  const evidenceIds = state.evidence.data.objects
+    .map((row) => typeof row.evidence_hash === 'string' ? row.evidence_hash : '')
+    .filter(Boolean);
 
   const facts: RootInstitutionalFact[] = [
     { id: 'institutional-position', label: 'Posición institucional', value: phi === null ? 'No determinada' : `ΦSFI ${phi.toFixed(3)}`, status: phi === null ? 'missing' : 'derived', source: 'Math Core / sfi_indicator_snapshots', observedAt: state.system.observedAt, evidenceIds: [], explanation: phi === null ? 'No existe una lectura ΦSFI suficiente en este corte.' : 'Lectura derivada disponible; no sustituye IHG, NTI ni LDI.', warning: null },
     { id: 'source-health', label: 'Fuentes de ROOT', value: `${healthySources.length}/${sources.length} sin error`, status: failedSources.length === 0 ? 'observed' : healthySources.length ? 'degraded' : 'missing', source: 'rootSovereignAdapter readers', observedAt: latest(sources.map((source) => source.observedAt)), evidenceIds: [], explanation: failedSources.length ? `${failedSources.length} lector(es) reportan error o degradación.` : 'Todos los lectores consultados respondieron sin error.', warning: failedSources.map((source) => `${source.source}: ${source.error}`).join(' | ') || null },
     { id: 'cognitive-execution', label: 'Runtime cognitivo', value: `${runtimeOperational}/${runtime.agents.length} con ejecución observada`, status: runtime.status === 'operational' ? 'observed' : runtime.status === 'degraded' ? 'degraded' : runtime.status === 'gated' ? 'gated' : 'missing', source: state.cognitiveRuntime.source, observedAt: state.cognitiveRuntime.observedAt, evidenceIds: runtime.eventGraph.recentEvents.filter((event) => event.eventName === 'SFI_AGENT_EXECUTED').map((event) => event.eventId).filter(Boolean), explanation: `${runtimeGated} gated · ${runtimeDegraded} degradados · ${runtimeMissing} missing. Registro y executor no constituyen ejecución.`, warning: state.cognitiveRuntime.error },
-    { id: 'traceability', label: 'Trazabilidad del grafo', value: trace.total === 0 ? 'Sin grafo persistido' : `${trace.traced}/${trace.total} elementos con evidencia o linaje`, status: trace.status, source: state.evidence.source, observedAt: state.evidence.observedAt, evidenceIds: state.evidence.data.nodes.flatMap((node) => node.evidenceIds).concat(state.evidence.data.edges.flatMap((edge) => edge.evidenceIds)), explanation: `${trace.tracedNodes}/${trace.nodes} nodos trazados · ${trace.tracedEdges}/${trace.edges} relaciones trazadas.`, warning: state.evidence.error },
+    { id: 'traceability', label: 'Trazabilidad del grafo', value: trace.total === 0 ? 'Sin grafo persistido' : `${trace.traced}/${trace.total} elementos semánticos con evidencia o linaje`, status: trace.status, source: state.evidence.source, observedAt: state.evidence.observedAt, evidenceIds: state.evidence.data.nodes.flatMap((node) => node.evidenceIds).concat(state.evidence.data.edges.flatMap((edge) => edge.evidenceIds)), explanation: `${trace.tracedNodes}/${trace.nodes} nodos de evidencia/atractor trazados · ${trace.tracedEdges}/${trace.edges} relaciones trazadas · ${trace.graphNodes} nodos totales incluyendo contexto taxonómico.`, warning: state.evidence.error },
     { id: 'execution-capability', label: 'Capacidad ejecutable', value: `${capability.available}/${capability.total} disponibles`, status: capability.status, source: state.execution.source, observedAt: state.execution.observedAt, evidenceIds: [], explanation: `${capability.partial} parciales · ${capability.gated} gated. “Disponible” significa que la ruta/contrato puede recibir una ejecución válida; no implica ejecución reciente.`, warning: state.execution.error },
     { id: 'governance-audit', label: 'Gobernanza y auditoría', value: `${governanceRows} registros persistidos`, status: state.governance.error ? 'degraded' : governanceRows > 0 ? 'observed' : 'missing', source: state.governance.source, observedAt: state.governance.observedAt, evidenceIds: [], explanation: `${state.governance.data.audits.length} auditorías · ${state.governance.data.events.length} eventos · ${state.governance.data.mutations.length} mutaciones.`, warning: state.governance.error },
-    { id: 'evidence-presence', label: 'Evidencia persistida', value: String(evidenceCount), status: state.evidence.error ? 'degraded' : evidenceCount > 0 ? 'observed' : 'missing', source: state.evidence.source, observedAt: state.evidence.observedAt, evidenceIds: state.evidence.data.nodes.flatMap((node) => node.evidenceIds), explanation: `${state.evidence.data.entries.length} entradas ROOT · ${state.evidence.data.ledger.length} registros de ledger. Cantidad no equivale a fuerza probatoria.`, warning: state.evidence.error },
+    { id: 'evidence-presence', label: 'Objetos canónicos de evidencia', value: String(evidenceCount), status: state.evidence.error ? 'degraded' : evidenceCount > 0 ? 'observed' : 'missing', source: state.evidence.source, observedAt: state.evidence.observedAt, evidenceIds, explanation: `${evidenceCount} objetos canónicos · ${state.evidence.data.entries.length} representaciones ROOT · ${state.evidence.data.ledger.length} representaciones ledger. Una misma evidencia persistida en dos tablas se cuenta una sola vez.`, warning: state.evidence.error },
+    { id: 'cognitive-twin-state', label: 'Cognitive Twin', value: state.cognitiveTwin.dataClass === 'missing' ? 'Sin memoria persistida visible' : `${String(state.cognitiveTwin.data.counts.memory ?? 0)} memorias · ${String(state.cognitiveTwin.data.counts.decisions ?? 0)} decisiones · ${String(state.cognitiveTwin.data.counts.runs ?? 0)} runs`, status: state.cognitiveTwin.dataClass, source: state.cognitiveTwin.source, observedAt: state.cognitiveTwin.observedAt, evidenceIds: state.cognitiveTwin.data.memory.flatMap((row) => Array.isArray(row.evidence_refs) ? row.evidence_refs.filter((value): value is string => typeof value === 'string') : []), explanation: 'Estado leído de las tablas canónicas sfi_cognitive_twin_*; no se infiere a partir del Predictive Engine.', warning: state.cognitiveTwin.error },
     { id: 'institutional-attractor', label: 'Atractor institucional', value: attractorCount ? `${attractorCount} persistido(s)` : 'No visible en este lector', status: state.amv.error ? 'degraded' : attractorCount > 0 ? 'observed' : 'missing', source: state.amv.source, observedAt: state.amv.observedAt, evidenceIds: [], explanation: attractorCount ? 'ROOT dispone de atractor persistido para contraste.' : 'ROOT no debe inferir convergencia sin un atractor expuesto por el lector correspondiente.', warning: state.amv.error },
   ];
 
@@ -103,7 +110,7 @@ export function interpretRootInstitution(state: RootStateInput): RootInstitution
     });
   }
   if (runtime.status !== 'operational') divergences.push({ id: 'cognitive-continuity', status: runtime.status === 'missing' ? 'blocking' : 'degraded', title: 'Continuidad cognitiva no demostrada', observation: `${runtimeOperational}/${runtime.agents.length} agentes tienen ejecución observada en la ventana del propio runtime.`, source: state.cognitiveRuntime.source });
-  if (trace.status !== 'observed') divergences.push({ id: 'graph-traceability', status: trace.total === 0 ? 'blocking' : 'degraded', title: 'Trazabilidad incompleta', observation: trace.total === 0 ? 'No existe grafo persistido en este lector.' : `${trace.total - trace.traced}/${trace.total} elementos carecen de evidencia o linaje.`, source: state.evidence.source });
+  if (trace.status !== 'observed') divergences.push({ id: 'graph-traceability', status: trace.total === 0 ? 'blocking' : 'degraded', title: 'Trazabilidad incompleta', observation: trace.total === 0 ? 'No existe grafo persistido en este lector.' : `${trace.total - trace.traced}/${trace.total} elementos semánticos carecen de evidencia o linaje.`, source: state.evidence.source });
   if (capability.status !== 'observed') divergences.push({ id: 'capability-gap', status: capability.available === 0 ? 'blocking' : 'degraded', title: 'Capacidad declarada mayor que capacidad disponible', observation: `${capability.available}/${capability.total} capacidades están disponibles; ${capability.partial} parciales; ${capability.gated} gated.`, source: state.execution.source });
   if (!attractorCount) divergences.push({ id: 'attractor-reader-gap', status: 'open', title: 'Atractor no expuesto por este lector', observation: 'La dirección institucional no debe reconstruirse desde texto de interfaz.', source: state.amv.source });
   if (phi === null) divergences.push({ id: 'institutional-position-gap', status: 'open', title: 'Posición institucional no determinada', observation: 'ROOT no dispone de ΦSFI suficiente en este corte.', source: 'Math Core / sfi_indicator_snapshots' });
@@ -116,8 +123,9 @@ export function interpretRootInstitution(state: RootStateInput): RootInstitution
 
   const narrative = [
     `ROOT recibió ${healthySources.length}/${sources.length} fuentes sin error en este corte.`,
+    `La capa de evidencia distingue ${evidenceCount} objetos canónicos de sus ${state.evidence.data.entries.length + state.evidence.data.ledger.length} representaciones persistidas.`,
     `El runtime cognitivo registra ${runtime.agents.length} agentes y observa ejecución reciente en ${runtimeOperational}; los demás permanecen explícitamente gated, degradados o missing según evidencia persistida.`,
-    trace.total === 0 ? 'El grafo de evidencia no está disponible en este corte.' : `El grafo expone ${trace.nodes} nodos y ${trace.edges} relaciones; ${trace.traced} de ${trace.total} elementos conservan evidencia o linaje explícito.`,
+    trace.total === 0 ? 'El grafo de evidencia no está disponible en este corte.' : `El grafo expone ${trace.graphNodes} nodos totales y ${trace.edges} relaciones; ${trace.traced} de ${trace.total} elementos semánticos conservan evidencia o linaje explícito.`,
     capability.total === 0 ? 'No hay capacidades ejecutables expuestas por el lector de ejecución.' : `El lector de ejecución expone ${capability.total} capacidades: ${capability.available} disponibles, ${capability.partial} parciales y ${capability.gated} gated.`,
     phi === null ? 'La posición ΦSFI permanece no determinada.' : `La posición institucional derivada disponible es ΦSFI ${phi.toFixed(3)}.`,
   ];

--- a/src/lib/root/sovereign/readers/readRootEvidenceGraph.ts
+++ b/src/lib/root/sovereign/readers/readRootEvidenceGraph.ts
@@ -1,10 +1,12 @@
 import 'server-only';
+import { canonicalEvidenceRow, canonicalizeEvidenceRows } from '@/lib/evidence/canonicalEvidence';
 import type { RootEvidenceEdge, RootEvidenceNode, RootRow } from '../rootSovereignState';
 import { dateValue, numberValue, selectRows, source, text } from './readerSupport';
 
 function strings(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && Boolean(item.trim())) : [];
 }
+
 function record(value: unknown): RootRow {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as RootRow : {};
 }
@@ -45,9 +47,6 @@ function edgeFrom(row: RootRow, table: string): RootEvidenceEdge {
 
 function dedupeNodes(primary: RootEvidenceNode[], secondary: RootEvidenceNode[]) {
   const nodes = new Map<string, RootEvidenceNode>();
-  // graph_nodes is the canonical evidence relation index. sfi_graph_nodes is a
-  // secondary institutional topology source. A duplicate must never overwrite
-  // the primary record simply because it was read later.
   for (const node of [...primary, ...secondary]) {
     if (!node.id.trim() || !node.label.trim() || nodes.has(node.id)) continue;
     nodes.set(node.id, node);
@@ -59,8 +58,6 @@ function dedupeEdges(primary: RootEvidenceEdge[], secondary: RootEvidenceEdge[],
   const edges = new Map<string, RootEvidenceEdge>();
   for (const edge of [...primary, ...secondary]) {
     if (!edge.id.trim() || !edge.from.trim() || !edge.to.trim()) continue;
-    // Orphan relations are not evidence graph edges. Keep them in persistence
-    // for forensic cleanup, but never let them enter the active ROOT topology.
     if (!nodeIds.has(edge.from) || !nodeIds.has(edge.to) || edges.has(edge.id)) continue;
     edges.set(edge.id, edge);
   }
@@ -69,14 +66,15 @@ function dedupeEdges(primary: RootEvidenceEdge[], secondary: RootEvidenceEdge[],
 
 export async function readRootEvidenceGraph() {
   const [rootEntries, ledger, graphNodes, graphEdges, sfiNodes, sfiEdges] = await Promise.all([
-    selectRows({ table: 'root_evidence_entries', select: 'id,evidence_hash,actor_id,title,content,evidence_type,target_node_id,payload,epistemic_event_id,created_at', order: 'created_at', limit: 60 }),
-    selectRows({ table: 'sfi_evidence_ledger', select: 'id,case_id,module,evidence_kind,source_name,source_url,private_ref,public_summary,evidence_hash,anonymized,trust_level,trust_score,ldi,public_weight,observed_at,created_at', order: 'observed_at', limit: 60 }),
-    selectRows({ table: 'graph_nodes', select: 'id,node_id,node_key,label,node_type,ontology_type,origin,epistemic_class,confidence,lineage,payload,attributes,created_at,updated_at', order: 'created_at', limit: 220 }),
-    selectRows({ table: 'graph_edges', select: 'id,edge_id,source_node_id,target_node_id,source_node_key,target_node_key,relation,relation_type,weight,w_ij,confidence,lineage,payload,attributes,created_at,updated_at', order: 'created_at', limit: 420 }),
+    selectRows({ table: 'root_evidence_entries', select: 'id,evidence_hash,actor_id,title,content,evidence_type,target_node_id,payload,epistemic_event_id,created_at', order: 'created_at', limit: 500 }),
+    selectRows({ table: 'sfi_evidence_ledger', select: 'id,case_id,module,evidence_kind,source_name,source_url,private_ref,public_summary,evidence_hash,anonymized,trust_level,trust_score,ldi,public_weight,observed_at,created_at', order: 'observed_at', limit: 500 }),
+    selectRows({ table: 'graph_nodes', select: 'id,node_id,node_key,label,node_type,ontology_type,origin,epistemic_class,confidence,lineage,payload,attributes,created_at,updated_at', order: 'created_at', limit: 320 }),
+    selectRows({ table: 'graph_edges', select: 'id,edge_id,source_node_id,target_node_id,source_node_key,target_node_key,relation,relation_type,weight,w_ij,confidence,lineage,payload,attributes,created_at,updated_at', order: 'created_at', limit: 640 }),
     selectRows({ table: 'sfi_graph_nodes', select: 'id,node_key,label,module,node_type,layer,parent_key,description,metrics,evidence_count,private_evidence_count,density,weight,degradation,status,position,visual,created_at,updated_at', order: 'created_at', limit: 220 }),
     selectRows({ table: 'sfi_graph_edges', select: 'id,from_key,to_key,edge_type,weight,evidence_count,degradation,metadata,created_at,updated_at', order: 'created_at', limit: 420 }),
   ]);
 
+  const objects = canonicalizeEvidenceRows(rootEntries.rows, ledger.rows).map((item) => canonicalEvidenceRow(item) as RootRow);
   const primaryNodes = graphNodes.rows.map((item) => nodeFrom(item, 'graph_nodes'));
   const secondaryNodes = sfiNodes.rows.map((item) => nodeFrom(item, 'sfi_graph_nodes'));
   const nodes = dedupeNodes(primaryNodes, secondaryNodes);
@@ -84,12 +82,15 @@ export async function readRootEvidenceGraph() {
   const primaryEdges = graphEdges.rows.map((item) => edgeFrom(item, 'graph_edges'));
   const secondaryEdges = sfiEdges.rows.map((item) => edgeFrom(item, 'sfi_graph_edges'));
   const edges = dedupeEdges(primaryEdges, secondaryEdges, nodeIds);
+  const observedAt = objects.map((item) => dateValue(item.observed_at)).filter((value): value is string => Boolean(value)).sort().at(-1)
+    ?? nodes.map((item) => item.observedAt).filter((value): value is string => Boolean(value)).sort().at(-1)
+    ?? null;
 
   return source(
-    { nodes, edges, entries: rootEntries.rows, ledger: ledger.rows },
-    'persisted evidence graphs',
+    { nodes, edges, objects, entries: rootEntries.rows, ledger: ledger.rows },
+    'canonical evidence objects + persisted evidence graph',
     [rootEntries.error, ledger.error, graphNodes.error, graphEdges.error, sfiNodes.error, sfiEdges.error],
-    nodes.map((item) => item.observedAt).filter(Boolean).sort().at(-1) ?? null,
-    !nodes.length && !rootEntries.rows.length,
+    observedAt,
+    !objects.length && !nodes.length,
   );
 }

--- a/src/lib/root/sovereign/readers/readRootPredictions.ts
+++ b/src/lib/root/sovereign/readers/readRootPredictions.ts
@@ -1,5 +1,32 @@
 import 'server-only';
+import type { RootRow } from '../rootSovereignState';
 import { dateValue, selectRows, source } from './readerSupport';
+
+function text(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : '';
+}
+
+function normalizedPrediction(row: RootRow) {
+  return text(row.prediccion_explicita).replace(/\s+/g, ' ').trim();
+}
+
+function meaningfulLegacyPrediction(row: RootRow) {
+  const prediction = normalizedPrediction(row);
+  if (prediction.length < 24) return false;
+  const normalized = prediction.toLowerCase();
+  if (['x', 'test', 'prueba', 'placeholder', 'n/a', 'na'].includes(normalized)) return false;
+  return true;
+}
+
+function qualifiedLegacyEntries(rows: RootRow[]) {
+  const unique = new Map<string, RootRow>();
+  for (const row of rows) {
+    if (!meaningfulLegacyPrediction(row)) continue;
+    const key = normalizedPrediction(row).toLowerCase();
+    if (!unique.has(key)) unique.set(key, row);
+  }
+  return [...unique.values()];
+}
 
 export async function readRootPredictions() {
   const [models, runs, requests, outcomes, learning, legacy, verifications] = await Promise.all([
@@ -16,15 +43,26 @@ export async function readRootPredictions() {
     selectRows({ table: 'sfi_predictive_evidence_requests', select: 'id,run_id,evidence_key,description,reason,source_candidates,auto_collectible,priority,status,fulfilled_evidence,fulfilled_at,created_at,updated_at', order: 'created_at', limit: 50 }),
     selectRows({ table: 'sfi_predictive_outcomes', select: 'id,run_id,return_window,actual_value,outcome_payload,source_type,source_ref,source_quality,intervention_fidelity,observed_at,evaluation_state,error_payload,created_by,created_at', order: 'observed_at', limit: 50 }),
     selectRows({ table: 'sfi_predictive_learning_events', select: 'id,run_id,outcome_id,model_id,learning_state,error_class,error_analysis,parameter_state_before,parameter_delta,parameter_state_after,quality_weight,amv_reflection,rollback_of,created_by,created_at', order: 'created_at', limit: 50 }),
-    selectRows({ table: 'sfi_prediction_entries', select: 'id,hypothesis_id,case_id,case_label,prediccion_explicita,probabilidad_estimativa,fenotipo_estimado,evidence_state,estado_observacion,prediction_registered_at,created_at,updated_at', order: 'created_at', limit: 50 }),
-    selectRows({ table: 'sfi_prediction_verifications', select: 'id,prediction_entry_id,hypothesis_id,return_window,verification_state,evaluation_result,verification_rule,ground_truth_source_type,ground_truth_source_url,source_checked_at,source_value,evaluation_confidence,evidence_state_after_verification,verification_notes,verified_by,created_at,updated_at', order: 'created_at', limit: 50 }),
+    selectRows({ table: 'sfi_prediction_entries', select: 'id,hypothesis_id,case_id,case_label,prediccion_explicita,probabilidad_estimativa,fenotipo_estimado,evidence_state,estado_observacion,prediction_registered_at,created_at,updated_at', order: 'created_at', limit: 100 }),
+    selectRows({ table: 'sfi_prediction_verifications', select: 'id,prediction_entry_id,hypothesis_id,return_window,verification_state,evaluation_result,verification_rule,ground_truth_source_type,ground_truth_source_url,source_checked_at,source_value,evaluation_confidence,evidence_state_after_verification,verification_notes,verified_by,created_at,updated_at', order: 'created_at', limit: 100 }),
   ]);
-  const observedAt = dateValue(runs.rows[0]?.updated_at ?? runs.rows[0]?.created_at ?? models.rows[0]?.updated_at ?? legacy.rows[0]?.updated_at ?? legacy.rows[0]?.created_at);
+
+  const qualifiedLegacy = qualifiedLegacyEntries(legacy.rows);
+  const observedAt = dateValue(runs.rows[0]?.updated_at ?? runs.rows[0]?.created_at ?? models.rows[0]?.updated_at ?? qualifiedLegacy[0]?.updated_at ?? qualifiedLegacy[0]?.created_at);
   return source(
-    { models: models.rows, runs: runs.rows, evidenceRequests: requests.rows, outcomes: outcomes.rows, learningEvents: learning.rows, legacyEntries: legacy.rows, legacyVerifications: verifications.rows },
-    'predictive engine + legacy registry',
+    {
+      models: models.rows,
+      runs: runs.rows,
+      evidenceRequests: requests.rows,
+      outcomes: outcomes.rows,
+      learningEvents: learning.rows,
+      legacyEntries: qualifiedLegacy,
+      legacyVerifications: verifications.rows,
+      legacyDiscarded: Math.max(0, legacy.rows.length - qualifiedLegacy.length),
+    },
+    'predictive engine + qualified legacy registry',
     [models.error, runs.error, requests.error, outcomes.error, learning.error, legacy.error, verifications.error],
     observedAt,
-    !models.rows.length && !legacy.rows.length,
+    !models.rows.length && !qualifiedLegacy.length,
   );
 }

--- a/src/lib/root/sovereign/rootSovereignAdapter.ts
+++ b/src/lib/root/sovereign/rootSovereignAdapter.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import { readCognitiveTwinState } from '@/lib/cognitive-twin/readState';
 import { readRootAgents } from './readers/readRootAgents';
 import { readRootAmv } from './readers/readRootAmv';
 import { readRootCognitiveRuntime } from './readers/readRootCognitiveRuntime';
@@ -11,7 +12,7 @@ import { readRootSystemState } from './readers/readRootSystemState';
 import { readRootTelemetry } from './readers/readRootTelemetry';
 import { dateValue, row, text } from './readers/readerSupport';
 import { interpretRootInstitution } from './institutionalInterpretation';
-import { observedValue, type RootSovereignState, type RootSource, type RootSystemItem } from './rootSovereignState';
+import { observedValue, type RootCognitiveTwinData, type RootRow, type RootSovereignState, type RootSource, type RootSystemItem } from './rootSovereignState';
 
 function item(input: {
   id: string;
@@ -31,12 +32,54 @@ function item(input: {
     openItems: observedValue({ value: input.openItems, source: input.source, observedAt: input.observedAt, explanation: 'Conteo directo de filas abiertas; no es un porcentaje.', warning: input.warning, status: input.warning ? 'degraded' : input.openItems === null ? 'missing' : 'observed' }),
   };
 }
-function warnings(sources: Array<RootSource<unknown>>) { return sources.flatMap((entry) => entry.error ? entry.error.split(' | ') : []); }
+
+function warnings(sources: Array<RootSource<unknown>>) {
+  return sources.flatMap((entry) => entry.error ? entry.error.split(' | ') : []);
+}
+
+function latestDate(rows: RootRow[]) {
+  return rows
+    .map((entry) => dateValue(entry.updated_at ?? entry.executed_at ?? entry.finished_at ?? entry.created_at))
+    .filter((value): value is string => Boolean(value))
+    .sort((a, b) => Date.parse(b) - Date.parse(a))[0] ?? null;
+}
 
 export async function readRootSovereignState(): Promise<RootSovereignState> {
-  const [system, governance, agents, predictions, amv, evidence, execution, mihmMatrix, telemetry, cognitiveRuntime] = await Promise.all([
-    readRootSystemState(), readRootGovernanceQueue(), readRootAgents(), readRootPredictions(), readRootAmv(), readRootEvidenceGraph(), readRootExecution(), readRootMihmMatrix(), readRootTelemetry(), readRootCognitiveRuntime(),
+  const [system, governance, agents, predictions, amv, evidence, execution, mihmMatrix, telemetry, cognitiveRuntime, cognitiveTwinRaw] = await Promise.all([
+    readRootSystemState(),
+    readRootGovernanceQueue(),
+    readRootAgents(),
+    readRootPredictions(),
+    readRootAmv(),
+    readRootEvidenceGraph(),
+    readRootExecution(),
+    readRootMihmMatrix(),
+    readRootTelemetry(),
+    readRootCognitiveRuntime(),
+    readCognitiveTwinState(),
   ]);
+
+  const cognitiveMemory = cognitiveTwinRaw.recentMemory as unknown as RootRow[];
+  const cognitiveDecisions = cognitiveTwinRaw.recentDecisions as unknown as RootRow[];
+  const cognitiveRuns = cognitiveTwinRaw.recentRuns as unknown as RootRow[];
+  const cognitiveEvaluations = cognitiveTwinRaw.recentEvaluations as unknown as RootRow[];
+  const cognitiveTwinError = cognitiveTwinRaw.errors.length ? cognitiveTwinRaw.errors.join(' | ') : null;
+  const cognitiveTwinCount = [cognitiveTwinRaw.counts.memory, cognitiveTwinRaw.counts.decisions, cognitiveTwinRaw.counts.runs]
+    .reduce((sum, value) => sum + (typeof value === 'number' ? value : 0), 0);
+  const cognitiveTwin: RootSource<RootCognitiveTwinData> = {
+    data: {
+      implementation: cognitiveTwinRaw.implementation as unknown as RootRow,
+      counts: cognitiveTwinRaw.counts as unknown as RootRow,
+      memory: cognitiveMemory,
+      decisions: cognitiveDecisions,
+      runs: cognitiveRuns,
+      evaluations: cognitiveEvaluations,
+    },
+    source: 'sfi_cognitive_twin_*',
+    dataClass: cognitiveTwinError ? 'degraded' : cognitiveTwinCount > 0 ? 'observed' : 'missing',
+    observedAt: latestDate([...cognitiveMemory, ...cognitiveDecisions, ...cognitiveRuns, ...cognitiveEvaluations]),
+    error: cognitiveTwinError,
+  };
 
   const governanceRuntime = row(system.data.governance);
   const openMutations = governance.error ? null : governance.data.mutations.filter((entry) => !['closed', 'executed'].includes(text(entry.status).toLowerCase())).length;
@@ -46,11 +89,12 @@ export async function readRootSovereignState(): Promise<RootSovereignState> {
 
   const matrix: RootSystemItem[] = [
     item({ id: 'governance', label: 'Governance', state: text(governanceRuntime.status, '') || null, source: 'governanceRuntime', observedAt: dateValue(governanceRuntime.acpLastSeenAt), openItems: openProposals === null || openMutations === null ? null : openProposals + openMutations, warning: text(governanceRuntime.warning, '') || governance.error, explanation: 'Estado ACP observado por el runtime de gobernanza.' }),
-    item({ id: 'neural-graph', label: 'Neural Graph', state: evidence.data.nodes.length ? 'observed' : null, source: evidence.source, observedAt: evidence.observedAt, openItems: evidence.error ? null : evidence.data.nodes.length, warning: evidence.error, explanation: 'Nodos y relaciones persistidos. La representación visual no constituye evidencia adicional.' }),
+    item({ id: 'neural-graph', label: 'Neural Graph', state: evidence.data.nodes.length && evidence.data.edges.length ? 'observed' : null, source: evidence.source, observedAt: evidence.observedAt, openItems: evidence.error ? null : evidence.data.nodes.length, warning: evidence.error || (evidence.data.nodes.length > 1 && !evidence.data.edges.length ? 'graph_nodes_without_relations' : null), explanation: 'Proyección relacional reconstruible sobre objetos canónicos de evidencia. Nodos sin relaciones no constituyen un grafo funcional.' }),
     item({ id: 'amv', label: 'AMV', state: amv.data.memories.length || amv.data.attractors.length || amv.data.ejectors.length ? 'observed' : null, source: amv.source, observedAt: amv.observedAt, openItems: amv.error ? null : amv.data.memories.length + amv.data.attractors.length + amv.data.ejectors.length, warning: amv.error, explanation: 'Memoria AMV, atractores y eyectores persistidos. Ingesta no equivale a verificación.' }),
-    item({ id: 'predictive', label: 'Predictive Engine', state: predictiveState, source: 'sfi_predictive_*', observedAt: predictions.observedAt, openItems: openPredictions, warning: predictions.error, explanation: 'Motor predictivo persistido, separado del registro manual legacy.' }),
+    item({ id: 'predictive', label: 'Predictive Engine', state: predictiveState, source: 'sfi_predictive_*', observedAt: predictions.observedAt, openItems: openPredictions, warning: predictions.error, explanation: 'Motor predictivo persistido, separado del registro manual legacy y filtrado de placeholders no predictivos.' }),
     item({ id: 'cognitive-runtime', label: 'Cognitive Runtime', state: cognitiveRuntime.data.status, source: cognitiveRuntime.source, observedAt: cognitiveRuntime.observedAt, openItems: cognitiveRuntime.data.contract.registeredAgents, warning: cognitiveRuntime.error, explanation: 'Registro, executor, ejecución observada y autoridad permanecen separados.' }),
-    item({ id: 'evidence', label: 'Evidence', state: evidence.data.entries.length || evidence.data.ledger.length ? 'observed' : null, source: evidence.source, observedAt: evidence.observedAt, openItems: evidence.error ? null : evidence.data.entries.length + evidence.data.ledger.length, warning: evidence.error, explanation: 'Evidencia persistida en ledger ROOT/SFI.' }),
+    item({ id: 'cognitive-twin', label: 'Cognitive Twin', state: cognitiveTwin.dataClass === 'observed' ? 'observed' : null, source: cognitiveTwin.source, observedAt: cognitiveTwin.observedAt, openItems: cognitiveTwin.error ? null : cognitiveTwinCount, warning: cognitiveTwin.error, explanation: 'Memoria, decisiones, evaluaciones y ejecuciones del Cognitive Twin. No se sustituyen con hipótesis del Predictive Engine.' }),
+    item({ id: 'evidence', label: 'Evidence', state: evidence.data.objects.length ? 'observed' : null, source: evidence.source, observedAt: evidence.observedAt, openItems: evidence.error ? null : evidence.data.objects.length, warning: evidence.error, explanation: 'Conteo de objetos canónicos de evidencia. Duplicar su persistencia en ROOT y ledger no duplica evidencia.' }),
     item({ id: 'cycle', label: 'ROOT Audited Activity', state: execution.data.recentActions.length ? 'observed' : null, source: execution.source, observedAt: execution.observedAt, openItems: null, warning: execution.error, explanation: 'Actividad ROOT auditada. No afirma por sí misma que un ciclo esté ejecutándose.' }),
     ...mihmMatrix,
   ];
@@ -67,7 +111,8 @@ export async function readRootSovereignState(): Promise<RootSovereignState> {
     execution,
     telemetry,
     cognitiveRuntime,
-    warnings: [...new Set(warnings([system, governance, agents, predictions, amv, evidence, execution, cognitiveRuntime]))],
+    cognitiveTwin,
+    warnings: [...new Set(warnings([system, governance, agents, predictions, amv, evidence, execution, cognitiveRuntime, cognitiveTwin]))],
   };
   const interpretation = interpretRootInstitution(base);
   return { ...base, interpretation };

--- a/src/lib/root/sovereign/rootSovereignAdapter.ts
+++ b/src/lib/root/sovereign/rootSovereignAdapter.ts
@@ -29,7 +29,7 @@ function item(input: {
     id: input.id,
     label: input.label,
     state: observedValue({ value: input.state, source: input.source, observedAt: input.observedAt, confidence: input.confidence, explanation: input.explanation, warning: input.warning, status: input.warning ? 'degraded' : input.state ? 'observed' : 'missing' }),
-    openItems: observedValue({ value: input.openItems, source: input.source, observedAt: input.observedAt, explanation: 'Conteo directo de filas abiertas; no es un porcentaje.', warning: input.warning, status: input.warning ? 'degraded' : input.openItems === null ? 'missing' : 'observed' }),
+    openItems: observedValue({ value: input.openItems, source: input.source, observedAt: input.observedAt, explanation: 'Conteo directo de registros para esta superficie; no es un porcentaje.', warning: input.warning, status: input.warning ? 'degraded' : input.openItems === null ? 'missing' : 'observed' }),
   };
 }
 
@@ -42,6 +42,10 @@ function latestDate(rows: RootRow[]) {
     .map((entry) => dateValue(entry.updated_at ?? entry.executed_at ?? entry.finished_at ?? entry.created_at))
     .filter((value): value is string => Boolean(value))
     .sort((a, b) => Date.parse(b) - Date.parse(a))[0] ?? null;
+}
+
+function numericCount(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
 export async function readRootSovereignState(): Promise<RootSovereignState> {
@@ -64,8 +68,10 @@ export async function readRootSovereignState(): Promise<RootSovereignState> {
   const cognitiveRuns = cognitiveTwinRaw.recentRuns as unknown as RootRow[];
   const cognitiveEvaluations = cognitiveTwinRaw.recentEvaluations as unknown as RootRow[];
   const cognitiveTwinError = cognitiveTwinRaw.errors.length ? cognitiveTwinRaw.errors.join(' | ') : null;
-  const cognitiveTwinCount = [cognitiveTwinRaw.counts.memory, cognitiveTwinRaw.counts.decisions, cognitiveTwinRaw.counts.runs]
-    .reduce((sum, value) => sum + (typeof value === 'number' ? value : 0), 0);
+  const cognitiveTwinCount = numericCount(cognitiveTwinRaw.counts.memory)
+    + numericCount(cognitiveTwinRaw.counts.decisions)
+    + numericCount(cognitiveTwinRaw.counts.runs)
+    + numericCount(cognitiveTwinRaw.counts.evaluations);
   const cognitiveTwin: RootSource<RootCognitiveTwinData> = {
     data: {
       implementation: cognitiveTwinRaw.implementation as unknown as RootRow,

--- a/src/lib/root/sovereign/rootSovereignState.ts
+++ b/src/lib/root/sovereign/rootSovereignState.ts
@@ -79,6 +79,15 @@ export type RootExecutionCapability = {
   description: string;
 };
 
+export type RootCognitiveTwinData = {
+  implementation: RootRow;
+  counts: RootRow;
+  memory: RootRow[];
+  decisions: RootRow[];
+  runs: RootRow[];
+  evaluations: RootRow[];
+};
+
 export type RootSovereignState = {
   generatedAt: string;
   system: RootSource<{
@@ -98,12 +107,14 @@ export type RootSovereignState = {
     learningEvents: RootRow[];
     legacyEntries: RootRow[];
     legacyVerifications: RootRow[];
+    legacyDiscarded: number;
   }>;
   amv: RootSource<{ memories: RootRow[]; attractors: RootRow[]; ejectors: RootRow[] }>;
-  evidence: RootSource<{ nodes: RootEvidenceNode[]; edges: RootEvidenceEdge[]; entries: RootRow[]; ledger: RootRow[] }>;
+  evidence: RootSource<{ nodes: RootEvidenceNode[]; edges: RootEvidenceEdge[]; objects: RootRow[]; entries: RootRow[]; ledger: RootRow[] }>;
   execution: RootSource<{ capabilities: RootExecutionCapability[]; recentActions: RootRow[] }>;
   telemetry: RootSource<TelemetryData>;
   cognitiveRuntime: RootSource<SfiCognitiveRuntimeSnapshot>;
+  cognitiveTwin: RootSource<RootCognitiveTwinData>;
   interpretation: RootInstitutionalInterpretation;
   warnings: string[];
 };


### PR DESCRIPTION
## Purpose

Repair the active ROOT epistemic surface after the evidence-ledger cleanup and graph reset.

## Structural changes

- Enforce `1 evidence_hash = 1 canonical evidence object` across `root_evidence_entries` and `sfi_evidence_ledger`.
- Rebuild `graph_nodes` / `graph_edges` as a derived projection instead of modeling database persistence surfaces as knowledge.
- Keep source URLs and persistence table references as provenance attributes rather than graph nodes.
- Replace arbitrary same-module evidence-to-evidence links with explicit module/case context nodes and declared relations.
- Make graph health degraded when nodes exist without relations.
- Count canonical evidence objects in ROOT instead of `ROOT rows + ledger rows`.
- Include the actual Cognitive Twin source in ROOT source health and institutional interpretation.
- Make the Cognitive Twin panel read `sfi_cognitive_twin_*` memory/decisions/runs rather than Predictive Engine hypotheses.
- Filter placeholder and exact-duplicate legacy prediction rows from the active predictive surface without deleting forensic history.
- Extend reconciliation audit output with canonical object and projection replacement counts.

## Database safety

This PR does **not** delete source evidence. The reconciler only replaces graph nodes it manages and reconstructs them from preserved primary evidence.

The live graph is currently intentionally empty after cleanup. After merge/deploy, reconciliation remains an explicit sovereign action; reading ROOT does not mutate the graph.

## QA

- Added canonical evidence invariant tests.
- Added focused QA script and acceptance criteria.
- Documented post-merge reconciliation procedure.

## Expected post-deploy sequence

1. Deploy merged code.
2. Open ROOT.
3. Verify canonical evidence object count independently from N/E.
4. Run **RECONCILIAR GRAFO PERSISTIDO** once.
5. Verify object count remains stable, graph gains explicit relations, source URLs do not become cognitive nodes, Cognitive Twin shows its real state, and placeholder predictions are absent from active display.