### PR TITLE
ROOT runtime truth, report inbox and recurring institutional reports

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Verify ROOT graph and navigation convergence
         run: npx tsx scripts/qa-sfi-root-graph-navigation.ts
 
+      - name: Verify ROOT reports and runtime truth
+        run: npx tsx scripts/qa-sfi-root-reports-runtime.ts
+
       - name: Verify canonical evidence identity
         run: node --import tsx --test src/lib/evidence/canonicalEvidence.test.ts
 

--- a/scripts/qa-sfi-root-reports-runtime.ts
+++ b/scripts/qa-sfi-root-reports-runtime.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+function read(path: string) { return readFileSync(path, 'utf8'); }
+
+const proxy = read('src/proxy.ts');
+assert.match(proxy, /X-Frame-Options', permitsRootInternalFrame\(pathname\) \? 'SAMEORIGIN' : 'DENY'/, 'ROOT-owned framed surfaces must be SAMEORIGIN while all other paths remain DENY');
+assert.match(proxy, /\/root\/reports/, 'Report surface must be explicitly allowed as an internal ROOT frame');
+assert.match(proxy, /\/root\/agents\/passports/, 'Agent passports must be explicitly allowed as an internal ROOT frame');
+
+const reportsUi = read('src/components/root/reports/RootReportsConsole.tsx');
+assert.match(reportsUi, /BUSCAR EN REPORTES YA GENERADOS/, 'Report Center must expose search over existing reports');
+assert.doesNotMatch(reportsUi, /api\/root\/agentic\/report[^/]/, 'Report Center must not invoke manual report generation');
+assert.doesNotMatch(reportsUi, /¿Qué quieres que SFI te explique\?/, 'Legacy prompt-first Report Center must not return');
+
+const scheduled = read('src/lib/reports/scheduledAgentReports.ts');
+for (const lane of ['world_daily', 'world_weekly', 'internal_daily', 'prospect_weekly', 'attractor_daily']) {
+  assert.ok(scheduled.includes(`'${lane}'`), `scheduled lane missing: ${lane}`);
+}
+assert.match(scheduled, /continuity-report-cron/, 'Scheduled reports must reuse the existing continuity-report cron');
+assert.match(scheduled, /status: input\.output\.ok && !input\.output\.provider\.startsWith\('degraded:'\)/, 'Degraded LLM fallback must not persist as READY');
+
+const passports = read('src/lib/sfi/cognitive-runtime/agentPassports.ts');
+for (const field of ['reads:', 'writes:', 'executes:', 'executionEvidence:']) {
+  assert.ok(passports.includes(field), `agent passport truth field missing: ${field}`);
+}
+const passportUi = read('src/components/root/agents/AgentPassportsConsole.tsx');
+for (const label of ['LEE', 'ESCRIBE', 'EJECUTA', 'EVIDENCIA DE EJECUCIÓN']) {
+  assert.ok(passportUi.includes(label), `agent passport visible section missing: ${label}`);
+}
+
+const vercel = read('vercel.json');
+const parsed = JSON.parse(vercel) as { crons?: Array<{ path?: string }> };
+assert.equal(parsed.crons?.filter((item) => item.path === '/api/cron/continuity-report').length, 1, 'Must reuse exactly one existing continuity-report cron');
+
+console.log(JSON.stringify({
+  ok: true,
+  invariants: [
+    'owned ROOT frames SAMEORIGIN; other paths DENY',
+    'Report Center reads/searches existing reports only',
+    'five recurring report lanes reuse existing cron',
+    'degraded provider output is not READY',
+    'agent passports visibly declare reads/writes/executes/evidence',
+  ],
+}, null, 2));

--- a/src/app/api/cron/continuity-report/route.ts
+++ b/src/app/api/cron/continuity-report/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createDailyContinuityReport } from '@/lib/continuity/runtime';
+import { runScheduledAgentReportCycle } from '@/lib/reports/scheduledAgentReports';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+export const maxDuration = 120;
 
 function bearer(request: NextRequest) {
   const match = (request.headers.get('authorization') ?? '').match(/^Bearer\s+(.+)$/i);
@@ -16,7 +18,20 @@ export async function GET(request: NextRequest) {
   }
   try {
     const report = await createDailyContinuityReport();
-    return NextResponse.json({ ok: true, report });
+    const scheduledReports = await runScheduledAgentReportCycle().catch((error) => ({
+      ok: false,
+      generated: 0,
+      skipped: 0,
+      failed: 1,
+      results: [],
+      error: error instanceof Error ? error.message : String(error),
+    }));
+    return NextResponse.json({
+      ok: true,
+      report,
+      scheduledReports,
+      schedulingRule: 'Uses the existing continuity-report cron. No additional Vercel cron invocation is introduced.',
+    });
   } catch (error) {
     return NextResponse.json({ ok: false, error: 'continuity_report_failed', details: error instanceof Error ? error.message : String(error) }, { status: 500 });
   }

--- a/src/app/api/root/agentic/report/health/route.ts
+++ b/src/app/api/root/agentic/report/health/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { requireRootViewer } from '@/lib/root/server';
+import { readRootReportHealth } from '@/lib/reports/rootReportInbox';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const gate = await requireRootViewer('agentic.report.health');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+  try {
+    return NextResponse.json({ ok: true, health: await readRootReportHealth() }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: 'report_health_failed', details: error instanceof Error ? error.message : String(error) }, { status: 503 });
+  }
+}

--- a/src/app/api/root/agentic/report/route.ts
+++ b/src/app/api/root/agentic/report/route.ts
@@ -48,32 +48,28 @@ export async function POST(request: Request) {
   const ifnorm = body.ifnorm && typeof body.ifnorm === 'object' && !Array.isArray(body.ifnorm)
     ? body.ifnorm as Record<string, unknown>
     : null;
-  const result = await runReportAgent({
-    type,
-    subject,
-    ifnorm: ifnorm as never,
-  });
+  const result = await runReportAgent({ type, subject, ifnorm: ifnorm as never });
   const finishedAt = new Date().toISOString();
+  const providerDegraded = result.provider.startsWith('degraded:');
+  const persistedStatus = result.ok && !providerDegraded ? 'READY' : 'BLOCKED';
+  const limitations = providerDegraded
+    ? [...new Set([...(result.warnings ?? []), 'LLM provider degraded/manual fallback: report persisted for inspection but not declared READY.'])]
+    : result.warnings ?? [];
 
   const persisted = await gate.ctx.service
     .from('sfi_cognitive_twin_runs')
     .insert({
       task_id: `report:${type}:${Date.now()}`,
-      contract_version: 'report-agent-v1',
+      contract_version: 'report-agent-v1.1-truthful-provider-state',
       provider: result.provider || null,
       model: null,
       role: 'report_agent',
-      status: result.ok ? 'READY' : 'BLOCKED',
+      status: persistedStatus,
       objective: subject ? `${type} · ${subject}` : type,
-      input_snapshot: {
-        reportType: type,
-        subject: subject ?? null,
-        ifnorm,
-        requestedBy: gate.ctx.user.id,
-      },
+      input_snapshot: { reportType: type, subject: subject ?? null, ifnorm, requestedBy: gate.ctx.user.id },
       output_envelope: result,
       evidence_refs: result.evidence ?? [],
-      limitations: result.warnings ?? [],
+      limitations,
       started_at: startedAt,
       finished_at: finishedAt,
     })
@@ -81,12 +77,7 @@ export async function POST(request: Request) {
     .single();
 
   if (persisted.error) {
-    return NextResponse.json({
-      ok: false,
-      error: 'agent_report_persistence_failed',
-      details: persisted.error.message,
-      report: result,
-    }, { status: 500 });
+    return NextResponse.json({ ok: false, error: 'agent_report_persistence_failed', details: persisted.error.message, report: result }, { status: 500 });
   }
 
   const audit = await auditRootAction({
@@ -96,11 +87,13 @@ export async function POST(request: Request) {
     payload: {
       subject: subject ?? null,
       ifnormEntity: typeof ifnorm?.entity_name === 'string' ? ifnorm.entity_name : null,
-      ok: result.ok,
+      agentResultOk: result.ok,
+      persistedStatus,
+      provider: result.provider,
       reportRunId: persisted.data.id,
     },
     request,
   });
   if (!audit.ok) return NextResponse.json(audit, { status: 500 });
-  return NextResponse.json({ ...result, reportRun: persisted.data, audit });
+  return NextResponse.json({ ...result, reportRun: persisted.data, audit, persistedStatus });
 }

--- a/src/app/api/root/agents/health/route.ts
+++ b/src/app/api/root/agents/health/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { requireRootViewer } from '@/lib/root/server';
+import { readAgentPassports } from '@/lib/sfi/cognitive-runtime/agentPassports';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const gate = await requireRootViewer('root.agents.health');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+  const data = await readAgentPassports();
+  return NextResponse.json({
+    ok: true,
+    generatedAt: data.generatedAt,
+    runtimeStatus: data.runtimeStatus,
+    counts: data.counts,
+    degraded: data.passports.filter((item) => item.lifecycle === 'DEGRADED').map((item) => ({ id: item.id, namespace: item.namespace, missing: item.missingTables, warnings: item.warnings })),
+    missing: data.passports.filter((item) => item.lifecycle === 'MISSING').map((item) => ({ id: item.id, namespace: item.namespace, missing: item.missingTables, warnings: item.warnings })),
+  }, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/src/app/api/root/reports/route.ts
+++ b/src/app/api/root/reports/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+import { requireRootViewer } from '@/lib/root/server';
+import { readRootReportHealth, readRootReportInbox } from '@/lib/reports/rootReportInbox';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const gate = await requireRootViewer('root.reports.read');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  try {
+    const inbox = await readRootReportInbox();
+    const health = await readRootReportHealth(inbox);
+    return NextResponse.json({ ok: true, inbox, health }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: 'root_reports_read_failed',
+      details: error instanceof Error ? error.message : String(error),
+    }, { status: 503 });
+  }
+}

--- a/src/app/root/reports/page.tsx
+++ b/src/app/root/reports/page.tsx
@@ -1,4 +1,5 @@
 import { requireRootObserverPage } from '@/lib/root/server';
+import { readRootReportHealth, readRootReportInbox } from '@/lib/reports/rootReportInbox';
 import { RootReportsConsole } from '@/components/root/reports/RootReportsConsole';
 
 export const dynamic = 'force-dynamic';
@@ -6,16 +7,12 @@ export const metadata = { robots: { index: false, follow: false, nocache: true }
 
 export default async function RootReportsPage() {
   const ctx = await requireRootObserverPage('/root/reports');
-  const reports = await ctx.service
-    .from('sfi_cognitive_twin_runs')
-    .select('id,task_id,status,objective,input_snapshot,output_envelope,evidence_refs,limitations,provider,model,started_at,finished_at,created_at')
-    .eq('role', 'report_agent')
-    .order('created_at', { ascending: false })
-    .limit(100);
+  const inbox = await readRootReportInbox();
+  const health = await readRootReportHealth(inbox);
 
   return <RootReportsConsole
-    initialReports={(reports.data ?? []) as Record<string, unknown>[]}
-    canGenerate={ctx.isRoot}
+    initialInbox={inbox}
+    initialHealth={health}
     actorLabel={ctx.profile?.alias || ctx.user?.email || 'ROOT'}
   />;
 }

--- a/src/components/root/agents/AgentPassportsConsole.tsx
+++ b/src/components/root/agents/AgentPassportsConsole.tsx
@@ -1,33 +1,42 @@
+import Link from 'next/link';
 import type { SfiAgentPassport } from '@/lib/sfi/cognitive-runtime/agentPassports';
-import { HumanReadableRecord } from '@/components/shared/HumanReadableRecord';
 
 export function AgentPassportsConsole({ data }: { data: { generatedAt: string; runtimeStatus: string; counts: Record<string, number>; passports: SfiAgentPassport[] } }) {
   return (
     <main style={{ minHeight: '100vh', background: '#070706', color: '#eee7d7', padding: 28, fontFamily: 'ui-monospace,SFMono-Regular,Menlo,monospace' }}>
-      <header style={{ borderBottom: '1px solid #6c5a2d', paddingBottom: 18 }}>
-        <span style={{ color: '#bba365', fontSize: 11, letterSpacing: '.16em' }}>SFI · ROOT · AGENT AUTHORITY</span>
-        <h1 style={{ margin: '7px 0' }}>PASAPORTES DE AGENTES</h1>
-        <p style={{ color: '#958c7b', maxWidth: 980 }}>Cada pasaporte se genera desde el contrato vigente, el executor enlazado, las fuentes disponibles y las ejecuciones persistidas. Tener archivo o contrato no equivale a estar operativo.</p>
+      <header style={{ borderBottom: '1px solid #6c5a2d', paddingBottom: 18, display: 'flex', justifyContent: 'space-between', gap: 18, alignItems: 'flex-start' }}>
+        <div>
+          <span style={{ color: '#bba365', fontSize: 11, letterSpacing: '.16em' }}>SFI · ROOT · AGENT AUTHORITY</span>
+          <h1 style={{ margin: '7px 0' }}>PASAPORTES DE AGENTES</h1>
+          <p style={{ color: '#958c7b', maxWidth: 1040 }}>Esta vista no confunde registro con operación. Cada pasaporte declara explícitamente qué lee, qué escribe, qué ejecuta y qué evidencia persistida demuestra su ejecución. Una fuente faltante degrada el contrato; una tabla vacía no se convierte en actividad ficticia.</p>
+        </div>
+        <Link href="/root" style={{ color: '#c9ad62', textDecoration: 'none', border: '1px solid #4b4024', padding: '8px 10px', fontSize: 10 }}>VOLVER A ROOT</Link>
       </header>
-      <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(180px,1fr))', gap: 10, margin: '16px 0' }}>
+      <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(160px,1fr))', gap: 10, margin: '16px 0' }}>
         {Object.entries(data.counts).map(([key, value]) => <article key={key} style={card}><small style={muted}>{key.toUpperCase()}</small><strong style={{ fontSize: 24, color: '#d8c488' }}>{value}</strong></article>)}
       </section>
       <section style={{ display: 'grid', gap: 10 }}>
         {data.passports.map((passport) => (
-          <article key={passport.id} style={card}>
+          <article key={`${passport.namespace}:${passport.id}`} style={card}>
             <div style={{ display: 'flex', justifyContent: 'space-between', gap: 14, alignItems: 'baseline', flexWrap: 'wrap' }}>
-              <div><small style={muted}>{passport.id} · {passport.layer} · {passport.authorityLevel}</small><h2 style={{ margin: '5px 0', fontSize: 16 }}>{passport.name}</h2></div>
-              <strong style={{ color: passport.lifecycle === 'OPERATIONAL' ? '#8fba92' : passport.lifecycle === 'MISSING' ? '#d27e7e' : '#d8b768' }}>{passport.lifecycle}</strong>
+              <div><small style={muted}>{passport.namespace.toUpperCase()} · {passport.id} · {passport.layer} · {passport.authorityLevel}</small><h2 style={{ margin: '5px 0', fontSize: 16 }}>{passport.name}</h2></div>
+              <strong style={{ color: passport.lifecycle === 'OPERATIONAL' ? '#8fba92' : passport.lifecycle === 'MISSING' ? '#d27e7e' : passport.lifecycle === 'DEGRADED' ? '#d58a72' : '#d8b768' }}>{passport.lifecycle}</strong>
             </div>
             <p style={{ color: '#b5ad9c', lineHeight: 1.6, fontSize: 12 }}>{passport.purpose}</p>
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(180px,1fr))', gap: 8 }}>
               <Metric label="Executor enlazado" value={passport.executorBound ? 'Sí' : 'No'} />
               <Metric label="Última ejecución" value={passport.latestExecutionAt ?? 'No observada'} />
-              <Metric label="Fuentes disponibles" value={`${passport.observedTables.length}/${passport.sourceTables.length}`} />
-              <Metric label="Aprobación humana" value={passport.humanApprovalRequired ? 'Requerida' : 'No para análisis interno'} />
+              <Metric label="Fuentes declaradas disponibles" value={`${passport.observedTables.length}/${passport.sourceTables.length}`} />
+              <Metric label="Aprobación humana" value={passport.humanApprovalRequired ? 'Requerida para acción gobernada' : 'No para análisis interno'} />
             </div>
-            {passport.warnings.length ? <p style={{ ...muted, color: '#caa176' }}>{passport.warnings.join(' · ')}</p> : null}
-            <HumanReadableRecord value={passport} title="Pasaporte completo" maxFields={14} />
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(260px,1fr))', gap: 9, marginTop: 12 }}>
+              <ContractList label="LEE" values={passport.reads} empty="Ninguna lectura declarada" />
+              <ContractList label="ESCRIBE" values={passport.writes} empty="Ninguna escritura declarada" />
+              <ContractList label="EJECUTA" values={passport.executes} empty="Ningún executor declarado" />
+              <ContractList label="EVIDENCIA DE EJECUCIÓN" values={passport.executionEvidence} empty="Sin ejecución persistida atribuible" />
+            </div>
+            {passport.missingTables.length ? <ContractList label="DEPENDENCIAS NO DISPONIBLES" values={passport.missingTables} empty="" bad /> : null}
+            {passport.warnings.length ? <p style={{ ...muted, color: '#caa176', marginTop: 12 }}>{passport.warnings.join(' · ')}</p> : null}
           </article>
         ))}
       </section>
