### PR TITLE
Wire final SFI closure through runtime surfaces

### DIFF
--- a/.github/workflows/sfi-final-closure.yml
+++ b/.github/workflows/sfi-final-closure.yml
@@ -11,7 +11,15 @@ on:
       - 'src/lib/studio/fieldHandoff.ts'
       - 'src/lib/field/returnContrastContract.ts'
       - 'src/lib/observatory/publicationGate.ts'
+      - 'src/lib/field/governedReturn.ts'
+      - 'src/lib/observatory/public/readGovernedPublicObservatoryState.ts'
+      - 'src/app/api/studio/implement/route.ts'
+      - 'src/app/api/field/cases/route.ts'
+      - 'src/app/api/field/cases/[id]/return/route.ts'
+      - 'src/app/observatory/page.tsx'
+      - 'src/components/root/method-lab/MethodLabConsole.tsx'
       - 'scripts/qa-sfi-final-closure.ts'
+      - 'scripts/qa-sfi-final-runtime-wiring.ts'
       - '.github/workflows/sfi-final-closure.yml'
   push:
     branches: [main]
@@ -24,7 +32,15 @@ on:
       - 'src/lib/studio/fieldHandoff.ts'
       - 'src/lib/field/returnContrastContract.ts'
       - 'src/lib/observatory/publicationGate.ts'
+      - 'src/lib/field/governedReturn.ts'
+      - 'src/lib/observatory/public/readGovernedPublicObservatoryState.ts'
+      - 'src/app/api/studio/implement/route.ts'
+      - 'src/app/api/field/cases/route.ts'
+      - 'src/app/api/field/cases/[id]/return/route.ts'
+      - 'src/app/observatory/page.tsx'
+      - 'src/components/root/method-lab/MethodLabConsole.tsx'
       - 'scripts/qa-sfi-final-closure.ts'
+      - 'scripts/qa-sfi-final-runtime-wiring.ts'
       - '.github/workflows/sfi-final-closure.yml'
 
 jobs:
@@ -39,5 +55,9 @@ jobs:
       - run: npm install --no-audit --no-fund
       - name: Verify final closure and Apex pilot
         run: npx tsx scripts/qa-sfi-final-closure.ts
+      - name: Verify runtime wiring
+        run: npx tsx scripts/qa-sfi-final-runtime-wiring.ts
       - name: Typecheck
         run: npx tsc --noEmit --pretty false --incremental false
+      - name: Build
+        run: npm run build

--- a/scripts/qa-sfi-final-runtime-wiring.ts
+++ b/scripts/qa-sfi-final-runtime-wiring.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createStudioFieldHandoff, verifyStudioFieldHandoff } from '../src/lib/studio/fieldHandoff';
+import { observatoryPublicationDisposition } from '../src/lib/observatory/publicationGate';
+import { APEX_SOCIOTECHNICAL_PILOT } from '../src/lib/method-lab/apexPilot';
+
+const handoff = createStudioFieldHandoff({
+  sourceObjectId: 'APEX-QA-OBJECT',
+  interventionId: 'APEX-QA-INTERVENTION',
+  predictionSeal: 'sha256:apex-qa',
+  returnWindow: '72h',
+  evidenceRefs: ['studio_run:qa', 'studio_artifact:qa'],
+  handoffId: 'SFI-HANDOFF-APEX-QA',
+  createdAt: '2026-08-11T18:00:00.000Z',
+});
+assert.equal(verifyStudioFieldHandoff(handoff), true);
+assert.equal(verifyStudioFieldHandoff({ ...handoff, interventionId: 'tampered' }), false);
+
+assert.equal(observatoryPublicationDisposition({
+  epistemicClass: 'DERIVED', authority: 'PUBLIC', sourceRefs: ['worldspect_snapshots'],
+}).disposition, 'PUBLISH');
+assert.equal(observatoryPublicationDisposition({
+  epistemicClass: 'SIMULATED', authority: 'PUBLIC', sourceRefs: ['simulation'],
+}).disposition, 'BLOCK');
+
+assert.equal(APEX_SOCIOTECHNICAL_PILOT.notASeparateLab, true);
+assert.equal(APEX_SOCIOTECHNICAL_PILOT.parentProtocolId, 'sociotechnical_simulation');
+assert.equal(APEX_SOCIOTECHNICAL_PILOT.authorityBoundary.automaticExternalExecution, false);
+
+const files = {
+  studioImplement: readFileSync('src/app/api/studio/implement/route.ts', 'utf8'),
+  fieldCases: readFileSync('src/app/api/field/cases/route.ts', 'utf8'),
+  fieldReturn: readFileSync('src/app/api/field/cases/[id]/return/route.ts', 'utf8'),
+  governedReturn: readFileSync('src/lib/field/governedReturn.ts', 'utf8'),
+  observatoryPage: readFileSync('src/app/observatory/page.tsx', 'utf8'),
+  governedObservatory: readFileSync('src/lib/observatory/public/readGovernedPublicObservatoryState.ts', 'utf8'),
+  methodLabConsole: readFileSync('src/components/root/method-lab/MethodLabConsole.tsx', 'utf8'),
+};
+
+assert.match(files.studioImplement, /createStudioFieldHandoff/);
+assert.match(files.studioImplement, /READY_FOR_FIELD/);
+assert.match(files.fieldCases, /studioHandoff/);
+assert.match(files.governedReturn, /verifyStudioFieldHandoff/);
+assert.match(files.governedReturn, /studioHandoffId/);
+assert.match(files.governedReturn, /frozenRivalHypothesis/);
+assert.match(files.governedReturn, /frozenStoppingCondition/);
+assert.match(files.fieldReturn, /submitGovernedFieldReturn/);
+assert.match(files.observatoryPage, /readGovernedPublicObservatoryState/);
+assert.match(files.governedObservatory, /observatoryPublicationDisposition/);
+assert.match(files.methodLabConsole, /APEX_SOCIOTECHNICAL_PILOT/);
+assert.match(files.methodLabConsole, /APEX PILOT ADSCRITO/);
+
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-FINAL-CLOSURE-RUNTIME-WIRING-1.0',
+  studioFieldIdentity: 'VERIFIED',
+  returnContrast: 'T0_FROZEN_AND_REQUIRED',
+  observatoryPublicationGate: 'WIRED',
+  apexPilotVisibility: 'WIRED_TO_METHOD_LAB',
+}, null, 2));