@@ -37,6 +46,9 @@ export function AgentPassportsConsole({ data }: { data: { generatedAt: string; r
 
 function Metric({ label, value }: { label: string; value: string }) {
   return <div style={{ borderTop: '1px solid #29251b', paddingTop: 7 }}><small style={muted}>{label}</small><div style={{ fontSize: 11, marginTop: 4 }}>{value}</div></div>;
+}
+function ContractList({ label, values, empty, bad = false }: { label: string; values: string[]; empty: string; bad?: boolean }) {
+  return <div style={{ border: `1px solid ${bad ? '#5f3027' : '#29251b'}`, background: bad ? '#120c09' : '#090908', padding: 10 }}><small style={{ ...muted, color: bad ? '#c98773' : '#9d8654' }}>{label}</small>{values.length ? <ul style={{ margin: '7px 0 0', paddingLeft: 18, color: bad ? '#cf9a87' : '#c2b9a9', fontSize: 10, lineHeight: 1.6 }}>{values.map((value) => <li key={value}>{value}</li>)}</ul> : <p style={{ ...muted, margin: '7px 0 0' }}>{empty}</p>}</div>;
 }
 const card = { border: '1px solid #29251b', background: '#0d0c09', padding: 15 } as const;
 const muted = { color: '#8f8878', fontSize: 10, lineHeight: 1.5 } as const;

--- a/src/components/root/reports/RootReportsConsole.tsx
+++ b/src/components/root/reports/RootReportsConsole.tsx
@@ -2,345 +2,151 @@
 
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
+import type { RootReportCategory, RootReportHealth, RootReportInbox, RootReportInboxItem } from '@/lib/reports/rootReportInbox';
 
-type Row = Record<string, unknown>;
-type ReportType =
-  | 'world_vector_internal'
-  | 'world_vector_public'
-  | 'ifnorm'
-  | 'sfi_dr01'
-  | 'neural_graph_evidence'
-  | 'amv_recurrence'
-  | 'calibration'
-  | 'atlas_entry'
-  | 'linkedin_draft'
-  | 'contact_draft';
-
-type ReportOption = {
-  type: ReportType;
-  label: string;
-  question: string;
-  description: string;
-  requiresSubject: boolean;
-  acceptsSubject: boolean;
-  subjectLabel?: string;
-  subjectPlaceholder?: string;
-  inputExplanation: string;
-  recommended?: boolean;
+const CATEGORY_LABEL: Record<RootReportCategory | 'all', string> = {
+  all: 'TODOS',
+  world: 'MUNDO',
+  internal: 'INTERNO',
+  prospects: 'PROSPECTOS',
+  attractor: 'ATRACTOR',
+  evidence: 'EVIDENCIA',
+  drafts: 'BORRADORES',
+  other: 'OTROS',
 };
 
-type OpportunityInput = {
-  entityName: string;
-  sector: string;
-  source: string;
-  publicSignal: string;
-  notes: string;
-};
-
-const EMPTY_OPPORTUNITY: OpportunityInput = { entityName: '', sector: '', source: '', publicSignal: '', notes: '' };
-
-const REPORT_OPTIONS: ReportOption[] = [
-  {
-    type: 'world_vector_internal',
-    label: 'Estado institucional',
-    question: '¿Qué está viendo SFI ahora?',
-    description: 'Resume señales, tensiones, fuentes degradadas y lectura interna del World Vector sin convertirla en publicación.',
-    requiresSubject: false,
-    acceptsSubject: false,
-    inputExplanation: 'Nada. SFI usa el estado institucional y la evidencia persistida disponible.',
-    recommended: true,
-  },
-  {
-    type: 'neural_graph_evidence',
-    label: 'Evidencia y trazabilidad',
-    question: '¿Qué está sustentado y qué no?',
-    description: 'Lee el grafo para separar nodos con soporte, huecos de linaje, contradicciones y evidencia relacionada.',
-    requiresSubject: false,
-    acceptsSubject: true,
-    subjectLabel: 'FOCO OPCIONAL',
-    subjectPlaceholder: 'Ej. Governance, REM618, Caso 01, Cognitive Twin',
-    inputExplanation: 'No necesitas escribir nada para una lectura global. Si quieres revisar un objeto concreto, escribe su nombre.',
-    recommended: true,
-  },
-  {
-    type: 'calibration',
-    label: 'Calibración',
-    question: '¿Dónde puede SFI estar sobreafirmando?',
-    description: 'Busca desajustes entre evidencia, confianza, claims, ejecución y estado declarado.',
-    requiresSubject: false,
-    acceptsSubject: true,
-    subjectLabel: 'FOCO OPCIONAL',
-    subjectPlaceholder: 'Ej. continuidad institucional, MIHM, Studio',
-    inputExplanation: 'Nada para calibración global; un foco sólo limita la lectura a un dominio concreto.',
-    recommended: true,
-  },
-  {
-    type: 'amv_recurrence',
-    label: 'Recurrencias AMV',
-    question: '¿Qué patrón está reapareciendo?',
-    description: 'Busca recurrencias en memoria, evidencia y trayectoria para señalar patrones persistentes sin confundir recurrencia con causalidad.',
-    requiresSubject: false,
-    acceptsSubject: true,
-    subjectLabel: 'FOCO OPCIONAL',
-    subjectPlaceholder: 'Ej. latencia, cierre prematuro, señal cultural',
-    inputExplanation: 'Nada para una búsqueda global; puedes dar un patrón o fenómeno para acotar la memoria consultada.',
-    recommended: true,
-  },
-  {
-    type: 'ifnorm',
-    label: 'Cazador de posibilidades',
-    question: '¿Qué empresa tiene una fricción que SFI puede convertir en propuesta?',
-    description: 'Ejecuta ClientFinder + IFNORM para devolver empresa, origen de la señal, dolor observable, evidencia, oferta SFI y siguiente acción.',
-    requiresSubject: false,
-    acceptsSubject: false,
-    inputExplanation: 'Indica empresa, origen y señal observada. SFI deriva el dolor como hipótesis, recomienda una oferta y conserva lo que aún falta verificar.',
-    recommended: true,
-  },
-  {
-    type: 'sfi_dr01',
-    label: 'Expediente SFI-DR01',
-    question: '¿Qué fricción muestra este caso?',
-    description: 'Construye una lectura diagnóstica de un caso concreto usando evidencia disponible y límites explícitos.',
-    requiresSubject: true,
-    acceptsSubject: true,
-    subjectLabel: 'CASO / SISTEMA',
-    subjectPlaceholder: 'Ej. Caso 01 · Kavak',
-    inputExplanation: 'Escribe el caso, sistema u objeto que quieres diagnosticar. El reporte no adivinará el foco.',
-  },
-  {
-    type: 'atlas_entry',
-    label: 'Entrada Atlas',
-    question: '¿Qué fenómeno debe conservarse?',
-    description: 'Prepara una entrada de memoria relacional para un fenómeno concreto, con procedencia y límites de interpretación.',
-    requiresSubject: true,
-    acceptsSubject: true,
-    subjectLabel: 'FENÓMENO / OBJETO',
-    subjectPlaceholder: 'Ej. REM618 · apertura de campo',
-    inputExplanation: 'Nombra el fenómeno u objeto que debe convertirse en entrada Atlas.',
-  },
-  {
-    type: 'world_vector_public',
-    label: 'World Vector público',
-    question: '¿Qué lectura podría hacerse pública?',
-    description: 'Genera un borrador público desde el estado disponible. Sigue siendo borrador y requiere aprobación humana.',
-    requiresSubject: false,
-    acceptsSubject: false,
-    inputExplanation: 'Nada. Parte del estado World Vector disponible y conserva la separación entre borrador y publicación.',
-  },
-  {
-    type: 'linkedin_draft',
-    label: 'Borrador LinkedIn',
-    question: '¿Qué puede comunicarse sin sobreafirmar?',
-    description: 'Produce un borrador editorial a partir de evidencia y estado persistidos. No publica automáticamente.',
-    requiresSubject: false,
-    acceptsSubject: true,
-    subjectLabel: 'TEMA OPCIONAL',
-    subjectPlaceholder: 'Ej. Caso 01 · latencia de ejecución',
-    inputExplanation: 'Puedes dejarlo vacío para que SFI use el estado más relevante o indicar el tema que quieres convertir en borrador.',
-  },
-  {
-    type: 'contact_draft',
-    label: 'Borrador de contacto',
-    question: '¿Qué mensaje se podría preparar?',
-    description: 'Prepara un borrador de contacto para una entidad o persona. No envía nada y debe pasar por aprobación.',
-    requiresSubject: true,
-    acceptsSubject: true,
-    subjectLabel: 'DESTINATARIO / FOCO',
-    subjectPlaceholder: 'Ej. Empresa X · responsable de operaciones',
-    inputExplanation: 'Indica para quién o para qué relación quieres preparar el mensaje.',
-  },
-];
-
-function record(value: unknown): Row {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
-}
-function strings(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
-}
-function text(value: unknown, fallback = '—') {
-  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
-}
-function when(value: unknown) {
-  if (typeof value !== 'string') return 'SIN FECHA';
+function when(value: string | null) {
+  if (!value) return 'SIN FECHA';
   const date = new Date(value);
-  return Number.isFinite(date.valueOf()) ? new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(date) : value;
+  return Number.isFinite(date.valueOf())
+    ? new Intl.DateTimeFormat('es-MX', { dateStyle: 'medium', timeStyle: 'short' }).format(date)
+    : value;
+}
+function searchable(item: RootReportInboxItem) {
+  return [
+    item.title,
+    item.body,
+    item.category,
+    item.cadence,
+    item.reportType,
+    item.scheduleKey ?? '',
+    item.status,
+    item.provider ?? '',
+    item.evidence.join(' '),
+    item.warnings.join(' '),
+    JSON.stringify(item.metadata),
+  ].join(' ').toLowerCase();
+}
+function tone(value: string) {
+  const normalized = value.toLowerCase();
+  if (normalized.includes('current') || normalized.includes('ready') || normalized.includes('observed') || normalized.includes('completed')) return 'ok';
+  if (normalized.includes('blocked') || normalized.includes('failed') || normalized.includes('missing')) return 'bad';
+  return 'warn';
 }
 
-export function RootReportsConsole({ initialReports, canGenerate, actorLabel }: {
-  initialReports: Row[];
-  canGenerate: boolean;
+export function RootReportsConsole({ initialInbox, initialHealth, actorLabel }: {
+  initialInbox: RootReportInbox;
+  initialHealth: RootReportHealth;
   actorLabel: string;
 }) {
-  const [reports, setReports] = useState<Row[]>(initialReports);
-  const [selectedId, setSelectedId] = useState<string | null>(() => text(initialReports[0]?.id, '') || null);
-  const [type, setType] = useState<ReportType>('world_vector_internal');
-  const [subject, setSubject] = useState('');
-  const [opportunity, setOpportunity] = useState<OpportunityInput>(EMPTY_OPPORTUNITY);
-  const [running, setRunning] = useState(false);
-  const [message, setMessage] = useState<string | null>(null);
+  const [inbox, setInbox] = useState(initialInbox);
+  const [health, setHealth] = useState(initialHealth);
+  const [selectedId, setSelectedId] = useState<string | null>(() => initialInbox.items[0]?.id ?? null);
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState<RootReportCategory | 'all'>('all');
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const option = REPORT_OPTIONS.find((item) => item.type === type) ?? REPORT_OPTIONS[0];
-  const selected = useMemo(
-    () => reports.find((row) => text(row.id, '') === selectedId) ?? reports[0] ?? null,
-    [reports, selectedId],
-  );
-  const output = record(selected?.output_envelope);
-  const trace = record(output.trace);
-  const inputSnapshot = record(selected?.input_snapshot);
-  const persistedIfnorm = record(inputSnapshot.ifnorm);
-  const evidence = strings(output.evidence).length ? strings(output.evidence) : strings(selected?.evidence_refs);
-  const warnings = strings(output.warnings).length ? strings(output.warnings) : strings(selected?.limitations);
-  const opportunityReady = Boolean(opportunity.entityName.trim() && opportunity.source.trim() && opportunity.publicSignal.trim());
-  const canRunSelection = canGenerate && !running && (type === 'ifnorm' ? opportunityReady : (!option.requiresSubject || Boolean(subject.trim())));
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return inbox.items.filter((item) => (category === 'all' || item.category === category) && (!q || searchable(item).includes(q)));
+  }, [inbox.items, category, query]);
 
-  function choose(nextType: ReportType) {
-    setType(nextType);
-    setSubject('');
-    setOpportunity(EMPTY_OPPORTUNITY);
-    setMessage(null);
-  }
+  const selected = useMemo(() => {
+    return filtered.find((item) => item.id === selectedId)
+      ?? inbox.items.find((item) => item.id === selectedId)
+      ?? filtered[0]
+      ?? null;
+  }, [filtered, inbox.items, selectedId]);
 
-  function setOpportunityField<K extends keyof OpportunityInput>(key: K, value: OpportunityInput[K]) {
-    setOpportunity((current) => ({ ...current, [key]: value }));
-  }
-
-  async function generate() {
-    if (!canRunSelection) return;
-    setRunning(true);
-    setMessage(null);
+  async function refresh() {
+    setRefreshing(true);
+    setError(null);
     try {
-      let generatedIfnorm: Row | null = null;
-      let reportSubject = option.acceptsSubject && subject.trim() ? subject.trim() : undefined;
-
-      if (type === 'ifnorm') {
-        const finderResponse = await fetch('/api/root/agentic/client-finder', {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(opportunity),
-        });
-        const finderBody = await finderResponse.json().catch(() => null) as Row | null;
-        if (!finderResponse.ok || !finderBody || finderBody.ok !== true) {
-          throw new Error(text(finderBody?.details ?? finderBody?.error, `ClientFinder HTTP ${finderResponse.status}`));
-        }
-        generatedIfnorm = record(finderBody.ifnorm);
-        reportSubject = opportunity.entityName.trim();
-      }
-
-      const response = await fetch('/api/root/agentic/report', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ type, subject: reportSubject, ifnorm: generatedIfnorm }),
-      });
-      const body = await response.json().catch(() => null) as Row | null;
-      if (!response.ok || !body || body.ok !== true) throw new Error(text(body?.details ?? body?.error, `HTTP ${response.status}`));
-      const run = record(body.reportRun);
-      if (text(run.id, '')) {
-        setReports((current) => [run, ...current.filter((row) => text(row.id, '') !== text(run.id, ''))]);
-        setSelectedId(text(run.id, ''));
-      }
-      setMessage(type === 'ifnorm'
-        ? 'ClientFinder + IFNORM ejecutados. El resultado quedó persistido como reporte para revisión; no se contactó a nadie.'
-        : 'Reporte generado y persistido en Cognitive Twin Runs. Sigue siendo un output para lectura/revisión, no una verdad canónica.');
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'No fue posible generar el reporte.');
+      const response = await fetch('/api/root/reports', { credentials: 'include', cache: 'no-store' });
+      const body = await response.json().catch(() => null) as { ok?: boolean; inbox?: RootReportInbox; health?: RootReportHealth; error?: string; details?: string } | null;
+      if (!response.ok || !body?.ok || !body.inbox || !body.health) throw new Error(body?.details ?? body?.error ?? `HTTP ${response.status}`);
+      setInbox(body.inbox);
+      setHealth(body.health);
+      setSelectedId((current) => current && body.inbox?.items.some((item) => item.id === current) ? current : body.inbox?.items[0]?.id ?? null);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'No fue posible actualizar los reportes.');
     } finally {
-      setRunning(false);
+      setRefreshing(false);
     }
   }
 
   return <main className="rr-root">
     <header className="rr-header">
       <div>
-        <span>SFI · ROOT · REPORTES</span>
-        <h1>¿Qué quieres que SFI te explique?</h1>
-        <p>No necesitas conocer el nombre técnico del agente. Elige la pregunta que quieres resolver; ROOT selecciona el contrato de reporte correspondiente y usa evidencia persistida.</p>
+        <span>SFI · ROOT · REPORT INBOX</span>
+        <h1>Reportes generados por SFI</h1>
+        <p>Esta superficie no te pide una pregunta para fabricar una lectura. Muestra reportes ya producidos por agentes, ciclos de continuidad y Prospect Radar. El único texto que escribes aquí es para <strong>buscar dentro de lo que ya existe</strong>.</p>
       </div>
-      <div className="rr-meta"><strong>{actorLabel}</strong><Link href="/root">VOLVER A ROOT</Link></div>
+      <div className="rr-meta"><strong>{actorLabel}</strong><button type="button" onClick={() => void refresh()} disabled={refreshing}>{refreshing ? 'ACTUALIZANDO' : 'ACTUALIZAR'}</button><Link href="/root">VOLVER A ROOT</Link></div>
     </header>
 
-    <section className="rr-question-zone">
-      <div className="rr-zone-title"><span>PREGUNTAS RECOMENDADAS</span><small>empieza aquí si sólo quieres entender el estado de SFI</small></div>
-      <div className="rr-question-grid">
-        {REPORT_OPTIONS.filter((item) => item.recommended).map((item) => <button key={item.type} type="button" className={type === item.type ? 'active' : ''} onClick={() => choose(item.type)} disabled={!canGenerate || running}>
-          <span>{item.label}</span><strong>{item.question}</strong><p>{item.description}</p>
-        </button>)}
-      </div>
-      <details className="rr-more">
-        <summary>OTROS REPORTES / BORRADORES</summary>
-        <div className="rr-more-grid">{REPORT_OPTIONS.filter((item) => !item.recommended).map((item) => <button key={item.type} type="button" className={type === item.type ? 'active' : ''} onClick={() => choose(item.type)} disabled={!canGenerate || running}><span>{item.label}</span><strong>{item.question}</strong></button>)}</div>
-      </details>
+    <section className="rr-health">
+      <div className="rr-health-summary"><span>REPORTES</span><strong>{health.totalReports}</strong><small>último · {when(health.latestReportAt)}</small></div>
+      {health.lanes.map((lane) => <div key={lane.key} className="rr-lane" data-tone={tone(lane.state)}>
+        <span>{lane.label}</span><strong>{lane.state === 'CURRENT' ? 'AL CORRIENTE' : lane.state === 'CURRENT_BLOCKED' ? 'PERIODO GENERADO · BLOQUEADO/DEGRADADO' : lane.state === 'NEVER_GENERATED' ? 'SIN PRIMER RUN' : 'FALTA PERIODO ACTUAL'}</strong><small>{lane.lastGeneratedAt ? when(lane.lastGeneratedAt) : 'sin ejecución persistida'}</small>
+      </div>)}
     </section>
 
-    <section className="rr-compose">
-      <div className="rr-selected-question">
-        <span>VAS A GENERAR</span>
-        <strong>{option.question}</strong>
-        <p>{option.description}</p>
-        <small>CONTRATO INTERNO · {option.type}</small>
-      </div>
-      <div className="rr-needed">
-        <span>QUÉ NECESITA DE TI</span>
-        <p>{option.inputExplanation}</p>
-        {type === 'ifnorm' ? <div className="rr-opportunity-inputs">
-          <label>EMPRESA / ENTIDAD <b>REQUERIDO</b><input value={opportunity.entityName} onChange={(event) => setOpportunityField('entityName', event.target.value)} placeholder="Ej. FEMSA" disabled={!canGenerate || running} /></label>
-          <label>ORIGEN / FUENTE <b>REQUERIDO</b><input value={opportunity.source} onChange={(event) => setOpportunityField('source', event.target.value)} placeholder="Ej. comunicado, nota, sitio oficial, evidencia interna" disabled={!canGenerate || running} /></label>
-          <label>SEÑAL / QUÉ ESTÁ PASANDO <b>REQUERIDO</b><textarea value={opportunity.publicSignal} onChange={(event) => setOpportunityField('publicSignal', event.target.value)} placeholder="Describe lo observable; SFI separará esto del dolor inferido." disabled={!canGenerate || running} /></label>
-          <label>SECTOR <i>OPCIONAL</i><input value={opportunity.sector} onChange={(event) => setOpportunityField('sector', event.target.value)} placeholder="Ej. logística, retail, fintech" disabled={!canGenerate || running} /></label>
-          <label>NOTAS <i>OPCIONAL</i><textarea value={opportunity.notes} onChange={(event) => setOpportunityField('notes', event.target.value)} placeholder="Contexto adicional, persona/rol o restricción." disabled={!canGenerate || running} /></label>
-        </div> : option.acceptsSubject ? <label>{option.subjectLabel ?? 'FOCO'}{option.requiresSubject ? <b>REQUERIDO</b> : <i>OPCIONAL</i>}
-          <input value={subject} onChange={(event) => setSubject(event.target.value)} placeholder={option.subjectPlaceholder} disabled={!canGenerate || running} />
-        </label> : <div className="rr-no-input">SIN INPUT MANUAL · usa estado persistido</div>}
-      </div>
-      <div className="rr-generate">
-        <button type="button" onClick={() => void generate()} disabled={!canRunSelection}>{running ? 'GENERANDO…' : canGenerate ? 'GENERAR ESTE REPORTE' : 'OBSERVER · SOLO LECTURA'}</button>
-        {type === 'ifnorm' && !opportunityReady ? <small>Faltan empresa, origen y señal observable.</small> : option.requiresSubject && !subject.trim() ? <small>Falta indicar {option.subjectLabel?.toLowerCase() ?? 'el foco'}.</small> : <small>Generar no aprueba, publica ni ejecuta acciones externas.</small>}
-      </div>
-      {message ? <p className="rr-message">{message}</p> : null}
+    {inbox.warnings.length || health.warnings.length || error ? <section className="rr-warning">
+      <strong>OBSERVABILIDAD</strong>
+      {error ? <p>{error}</p> : null}
+      {[...new Set([...inbox.warnings, ...health.warnings])].map((warning) => <p key={warning}>{warning}</p>)}
+    </section> : null}
+
+    <section className="rr-controls">
+      <label><span>BUSCAR EN REPORTES YA GENERADOS</span><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="empresa, evidencia, mundo, MIHM, atractor, agente, señal…" /></label>
+      <div className="rr-filters">{(['all', 'world', 'internal', 'prospects', 'attractor', 'evidence', 'drafts', 'other'] as const).map((item) => <button key={item} type="button" className={category === item ? 'active' : ''} onClick={() => setCategory(item)}>{CATEGORY_LABEL[item]}<b>{item === 'all' ? inbox.counts.total : inbox.counts[item]}</b></button>)}</div>
     </section>
 
     <section className="rr-workspace">
       <aside className="rr-list">
-        <div className="rr-list-title"><span>HISTORIAL</span><b>{reports.length}</b></div>
-        {reports.length ? reports.map((row) => {
-          const envelope = record(row.output_envelope);
-          const id = text(row.id, '');
-          return <button key={id || text(row.task_id)} type="button" className={selectedId === id ? 'active' : ''} onClick={() => setSelectedId(id)}>
-            <span>{text(envelope.title, text(row.objective, 'Reporte'))}</span>
-            <small>{when(row.created_at)} · {text(row.status, 'UNKNOWN')}</small>
-          </button>;
-        }) : <div className="rr-empty"><strong>TODAVÍA NO HAY REPORTES.</strong><p>Elige una pregunta arriba. Para “¿Qué está viendo SFI ahora?” no tienes que escribir absolutamente nada.</p></div>}
+        <div className="rr-list-title"><span>RESULTADOS</span><b>{filtered.length}</b></div>
+        {filtered.length ? filtered.map((item) => <button key={item.id} type="button" className={selected?.id === item.id ? 'active' : ''} onClick={() => setSelectedId(item.id)}>
+          <span className="rr-item-type">{CATEGORY_LABEL[item.category]} · {item.cadence.toUpperCase()}</span>
+          <strong>{item.title}</strong>
+          <small>{when(item.createdAt)} · {item.status}</small>
+          <em>{item.sourceTable}</em>
+        </button>) : <div className="rr-empty"><strong>SIN COINCIDENCIAS</strong><p>El buscador no genera contenido. Ajusta el texto o el filtro para localizar un reporte existente.</p></div>}
       </aside>
 
       <article className="rr-reader">
         {selected ? <>
-          <div className="rr-kicker">{text(output.type, 'report').replaceAll('_', ' ')} · {text(selected.status, 'UNKNOWN')}</div>
-          <h2>{text(output.title, text(selected.objective, 'Reporte'))}</h2>
-          <div className="rr-runmeta"><span>{when(selected.created_at)}</span><span>{text(selected.provider, text(output.provider, 'provider n/d'))}</span><span>{evidence.length} evidencias referenciadas</span></div>
-          {Object.keys(persistedIfnorm).length ? <section className="rr-opportunity-result">
-            <div><span>EMPRESA</span><strong>{text(persistedIfnorm.entity_name)}</strong></div>
-            <div><span>ORIGEN</span><strong>{text(persistedIfnorm.source)}</strong></div>
-            <div><span>QUÉ LE DUELE</span><strong>{text(persistedIfnorm.detected_pain)}</strong></div>
-            <div><span>QUÉ PUEDE OFRECER SFI</span><strong>{text(persistedIfnorm.recommended_offer)}</strong></div>
-            <div className="wide"><span>POR QUÉ ENCAJA</span><strong>{text(persistedIfnorm.why_sfi_fits)}</strong></div>
-            <div className="wide"><span>SIGUIENTE ACCIÓN</span><strong>{text(persistedIfnorm.recommended_action)}</strong></div>
-          </section> : null}
-          <div className="rr-body">{text(output.body, 'MISSING · el run no contiene body legible.')}</div>
-          <details open><summary>EVIDENCIA UTILIZADA · {evidence.length}</summary>{evidence.length ? <ul>{evidence.map((item, index) => <li key={`${item}-${index}`}>{item}</li>)}</ul> : <p>MISSING · no hay referencias de evidencia persistidas para este reporte.</p>}</details>
-          <details><summary>PROVENANCE / TRACE</summary><pre>{Object.keys(trace).length ? JSON.stringify(trace, null, 2) : 'MISSING · no hay trace persistido.'}</pre></details>
-          <details><summary>LIMITACIONES / WARNINGS · {warnings.length}</summary>{warnings.length ? <ul>{warnings.map((item, index) => <li key={`${item}-${index}`}>{item}</li>)}</ul> : <p>Sin warnings declarados en este run.</p>}</details>
-          <details><summary>ESTADO DE APROBACIÓN</summary><pre>{JSON.stringify(record(output.approval_queue), null, 2)}</pre></details>
-        </> : <div className="rr-empty-reader"><strong>NO HAY NADA QUE LEER TODAVÍA.</strong><p>Selecciona una pregunta en la parte superior y genera el primer reporte.</p></div>}
+          <div className="rr-kicker">{CATEGORY_LABEL[selected.category]} · {selected.reportType.replaceAll('_', ' ')} · {selected.cadence}</div>
+          <h2>{selected.title}</h2>
+          <div className="rr-runmeta"><span>{when(selected.createdAt)}</span><span>{selected.status}</span><span>{selected.provider ?? 'provider n/d'}</span><span>{selected.evidence.length} referencias</span><span>{selected.sourceTable}</span></div>
+          <div className="rr-body">{selected.body}</div>
+          <details open><summary>EVIDENCIA / FUENTES · {selected.evidence.length}</summary>{selected.evidence.length ? <ul>{selected.evidence.map((item, index) => <li key={`${item}-${index}`}>{item}</li>)}</ul> : <p>MISSING · este reporte no declaró referencias de evidencia.</p>}</details>
+          <details><summary>LIMITACIONES / WARNINGS · {selected.warnings.length}</summary>{selected.warnings.length ? <ul>{selected.warnings.map((item, index) => <li key={`${item}-${index}`}>{item}</li>)}</ul> : <p>Sin warnings declarados.</p>}</details>
+          <details><summary>PROVENANCE / TRACE</summary><pre>{Object.keys(selected.trace).length ? JSON.stringify(selected.trace, null, 2) : 'MISSING · no hay trace persistido.'}</pre></details>
+          <details><summary>METADATA</summary><pre>{JSON.stringify(selected.metadata, null, 2)}</pre></details>
+          <details><summary>GOBERNANZA / APROBACIÓN</summary><pre>{Object.keys(selected.approvalQueue).length ? JSON.stringify(selected.approvalQueue, null, 2) : 'Lectura interna; no hay acción externa en cola para este reporte.'}</pre></details>
+        </> : <div className="rr-empty-reader"><strong>NO HAY REPORTES QUE LEER.</strong><p>ROOT no inventará uno para llenar la pantalla. El próximo ciclo programado aparecerá cuando exista un run persistido.</p></div>}
       </article>
     </section>
 
     <style jsx>{`
-      .rr-root{min-height:100vh;background:#060605;color:#c8c4b8;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;padding:28px;box-sizing:border-box}.rr-header{display:flex;justify-content:space-between;gap:30px;border-bottom:1px solid rgba(200,169,81,.18);padding-bottom:22px}.rr-header span,.rr-kicker,.rr-zone-title span,.rr-selected-question>span,.rr-needed>span{font-size:9px;letter-spacing:.16em;color:#9d8654}.rr-header h1{margin:7px 0 8px;font:400 34px Georgia,serif;color:#e3d4b0}.rr-header p{margin:0;max-width:900px;color:#81796c;font:14px/1.6 Georgia,serif}.rr-meta{display:flex;align-items:flex-start;gap:10px;font-size:9px}.rr-meta strong,.rr-meta a{border:1px solid rgba(200,169,81,.24);padding:8px 10px;color:#baa665;text-decoration:none}
-      .rr-question-zone{padding:20px 0;border-bottom:1px solid rgba(200,169,81,.1)}.rr-zone-title{display:flex;justify-content:space-between;gap:15px;margin-bottom:12px}.rr-zone-title small{font-size:8px;color:#5f594e}.rr-question-grid{display:grid;grid-template-columns:repeat(5,1fr);gap:9px}.rr-question-grid button{min-height:150px;text-align:left;border:1px solid rgba(200,169,81,.12);background:#090908;padding:15px;color:#a69e90;cursor:pointer}.rr-question-grid button:hover,.rr-question-grid button.active,.rr-more-grid button.active{border-color:rgba(200,169,81,.52);background:rgba(200,169,81,.045)}.rr-question-grid button span,.rr-more-grid button span{display:block;font-size:8px;color:#89774d;letter-spacing:.08em}.rr-question-grid button strong,.rr-more-grid button strong{display:block;margin-top:8px;color:#dec88d;font:400 17px/1.25 Georgia,serif}.rr-question-grid button p{font:11px/1.55 Georgia,serif;color:#716b60}.rr-question-grid button:disabled,.rr-more-grid button:disabled{opacity:.45;cursor:not-allowed}.rr-more{margin-top:12px}.rr-more summary{cursor:pointer;color:#75684a;font-size:8px;letter-spacing:.12em}.rr-more-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:7px;margin-top:10px}.rr-more-grid button{text-align:left;border:1px solid rgba(200,169,81,.08);background:#080807;padding:11px;color:#999;cursor:pointer}.rr-more-grid button strong{font-size:14px}
-      .rr-compose{display:grid;grid-template-columns:1.1fr 1.4fr 240px;gap:18px;align-items:stretch;padding:20px 0;border-bottom:1px solid rgba(200,169,81,.1)}.rr-selected-question,.rr-needed,.rr-generate{border:1px solid rgba(200,169,81,.08);padding:15px;background:#080807}.rr-selected-question strong{display:block;margin-top:8px;color:#e1cd95;font:400 21px/1.3 Georgia,serif}.rr-selected-question p,.rr-needed p{color:#827a6c;font:11px/1.6 Georgia,serif}.rr-selected-question small{font-size:7px;color:#4e4a42}.rr-needed label{display:grid;gap:7px;margin-top:12px;color:#766b50;font-size:8px;letter-spacing:.1em}.rr-needed label b,.rr-needed label i{font-size:7px;font-style:normal;color:#b67d63}.rr-needed label i{color:#6e675a}.rr-needed input,.rr-needed textarea{background:#0a0a09;border:1px solid rgba(200,169,81,.22);color:#d5c7a7;padding:10px;font:11px ui-monospace,monospace}.rr-needed textarea{min-height:70px;resize:vertical}.rr-opportunity-inputs{display:grid;grid-template-columns:1fr 1fr;gap:0 10px}.rr-opportunity-inputs label:nth-child(3),.rr-opportunity-inputs label:nth-child(5){grid-column:1/-1}.rr-no-input{margin-top:14px;border-left:2px solid rgba(91,151,101,.55);padding:10px;color:#7cad83;font-size:8px}.rr-generate{display:flex;flex-direction:column;justify-content:center}.rr-generate button{min-height:48px;border:1px solid rgba(200,169,81,.42);background:rgba(200,169,81,.03);color:#d3b96e;padding:0 15px;font:9px ui-monospace,monospace;letter-spacing:.08em}.rr-generate button:disabled{opacity:.35}.rr-generate small{margin-top:9px;color:#625c51;font-size:8px;line-height:1.5}.rr-message{grid-column:1/-1;margin:0;color:#ad9967;font-size:9px}
-      .rr-workspace{display:grid;grid-template-columns:minmax(280px,360px) 1fr;min-height:520px}.rr-list{border-right:1px solid rgba(200,169,81,.1);padding:15px 14px 15px 0;max-height:720px;overflow:auto;scrollbar-width:thin;scrollbar-color:rgba(200,169,81,.24) transparent}.rr-list-title{display:flex;justify-content:space-between;padding:0 5px 10px;color:#6f644a;font-size:8px;letter-spacing:.15em}.rr-list button{width:100%;display:grid;gap:4px;text-align:left;background:transparent;border:0;border-bottom:1px solid rgba(200,169,81,.06);padding:11px 8px;color:#aaa399;font:10px ui-monospace,monospace;cursor:pointer}.rr-list button.active{background:rgba(200,169,81,.06);color:#e0c987;border-left:2px solid #a98b45}.rr-list button small{color:#5d584e;font-size:8px}.rr-reader{padding:30px 38px;max-height:720px;overflow:auto;scrollbar-width:thin;scrollbar-color:rgba(200,169,81,.24) transparent}.rr-reader h2{font:400 28px/1.2 Georgia,serif;color:#e7d8b4;margin:8px 0 12px}.rr-runmeta{display:flex;gap:14px;flex-wrap:wrap;color:#5e594f;font-size:8px;padding-bottom:22px}.rr-opportunity-result{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin:0 0 24px}.rr-opportunity-result>div{border:1px solid rgba(93,151,103,.16);background:rgba(63,118,72,.035);padding:11px}.rr-opportunity-result .wide{grid-column:span 2}.rr-opportunity-result span{display:block;color:#638069;font-size:7px;letter-spacing:.1em}.rr-opportunity-result strong{display:block;margin-top:6px;color:#b8c9b9;font:12px/1.45 Georgia,serif}.rr-body{white-space:pre-wrap;font:15px/1.72 Georgia,serif;color:#bbb3a5;max-width:1050px;padding:0 0 25px}.rr-reader details{border-top:1px solid rgba(200,169,81,.08);padding:13px 0}.rr-reader summary{cursor:pointer;color:#8d7b50;font-size:8px;letter-spacing:.12em}.rr-reader ul,.rr-reader p,.rr-reader pre{color:#827b70;font-size:10px;line-height:1.6;white-space:pre-wrap;overflow-wrap:anywhere}.rr-empty,.rr-empty-reader{color:#70685b;font:13px/1.6 Georgia,serif;padding:30px 10px}.rr-empty strong,.rr-empty-reader strong{color:#9b8756;font:9px ui-monospace,monospace;letter-spacing:.1em}.rr-empty p,.rr-empty-reader p{margin-top:8px}.rr-empty-reader{padding:80px 20px;text-align:center}
-      @media(max-width:1250px){.rr-question-grid{grid-template-columns:repeat(3,1fr)}.rr-compose{grid-template-columns:1fr 1fr}.rr-generate{grid-column:1/-1}.rr-more-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:760px){.rr-root{padding:18px}.rr-header{display:grid}.rr-question-grid,.rr-more-grid,.rr-compose,.rr-workspace,.rr-opportunity-inputs,.rr-opportunity-result{grid-template-columns:1fr}.rr-opportunity-inputs label:nth-child(3),.rr-opportunity-inputs label:nth-child(5),.rr-opportunity-result .wide{grid-column:auto}.rr-list{border-right:0;border-bottom:1px solid rgba(200,169,81,.1);max-height:240px;padding-right:0}.rr-reader{max-height:none;padding:25px 4px}}
+      .rr-root{min-height:100vh;background:#060605;color:#c8c4b8;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;padding:28px;box-sizing:border-box}.rr-header{display:flex;justify-content:space-between;gap:30px;border-bottom:1px solid rgba(200,169,81,.18);padding-bottom:22px}.rr-header>div:first-child{max-width:980px}.rr-header span,.rr-kicker,.rr-controls label>span{font-size:9px;letter-spacing:.16em;color:#9d8654}.rr-header h1{margin:7px 0 8px;font:400 34px Georgia,serif;color:#e3d4b0}.rr-header p{margin:0;color:#81796c;font:14px/1.6 Georgia,serif}.rr-header p strong{color:#bba56e;font-weight:400}.rr-meta{display:flex;align-items:flex-start;gap:8px;flex-wrap:wrap;font-size:9px}.rr-meta strong,.rr-meta a,.rr-meta button{border:1px solid rgba(200,169,81,.24);background:transparent;padding:8px 10px;color:#baa665;text-decoration:none;font:9px ui-monospace,monospace}.rr-meta button{cursor:pointer}.rr-meta button:disabled{opacity:.45}
+      .rr-health{display:grid;grid-template-columns:180px repeat(5,minmax(150px,1fr));gap:8px;padding:18px 0;border-bottom:1px solid rgba(200,169,81,.1)}.rr-health-summary,.rr-lane{border:1px solid rgba(200,169,81,.1);background:#090908;padding:12px;display:grid;gap:6px}.rr-health-summary span,.rr-lane span{font-size:7px;letter-spacing:.12em;color:#75694d}.rr-health-summary strong{font-size:24px;color:#d8c488}.rr-lane strong{font-size:9px;color:#aa9b76}.rr-health-summary small,.rr-lane small{font-size:7px;color:#5e594e}.rr-lane[data-tone=ok]{border-color:rgba(91,151,101,.28)}.rr-lane[data-tone=ok] strong{color:#7cad83}.rr-lane[data-tone=bad]{border-color:rgba(172,86,75,.28)}.rr-lane[data-tone=bad] strong{color:#c37a70}.rr-lane[data-tone=warn] strong{color:#c0a35f}
+      .rr-warning{margin:14px 0;border-left:2px solid rgba(190,132,76,.6);background:rgba(150,92,45,.04);padding:10px 14px}.rr-warning strong{font-size:8px;color:#b98758}.rr-warning p{margin:5px 0;color:#8f765f;font-size:9px;overflow-wrap:anywhere}
+      .rr-controls{display:grid;gap:12px;padding:18px 0;border-bottom:1px solid rgba(200,169,81,.1)}.rr-controls label{display:grid;gap:7px}.rr-controls input{width:min(980px,100%);box-sizing:border-box;background:#090908;border:1px solid rgba(200,169,81,.24);padding:12px 13px;color:#dfd2b4;font:12px ui-monospace,monospace;outline:none}.rr-controls input:focus{border-color:rgba(200,169,81,.55)}.rr-filters{display:flex;gap:6px;flex-wrap:wrap}.rr-filters button{border:1px solid rgba(200,169,81,.12);background:#080807;color:#746b58;padding:8px 10px;font:8px ui-monospace,monospace;cursor:pointer}.rr-filters button b{margin-left:7px;color:#a6915f}.rr-filters button.active{border-color:rgba(200,169,81,.48);color:#d2bb7d;background:rgba(200,169,81,.045)}
+      .rr-workspace{display:grid;grid-template-columns:minmax(300px,390px) 1fr;min-height:620px}.rr-list{border-right:1px solid rgba(200,169,81,.1);padding:15px 14px 15px 0;max-height:760px;overflow:auto;scrollbar-width:thin;scrollbar-color:rgba(200,169,81,.24) transparent}.rr-list-title{display:flex;justify-content:space-between;padding:0 7px 10px;color:#6f644a;font-size:8px;letter-spacing:.15em}.rr-list button{width:100%;display:grid;gap:5px;text-align:left;background:transparent;border:0;border-bottom:1px solid rgba(200,169,81,.06);padding:12px 9px;color:#aaa399;cursor:pointer}.rr-list button.active{background:rgba(200,169,81,.06);border-left:2px solid #a98b45}.rr-item-type{font-size:7px;color:#806f48;letter-spacing:.1em}.rr-list button strong{font:400 13px/1.35 Georgia,serif;color:#bcb3a3}.rr-list button.active strong{color:#e0c987}.rr-list button small{color:#5d584e;font-size:8px}.rr-list button em{font-style:normal;color:#444139;font-size:7px}.rr-reader{padding:30px 38px;max-height:760px;overflow:auto;scrollbar-width:thin;scrollbar-color:rgba(200,169,81,.24) transparent}.rr-reader h2{font:400 29px/1.2 Georgia,serif;color:#e7d8b4;margin:8px 0 12px}.rr-runmeta{display:flex;gap:12px;flex-wrap:wrap;color:#5e594f;font-size:8px;padding-bottom:22px}.rr-body{white-space:pre-wrap;font:15px/1.72 Georgia,serif;color:#bbb3a5;max-width:1100px;padding:0 0 25px}.rr-reader details{border-top:1px solid rgba(200,169,81,.08);padding:13px 0}.rr-reader summary{cursor:pointer;color:#8d7b50;font-size:8px;letter-spacing:.12em}.rr-reader ul,.rr-reader p,.rr-reader pre{color:#827b70;font-size:10px;line-height:1.6;white-space:pre-wrap;overflow-wrap:anywhere}.rr-empty,.rr-empty-reader{color:#70685b;font:13px/1.6 Georgia,serif;padding:30px 10px}.rr-empty strong,.rr-empty-reader strong{color:#9b8756;font:9px ui-monospace,monospace;letter-spacing:.1em}.rr-empty p,.rr-empty-reader p{margin-top:8px}.rr-empty-reader{padding:80px 20px;text-align:center}
+      @media(max-width:1350px){.rr-health{grid-template-columns:repeat(3,1fr)}}@media(max-width:760px){.rr-root{padding:18px}.rr-header{display:grid}.rr-health{grid-template-columns:1fr}.rr-workspace{grid-template-columns:1fr}.rr-list{border-right:0;border-bottom:1px solid rgba(200,169,81,.1);max-height:280px;padding-right:0}.rr-reader{max-height:none;padding:25px 4px}}
     `}</style>
   </main>;
 }