--- a/src/app/api/field/cases/[id]/return/route.ts
+++ b/src/app/api/field/cases/[id]/return/route.ts
@@ -16,12 +16,6 @@ function text(value: unknown, maximum = 6000) {
   return typeof value === 'string' ? value.trim().slice(0, maximum) : '';
 }
 
-function requiredText(value: unknown, field: string, maximum = 6000) {
-  const parsed = text(value, maximum);
-  if (!parsed) throw new Error(`${field}_REQUIRED`);
-  return parsed;
-}
-
 function requiredNumber01(value: unknown, field: string) {
   if (value === null || typeof value === 'undefined' || value === '') throw new Error(`${field}_REQUIRED`);
   const parsed = typeof value === 'number' ? value : typeof value === 'string' && value.trim() ? Number(value) : Number.NaN;
@@ -43,8 +37,6 @@ export async function POST(request: Request, context: RouteContext) {
       actualOutcome: requiredNumber01(body.actualOutcome, 'FIELD_RETURN_ACTUAL_OUTCOME'),
       interventionFidelity: requiredNumber01(body.interventionFidelity, 'FIELD_RETURN_INTERVENTION_FIDELITY'),
       observedAt: text(body.observedAt, 80) || null,
-      rivalInterpretation: requiredText(body.rivalInterpretation, 'FIELD_RETURN_RIVAL_INTERPRETATION'),
-      stoppingCondition: requiredText(body.stoppingCondition, 'FIELD_RETURN_STOPPING_CONDITION'),
     });
     return NextResponse.json({ ok: true, result }, { status: 201 });
   } catch (error) {

--- a/src/app/api/field/cases/[id]/return/route.ts
+++ b/src/app/api/field/cases/[id]/return/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { submitFieldReturn } from '@/lib/field/operationalCycle';
+import { submitGovernedFieldReturn } from '@/lib/field/governedReturn';
 import { AccessDeniedError, requireAuthenticatedUser } from '@/lib/system/access/server';
 
 export const dynamic = 'force-dynamic';
@@ -16,6 +16,12 @@ function text(value: unknown, maximum = 6000) {
   return typeof value === 'string' ? value.trim().slice(0, maximum) : '';
 }
 
+function requiredText(value: unknown, field: string, maximum = 6000) {
+  const parsed = text(value, maximum);
+  if (!parsed) throw new Error(`${field}_REQUIRED`);
+  return parsed;
+}
+
 function requiredNumber01(value: unknown, field: string) {
   if (value === null || typeof value === 'undefined' || value === '') throw new Error(`${field}_REQUIRED`);
   const parsed = typeof value === 'number' ? value : typeof value === 'string' && value.trim() ? Number(value) : Number.NaN;
@@ -29,7 +35,7 @@ export async function POST(request: Request, context: RouteContext) {
     const { id } = await Promise.resolve(context.params);
     const caseId = decodeURIComponent(id);
     const body = record(await request.json().catch(() => null));
-    const result = await submitFieldReturn(user.id, caseId, {
+    const result = await submitGovernedFieldReturn(user.id, caseId, {
       evidenceNote: text(body.evidenceNote),
       evidenceSource: text(body.evidenceSource, 180) || 'participant_return',
       evidenceUri: text(body.evidenceUri, 1000) || null,
@@ -37,6 +43,8 @@ export async function POST(request: Request, context: RouteContext) {
       actualOutcome: requiredNumber01(body.actualOutcome, 'FIELD_RETURN_ACTUAL_OUTCOME'),
       interventionFidelity: requiredNumber01(body.interventionFidelity, 'FIELD_RETURN_INTERVENTION_FIDELITY'),
       observedAt: text(body.observedAt, 80) || null,
+      rivalInterpretation: requiredText(body.rivalInterpretation, 'FIELD_RETURN_RIVAL_INTERPRETATION'),
+      stoppingCondition: requiredText(body.stoppingCondition, 'FIELD_RETURN_STOPPING_CONDITION'),
     });
     return NextResponse.json({ ok: true, result }, { status: 201 });
   } catch (error) {

--- a/src/app/api/field/cases/route.ts
+++ b/src/app/api/field/cases/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { createFieldCycle, listFieldCycles, type FieldVerificationWindow } from '@/lib/field/operationalCycle';
+import { listFieldCycles, type FieldVerificationWindow } from '@/lib/field/operationalCycle';
+import { createGovernedFieldCycle } from '@/lib/field/governedReturn';
 import { AccessDeniedError, requireAuthenticatedUser } from '@/lib/system/access/server';
 
 export const dynamic = 'force-dynamic';
@@ -70,7 +71,7 @@ export async function POST(request: Request) {
   try {
     const { user } = await requireAuthenticatedUser();
     const body = record(await request.json().catch(() => null));
-    const result = await createFieldCycle(user.id, {
+    const result = await createGovernedFieldCycle(user.id, {
       title: text(body.title, 180),
       domain: text(body.domain, 80) || 'other',
       stuckSystem: text(body.stuckSystem),
@@ -84,6 +85,8 @@ export async function POST(request: Request) {
       reliability: number01(body.reliability, 0.45),
       verificationWindow: windowValue(body.verificationWindow),
       consent: body.consent === true,
+      rivalHypothesis: text(body.rivalHypothesis) || undefined,
+      stoppingCondition: text(body.stoppingCondition) || undefined,
     });
     return NextResponse.json({ ok: true, result }, { status: 201 });
   } catch (error) {

--- a/src/app/api/field/cases/route.ts
+++ b/src/app/api/field/cases/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { listFieldCycles, type FieldVerificationWindow } from '@/lib/field/operationalCycle';
 import { createGovernedFieldCycle } from '@/lib/field/governedReturn';
+import type { StudioFieldHandoff } from '@/lib/studio/fieldHandoff';
 import { AccessDeniedError, requireAuthenticatedUser } from '@/lib/system/access/server';
 
 export const dynamic = 'force-dynamic';
@@ -26,12 +27,16 @@ function windowValue(value: unknown): FieldVerificationWindow {
   return value === '7d' || value === '30d' ? value : '72h';
 }
 
+function studioHandoff(value: unknown): StudioFieldHandoff | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as StudioFieldHandoff : null;
+}
+
 function failure(error: unknown) {
   if (error instanceof AccessDeniedError) {
     return NextResponse.json({ ok: false, error: error.code, details: error.message }, { status: error.status });
   }
   const details = error instanceof Error ? error.message : String(error);
-  const status = details.includes('_REQUIRED') || details.includes('_INVALID') || details.includes('_NOT_OPEN') || details.includes('_NOT_READY')
+  const status = details.includes('_REQUIRED') || details.includes('_INVALID') || details.includes('_NOT_OPEN') || details.includes('_NOT_READY') || details.includes('HANDOFF')
     ? 400
     : details.includes('NOT_FOUND')
       ? 404
@@ -87,6 +92,7 @@ export async function POST(request: Request) {
       consent: body.consent === true,
       rivalHypothesis: text(body.rivalHypothesis) || undefined,
       stoppingCondition: text(body.stoppingCondition) || undefined,
+      studioHandoff: studioHandoff(body.studioHandoff),
     });
     return NextResponse.json({ ok: true, result }, { status: 201 });
   } catch (error) {

--- a/src/app/api/studio/implement/route.ts
+++ b/src/app/api/studio/implement/route.ts
@@ -1,6 +1,8 @@
+import { createHash } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { runStudioCulturalPipeline } from '@/lib/studio/cultural-lab/pipeline';
-import type { StudioArtifactInput } from '@/lib/studio/cultural-lab/types';
+import type { InterventionCandidate, StudioArtifactInput } from '@/lib/studio/cultural-lab/types';
+import { createStudioFieldHandoff } from '@/lib/studio/fieldHandoff';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -10,7 +12,41 @@ export async function POST(request: Request) {
     const input = (await request.json()) as StudioArtifactInput;
     const trace = await runStudioCulturalPipeline(input);
     const implementation = trace.stages.find((stage) => stage.id === 'implementation_console');
-    return NextResponse.json({ ok: true, implementation, trace });
+    const interventionsStage = trace.stages.find((stage) => stage.id === 'intervention_design');
+    const forecastStage = trace.stages.find((stage) => stage.id === 'outcome_forecast');
+    const candidates = Array.isArray(interventionsStage?.data)
+      ? interventionsStage.data as InterventionCandidate[]
+      : [];
+    const selected = candidates.find((candidate) => candidate.reversible && candidate.risk === 'low')
+      ?? candidates.find((candidate) => candidate.reversible)
+      ?? null;
+
+    const predictionSeal = createHash('sha256').update(JSON.stringify({
+      studioRunId: trace.runId,
+      artifactId: trace.artifactId,
+      selectedIntervention: selected,
+      forecast: forecastStage?.data ?? null,
+    })).digest('hex');
+
+    const handoff = selected
+      ? createStudioFieldHandoff({
+          sourceObjectId: trace.artifactId,
+          interventionId: selected.id,
+          predictionSeal,
+          returnWindow: '72h',
+          evidenceRefs: [`studio_run:${trace.runId}`, `studio_artifact:${trace.artifactId}`],
+          createdAt: trace.createdAt,
+        })
+      : null;
+
+    return NextResponse.json({
+      ok: true,
+      implementation,
+      trace,
+      handoff,
+      handoffStatus: handoff ? 'READY_FOR_FIELD' : 'NO_REVERSIBLE_INTERVENTION_AVAILABLE',
+      claimBoundary: 'The handoff preserves Studio intervention identity and prediction seal. It does not authorize Field execution by itself.',
+    });
   } catch (error) {
     console.error('[Studio Implement] Error:', error);
     const errorMessage = error instanceof Error ? error.message : 'error_desconocido';

--- a/src/app/observatory/page.tsx
+++ b/src/app/observatory/page.tsx
@@ -4,7 +4,7 @@ import { AmvPhaseStatusPanel } from '@/components/amv/AmvPhaseStatusPanel';
 import { PublicObservatoryTimelineNavigator } from '@/components/observatory/public/PublicObservatoryTimelineNavigator';
 import { PublicWorldVectorObservatory } from '@/components/observatory/public/PublicWorldVectorObservatory';
 import { SfiSurfaceGuide } from '@/components/sfi/SfiSurfaceGuide';
-import { readPublicObservatoryState } from '@/lib/observatory/public/readPublicObservatoryState';
+import { readGovernedPublicObservatoryState } from '@/lib/observatory/public/readGovernedPublicObservatoryState';
 
 const PUBLIC_OBSERVATORY_DESCRIPTION =
   'Public 90-day World State synthesis: World Vector, longitudinal WorldSpect observation, dominant tensions and the Daily Reading by System Friction Institute.';
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
 };
 
 export default async function ObservatoryPage() {
-  const state = await readPublicObservatoryState();
+  const state = await readGovernedPublicObservatoryState();
   return (
     <main className="min-h-screen bg-[#060605]">
       <SfiSurfaceGuide

--- a/src/components/root/method-lab/MethodLabConsole.tsx
+++ b/src/components/root/method-lab/MethodLabConsole.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import type { MethodLabState } from '@/lib/method-lab/readModel';
+import { APEX_SOCIOTECHNICAL_PILOT } from '@/lib/method-lab/apexPilot';
 
 const STATUS: Record<string, string> = {
   OPERATIONAL: 'EJECUCIÓN OBSERVADA',
@@ -40,6 +41,20 @@ export function MethodLabConsole({ state: initial }: { state: MethodLabState }) 
       <div className="wide"><small>GOBERNANZA</small><p>{state.promotionRule}</p></div>
     </section>
 
+    <section className="ml-apex">
+      <div className="ml-card-head"><span>PILOTO EXTERNO · {APEX_SOCIOTECHNICAL_PILOT.contractVersion}</span><strong>{APEX_SOCIOTECHNICAL_PILOT.status}</strong></div>
+      <h2>{APEX_SOCIOTECHNICAL_PILOT.name}</h2>
+      <p>{APEX_SOCIOTECHNICAL_PILOT.purpose}</p>
+      <dl>
+        <div><dt>CASA INSTITUCIONAL</dt><dd>{APEX_SOCIOTECHNICAL_PILOT.institutionalHome}</dd></div>
+        <div><dt>PROTOCOLO PADRE</dt><dd>{APEX_SOCIOTECHNICAL_PILOT.parentProtocolId}</dd></div>
+        <div><dt>PARTNER</dt><dd>{APEX_SOCIOTECHNICAL_PILOT.externalParty}</dd></div>
+        <div><dt>LAB SEPARADO</dt><dd>{APEX_SOCIOTECHNICAL_PILOT.notASeparateLab ? 'NO' : 'SÍ'}</dd></div>
+      </dl>
+      <div className="ml-store"><b>TRACKS</b>{APEX_SOCIOTECHNICAL_PILOT.tracks.map((item) => <span key={item}>{item}</span>)}</div>
+      <div className="ml-card-warning">SIN RUN OBSERVADO · requiere autorización humana de Apex para cualquier cambio operacional · no autoriza ejecución automática.</div>
+    </section>
+
     {state.warnings.length ? <section className="ml-warning">{state.warnings.map((warning) => <p key={warning}>{warning}</p>)}</section> : null}
 
     <section className="ml-grid">
@@ -61,14 +76,14 @@ export function MethodLabConsole({ state: initial }: { state: MethodLabState }) 
           {protocol.id === 'cognitive_relational_lab' ? <a href="/root/method-lab/crl">ABRIR CRL</a> : null}
           {protocol.id === 'chronos_olympics' ? <span>LOCAL / LOOPBACK · scripts/cognitive-olympics</span> : null}
           {protocol.id === 'ct_reentry' ? <span>REENTRADA · GATE DE EVALUACIÓN</span> : null}
-          {protocol.id === 'sociotechnical_simulation' ? <span>SIMULACIÓN · AGENTES SFI</span> : null}
+          {protocol.id === 'sociotechnical_simulation' ? <span>SIMULACIÓN · AGENTES SFI · APEX PILOT ADSCRITO</span> : null}
           {protocol.id === 'economic_simulation' ? <span>SIMULACIÓN ECONÓMICA · AGENTE SFI</span> : null}
         </div>
         {protocol.warnings.length ? <div className="ml-card-warning">{protocol.warnings.join(' · ')}</div> : null}
       </article>)}
     </section>
     <style jsx>{`
-      .ml-root{min-height:100vh;background:#060605;color:#c8c2b3;padding:28px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;box-sizing:border-box}.ml-root header{display:flex;justify-content:space-between;gap:28px;border-bottom:1px solid rgba(197,164,75,.18);padding-bottom:20px}.ml-root header>div{max-width:1000px}.ml-root header span,.ml-policy small,.ml-card-head span,dt{font-size:8px;letter-spacing:.15em;color:#88744a}.ml-root h1{font:400 34px Georgia,serif;color:#e0d0aa;margin:7px 0}.ml-root header p{font:14px/1.6 Georgia,serif;color:#81786a;margin:0}.ml-root button{height:max-content;border:1px solid #4a3f25;background:#0a0907;color:#c3a85d;padding:9px 11px;font:9px ui-monospace,monospace}.ml-policy{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;padding:18px 0}.ml-policy>div{border:1px solid #252117;background:#0a0907;padding:12px}.ml-policy strong{display:block;color:#c8b16d;font-size:11px;margin-top:6px}.ml-policy .wide{grid-column:span 3}.ml-policy p{margin:6px 0 0;color:#8e8677;font-size:10px;line-height:1.5}.ml-warning{border-left:2px solid #9b5f46;background:#100b08;padding:8px 12px;color:#bb8067;font-size:9px}.ml-warning p{margin:4px 0}.ml-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:10px}.ml-grid article{border:1px solid #29251b;background:#0b0a08;padding:16px}.ml-grid article[data-status=OPERATIONAL]{border-color:rgba(101,159,109,.36)}.ml-grid article[data-status=DEGRADED]{border-color:rgba(180,91,74,.4)}.ml-card-head{display:flex;justify-content:space-between;gap:10px}.ml-card-head strong{font-size:8px;color:#a68d50}.ml-grid h2{font:400 19px Georgia,serif;color:#d9c89e;margin:9px 0}.ml-grid article>p{font:12px/1.55 Georgia,serif;color:#8d8578}.ml-grid dl{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin:15px 0}.ml-grid dl div{border-top:1px solid #211e17;padding-top:6px}.ml-grid dd{margin:5px 0 0;font-size:9px;color:#aaa18f;overflow-wrap:anywhere}.ml-store{border-top:1px solid #29251b;padding-top:9px;display:grid;gap:4px}.ml-store b{font-size:8px;color:#806d45}.ml-store span{font-size:8px;color:#777064}.ml-actions{display:flex;gap:7px;align-items:center;flex-wrap:wrap;margin-top:11px}.ml-actions a,.ml-actions span{border:1px solid #3b3321;background:#080807;padding:7px 8px;color:#9c8855;text-decoration:none;font-size:8px}.ml-actions a{color:#ceb46b;border-color:#5a4a27}.ml-card-warning{margin-top:10px;color:#b0775f;font-size:8px;line-height:1.5}@media(max-width:700px){.ml-root{padding:18px}.ml-root header{display:grid}.ml-policy{grid-template-columns:1fr}.ml-policy .wide{grid-column:auto}.ml-grid{grid-template-columns:1fr}}
+      .ml-root{min-height:100vh;background:#060605;color:#c8c2b3;padding:28px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;box-sizing:border-box}.ml-root header{display:flex;justify-content:space-between;gap:28px;border-bottom:1px solid rgba(197,164,75,.18);padding-bottom:20px}.ml-root header>div{max-width:1000px}.ml-root header span,.ml-policy small,.ml-card-head span,dt{font-size:8px;letter-spacing:.15em;color:#88744a}.ml-root h1{font:400 34px Georgia,serif;color:#e0d0aa;margin:7px 0}.ml-root header p{font:14px/1.6 Georgia,serif;color:#81786a;margin:0}.ml-root button{height:max-content;border:1px solid #4a3f25;background:#0a0907;color:#c3a85d;padding:9px 11px;font:9px ui-monospace,monospace}.ml-policy{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;padding:18px 0}.ml-policy>div{border:1px solid #252117;background:#0a0907;padding:12px}.ml-policy strong{display:block;color:#c8b16d;font-size:11px;margin-top:6px}.ml-policy .wide{grid-column:span 3}.ml-policy p{margin:6px 0 0;color:#8e8677;font-size:10px;line-height:1.5}.ml-warning{border-left:2px solid #9b5f46;background:#100b08;padding:8px 12px;color:#bb8067;font-size:9px}.ml-warning p{margin:4px 0}.ml-apex{border:1px solid rgba(197,164,75,.34);background:#0b0a08;padding:16px;margin:0 0 14px}.ml-apex h2{font:400 21px Georgia,serif;color:#dfc985;margin:9px 0}.ml-apex>p{font:12px/1.55 Georgia,serif;color:#8d8578}.ml-apex dl{display:grid;grid-template-columns:repeat(4,1fr);gap:6px;margin:15px 0}.ml-apex dl div{border-top:1px solid #29251b;padding-top:6px}.ml-apex dd{margin:5px 0 0;font-size:9px;color:#aaa18f;overflow-wrap:anywhere}.ml-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:10px}.ml-grid article{border:1px solid #29251b;background:#0b0a08;padding:16px}.ml-grid article[data-status=OPERATIONAL]{border-color:rgba(101,159,109,.36)}.ml-grid article[data-status=DEGRADED]{border-color:rgba(180,91,74,.4)}.ml-card-head{display:flex;justify-content:space-between;gap:10px}.ml-card-head strong{font-size:8px;color:#a68d50}.ml-grid h2{font:400 19px Georgia,serif;color:#d9c89e;margin:9px 0}.ml-grid article>p{font:12px/1.55 Georgia,serif;color:#8d8578}.ml-grid dl{display:grid;grid-template-columns:1fr 1fr;gap:6px;margin:15px 0}.ml-grid dl div{border-top:1px solid #211e17;padding-top:6px}.ml-grid dd{margin:5px 0 0;font-size:9px;color:#aaa18f;overflow-wrap:anywhere}.ml-store{border-top:1px solid #29251b;padding-top:9px;display:grid;gap:4px}.ml-store b{font-size:8px;color:#806d45}.ml-store span{font-size:8px;color:#777064}.ml-actions{display:flex;gap:7px;align-items:center;flex-wrap:wrap;margin-top:11px}.ml-actions a,.ml-actions span{border:1px solid #3b3321;background:#080807;padding:7px 8px;color:#9c8855;text-decoration:none;font-size:8px}.ml-actions a{color:#ceb46b;border-color:#5a4a27}.ml-card-warning{margin-top:10px;color:#b0775f;font-size:8px;line-height:1.5}@media(max-width:700px){.ml-root{padding:18px}.ml-root header{display:grid}.ml-policy{grid-template-columns:1fr}.ml-policy .wide{grid-column:auto}.ml-apex dl{grid-template-columns:1fr 1fr}.ml-grid{grid-template-columns:1fr}}
     `}</style>
   </main>;
 }

--- a/src/lib/field/governedReturn.ts
+++ b/src/lib/field/governedReturn.ts
@@ -8,6 +8,7 @@ import {
   type ReturnFieldCycleInput,
 } from './operationalCycle';
 import { finalizeReturnContrast, canMarkLongitudinalCaseComplete } from './returnContrastContract';
+import { verifyStudioFieldHandoff, type StudioFieldHandoff } from '@/lib/studio/fieldHandoff';
 
 type Row = Record<string, unknown>;
 function record(value: unknown): Row {
@@ -18,9 +19,14 @@ function text(value: unknown) { return typeof value === 'string' ? value.trim() 
 export type GovernedFieldCreateInput = CreateFieldCycleInput & {
   rivalHypothesis?: string;
   stoppingCondition?: string;
+  studioHandoff?: StudioFieldHandoff | null;
 };
 
 export async function createGovernedFieldCycle(ownerId: string, input: GovernedFieldCreateInput) {
+  if (input.studioHandoff && !verifyStudioFieldHandoff(input.studioHandoff)) {
+    throw new Error('FIELD_STUDIO_HANDOFF_INVALID');
+  }
+
   const result = await createFieldCycle(ownerId, input);
   const db = createServiceSupabaseClient();
   const fieldCase = record(result.case);
@@ -41,6 +47,9 @@ export async function createGovernedFieldCycle(ownerId: string, input: GovernedF
     contrastContract: 'SFI-RETURN-CONTRAST-1.0',
     contrastFrozenAt: frozenAt,
     longitudinalComplete: false,
+    studioFieldHandoff: input.studioHandoff ?? null,
+    studioHandoffId: input.studioHandoff?.handoffId ?? null,
+    studioHandoffHash: input.studioHandoff?.immutableHash ?? null,
   };
   const update = await db.from('field_cases').update({ metadata: governedMetadata }).eq('id', caseId).eq('owner_id', ownerId).select('*').single();
   if (update.error || !update.data) throw new Error(`FIELD_GOVERNED_CASE_FREEZE_FAILED:${update.error?.message ?? 'unknown'}`);
@@ -51,6 +60,7 @@ export async function createGovernedFieldCycle(ownerId: string, input: GovernedF
     frozenRivalHypothesis,
     frozenStoppingCondition,
     contrastFrozenAt: frozenAt,
+    studioHandoff: input.studioHandoff ?? null,
   };
 }
 
@@ -65,6 +75,11 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
   if (!predictionSeal) throw new Error('FIELD_RETURN_PREDICTION_SEAL_REQUIRED');
   if (!rivalInterpretation) throw new Error('FIELD_RETURN_RIVAL_NOT_FROZEN_AT_T0');
   if (!stoppingCondition) throw new Error('FIELD_RETURN_STOPPING_CONDITION_NOT_FROZEN_AT_T0');
+
+  const handoffValue = metadata.studioFieldHandoff;
+  if (handoffValue && !verifyStudioFieldHandoff(handoffValue as StudioFieldHandoff)) {
+    throw new Error('FIELD_STUDIO_HANDOFF_INTEGRITY_FAILED_AT_RETURN');
+  }
 
   const result = await submitFieldReturn(ownerId, caseId, input);
   const evidence = record(result.evidence);
@@ -86,7 +101,13 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
   }
 
   const persisted = await db.from('field_returns').update({
-    payload: { ...record(returnRow.data.payload), returnContrast: contrast, longitudinalComplete: true },
+    payload: {
+      ...record(returnRow.data.payload),
+      returnContrast: contrast,
+      longitudinalComplete: true,
+      studioHandoffId: text(metadata.studioHandoffId) || null,
+      studioHandoffHash: text(metadata.studioHandoffHash) || null,
+    },
   }).eq('id', returnRow.data.id).eq('owner_id', ownerId);
   if (persisted.error) {
     await db.from('field_cases').update({ status: 'CLOSED_RETURN_CONTRAST_INCOMPLETE', updated_at: new Date().toISOString() }).eq('id', caseId).eq('owner_id', ownerId);
@@ -101,5 +122,11 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
     throw new Error(`FIELD_CASE_CONTRAST_PERSIST_FAILED:${casePersist.error.message}`);
   }
 
-  return { ...result, returnContrast: contrast, longitudinalComplete: true as const };
+  return {
+    ...result,
+    returnContrast: contrast,
+    longitudinalComplete: true as const,
+    studioHandoffId: text(metadata.studioHandoffId) || null,
+    studioHandoffHash: text(metadata.studioHandoffHash) || null,
+  };
 }

--- a/src/lib/field/governedReturn.ts
+++ b/src/lib/field/governedReturn.ts
@@ -1,7 +1,12 @@
 import 'server-only';
 
 import { createServiceSupabaseClient } from '@/runtime/supabase/server';
-import { submitFieldReturn, type ReturnFieldCycleInput } from './operationalCycle';
+import {
+  createFieldCycle,
+  submitFieldReturn,
+  type CreateFieldCycleInput,
+  type ReturnFieldCycleInput,
+} from './operationalCycle';
 import { finalizeReturnContrast, canMarkLongitudinalCaseComplete } from './returnContrastContract';
 
 type Row = Record<string, unknown>;
@@ -10,21 +15,56 @@ function record(value: unknown): Row {
 }
 function text(value: unknown) { return typeof value === 'string' ? value.trim() : ''; }
 
-export type GovernedFieldReturnInput = ReturnFieldCycleInput & {
-  rivalInterpretation: string;
-  stoppingCondition: string;
+export type GovernedFieldCreateInput = CreateFieldCycleInput & {
+  rivalHypothesis?: string;
+  stoppingCondition?: string;
 };
 
-export async function submitGovernedFieldReturn(ownerId: string, caseId: string, input: GovernedFieldReturnInput) {
-  if (!input.rivalInterpretation.trim()) throw new Error('FIELD_RETURN_RIVAL_INTERPRETATION_REQUIRED');
-  if (!input.stoppingCondition.trim()) throw new Error('FIELD_RETURN_STOPPING_CONDITION_REQUIRED');
+export async function createGovernedFieldCycle(ownerId: string, input: GovernedFieldCreateInput) {
+  const result = await createFieldCycle(ownerId, input);
+  const db = createServiceSupabaseClient();
+  const fieldCase = record(result.case);
+  const caseId = text(fieldCase.id);
+  if (!caseId) throw new Error('FIELD_GOVERNED_CASE_ID_MISSING');
 
+  const frozenRivalHypothesis = input.rivalHypothesis?.trim()
+    || 'Null-compatible rival: any observed change may be explained by baseline drift, external field/context, measurement error, or intervention fidelity rather than the intervention itself.';
+  const frozenStoppingCondition = input.stoppingCondition?.trim()
+    || `Stop interpretation after one declared ${input.verificationWindow} return window and one observed return. Any extension or second intervention requires a new sealed cycle.`;
+
+  const originalMetadata = record(fieldCase.metadata);
+  const frozenAt = new Date().toISOString();
+  const governedMetadata = {
+    ...originalMetadata,
+    frozenRivalHypothesis,
+    frozenStoppingCondition,
+    contrastContract: 'SFI-RETURN-CONTRAST-1.0',
+    contrastFrozenAt: frozenAt,
+    longitudinalComplete: false,
+  };
+  const update = await db.from('field_cases').update({ metadata: governedMetadata }).eq('id', caseId).eq('owner_id', ownerId).select('*').single();
+  if (update.error || !update.data) throw new Error(`FIELD_GOVERNED_CASE_FREEZE_FAILED:${update.error?.message ?? 'unknown'}`);
+
+  return {
+    ...result,
+    case: update.data,
+    frozenRivalHypothesis,
+    frozenStoppingCondition,
+    contrastFrozenAt: frozenAt,
+  };
+}
+
+export async function submitGovernedFieldReturn(ownerId: string, caseId: string, input: ReturnFieldCycleInput) {
   const db = createServiceSupabaseClient();
   const before = await db.from('field_cases').select('id,metadata,status').eq('id', caseId).eq('owner_id', ownerId).maybeSingle();
   if (before.error || !before.data) throw new Error('FIELD_CASE_NOT_FOUND');
   const metadata = record(before.data.metadata);
   const predictionSeal = text(metadata.returnHash);
+  const rivalInterpretation = text(metadata.frozenRivalHypothesis);
+  const stoppingCondition = text(metadata.frozenStoppingCondition);
   if (!predictionSeal) throw new Error('FIELD_RETURN_PREDICTION_SEAL_REQUIRED');
+  if (!rivalInterpretation) throw new Error('FIELD_RETURN_RIVAL_NOT_FROZEN_AT_T0');
+  if (!stoppingCondition) throw new Error('FIELD_RETURN_STOPPING_CONDITION_NOT_FROZEN_AT_T0');
 
   const result = await submitFieldReturn(ownerId, caseId, input);
   const evidence = record(result.evidence);
@@ -33,8 +73,8 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
     predictionSeal,
     expected: result.expectedValue,
     observed: result.actualValue,
-    rivalInterpretation: input.rivalInterpretation,
-    stoppingCondition: input.stoppingCondition,
+    rivalInterpretation,
+    stoppingCondition,
     evidenceRefs: evidenceId ? [`field_case_evidence:${evidenceId}`] : [],
   });
   if (!canMarkLongitudinalCaseComplete(contrast)) throw new Error('FIELD_RETURN_CONTRAST_INCOMPLETE');
@@ -54,7 +94,7 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
   }
 
   const casePersist = await db.from('field_cases').update({
-    metadata: { ...metadata, returnedAt: record(result.outcome).recorded_at ?? null, returnContrast: contrast, longitudinalComplete: true },
+    metadata: { ...metadata, returnContrast: contrast, longitudinalComplete: true },
   }).eq('id', caseId).eq('owner_id', ownerId);
   if (casePersist.error) {
     await db.from('field_cases').update({ status: 'CLOSED_RETURN_CONTRAST_INCOMPLETE', updated_at: new Date().toISOString() }).eq('id', caseId).eq('owner_id', ownerId);

--- a/src/lib/field/governedReturn.ts
+++ b/src/lib/field/governedReturn.ts
@@ -1,0 +1,65 @@
+import 'server-only';
+
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { submitFieldReturn, type ReturnFieldCycleInput } from './operationalCycle';
+import { finalizeReturnContrast, canMarkLongitudinalCaseComplete } from './returnContrastContract';
+
+type Row = Record<string, unknown>;
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function text(value: unknown) { return typeof value === 'string' ? value.trim() : ''; }
+
+export type GovernedFieldReturnInput = ReturnFieldCycleInput & {
+  rivalInterpretation: string;
+  stoppingCondition: string;
+};
+
+export async function submitGovernedFieldReturn(ownerId: string, caseId: string, input: GovernedFieldReturnInput) {
+  if (!input.rivalInterpretation.trim()) throw new Error('FIELD_RETURN_RIVAL_INTERPRETATION_REQUIRED');
+  if (!input.stoppingCondition.trim()) throw new Error('FIELD_RETURN_STOPPING_CONDITION_REQUIRED');
+
+  const db = createServiceSupabaseClient();
+  const before = await db.from('field_cases').select('id,metadata,status').eq('id', caseId).eq('owner_id', ownerId).maybeSingle();
+  if (before.error || !before.data) throw new Error('FIELD_CASE_NOT_FOUND');
+  const metadata = record(before.data.metadata);
+  const predictionSeal = text(metadata.returnHash);
+  if (!predictionSeal) throw new Error('FIELD_RETURN_PREDICTION_SEAL_REQUIRED');
+
+  const result = await submitFieldReturn(ownerId, caseId, input);
+  const evidence = record(result.evidence);
+  const evidenceId = text(evidence.id);
+  const contrast = finalizeReturnContrast({
+    predictionSeal,
+    expected: result.expectedValue,
+    observed: result.actualValue,
+    rivalInterpretation: input.rivalInterpretation,
+    stoppingCondition: input.stoppingCondition,
+    evidenceRefs: evidenceId ? [`field_case_evidence:${evidenceId}`] : [],
+  });
+  if (!canMarkLongitudinalCaseComplete(contrast)) throw new Error('FIELD_RETURN_CONTRAST_INCOMPLETE');
+
+  const returnRow = await db.from('field_returns').select('id,payload').eq('case_id', caseId).eq('owner_id', ownerId).order('created_at', { ascending: false }).limit(1).maybeSingle();
+  if (returnRow.error || !returnRow.data?.id) {
+    await db.from('field_cases').update({ status: 'CLOSED_RETURN_CONTRAST_INCOMPLETE', updated_at: new Date().toISOString() }).eq('id', caseId).eq('owner_id', ownerId);
+    throw new Error('FIELD_RETURN_CONTRAST_PERSISTENCE_TARGET_MISSING');
+  }
+
+  const persisted = await db.from('field_returns').update({
+    payload: { ...record(returnRow.data.payload), returnContrast: contrast, longitudinalComplete: true },
+  }).eq('id', returnRow.data.id).eq('owner_id', ownerId);
+  if (persisted.error) {
+    await db.from('field_cases').update({ status: 'CLOSED_RETURN_CONTRAST_INCOMPLETE', updated_at: new Date().toISOString() }).eq('id', caseId).eq('owner_id', ownerId);
+    throw new Error(`FIELD_RETURN_CONTRAST_PERSIST_FAILED:${persisted.error.message}`);
+  }
+
+  const casePersist = await db.from('field_cases').update({
+    metadata: { ...metadata, returnedAt: record(result.outcome).recorded_at ?? null, returnContrast: contrast, longitudinalComplete: true },
+  }).eq('id', caseId).eq('owner_id', ownerId);
+  if (casePersist.error) {
+    await db.from('field_cases').update({ status: 'CLOSED_RETURN_CONTRAST_INCOMPLETE', updated_at: new Date().toISOString() }).eq('id', caseId).eq('owner_id', ownerId);
+    throw new Error(`FIELD_CASE_CONTRAST_PERSIST_FAILED:${casePersist.error.message}`);
+  }
+
+  return { ...result, returnContrast: contrast, longitudinalComplete: true as const };
+}

--- a/src/lib/observatory/public/readGovernedPublicObservatoryState.ts
+++ b/src/lib/observatory/public/readGovernedPublicObservatoryState.ts
@@ -1,0 +1,29 @@
+import 'server-only';
+
+import { observatoryPublicationDisposition } from '@/lib/observatory/publicationGate';
+import { readPublicObservatoryState } from './readPublicObservatoryState';
+
+export async function readGovernedPublicObservatoryState() {
+  const state = await readPublicObservatoryState();
+  const sourceRefs = Array.from(new Set(
+    (state.provenance.basedOn ?? []).filter((item): item is string => typeof item === 'string' && item.trim().length > 0),
+  ));
+  const gate = observatoryPublicationDisposition({
+    epistemicClass: 'DERIVED',
+    authority: 'PUBLIC',
+    sourceRefs,
+  });
+  if (gate.disposition === 'BLOCK') {
+    throw new Error(`OBSERVATORY_PUBLICATION_BLOCKED:${gate.reason}`);
+  }
+  return {
+    ...state,
+    provenance: {
+      ...state.provenance,
+      limits: Array.from(new Set([
+        ...state.provenance.limits,
+        `publication_gate:${gate.disposition}:${gate.reason}`,
+      ])),
+    },
+  };
+}


### PR DESCRIPTION
Completes the runtime wiring left after #205. Studio implementation now emits an immutable Studio→Field handoff; Field verifies and preserves the same handoff ID/hash through cycle creation and return, while freezing rival hypothesis and stopping condition at T0 and requiring Return/Contrast for longitudinal completion. The public Observatory now reads through the publication gate. Apex is surfaced inside ROOT Method Lab as a proposed partner pilot adscribed to the existing sociotechnical simulation protocol, not as a separate lab. Adds runtime-wiring QA, typecheck and build gates. This does not claim a live Apex run, production CRL migration verification, external timestamp anchoring, or independent replication.