--- a/src/components/root/sovereign/views/RootCognitiveRuntimeView.tsx
+++ b/src/components/root/sovereign/views/RootCognitiveRuntimeView.tsx
@@ -40,6 +40,7 @@ export function RootCognitiveRuntimeView({ state, onSelect }: {
   const [planning, setPlanning] = useState(false);
   const [plan, setPlan] = useState<SfiTaskGraph | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const recentlyExecutedAgents = runtime.agents.filter((agent) => agent.status === 'operational').length;
 
   const grouped = useMemo(() => runtime.layers.map((layer) => ({
     ...layer,
@@ -76,7 +77,8 @@ export function RootCognitiveRuntimeView({ state, onSelect }: {
 
       <div className="rs-stat-strip">
         <span><b>{runtime.contract.registeredAgents}</b>AGENTES REGISTRADOS</span>
-        <span><b>{runtime.contract.executorAgents}</b>EJECUCIÓN OBSERVADA</span>
+        <span><b>{runtime.contract.executorAgents}</b>EXECUTORES ENLAZADOS</span>
+        <span><b>{recentlyExecutedAgents}</b>EJECUTADOS RECIENTEMENTE</span>
         <span><b>{runtime.contract.humanApprovalAgents}</b>REQUIEREN AUTORIDAD HUMANA</span>
         <span><b>{runtime.eventGraph.recentEvents.length}</b>EVENTOS RECIENTES</span>
       </div>

--- a/src/lib/reports/rootReportInbox.ts
+++ b/src/lib/reports/rootReportInbox.ts
@@ -8,7 +8,7 @@ export type RootReportCadence = 'daily' | 'weekly' | 'event' | 'manual' | 'unkno
 
 export type RootReportInboxItem = {
   id: string;
-  source: 'report_agent' | 'prospect_radar' | 'continuity';
+  source: 'report_agent' | 'scheduled_system' | 'prospect_radar' | 'continuity';
   sourceTable: string;
   category: RootReportCategory;
   cadence: RootReportCadence;
@@ -133,7 +133,7 @@ function normalizeAgentRun(input: Row): RootReportInboxItem {
   const objective = text(input.objective, 'Reporte');
   return {
     id: text(input.id, `report:${text(input.task_id, crypto.randomUUID())}`),
-    source: 'report_agent',
+    source: text(input.role) === 'report_scheduler' ? 'scheduled_system' : 'report_agent',
     sourceTable: 'sfi_cognitive_twin_runs',
     category: categoryFrom(type, scheduleKey, objective),
     cadence: cadenceFrom(scheduleKey, schedule.cadence),
@@ -220,8 +220,8 @@ export async function readRootReportInbox(limit = 240): Promise<RootReportInbox>
   const db = createServiceSupabaseClient();
   const [agentRuns, prospectReports, prospectSources, prospectRuns, continuityReports] = await Promise.all([
     db.from('sfi_cognitive_twin_runs')
-      .select('id,task_id,status,objective,input_snapshot,output_envelope,evidence_refs,limitations,provider,model,started_at,finished_at,created_at')
-      .eq('role', 'report_agent')
+      .select('id,task_id,role,status,objective,input_snapshot,output_envelope,evidence_refs,limitations,provider,model,started_at,finished_at,created_at')
+      .in('role', ['report_agent', 'report_scheduler'])
       .order('created_at', { ascending: false })
       .limit(limit),
     db.from('prospect_opportunity_reports')
@@ -303,7 +303,7 @@ export async function readRootReportHealth(existingInbox?: RootReportInbox): Pro
     };
   });
 
-  const providers = getLlmProviderStatus().map((item) => ({ id: item.id, available: item.available, model: item.model || null }));
+  const providers = getLlmProviderStatus().map((item) => ({ id: item.id, available: item.available, model: 'model' in item ? text((item as Row).model) || null : null }));
   return {
     generatedAt: new Date().toISOString(),
     inboxReadable: !inbox.warnings.some((warning) => warning.startsWith('sfi_cognitive_twin_runs:')),

--- a/src/lib/reports/rootReportInbox.ts
+++ b/src/lib/reports/rootReportInbox.ts
@@ -1,0 +1,316 @@
+import 'server-only';
+
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { getLlmProviderStatus } from '@/lib/ai/providerRouter';
+
+export type RootReportCategory = 'world' | 'internal' | 'prospects' | 'attractor' | 'evidence' | 'drafts' | 'other';
+export type RootReportCadence = 'daily' | 'weekly' | 'event' | 'manual' | 'unknown';
+
+export type RootReportInboxItem = {
+  id: string;
+  source: 'report_agent' | 'prospect_radar' | 'continuity';
+  sourceTable: string;
+  category: RootReportCategory;
+  cadence: RootReportCadence;
+  scheduleKey: string | null;
+  reportType: string;
+  title: string;
+  body: string;
+  status: string;
+  createdAt: string | null;
+  provider: string | null;
+  model: string | null;
+  evidence: string[];
+  warnings: string[];
+  trace: Record<string, unknown>;
+  approvalQueue: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+};
+
+export type RootReportInbox = {
+  generatedAt: string;
+  items: RootReportInboxItem[];
+  warnings: string[];
+  counts: Record<RootReportCategory | 'total', number>;
+};
+
+export type ScheduledReportLane = {
+  key: 'world_daily' | 'world_weekly' | 'internal_daily' | 'prospect_weekly' | 'attractor_daily';
+  cadence: 'daily' | 'weekly';
+  label: string;
+  lastGeneratedAt: string | null;
+  lastStatus: string | null;
+  currentPeriodPresent: boolean;
+  state: 'CURRENT' | 'CURRENT_BLOCKED' | 'MISSING_CURRENT_PERIOD' | 'NEVER_GENERATED';
+};
+
+export type RootReportHealth = {
+  generatedAt: string;
+  inboxReadable: boolean;
+  totalReports: number;
+  latestReportAt: string | null;
+  providers: Array<{ id: string; available: boolean; model?: string | null }>;
+  lanes: ScheduledReportLane[];
+  warnings: string[];
+};
+
+type Row = Record<string, unknown>;
+
+function row(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function rows(value: unknown): Row[] {
+  return Array.isArray(value) ? value.filter((item): item is Row => Boolean(item) && typeof item === 'object' && !Array.isArray(item)) : [];
+}
+function text(value: unknown, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : [];
+}
+function unique(values: Array<string | null | undefined>) {
+  return [...new Set(values.filter((value): value is string => Boolean(value && value.trim())))];
+}
+function iso(value: unknown): string | null {
+  const candidate = text(value);
+  if (!candidate) return null;
+  const parsed = new Date(candidate);
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : candidate;
+}
+
+function mexicoParts(date = new Date()) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Mexico_City',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    weekday: 'short',
+  }).formatToParts(date);
+  const pick = (type: Intl.DateTimeFormatPartTypes) => parts.find((item) => item.type === type)?.value ?? '';
+  return {
+    dateKey: `${pick('year')}-${pick('month')}-${pick('day')}`,
+    weekday: pick('weekday').toLowerCase(),
+  };
+}
+
+function isoWeekKey(dateKey: string) {
+  const date = new Date(`${dateKey}T12:00:00Z`);
+  const target = new Date(date);
+  const day = (target.getUTCDay() + 6) % 7;
+  target.setUTCDate(target.getUTCDate() - day + 3);
+  const firstThursday = new Date(Date.UTC(target.getUTCFullYear(), 0, 4));
+  const firstDay = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstDay + 3);
+  const week = 1 + Math.round((target.getTime() - firstThursday.getTime()) / 604_800_000);
+  return `${target.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+}
+
+function categoryFrom(type: string, scheduleKey: string | null, objective: string): RootReportCategory {
+  const value = `${type} ${scheduleKey ?? ''} ${objective}`.toLowerCase();
+  if (value.includes('prospect') || value.includes('ifnorm') || value.includes('client')) return 'prospects';
+  if (value.includes('attractor')) return 'attractor';
+  if (value.includes('world')) return 'world';
+  if (value.includes('evidence') || value.includes('graph')) return 'evidence';
+  if (value.includes('draft') || value.includes('linkedin') || value.includes('contact')) return 'drafts';
+  if (value.includes('internal') || value.includes('calibration') || value.includes('continuity') || value.includes('institution')) return 'internal';
+  return 'other';
+}
+
+function cadenceFrom(scheduleKey: string | null, value: unknown): RootReportCadence {
+  const explicit = text(value).toLowerCase();
+  if (explicit === 'daily' || explicit === 'weekly' || explicit === 'event' || explicit === 'manual') return explicit;
+  if (scheduleKey?.includes('daily')) return 'daily';
+  if (scheduleKey?.includes('weekly')) return 'weekly';
+  return scheduleKey ? 'unknown' : 'manual';
+}
+
+function normalizeAgentRun(input: Row): RootReportInboxItem {
+  const output = row(input.output_envelope);
+  const snapshot = row(input.input_snapshot);
+  const schedule = row(snapshot.schedule);
+  const scheduleKey = text(snapshot.scheduleKey ?? schedule.key) || null;
+  const type = text(output.type ?? snapshot.reportType, 'report');
+  const objective = text(input.objective, 'Reporte');
+  return {
+    id: text(input.id, `report:${text(input.task_id, crypto.randomUUID())}`),
+    source: 'report_agent',
+    sourceTable: 'sfi_cognitive_twin_runs',
+    category: categoryFrom(type, scheduleKey, objective),
+    cadence: cadenceFrom(scheduleKey, schedule.cadence),
+    scheduleKey,
+    reportType: type,
+    title: text(output.title, objective),
+    body: text(output.body, 'MISSING · el run no contiene body legible.'),
+    status: text(input.status, 'UNKNOWN'),
+    createdAt: iso(input.created_at ?? input.finished_at ?? input.started_at),
+    provider: text(input.provider ?? output.provider) || null,
+    model: text(input.model) || null,
+    evidence: unique([...strings(output.evidence), ...strings(input.evidence_refs)]),
+    warnings: unique([...strings(output.warnings), ...strings(input.limitations)]),
+    trace: row(output.trace),
+    approvalQueue: row(output.approval_queue),
+    metadata: { taskId: input.task_id ?? null, objective, inputSnapshot: snapshot },
+  };
+}
+
+function normalizeProspect(input: Row, sourceRows: Row[], runRows: Row[]): RootReportInboxItem {
+  const runId = text(input.run_id);
+  const fit = row(input.sfi_fit);
+  const window = row(input.critical_window);
+  const contact = row(input.contact);
+  const payload = row(input.payload);
+  const sources = sourceRows.filter((item) => text(item.run_id) === runId);
+  const run = runRows.find((item) => text(item.id) === runId) ?? {};
+  const evidence = unique(sources.map((item) => text(item.url)));
+  const company = text(input.company_name, 'Prospecto no identificado');
+  const body = [
+    `EMPRESA / ENTIDAD\n${company}`,
+    `\nDOLOR OBSERVADO\n${text(input.pain_statement, 'MISSING')}`,
+    `\nVENTANA CRÍTICA / PROYECTADA\n${text(window.startDate ?? window.start_date, '—')} → ${text(window.endDate ?? window.end_date, '—')}`,
+    `\nENCAJE SFI\n${text(fit.offerId ?? fit.offer_id, '—')} · ${text(fit.offerName ?? fit.offer_name, '')}`,
+    `\nCONTACTO\n${contact.verified === true ? text(contact.role, 'verificado') : 'No verificado; no inferir nombre ni correo.'}`,
+    `\nPROPUESTA\n${text(input.proposal_document, 'MISSING')}`,
+  ].join('');
+  return {
+    id: text(input.id, `prospect:${runId}`),
+    source: 'prospect_radar',
+    sourceTable: 'prospect_opportunity_reports',
+    category: 'prospects',
+    cadence: text(payload.scheduleCadence).toLowerCase() === 'weekly' ? 'weekly' : 'event',
+    scheduleKey: text(payload.scheduleKey) || null,
+    reportType: 'prospect_radar',
+    title: `Prospect Radar · ${company}`,
+    body,
+    status: text(input.epistemic_status, 'projected_not_validated'),
+    createdAt: iso(input.created_at),
+    provider: text(run.search_provider ?? payload.provider) || null,
+    model: null,
+    evidence,
+    warnings: unique([...strings(payload.limitations), ...strings(run.warnings)]),
+    trace: { runId, sourceCount: sources.length, confidence: input.confidence ?? null },
+    approvalQueue: { approval_required: true, action: 'review_before_contact', status: 'queued_for_approval' },
+    metadata: { sector: input.sector ?? null, region: input.region ?? null, confidence: input.confidence ?? null, researchRun: { id: runId, mode: run.mode ?? null, searchProvider: run.search_provider ?? null, queryPlan: run.query_plan ?? [], status: run.status ?? null }, payload },
+  };
+}
+
+function normalizeContinuity(input: Row): RootReportInboxItem {
+  return {
+    id: text(input.id, `continuity:${text(input.period_end, crypto.randomUUID())}`),
+    source: 'continuity',
+    sourceTable: 'sfi_continuity_reports',
+    category: 'internal',
+    cadence: 'daily',
+    scheduleKey: 'continuity_daily',
+    reportType: 'continuity_daily',
+    title: `Continuidad institucional · ${text(input.mode, 'UNKNOWN')}`,
+    body: text(input.content, JSON.stringify(input.summary ?? {}, null, 2)),
+    status: 'OBSERVED_INTERNAL_REPORT',
+    createdAt: iso(input.created_at ?? input.period_end),
+    provider: 'deterministic:continuity-runtime',
+    model: null,
+    evidence: [],
+    warnings: [],
+    trace: { periodStart: input.period_start ?? null, periodEnd: input.period_end ?? null },
+    approvalQueue: {},
+    metadata: { summary: input.summary ?? {}, mode: input.mode ?? null },
+  };
+}
+
+export async function readRootReportInbox(limit = 240): Promise<RootReportInbox> {
+  const db = createServiceSupabaseClient();
+  const [agentRuns, prospectReports, prospectSources, prospectRuns, continuityReports] = await Promise.all([
+    db.from('sfi_cognitive_twin_runs')
+      .select('id,task_id,status,objective,input_snapshot,output_envelope,evidence_refs,limitations,provider,model,started_at,finished_at,created_at')
+      .eq('role', 'report_agent')
+      .order('created_at', { ascending: false })
+      .limit(limit),
+    db.from('prospect_opportunity_reports')
+      .select('id,run_id,company_name,sector,region,pain_statement,critical_window,sfi_fit,contact,proposal_document,confidence,epistemic_status,payload,created_at')
+      .order('created_at', { ascending: false })
+      .limit(80),
+    db.from('prospect_research_sources')
+      .select('run_id,url,title,publisher,reliability,created_at')
+      .order('created_at', { ascending: false })
+      .limit(400),
+    db.from('prospect_research_runs')
+      .select('id,mode,status,search_provider,query_plan,warnings,created_at,completed_at')
+      .order('created_at', { ascending: false })
+      .limit(100),
+    db.from('sfi_continuity_reports')
+      .select('id,period_start,period_end,mode,summary,content,created_at')
+      .order('created_at', { ascending: false })
+      .limit(30),
+  ]);
+
+  const warnings = unique([
+    agentRuns.error ? `sfi_cognitive_twin_runs:${agentRuns.error.message}` : null,
+    prospectReports.error ? `prospect_opportunity_reports:${prospectReports.error.message}` : null,
+    prospectSources.error ? `prospect_research_sources:${prospectSources.error.message}` : null,
+    prospectRuns.error ? `prospect_research_runs:${prospectRuns.error.message}` : null,
+    continuityReports.error ? `sfi_continuity_reports:${continuityReports.error.message}` : null,
+  ]);
+  const sourceRows = rows(prospectSources.data);
+  const runRows = rows(prospectRuns.data);
+  const items = [
+    ...rows(agentRuns.data).map(normalizeAgentRun),
+    ...rows(prospectReports.data).map((item) => normalizeProspect(item, sourceRows, runRows)),
+    ...rows(continuityReports.data).map(normalizeContinuity),
+  ]
+    .sort((a, b) => Date.parse(b.createdAt ?? '') - Date.parse(a.createdAt ?? ''))
+    .slice(0, limit);
+
+  const categories: RootReportCategory[] = ['world', 'internal', 'prospects', 'attractor', 'evidence', 'drafts', 'other'];
+  const counts = Object.fromEntries(categories.map((category) => [category, items.filter((item) => item.category === category).length])) as Record<RootReportCategory, number>;
+
+  return {
+    generatedAt: new Date().toISOString(),
+    items,
+    warnings,
+    counts: { total: items.length, ...counts },
+  };
+}
+
+function currentTaskId(key: ScheduledReportLane['key'], dateKey: string, weekKey: string) {
+  const period = key.includes('weekly') ? weekKey : dateKey;
+  return `scheduled-report:${key}:${period}`;
+}
+
+export async function readRootReportHealth(existingInbox?: RootReportInbox): Promise<RootReportHealth> {
+  const inbox = existingInbox ?? await readRootReportInbox(260);
+  const { dateKey } = mexicoParts();
+  const weekKey = isoWeekKey(dateKey);
+  const laneDefs: Array<Pick<ScheduledReportLane, 'key' | 'cadence' | 'label'>> = [
+    { key: 'world_daily', cadence: 'daily', label: 'Mundo · diario' },
+    { key: 'world_weekly', cadence: 'weekly', label: 'Mundo · semanal' },
+    { key: 'internal_daily', cadence: 'daily', label: 'SFI interno · diario' },
+    { key: 'prospect_weekly', cadence: 'weekly', label: 'Prospectos · semanal' },
+    { key: 'attractor_daily', cadence: 'daily', label: 'Atractor institucional · diario' },
+  ];
+
+  const lanes = laneDefs.map((definition): ScheduledReportLane => {
+    const laneItems = inbox.items.filter((item) => item.scheduleKey === definition.key);
+    const latest = laneItems[0] ?? null;
+    const expectedTaskId = currentTaskId(definition.key, dateKey, weekKey);
+    const current = laneItems.find((item) => text(item.metadata.taskId) === expectedTaskId) ?? null;
+    const currentPeriodPresent = Boolean(current);
+    const blocked = Boolean(current && ['BLOCKED', 'FAILED', 'REJECTED'].includes(current.status.toUpperCase()));
+    return {
+      ...definition,
+      lastGeneratedAt: latest?.createdAt ?? null,
+      lastStatus: latest?.status ?? null,
+      currentPeriodPresent,
+      state: currentPeriodPresent ? (blocked ? 'CURRENT_BLOCKED' : 'CURRENT') : latest ? 'MISSING_CURRENT_PERIOD' : 'NEVER_GENERATED',
+    };
+  });
+
+  const providers = getLlmProviderStatus().map((item) => ({ id: item.id, available: item.available, model: item.model || null }));
+  return {
+    generatedAt: new Date().toISOString(),
+    inboxReadable: !inbox.warnings.some((warning) => warning.startsWith('sfi_cognitive_twin_runs:')),
+    totalReports: inbox.items.length,
+    latestReportAt: inbox.items[0]?.createdAt ?? null,
+    providers,
+    lanes,
+    warnings: inbox.warnings,
+  };
+}

--- a/src/lib/reports/scheduledAgentReports.ts
+++ b/src/lib/reports/scheduledAgentReports.ts
@@ -1,0 +1,376 @@
+import 'server-only';
+
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { runReportAgent } from '@/lib/agents/sfiAgents';
+import { runNoKeyProspectRadar } from '@/lib/agents/noKeyProspectRadar';
+import { buildWorldVectorOperationalState } from '@/lib/world-vector/operationalState';
+import { readObservedSfiCognitiveRuntime } from '@/lib/sfi/cognitive-runtime/observedRuntime';
+import { readContinuityDashboard } from '@/lib/continuity/runtime';
+import { readInstitutionalAttractor, refreshInstitutionalAttractorTrajectory } from '@/lib/institution/institutionalAttractor';
+
+export type ScheduledReportKey = 'world_daily' | 'world_weekly' | 'internal_daily' | 'prospect_weekly' | 'attractor_daily';
+
+type Row = Record<string, unknown>;
+type ReportEnvelope = {
+  ok: boolean;
+  type: string;
+  title: string;
+  body: string;
+  evidence: string[];
+  provider: string;
+  warnings: string[];
+  trace: Record<string, unknown>;
+  approval_queue: Record<string, unknown>;
+};
+
+type ScheduledResult = {
+  key: ScheduledReportKey;
+  taskId: string;
+  state: 'GENERATED' | 'SKIPPED_EXISTING' | 'FAILED';
+  reportId: string | null;
+  error: string | null;
+};
+
+function rec(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function text(value: unknown, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : [];
+}
+function unique(values: Array<string | null | undefined>) {
+  return [...new Set(values.filter((value): value is string => Boolean(value && value.trim())))];
+}
+function mexicoDateKey(date = new Date()) {
+  const values = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Mexico_City',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+  const part = (type: Intl.DateTimeFormatPartTypes) => values.find((item) => item.type === type)?.value ?? '';
+  return `${part('year')}-${part('month')}-${part('day')}`;
+}
+function isoWeekKey(dateKey: string) {
+  const date = new Date(`${dateKey}T12:00:00Z`);
+  const target = new Date(date);
+  const day = (target.getUTCDay() + 6) % 7;
+  target.setUTCDate(target.getUTCDate() - day + 3);
+  const firstThursday = new Date(Date.UTC(target.getUTCFullYear(), 0, 4));
+  const firstDay = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstDay + 3);
+  const week = 1 + Math.round((target.getTime() - firstThursday.getTime()) / 604_800_000);
+  return `${target.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+}
+function taskId(key: ScheduledReportKey, dateKey: string, weekKey: string) {
+  return `scheduled-report:${key}:${key.includes('weekly') ? weekKey : dateKey}`;
+}
+function scheduleCadence(key: ScheduledReportKey) {
+  return key.includes('weekly') ? 'weekly' as const : 'daily' as const;
+}
+
+async function persistScheduledReport(input: {
+  key: ScheduledReportKey;
+  dateKey: string;
+  weekKey: string;
+  title: string;
+  output: ReportEnvelope;
+  extraInput?: Record<string, unknown>;
+}) {
+  const db = createServiceSupabaseClient();
+  const id = taskId(input.key, input.dateKey, input.weekKey);
+  const existing = await db.from('sfi_cognitive_twin_runs')
+    .select('id,status,created_at')
+    .eq('role', 'report_agent')
+    .eq('task_id', id)
+    .maybeSingle();
+  if (existing.error) throw new Error(`scheduled_report_lookup_failed:${existing.error.message}`);
+  if (existing.data?.id) return { id: String(existing.data.id), skipped: true };
+
+  const startedAt = new Date().toISOString();
+  const inserted = await db.from('sfi_cognitive_twin_runs').insert({
+    task_id: id,
+    contract_version: 'report-agent-scheduled-v1',
+    provider: input.output.provider || null,
+    model: null,
+    role: 'report_agent',
+    status: input.output.ok && !input.output.provider.startsWith('degraded:') && !input.output.provider.startsWith('blocked:') ? 'READY' : 'BLOCKED',
+    objective: input.title,
+    input_snapshot: {
+      reportType: input.output.type,
+      scheduleKey: input.key,
+      schedule: {
+        key: input.key,
+        cadence: scheduleCadence(input.key),
+        period: input.key.includes('weekly') ? input.weekKey : input.dateKey,
+        timezone: 'America/Mexico_City',
+        generatedBy: 'continuity-report-cron',
+      },
+      ...input.extraInput,
+    },
+    output_envelope: input.output,
+    evidence_refs: input.output.evidence,
+    limitations: input.output.warnings,
+    started_at: startedAt,
+    finished_at: new Date().toISOString(),
+  }).select('id').single();
+  if (inserted.error || !inserted.data?.id) throw new Error(`scheduled_report_persistence_failed:${inserted.error?.message ?? 'unknown'}`);
+  return { id: String(inserted.data.id), skipped: false };
+}
+
+function internalEnvelope(input: {
+  runtime: Awaited<ReturnType<typeof readObservedSfiCognitiveRuntime>>;
+  continuity: Awaited<ReturnType<typeof readContinuityDashboard>>;
+  attractor: Awaited<ReturnType<typeof readInstitutionalAttractor>>;
+  dateKey: string;
+}): ReportEnvelope {
+  const operational = input.runtime.agents.filter((agent) => agent.status === 'operational');
+  const degraded = input.runtime.agents.filter((agent) => agent.status === 'degraded');
+  const missing = input.runtime.agents.filter((agent) => agent.status === 'missing');
+  const gated = input.runtime.agents.filter((agent) => agent.status === 'gated');
+  const latestTrajectory = rec(input.attractor.latestTrajectory);
+  const body = [
+    `SFI · REPORTE INTERNO DIARIO · ${input.dateKey}`,
+    '',
+    'RUNTIME COGNITIVO',
+    input.runtime.summary,
+    `Operativos: ${operational.length}; gated: ${gated.length}; degradados: ${degraded.length}; missing: ${missing.length}.`,
+    degraded.length ? `Degradados: ${degraded.map((agent) => `${agent.id} [${agent.evidence.missingTables.join(', ') || 'dependencia parcial'}]`).join(' · ')}` : 'Sin agentes degradados declarados.',
+    missing.length ? `Sin soporte suficiente: ${missing.map((agent) => agent.id).join(', ')}` : 'Sin agentes missing declarados.',
+    '',
+    'CONTINUIDAD INSTITUCIONAL',
+    `Modo: ${text(rec(input.continuity.state).mode, 'UNKNOWN')}. Incidentes abiertos: ${input.continuity.incidents.length}. Decisiones pendientes: ${input.continuity.decisions.length}.`,
+    '',
+    'ATRACTOR INSTITUCIONAL',
+    `Cobertura de evidencia: ${text(latestTrajectory.evidence_coverage, 'MISSING')}. Esto es cobertura de dimensiones con evidencia/contradicción; NO es porcentaje de cumplimiento del atractor.`,
+    `Dimensiones soportadas: ${strings(latestTrajectory.supported_dimensions).join(', ') || 'ninguna observada'}.`,
+    `Dimensiones faltantes: ${strings(latestTrajectory.missing_dimensions).join(', ') || 'ninguna declarada'}.`,
+    `Dimensiones contradichas/conflictivas: ${strings(latestTrajectory.contradicted_dimensions).join(', ') || 'ninguna declarada'}.`,
+    '',
+    'SIGUIENTE LECTURA',
+    degraded.length || missing.length
+      ? 'Primero reconciliar dependencias/contratos del runtime; no elevar capacidad por presencia de código.'
+      : 'Runtime sin degradación estructural observada en esta lectura; continuar con retorno, calibración y gobernanza.',
+  ].join('\n');
+  return {
+    ok: true,
+    type: 'internal_daily',
+    title: `SFI interno · ${input.dateKey}`,
+    body,
+    evidence: unique([
+      ...input.runtime.eventGraph.recentEvents.slice(0, 30).map((event) => event.eventId),
+      ...strings(latestTrajectory.evidence_refs),
+    ]),
+    provider: 'deterministic:sfi-internal-observer',
+    warnings: unique([...input.runtime.eventGraph.warnings.map(String), ...input.continuity.errors.map(String), ...input.attractor.warnings]),
+    trace: {
+      runtimeSchema: input.runtime.schemaVersion,
+      continuityRuns: input.continuity.runs.length,
+      attractorSnapshot: latestTrajectory.id ?? null,
+    },
+    approval_queue: {},
+  };
+}
+
+function attractorEnvelope(input: {
+  refresh: Awaited<ReturnType<typeof refreshInstitutionalAttractorTrajectory>>;
+  attractor: Awaited<ReturnType<typeof readInstitutionalAttractor>>;
+  world: Awaited<ReturnType<typeof buildWorldVectorOperationalState>>;
+  dateKey: string;
+}): ReportEnvelope {
+  const latest = rec(input.attractor.latestTrajectory);
+  const dimensions = rec(latest.dimension_state);
+  const dimensionLines = Object.entries(dimensions).map(([key, value]) => {
+    const state = rec(value);
+    return `- ${key}: ${text(state.status, 'MISSING')} · soporte ${text(state.observedCount, '0')} · contradicción ${text(state.contradictionCount, '0')}`;
+  });
+  const attractorRecord = rec(input.attractor.attractor);
+  const attractorVector = rec(attractorRecord.vector);
+  const body = [
+    `SFI · ATRACTOR DECLARADO / EVIDENCIA / MUNDO · ${input.dateKey}`,
+    '',
+    `Atractor: ${input.refresh.attractorKey}`,
+    `Estado deseado declarado: ${text(attractorVector.desiredState, 'MISSING · no se recuperó desiredState del atractor persistido')}.`,
+    `Cobertura de evidencia: ${input.refresh.evidenceCoverage}. NO equivale a cumplimiento ni proximidad porcentual al atractor.`,
+    '',
+    'DIMENSIONES',
+    ...(dimensionLines.length ? dimensionLines : ['- MISSING · no hay dimension_state persistido.']),
+    '',
+    'MUNDO ACTUAL',
+    `World Vector status: ${input.world.today.observation.status}.`,
+    `Señal dominante: ${input.world.today.observation.dominant_signal ?? 'MISSING'}.`,
+    `Interpretación: ${input.world.today.observation.interpretation}.`,
+    '',
+    'LECTURA DE TRAYECTORIA',
+    input.refresh.contradictedDimensions.length
+      ? `Hay contradicción/conflicto en: ${input.refresh.contradictedDimensions.join(', ')}.`
+      : 'No hay dimensiones contradichas en el snapshot generado.',
+    input.refresh.missingDimensions.length
+      ? `Falta evidencia explícita para: ${input.refresh.missingDimensions.join(', ')}.`
+      : 'Todas las dimensiones tienen al menos evidencia o contradicción persistida; eso no prueba attainment.',
+    '',
+    'REGLA',
+    'Este reporte compara el atractor declarado contra evidencia persistida y contexto mundial. No convierte intención en evidencia, cobertura en éxito ni correlación en causalidad.',
+  ].join('\n');
+  return {
+    ok: input.refresh.ok,
+    type: 'attractor_progress',
+    title: `Atractor declarado · evidencia + mundo · ${input.dateKey}`,
+    body,
+    evidence: unique([
+      ...input.refresh.dimensions.flatMap((dimension) => [...dimension.evidenceRefs, ...dimension.contradictionRefs]),
+      ...strings(latest.evidence_refs),
+      input.world.today.observation.source_snapshot_id ?? null,
+    ]),
+    provider: 'deterministic:institutional-attractor-observer',
+    warnings: unique([...input.refresh.warnings, ...input.attractor.warnings, ...input.world.agent_audit.blocked]),
+    trace: {
+      attractorKey: input.refresh.attractorKey,
+      trajectoryObservedAt: input.refresh.observedAt,
+      worldSnapshot: input.world.today.observation.source_snapshot_id ?? null,
+    },
+    approval_queue: {},
+  };
+}
+
+function prospectEnvelope(report: Awaited<ReturnType<typeof runNoKeyProspectRadar>>, weekKey: string): ReportEnvelope {
+  const candidates = report.candidates.length
+    ? report.candidates.map((candidate) => `- ${candidate.company} · ${candidate.sector} · confidence ${candidate.confidence}: ${candidate.reason}`).join('\n')
+    : '- MISSING · no se recuperaron candidatos verificables.';
+  const body = [
+    `SFI · PROSPECT RADAR SEMANAL · ${weekKey}`,
+    '',
+    'CANDIDATOS',
+    candidates,
+    '',
+    `Candidato principal: ${report.company.name}`,
+    `Dolor observado/provisional: ${report.observedPain.statement}`,
+    `Encaje SFI: ${report.sfiFit.offerId} · ${report.sfiFit.offerName} · ${report.sfiFit.offerStatus}`,
+    `Ventana proyectada: ${report.criticalWindow.startDate} → ${report.criticalWindow.endDate}.`,
+    `Contacto verificable: ${report.contact.verified ? 'sí' : 'no'}.`,
+    '',
+    'LÍMITE',
+    'Este reporte descubre señales públicas y candidatos. No autoriza contacto, no afirma causalidad y no convierte titulares en dolor institucional confirmado.',
+  ].join('\n');
+  return {
+    ok: true,
+    type: 'prospect_scan',
+    title: `Prospect Radar · ${weekKey}`,
+    body,
+    evidence: unique(report.sources.map((source) => source.url)),
+    provider: report.researchProvider,
+    warnings: unique([...report.warnings, ...report.limitations]),
+    trace: { runId: report.runId, queryPlan: report.queryPlan, confidence: report.confidence },
+    approval_queue: {
+      approval_required: true,
+      action: 'review_before_contact',
+      status: 'queued_for_approval',
+      reason: 'External contact remains founder-governed.',
+    },
+  };
+}
+
+async function rootActorId() {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('profiles').select('user_id,role').eq('role', 'root').limit(1).maybeSingle();
+  return result.error ? null : text(rec(result.data).user_id) || null;
+}
+
+async function ensure(input: {
+  key: ScheduledReportKey;
+  dateKey: string;
+  weekKey: string;
+  title: string;
+  generate: () => Promise<ReportEnvelope>;
+  extraInput?: Record<string, unknown>;
+}): Promise<ScheduledResult> {
+  const id = taskId(input.key, input.dateKey, input.weekKey);
+  try {
+    const db = createServiceSupabaseClient();
+    const existing = await db.from('sfi_cognitive_twin_runs').select('id').eq('role', 'report_agent').eq('task_id', id).maybeSingle();
+    if (existing.error) throw new Error(existing.error.message);
+    if (existing.data?.id) return { key: input.key, taskId: id, state: 'SKIPPED_EXISTING', reportId: String(existing.data.id), error: null };
+    const output = await input.generate();
+    const persisted = await persistScheduledReport({ ...input, output });
+    return { key: input.key, taskId: id, state: persisted.skipped ? 'SKIPPED_EXISTING' : 'GENERATED', reportId: persisted.id, error: null };
+  } catch (error) {
+    return { key: input.key, taskId: id, state: 'FAILED', reportId: null, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function runScheduledAgentReportCycle() {
+  const dateKey = mexicoDateKey();
+  const weekKey = isoWeekKey(dateKey);
+  const results: ScheduledResult[] = [];
+
+  results.push(await ensure({
+    key: 'world_daily', dateKey, weekKey, title: `Mundo · reporte diario · ${dateKey}`,
+    generate: async () => {
+      const report = await runReportAgent({ type: 'world_vector_internal', subject: `WORLD DAILY ${dateKey} · describe sólo evidencia disponible y tensiones actuales; separa observado, inferido y proyectado.` });
+      return { ...report, type: 'world_daily', title: `Mundo · reporte diario · ${dateKey}` };
+    },
+  }));
+
+  results.push(await ensure({
+    key: 'internal_daily', dateKey, weekKey, title: `SFI interno · ${dateKey}`,
+    generate: async () => {
+      const [runtime, continuity, attractor] = await Promise.all([
+        readObservedSfiCognitiveRuntime(),
+        readContinuityDashboard(),
+        readInstitutionalAttractor(),
+      ]);
+      return internalEnvelope({ runtime, continuity, attractor, dateKey });
+    },
+  }));
+
+  results.push(await ensure({
+    key: 'attractor_daily', dateKey, weekKey, title: `Atractor declarado · evidencia + mundo · ${dateKey}`,
+    generate: async () => {
+      const refresh = await refreshInstitutionalAttractorTrajectory();
+      const [attractor, world] = await Promise.all([readInstitutionalAttractor(), buildWorldVectorOperationalState()]);
+      return attractorEnvelope({ refresh, attractor, world, dateKey });
+    },
+  }));
+
+  results.push(await ensure({
+    key: 'world_weekly', dateKey, weekKey, title: `Mundo · reporte semanal · ${weekKey}`,
+    generate: async () => {
+      const report = await runReportAgent({ type: 'world_vector_internal', subject: `WORLD WEEKLY ${weekKey} · sintetiza trayectoria de la semana usando sólo estado/evidencia disponible; identifica tensiones persistentes, cambios, contradicciones y qué observar la próxima semana.` });
+      return { ...report, type: 'world_weekly', title: `Mundo · reporte semanal · ${weekKey}` };
+    },
+  }));
+
+  results.push(await ensure({
+    key: 'prospect_weekly', dateKey, weekKey, title: `Prospect Radar · ${weekKey}`,
+    generate: async () => {
+      const actorId = await rootActorId();
+      if (!actorId) {
+        return {
+          ok: false,
+          type: 'prospect_scan',
+          title: `Prospect Radar · ${weekKey}`,
+          body: 'BLOCKED · no existe un actor ROOT persistido que pueda atribuir la corrida de Prospect Radar. No se fabrica identidad de ejecución.',
+          evidence: [],
+          provider: 'blocked:no-root-actor',
+          warnings: ['root_actor_missing_for_prospect_radar'],
+          trace: { weekKey },
+          approval_queue: {},
+        } satisfies ReportEnvelope;
+      }
+      const report = await runNoKeyProspectRadar({ mode: 'discover', region: 'Mexico', lookbackDays: 30, maxCandidates: 3, allowProvisionalOffers: false }, actorId);
+      return prospectEnvelope(report, weekKey);
+    },
+  }));
+
+  return {
+    ok: results.every((result) => result.state !== 'FAILED'),
+    dateKey,
+    weekKey,
+    generated: results.filter((result) => result.state === 'GENERATED').length,
+    skipped: results.filter((result) => result.state === 'SKIPPED_EXISTING').length,
+    failed: results.filter((result) => result.state === 'FAILED').length,
+    results,
+  };
+}

--- a/src/lib/reports/scheduledAgentReports.ts
+++ b/src/lib/reports/scheduledAgentReports.ts
@@ -70,6 +70,9 @@ function taskId(key: ScheduledReportKey, dateKey: string, weekKey: string) {
 function scheduleCadence(key: ScheduledReportKey) {
   return key.includes('weekly') ? 'weekly' as const : 'daily' as const;
 }
+function producerRole(key: ScheduledReportKey) {
+  return key === 'world_daily' || key === 'world_weekly' ? 'report_agent' : 'report_scheduler';
+}
 
 async function persistScheduledReport(input: {
   key: ScheduledReportKey;
@@ -83,7 +86,7 @@ async function persistScheduledReport(input: {
   const id = taskId(input.key, input.dateKey, input.weekKey);
   const existing = await db.from('sfi_cognitive_twin_runs')
     .select('id,status,created_at')
-    .eq('role', 'report_agent')
+    .in('role', ['report_agent', 'report_scheduler'])
     .eq('task_id', id)
     .maybeSingle();
   if (existing.error) throw new Error(`scheduled_report_lookup_failed:${existing.error.message}`);
@@ -95,7 +98,7 @@ async function persistScheduledReport(input: {
     contract_version: 'report-agent-scheduled-v1',
     provider: input.output.provider || null,
     model: null,
-    role: 'report_agent',
+    role: producerRole(input.key),
     status: input.output.ok && !input.output.provider.startsWith('degraded:') && !input.output.provider.startsWith('blocked:') ? 'READY' : 'BLOCKED',
     objective: input.title,
     input_snapshot: {
@@ -107,6 +110,7 @@ async function persistScheduledReport(input: {
         period: input.key.includes('weekly') ? input.weekKey : input.dateKey,
         timezone: 'America/Mexico_City',
         generatedBy: 'continuity-report-cron',
+        producerRole: producerRole(input.key),
       },
       ...input.extraInput,
     },
@@ -289,7 +293,7 @@ async function ensure(input: {
   const id = taskId(input.key, input.dateKey, input.weekKey);
   try {
     const db = createServiceSupabaseClient();
-    const existing = await db.from('sfi_cognitive_twin_runs').select('id').eq('role', 'report_agent').eq('task_id', id).maybeSingle();
+    const existing = await db.from('sfi_cognitive_twin_runs').select('id').in('role', ['report_agent', 'report_scheduler']).eq('task_id', id).maybeSingle();
     if (existing.error) throw new Error(existing.error.message);
     if (existing.data?.id) return { key: input.key, taskId: id, state: 'SKIPPED_EXISTING', reportId: String(existing.data.id), error: null };
     const output = await input.generate();

--- a/src/lib/root/sovereign/readers/readRootAgents.ts
+++ b/src/lib/root/sovereign/readers/readRootAgents.ts
@@ -1,34 +1,43 @@
 import 'server-only';
 
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
 import { readObservedSfiCognitiveRuntime } from '@/lib/sfi/cognitive-runtime/observedRuntime';
+import { SFI_AGENTIC_CAPABILITIES, type SfiAgenticCapabilityContract } from '@/lib/sfi/agenticCapabilityRegistry';
 import type { RootAgent, RootDataStatus } from '../rootSovereignState';
 import { source } from './readerSupport';
-
-type AgenticCapability = {
-  id: string;
-  name: string;
-  purpose: string;
-  layer: string;
-  route: string;
-  providerAware?: boolean;
-  approvalRequired?: boolean;
-};
-
-const AGENTIC_CAPABILITIES: AgenticCapability[] = [
-  { id: 'world_vector_agent', name: 'World Vector Agent', purpose: 'Integra observación mundial, oportunidades y estado operativo para producir una lectura trazable.', layer: 'observar', route: '/api/root/agentic/world-vector' },
-  { id: 'moph_agent', name: 'MOP-H Agent', purpose: 'Interpreta una fricción observada y propone una perturbación mínima reversible sustentada por evidencia.', layer: 'reconstruir', route: '/api/interface/observatory/interpret', providerAware: true },
-  { id: 'neural_graph_agent', name: 'Neural Graph Agent', purpose: 'Recupera relaciones y evidencia del grafo persistido sin crear conexiones de respaldo.', layer: 'relacionar', route: '/api/root/agentic/neural-graph' },
-  { id: 'amv_agent', name: 'AMV Agent', purpose: 'Recupera memoria operativa, recurrencias y asociaciones institucionales persistidas.', layer: 'recordar', route: '/api/root/agentic/amv' },
-  { id: 'prediction_agent', name: 'Prediction Agent', purpose: 'Formula predicciones y probabilidades con base explícita de evidencia e incertidumbre.', layer: 'proyectar', route: '/api/root/agentic/prediction' },
-  { id: 'client_finder_agent', name: 'Client Finder Agent', purpose: 'Detecta oportunidades comerciales, ejecuta IFNORM y prepara una propuesta para revisión humana.', layer: 'proponer', route: '/api/root/agentic/client-finder', providerAware: true, approvalRequired: true },
-  { id: 'report_agent', name: 'Report Agent', purpose: 'Genera lecturas institucionales, calibraciones, borradores y reportes sustentados por evidencia.', layer: 'reportar', route: '/api/root/agentic/report', providerAware: true, approvalRequired: true },
-];
 
 function rootStatus(status: string): RootDataStatus {
   if (status === 'operational') return 'observed';
   if (status === 'degraded') return 'degraded';
   if (status === 'missing') return 'missing';
   return 'gated';
+}
+
+function iso(value: unknown): string | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : value;
+}
+
+async function readAgenticExecution(contract: SfiAgenticCapabilityContract) {
+  if (!contract.executionEvidence) return { status: 'gated' as const, at: null as string | null, id: null as string | null, warning: 'Ruta/contrato registrados; esta capacidad no tiene aún un ledger de ejecución específico reconciliado.' };
+  try {
+    const db = createServiceSupabaseClient();
+    let query = db.from(contract.executionEvidence.table).select(`id,${contract.executionEvidence.timeColumn}`).order(contract.executionEvidence.timeColumn, { ascending: false }).limit(1);
+    if (contract.executionEvidence.filter) query = query.eq(contract.executionEvidence.filter.column, contract.executionEvidence.filter.value);
+    const result = await query.maybeSingle();
+    if (result.error) return { status: 'degraded' as const, at: null, id: null, warning: `${contract.executionEvidence.table}: ${result.error.message}` };
+    if (!result.data) return { status: 'gated' as const, at: null, id: null, warning: 'Contrato disponible; no existe ejecución persistida atribuible todavía.' };
+    const record = result.data as Record<string, unknown>;
+    return { status: 'operational' as const, at: iso(record[contract.executionEvidence.timeColumn]), id: typeof record.id === 'string' ? record.id : null, warning: null };
+  } catch (error) {
+    return { status: 'degraded' as const, at: null, id: null, warning: error instanceof Error ? error.message : 'agentic_execution_read_failed' };
+  }
+}
+
+function isStructuralWarning(value: string) {
+  const lower = value.toLowerCase();
+  return !lower.includes('sin ejecución') && !lower.includes('no tiene aún un ledger') && !lower.includes('no existe ejecución') && !lower.includes('todavía no existe');
 }
 
 export async function readRootAgents() {
@@ -52,7 +61,7 @@ export async function readRootAgents() {
         observedAt: latest?.at ?? runtime.generatedAt,
         confidence: null,
         evidenceIds: latest?.id ? [latest.id] : [],
-        explanation: entry.purpose,
+        explanation: `${entry.purpose} · LEE: ${entry.readsMemory.map((item) => item.memory).join(', ') || 'ninguna fuente declarada'} · ESCRIBE: ${entry.writesMemory.map((item) => item.memory).join(', ') || 'ningún writer declarado'}`,
         warning,
       },
       provider: null,
@@ -64,35 +73,40 @@ export async function readRootAgents() {
     };
   });
 
-  for (const entry of AGENTIC_CAPABILITIES) {
+  const agenticExecutions = await Promise.all(SFI_AGENTIC_CAPABILITIES.map(async (entry) => ({ entry, observed: await readAgenticExecution(entry) })));
+  for (const { entry, observed } of agenticExecutions) {
     if (agents.some((item) => item.id === entry.id)) continue;
     agents.push({
       id: entry.id,
       role: entry.name,
       state: {
-        value: entry.approvalRequired ? 'ruta registrada · requiere autorización' : 'ruta registrada · ejecución no medida aquí',
-        status: 'gated',
-        source: 'Registro de capacidades agentic; no constituye prueba de ejecución',
-        observedAt: null,
+        value: observed.status === 'operational' ? 'ejecución persistida observada' : observed.status === 'degraded' ? 'dependencia de ejecución degradada' : 'contrato disponible · sin ejecución atribuible',
+        status: rootStatus(observed.status),
+        source: observed.id ? `${entry.executionEvidence?.table ?? 'execution ledger'}:${observed.id}` : 'Registro agentic + contrato de ejecución',
+        observedAt: observed.at,
         confidence: null,
-        evidenceIds: [],
-        explanation: `Capa ${entry.layer}. ${entry.purpose}`,
-        warning: entry.approvalRequired ? 'Requiere revisión antes de publicación, contacto o mutación.' : 'La ruta existe, pero esta vista no posee una traza reciente atribuible.',
+        evidenceIds: observed.id ? [observed.id] : [],
+        explanation: `${entry.purpose} · LEE: ${entry.reads.join(', ')} · ESCRIBE: ${entry.writes.join(', ')} · EJECUTA: ${entry.executes.join(', ')}`,
+        warning: observed.warning,
       },
-      provider: entry.providerAware ? 'se resuelve durante la ejecución' : null,
-      model: entry.providerAware ? 'se resuelve durante la ejecución' : null,
-      lastRun: null,
+      provider: entry.providerAware ? 'se registra durante la ejecución' : null,
+      model: entry.providerAware ? 'se registra durante la ejecución' : null,
+      lastRun: observed.at,
       lastResult: entry.purpose,
-      availability: 'gated',
-      error: null,
+      availability: observed.status,
+      error: observed.warning,
     });
   }
 
   agents.sort((a, b) => a.role.localeCompare(b.role, 'es'));
+  const warnings = [
+    ...runtime.eventGraph.warnings,
+    ...agenticExecutions.map((item) => item.observed.warning).filter((value): value is string => Boolean(value && isStructuralWarning(value))),
+  ];
   return source(
     { agents },
-    'Cognitive Runtime observado + capacidades agentic registradas',
-    runtime.eventGraph.warnings,
+    'Cognitive Runtime observado + capacidades agentic + ejecución persistida',
+    warnings,
     runtime.generatedAt,
     runtime.status === 'missing',
   );

--- a/src/lib/root/sovereign/readers/readRootAgents.ts
+++ b/src/lib/root/sovereign/readers/readRootAgents.ts
@@ -19,6 +19,15 @@ function iso(value: unknown): string | null {
   return Number.isFinite(parsed.getTime()) ? parsed.toISOString() : value;
 }
 
+function executionLifecycle(contract: SfiAgenticCapabilityContract, record: Record<string, unknown>) {
+  const rule = contract.executionEvidence?.status;
+  if (!rule) return { status: 'operational' as const, warning: null as string | null };
+  const observed = typeof record[rule.column] === 'string' ? String(record[rule.column]).trim().toLowerCase() : '';
+  if (rule.operationalValues.map((value) => value.toLowerCase()).includes(observed)) return { status: 'operational' as const, warning: null };
+  if (rule.degradedValues.map((value) => value.toLowerCase()).includes(observed)) return { status: 'degraded' as const, warning: `Última ejecución persistida con estado ${observed || 'unknown'}.` };
+  return { status: 'gated' as const, warning: `Estado de ejecución no reconocido como operativo: ${observed || 'missing'}.` };
+}
+
 async function readAgenticExecution(contract: SfiAgenticCapabilityContract) {
   if (!contract.executionEvidence) return { status: 'gated' as const, at: null as string | null, id: null as string | null, warning: 'Ruta/contrato registrados; esta capacidad no tiene aún un ledger de ejecución específico reconciliado.' };
   try {
@@ -29,7 +38,8 @@ async function readAgenticExecution(contract: SfiAgenticCapabilityContract) {
     if (result.error) return { status: 'degraded' as const, at: null, id: null, warning: `${contract.executionEvidence.table}: ${result.error.message}` };
     if (!result.data) return { status: 'gated' as const, at: null, id: null, warning: 'Contrato disponible; no existe ejecución persistida atribuible todavía.' };
     const record = result.data as Record<string, unknown>;
-    return { status: 'operational' as const, at: iso(record[contract.executionEvidence.timeColumn]), id: typeof record.id === 'string' ? record.id : null, warning: null };
+    const lifecycle = executionLifecycle(contract, record);
+    return { status: lifecycle.status, at: iso(record[contract.executionEvidence.timeColumn]), id: typeof record.id === 'string' ? record.id : null, warning: lifecycle.warning };
   } catch (error) {
     return { status: 'degraded' as const, at: null, id: null, warning: error instanceof Error ? error.message : 'agentic_execution_read_failed' };
   }
@@ -80,7 +90,7 @@ export async function readRootAgents() {
       id: entry.id,
       role: entry.name,
       state: {
-        value: observed.status === 'operational' ? 'ejecución persistida observada' : observed.status === 'degraded' ? 'dependencia de ejecución degradada' : 'contrato disponible · sin ejecución atribuible',
+        value: observed.status === 'operational' ? 'ejecución persistida observada' : observed.status === 'degraded' ? 'ejecución persistida degradada' : 'contrato disponible · sin ejecución atribuible',
         status: rootStatus(observed.status),
         source: observed.id ? `${entry.executionEvidence?.table ?? 'execution ledger'}:${observed.id}` : 'Registro agentic + contrato de ejecución',
         observedAt: observed.at,

--- a/src/lib/root/sovereign/readers/readRootAgents.ts
+++ b/src/lib/root/sovereign/readers/readRootAgents.ts
@@ -23,7 +23,7 @@ async function readAgenticExecution(contract: SfiAgenticCapabilityContract) {
   if (!contract.executionEvidence) return { status: 'gated' as const, at: null as string | null, id: null as string | null, warning: 'Ruta/contrato registrados; esta capacidad no tiene aún un ledger de ejecución específico reconciliado.' };
   try {
     const db = createServiceSupabaseClient();
-    let query = db.from(contract.executionEvidence.table).select(`id,${contract.executionEvidence.timeColumn}`).order(contract.executionEvidence.timeColumn, { ascending: false }).limit(1);
+    let query = db.from(contract.executionEvidence.table).select('*').order(contract.executionEvidence.timeColumn, { ascending: false }).limit(1);
     if (contract.executionEvidence.filter) query = query.eq(contract.executionEvidence.filter.column, contract.executionEvidence.filter.value);
     const result = await query.maybeSingle();
     if (result.error) return { status: 'degraded' as const, at: null, id: null, warning: `${contract.executionEvidence.table}: ${result.error.message}` };

--- a/src/lib/sfi/agenticCapabilityRegistry.ts
+++ b/src/lib/sfi/agenticCapabilityRegistry.ts
@@ -13,6 +13,7 @@ export type SfiAgenticCapabilityContract = {
     table: string;
     timeColumn: string;
     filter?: { column: string; value: string };
+    status?: { column: string; operationalValues: string[]; degradedValues: string[] };
   } | null;
 };
 
@@ -106,7 +107,12 @@ export const SFI_AGENTIC_CAPABILITIES: SfiAgenticCapabilityContract[] = [
     reads: ['World Vector / WorldSpect state', 'canonical evidence graph', 'AMV operational memory', 'optional IFNORM context'],
     writes: ['sfi_cognitive_twin_runs(role=report_agent)', 'root_audit_events'],
     executes: ['runReportAgent', 'buildWorldVectorOperationalState', 'runNeuralGraphAgent', 'readAmvOperationalMemory', 'runLlmTask'],
-    executionEvidence: { table: 'sfi_cognitive_twin_runs', timeColumn: 'created_at', filter: { column: 'role', value: 'report_agent' } },
+    executionEvidence: {
+      table: 'sfi_cognitive_twin_runs',
+      timeColumn: 'created_at',
+      filter: { column: 'role', value: 'report_agent' },
+      status: { column: 'status', operationalValues: ['ready'], degradedValues: ['blocked', 'failed'] },
+    },
   },
   {
     id: 'prospect_radar_agent',
@@ -119,6 +125,10 @@ export const SFI_AGENTIC_CAPABILITIES: SfiAgenticCapabilityContract[] = [
     reads: ['Bing News RSS', 'Google News RSS', 'SFI service catalog', 'optional Ollama synthesis'],
     writes: ['prospect_research_runs', 'prospect_research_sources', 'prospect_opportunity_reports', 'root_audit_events'],
     executes: ['runNoKeyProspectRadar', 'runNoKeyNewsFeeds', 'matchSfiOffer', 'optional Ollama synthesis'],
-    executionEvidence: { table: 'prospect_research_runs', timeColumn: 'created_at' },
+    executionEvidence: {
+      table: 'prospect_research_runs',
+      timeColumn: 'created_at',
+      status: { column: 'status', operationalValues: ['completed'], degradedValues: ['failed', 'blocked', 'error'] },
+    },
   },
 ];

--- a/src/lib/sfi/agenticCapabilityRegistry.ts
+++ b/src/lib/sfi/agenticCapabilityRegistry.ts
@@ -1,0 +1,124 @@
+export type SfiAgenticCapabilityContract = {
+  id: string;
+  name: string;
+  purpose: string;
+  layer: string;
+  route: string;
+  providerAware: boolean;
+  approvalRequired: boolean;
+  reads: string[];
+  writes: string[];
+  executes: string[];
+  executionEvidence: {
+    table: string;
+    timeColumn: string;
+    filter?: { column: string; value: string };
+  } | null;
+};
+
+export const SFI_AGENTIC_CAPABILITIES: SfiAgenticCapabilityContract[] = [
+  {
+    id: 'world_vector_agent',
+    name: 'World Vector Agent',
+    purpose: 'Integra observación mundial, oportunidades y estado operativo para producir una lectura trazable.',
+    layer: 'observar',
+    route: '/api/root/agentic/world-vector',
+    providerAware: false,
+    approvalRequired: false,
+    reads: ['world_vector_observations', 'worldspect_snapshots', 'world opportunities', 'SFI operational state'],
+    writes: ['No persistent write declared by the agent contract'],
+    executes: ['runWorldVectorAgent', 'buildWorldVectorOperationalState', 'readOperationalConsoleState', 'loadWorldOpportunities'],
+    executionEvidence: null,
+  },
+  {
+    id: 'moph_agent',
+    name: 'MOP-H Agent',
+    purpose: 'Interpreta una fricción observada y propone una perturbación mínima reversible sustentada por evidencia.',
+    layer: 'reconstruir',
+    route: '/api/interface/observatory/interpret',
+    providerAware: true,
+    approvalRequired: false,
+    reads: ['declared MOP-H input', 'AMV operational memory', 'canonical evidence graph'],
+    writes: ['No persistent write declared by runMophAgent; caller owns persistence'],
+    executes: ['runMophAgent', 'readAmvOperationalMemory', 'runNeuralGraphAgent', 'runLlmTask'],
+    executionEvidence: null,
+  },
+  {
+    id: 'neural_graph_agent',
+    name: 'Neural Graph Agent',
+    purpose: 'Recupera relaciones y evidencia del grafo persistido sin crear conexiones de respaldo.',
+    layer: 'relacionar',
+    route: '/api/root/agentic/neural-graph',
+    providerAware: false,
+    approvalRequired: false,
+    reads: ['canonical graph projection', 'canonical evidence objects', 'related prediction/report/AMV context'],
+    writes: ['No persistent write declared by the read agent'],
+    executes: ['runNeuralGraphAgent'],
+    executionEvidence: null,
+  },
+  {
+    id: 'amv_agent',
+    name: 'AMV Agent',
+    purpose: 'Recupera memoria operativa, recurrencias y asociaciones institucionales persistidas.',
+    layer: 'recordar',
+    route: '/api/root/agentic/amv',
+    providerAware: false,
+    approvalRequired: false,
+    reads: ['sfi_amv_memory', 'related evidence/context'],
+    writes: ['No persistent write declared by readAmvOperationalMemory'],
+    executes: ['readAmvOperationalMemory'],
+    executionEvidence: null,
+  },
+  {
+    id: 'prediction_agent',
+    name: 'Prediction Agent',
+    purpose: 'Formula predicciones y probabilidades con base explícita de evidencia e incertidumbre.',
+    layer: 'proyectar',
+    route: '/api/root/agentic/prediction',
+    providerAware: false,
+    approvalRequired: false,
+    reads: ['canonical evidence graph', 'AMV operational memory', 'declared signal/entity context'],
+    writes: ['No persistent write declared by runPredictionAgent; predictive registry owns governed persistence'],
+    executes: ['runPredictionAgent', 'runNeuralGraphAgent', 'readAmvOperationalMemory'],
+    executionEvidence: null,
+  },
+  {
+    id: 'client_finder_agent',
+    name: 'Client Finder Agent',
+    purpose: 'Convierte una entidad y señal observada en una hipótesis comercial/IFNORM para revisión humana.',
+    layer: 'proponer',
+    route: '/api/root/agentic/client-finder',
+    providerAware: true,
+    approvalRequired: true,
+    reads: ['manual/public entity signal', 'canonical evidence graph', 'AMV memory', 'prediction context'],
+    writes: ['root_audit_events through ROOT route; no automatic outreach'],
+    executes: ['runClientFinderAgent', 'runPredictionAgent', 'runNeuralGraphAgent', 'readAmvOperationalMemory', 'runLlmTask'],
+    executionEvidence: null,
+  },
+  {
+    id: 'report_agent',
+    name: 'Report Agent',
+    purpose: 'Genera lecturas institucionales y reportes sustentados por evidencia; publicación/contacto permanecen gobernados.',
+    layer: 'reportar',
+    route: '/api/root/agentic/report',
+    providerAware: true,
+    approvalRequired: true,
+    reads: ['World Vector / WorldSpect state', 'canonical evidence graph', 'AMV operational memory', 'optional IFNORM context'],
+    writes: ['sfi_cognitive_twin_runs(role=report_agent)', 'root_audit_events'],
+    executes: ['runReportAgent', 'buildWorldVectorOperationalState', 'runNeuralGraphAgent', 'readAmvOperationalMemory', 'runLlmTask'],
+    executionEvidence: { table: 'sfi_cognitive_twin_runs', timeColumn: 'created_at', filter: { column: 'role', value: 'report_agent' } },
+  },
+  {
+    id: 'prospect_radar_agent',
+    name: 'Prospect Radar Agent',
+    purpose: 'Busca señales públicas de organizaciones, conserva las fuentes y produce dossiers comerciales proyectivos sin contacto automático.',
+    layer: 'proponer',
+    route: '/api/root/agentic/prospect-radar',
+    providerAware: true,
+    approvalRequired: true,
+    reads: ['Bing News RSS', 'Google News RSS', 'SFI service catalog', 'optional Ollama synthesis'],
+    writes: ['prospect_research_runs', 'prospect_research_sources', 'prospect_opportunity_reports', 'root_audit_events'],
+    executes: ['runNoKeyProspectRadar', 'runNoKeyNewsFeeds', 'matchSfiOffer', 'optional Ollama synthesis'],
+    executionEvidence: { table: 'prospect_research_runs', timeColumn: 'created_at' },
+  },
+];

--- a/src/lib/sfi/cognitive-runtime/agentPassports.ts
+++ b/src/lib/sfi/cognitive-runtime/agentPassports.ts
@@ -1,15 +1,17 @@
 import 'server-only';
 
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
 import { readObservedSfiCognitiveRuntime } from './observedRuntime';
 import { SFI_CONVERGED_COGNITIVE_AGENT_REGISTRY } from './convergedRegistry';
 import { SFI_AGENT_EXECUTION_MAP } from './agentExecutionMap';
 import { institutionalAssignmentsFor } from './institutionalAssignments';
+import { SFI_AGENTIC_CAPABILITIES, type SfiAgenticCapabilityContract } from '@/lib/sfi/agenticCapabilityRegistry';
 
 export type SfiAgentPassport = {
-  passportVersion: 'SFI-AGENT-PASSPORT-1.1';
+  passportVersion: 'SFI-AGENT-PASSPORT-1.2';
   id: string;
   name: string;
-  namespace: 'cognitive_runtime';
+  namespace: 'cognitive_runtime' | 'agentic_runtime';
   purpose: string;
   domain: string;
   layer: string;
@@ -27,23 +29,52 @@ export type SfiAgentPassport = {
   sourceTables: string[];
   observedTables: string[];
   missingTables: string[];
+  reads: string[];
+  writes: string[];
+  executes: string[];
+  executionEvidence: string[];
   latestExecutionAt: string | null;
   evidenceEventIds: string[];
   institutionalDuties: string[];
   warnings: string[];
 };
 
+type AgenticObservation = { lifecycle: SfiAgentPassport['lifecycle']; at: string | null; id: string | null; warning: string | null };
+
+function iso(value: unknown): string | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : value;
+}
+
+async function observeAgentic(contract: SfiAgenticCapabilityContract): Promise<AgenticObservation> {
+  if (!contract.executionEvidence) return { lifecycle: 'GATED', at: null, id: null, warning: 'Contrato disponible; todavía no existe un ledger específico reconciliado para demostrar ejecución.' };
+  try {
+    const db = createServiceSupabaseClient();
+    let query = db.from(contract.executionEvidence.table).select(`id,${contract.executionEvidence.timeColumn}`).order(contract.executionEvidence.timeColumn, { ascending: false }).limit(1);
+    if (contract.executionEvidence.filter) query = query.eq(contract.executionEvidence.filter.column, contract.executionEvidence.filter.value);
+    const result = await query.maybeSingle();
+    if (result.error) return { lifecycle: 'DEGRADED', at: null, id: null, warning: `${contract.executionEvidence.table}: ${result.error.message}` };
+    if (!result.data) return { lifecycle: 'GATED', at: null, id: null, warning: 'No existe una ejecución persistida atribuible todavía.' };
+    const record = result.data as Record<string, unknown>;
+    return { lifecycle: 'OPERATIONAL', at: iso(record[contract.executionEvidence.timeColumn]), id: typeof record.id === 'string' ? record.id : null, warning: null };
+  } catch (error) {
+    return { lifecycle: 'DEGRADED', at: null, id: null, warning: error instanceof Error ? error.message : 'agentic_execution_observation_failed' };
+  }
+}
+
 export async function readAgentPassports() {
   const runtime = await readObservedSfiCognitiveRuntime();
   const byId = new Map(runtime.agents.map((agent) => [agent.id, agent]));
   const executionEvents = runtime.eventGraph.recentEvents.filter((event) => event.eventName === 'SFI_AGENT_EXECUTED');
 
-  const passports: SfiAgentPassport[] = SFI_CONVERGED_COGNITIVE_AGENT_REGISTRY.map((contract) => {
+  const cognitive: SfiAgentPassport[] = SFI_CONVERGED_COGNITIVE_AGENT_REGISTRY.map((contract) => {
     const observed = byId.get(contract.id);
     const agentEvents = executionEvents.filter((event) => event.sourceId === contract.id);
     const latestExecutionAt = agentEvents.map((event) => event.occurredAt).filter((value): value is string => Boolean(value)).sort().at(-1) ?? null;
+    const executorBound = typeof SFI_AGENT_EXECUTION_MAP[contract.id] === 'function';
     return {
-      passportVersion: 'SFI-AGENT-PASSPORT-1.1',
+      passportVersion: 'SFI-AGENT-PASSPORT-1.2',
       id: contract.id,
       name: contract.name,
       namespace: 'cognitive_runtime',
@@ -53,7 +84,7 @@ export async function readAgentPassports() {
       authorityLevel: contract.authorityLevel,
       lifecycle: (observed?.status ?? 'missing').toUpperCase() as SfiAgentPassport['lifecycle'],
       registryBound: true,
-      executorBound: typeof SFI_AGENT_EXECUTION_MAP[contract.id] === 'function',
+      executorBound,
       humanApprovalRequired: contract.humanApprovalRequired,
       simulationAllowed: contract.simulationAllowed,
       route: contract.route,
@@ -64,6 +95,10 @@ export async function readAgentPassports() {
       sourceTables: contract.sourceTables,
       observedTables: observed?.evidence.observedTables ?? [],
       missingTables: observed?.evidence.missingTables ?? contract.sourceTables,
+      reads: contract.readsMemory,
+      writes: contract.writesMemory,
+      executes: executorBound ? [`SFI_AGENT_EXECUTION_MAP.${contract.id}`] : [],
+      executionEvidence: agentEvents.map((event) => event.eventId).filter(Boolean),
       latestExecutionAt,
       evidenceEventIds: agentEvents.map((event) => event.eventId).filter(Boolean),
       institutionalDuties: institutionalAssignmentsFor(contract.id),
@@ -71,11 +106,47 @@ export async function readAgentPassports() {
     };
   });
 
+  const agenticObserved = await Promise.all(SFI_AGENTIC_CAPABILITIES.map(async (contract) => ({ contract, observed: await observeAgentic(contract) })));
+  const agentic: SfiAgentPassport[] = agenticObserved.map(({ contract, observed }) => ({
+    passportVersion: 'SFI-AGENT-PASSPORT-1.2',
+    id: contract.id,
+    name: contract.name,
+    namespace: 'agentic_runtime',
+    purpose: contract.purpose,
+    domain: 'agentic',
+    layer: contract.layer,
+    authorityLevel: contract.approvalRequired ? 'advisor_governed' : 'analyst',
+    lifecycle: observed.lifecycle,
+    registryBound: true,
+    executorBound: true,
+    humanApprovalRequired: contract.approvalRequired,
+    simulationAllowed: false,
+    route: contract.route,
+    listensTo: [],
+    emits: [],
+    readsMemory: [],
+    writesMemory: [],
+    sourceTables: contract.reads,
+    observedTables: observed.lifecycle === 'OPERATIONAL' ? contract.reads : [],
+    missingTables: observed.lifecycle === 'DEGRADED' ? contract.reads : [],
+    reads: contract.reads,
+    writes: contract.writes,
+    executes: contract.executes,
+    executionEvidence: observed.id ? [`${contract.executionEvidence?.table ?? 'ledger'}:${observed.id}`] : [],
+    latestExecutionAt: observed.at,
+    evidenceEventIds: [],
+    institutionalDuties: institutionalAssignmentsFor(contract.id),
+    warnings: observed.warning ? [observed.warning] : [],
+  }));
+
+  const passports = [...cognitive, ...agentic].sort((a, b) => a.name.localeCompare(b.name, 'es'));
   return {
     generatedAt: runtime.generatedAt,
     runtimeStatus: runtime.status,
     counts: {
       total: passports.length,
+      cognitive: cognitive.length,
+      agentic: agentic.length,
       executorBound: passports.filter((item) => item.executorBound).length,
       assigned: passports.filter((item) => item.institutionalDuties.length > 0).length,
       operational: passports.filter((item) => item.lifecycle === 'OPERATIONAL').length,

--- a/src/lib/sfi/cognitive-runtime/agentPassports.ts
+++ b/src/lib/sfi/cognitive-runtime/agentPassports.ts
@@ -47,6 +47,15 @@ function iso(value: unknown): string | null {
   return Number.isFinite(date.getTime()) ? date.toISOString() : value;
 }
 
+function executionLifecycle(contract: SfiAgenticCapabilityContract, record: Record<string, unknown>) {
+  const rule = contract.executionEvidence?.status;
+  if (!rule) return { status: 'operational' as const, warning: null as string | null };
+  const observed = typeof record[rule.column] === 'string' ? String(record[rule.column]).trim().toLowerCase() : '';
+  if (rule.operationalValues.map((value) => value.toLowerCase()).includes(observed)) return { status: 'operational' as const, warning: null };
+  if (rule.degradedValues.map((value) => value.toLowerCase()).includes(observed)) return { status: 'degraded' as const, warning: `Última ejecución persistida con estado ${observed || 'unknown'}.` };
+  return { status: 'gated' as const, warning: `Estado de ejecución no reconocido como operativo: ${observed || 'missing'}.` };
+}
+
 async function observeAgentic(contract: SfiAgenticCapabilityContract): Promise<AgenticObservation> {
   if (!contract.executionEvidence) return { lifecycle: 'GATED', at: null, id: null, warning: 'Contrato disponible; todavía no existe un ledger específico reconciliado para demostrar ejecución.' };
   try {
@@ -57,7 +66,8 @@ async function observeAgentic(contract: SfiAgenticCapabilityContract): Promise<A
     if (result.error) return { lifecycle: 'DEGRADED', at: null, id: null, warning: `${contract.executionEvidence.table}: ${result.error.message}` };
     if (!result.data) return { lifecycle: 'GATED', at: null, id: null, warning: 'No existe una ejecución persistida atribuible todavía.' };
     const record = result.data as Record<string, unknown>;
-    return { lifecycle: 'OPERATIONAL', at: iso(record[contract.executionEvidence.timeColumn]), id: typeof record.id === 'string' ? record.id : null, warning: null };
+    const lifecycle = executionLifecycle(contract, record);
+    return { lifecycle: lifecycle.status.toUpperCase() as AgenticObservation['lifecycle'], at: iso(record[contract.executionEvidence.timeColumn]), id: typeof record.id === 'string' ? record.id : null, warning: lifecycle.warning };
   } catch (error) {
     return { lifecycle: 'DEGRADED', at: null, id: null, warning: error instanceof Error ? error.message : 'agentic_execution_observation_failed' };
   }

--- a/src/lib/sfi/cognitive-runtime/agentPassports.ts
+++ b/src/lib/sfi/cognitive-runtime/agentPassports.ts
@@ -51,7 +51,7 @@ async function observeAgentic(contract: SfiAgenticCapabilityContract): Promise<A
   if (!contract.executionEvidence) return { lifecycle: 'GATED', at: null, id: null, warning: 'Contrato disponible; todavía no existe un ledger específico reconciliado para demostrar ejecución.' };
   try {
     const db = createServiceSupabaseClient();
-    let query = db.from(contract.executionEvidence.table).select(`id,${contract.executionEvidence.timeColumn}`).order(contract.executionEvidence.timeColumn, { ascending: false }).limit(1);
+    let query = db.from(contract.executionEvidence.table).select('*').order(contract.executionEvidence.timeColumn, { ascending: false }).limit(1);
     if (contract.executionEvidence.filter) query = query.eq(contract.executionEvidence.filter.column, contract.executionEvidence.filter.value);
     const result = await query.maybeSingle();
     if (result.error) return { lifecycle: 'DEGRADED', at: null, id: null, warning: `${contract.executionEvidence.table}: ${result.error.message}` };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,6 +6,23 @@ import { findInstitutionalMember } from '@/lib/system/access/institutionalMember
 
 const AUTH_COOKIE_NAMES = ['sb-access-token', 'sb-refresh-token', 'supabase-auth-token']
 
+const ROOT_INTERNAL_FRAME_PREFIXES = [
+  '/root/institutionalization',
+  '/root/reports',
+  '/root/contracts',
+  '/root/agents/passports',
+  '/root/cognitive-twin',
+  '/root/predictions',
+  '/root/attractor',
+  '/root/longitudinal',
+  '/root/decisions',
+  '/root/continuity',
+  '/field',
+  '/studio',
+  '/interface/observatory',
+  '/library',
+] as const
+
 type ModuleAccess = Record<string, unknown> | null | undefined
 
 function isRefreshTokenMissing(error: unknown) {
@@ -76,11 +93,17 @@ function isLocalStudioBypass(request: NextRequest) {
   return host === 'localhost' || host === '127.0.0.1' || host === '0.0.0.0'
 }
 
+function permitsRootInternalFrame(pathname: string) {
+  return ROOT_INTERNAL_FRAME_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`))
+}
+
 export async function proxy(request: NextRequest) {
   let response = NextResponse.next()
   const { pathname } = request.nextUrl
 
-  response.headers.set('X-Frame-Options', 'DENY')
+  // SFI remains non-frameable by default. Only explicit owned surfaces used by
+  // ROOT's internal observation window may be embedded, and only by the same origin.
+  response.headers.set('X-Frame-Options', permitsRootInternalFrame(pathname) ? 'SAMEORIGIN' : 'DENY')
   response.headers.set('X-Content-Type-Options', 'nosniff')
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"agent/root-runtime-reports-convergence\" ]; then exit 0; else exit 1; fi",
   "crons": [
     {
       "path": "/api/cron/continuity-heartbeat",


### PR DESCRIPTION
## Objective
Close the immediate ROOT observability gap before Method Lab / Cognitive Twin reentry: agents must state what they read, write and execute; ROOT must be able to open its owned internal surfaces; generated reports must be readable/searchable without prompting the system to manufacture a new report; recurring report lanes must reuse existing infrastructure.

## What changes

### Agent truth
- Extends agent passports to cover both Cognitive Runtime and agentic capabilities.
- Shows `LEE`, `ESCRIBE`, `EJECUTA` and persisted execution evidence explicitly.
- Adds ROOT health endpoint for degraded/missing contracts.
- Separates linked executors from recently observed execution in the Cognitive Runtime UI.
- Does not relabel missing dependencies as healthy.

### ROOT internal surface connection
- Keeps `X-Frame-Options: DENY` by default.
- Allows `SAMEORIGIN` only for the explicit SFI surfaces that ROOT embeds internally.
- Fixes the previous contradiction where ROOT used iframes while the proxy denied every frame, producing “systemfriction.org rechazó la conexión”.

### Report Center
- Replaces prompt-first generation UI with a read-only/searchable inbox over persisted reports.
- Search text only filters existing reports; it does not generate content.
- Normalizes existing stores: Report Agent runs, Prospect Radar dossiers and Continuity reports.
- Exposes report health/cadence state and provenance, evidence, warnings and governance metadata.

### Recurring reports
Reuses the existing `/api/cron/continuity-report` tick; no additional Vercel cron is added.

Carries five idempotent lanes:
1. world daily
2. world weekly
3. SFI internal daily
4. prospect radar weekly
5. declared institutional attractor + evidence + world context daily

Scheduled task IDs are deterministic, so repeated cron calls do not duplicate the same period.

The attractor report explicitly treats evidence coverage as coverage, **not percentage of attainment**.

### Epistemic/provider boundary
- A degraded/manual LLM fallback may be persisted for inspection but is `BLOCKED`, never `READY`.
- External prospect contact remains founder-governed; the recurring radar only produces a report/dossier.

### Health / QA
- Adds `/api/root/agents/health`.
- Adds `/api/root/agentic/report/health`.
- Adds `/api/root/reports` read endpoint.
- Adds `qa-sfi-root-reports-runtime.ts` to SFI Verify.

## Vercel budget
This integration branch is configured through Vercel's ignored-build mechanism to skip branch previews. Main/production remains buildable. This prevents the implementation commits from consuming preview builds; GitHub Actions remains the validation path for the PR.

## Boundaries
- No new database table.
- No new Vercel cron.
- No automatic external contact.
- No canonical promotion.
- No attempt to turn a missing dependency green by inventing aliases or fallback data.
