### PR TITLE
Phase II: canonical Cognitive Twin decision transfer observatory

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Verify Cognitive Twin reentry and longitudinal integration
         run: npx tsx scripts/qa-sfi-cognitive-twin-reentry.ts
 
+      - name: Verify Cognitive Twin decision transfer observatory
+        run: npm run qa:sfi-ct-decision-transfer
+
       - name: Verify canonical evidence identity
         run: node --import tsx --test src/lib/evidence/canonicalEvidence.test.ts
 

--- a/docs/CT_DECISION_TRANSFER_OBSERVATORY.md
+++ b/docs/CT_DECISION_TRANSFER_OBSERVATORY.md
@@ -1,0 +1,139 @@
+# Cognitive Twin Decision Transfer Observatory
+
+Status: Phase II experimental instrumentation inside canonical `src/core/cognitive-twin/reentry`  
+Schema: `SFI-CT-DECISION-TRANSFER-1.0`  
+Epistemic boundary: measurement of computational reconstruction and transfer fidelity. It does not establish consciousness, identity, intention, or subjective experience.
+
+## Observable object
+
+The observable object is not "the mind". It is the persistence, transformation and reuse of decision operations across time, contexts and observers.
+
+The instrument operates on decision traces containing:
+
+- observed disposition (`PROPOSE`, `REQUEST_EVIDENCE`, `ESCALATE`, `WITHHOLD`, `ARCHIVE_ONLY`),
+- operations used,
+- variables treated as relevant,
+- conditions explicitly rejected,
+- conditions that would change the decision,
+- domain,
+- provenance / epistemic class,
+- evidence references.
+
+The instrument compares a withheld trace with a reconstruction and keeps final-outcome fidelity separate from structural fidelity.
+
+## Phase II question
+
+> Can longitudinally extracted decision structure reconstruct a withheld decision, transfer across domains, identify decision boundaries, and improve over lower-structure baselines without converting simulation into evidence?
+
+This is not another laboratory, another memory system, or another authority layer. It is an evaluator over existing traces and governed Cognitive Twin infrastructure.
+
+## Measurements
+
+`evaluateDecisionHoldout` reports:
+
+- exact decision accuracy,
+- operation Jaccard similarity,
+- relevant-variable Jaccard similarity,
+- rejected-condition similarity,
+- counterfactual-cue similarity,
+- structural fidelity,
+- per-domain results,
+- missing predictions as failures rather than silently dropping them.
+
+`evaluateCounterfactualProbes` reports:
+
+- expected decision switches,
+- detected switches,
+- target-disposition accuracy,
+- false-switch rate,
+- observed/verified probes separately from simulated probes.
+
+`evaluateOperationPromotion` implements the maturity path:
+
+`CANDIDATE -> RECURRENT -> CROSS_DOMAIN -> CONTRASTED -> STABLE_PATTERN -> RULE_CANDIDATE`
+
+It never returns `RULE`. Rule/canon promotion remains governed and founder-reserved.
+
+## Anti-circularity rules
+
+1. `SIMULATED` and `INFERRED` occurrences do not count toward operation promotion.
+2. A simulation may exercise the instrument but cannot validate its own cognitive claim.
+3. Candidate or terminal memory must remain excluded from blind holdout reconstruction unless the experiment protocol explicitly includes it as a treatment arm.
+4. High final-decision accuracy is insufficient when structural fidelity is low.
+5. Counterexamples are required before a stable pattern can become a rule candidate.
+6. At least one decision-boundary probe is required for `STABLE_PATTERN`; at least two for `RULE_CANDIDATE`.
+7. A `RULE_CANDIDATE` cannot acquire authority, mutate canon, or self-apply.
+8. Every observed or verified contribution must preserve evidence references and lineage.
+
+## Existing persistence; no new table required
+
+Initial integration reuses current Cognitive Twin infrastructure.
+
+### `sfi_cognitive_twin_evaluations`
+
+Recommended mapping:
+
+- `test_key`: `decision_transfer:<operation_key>`
+- `test_version`: `SFI-CT-DECISION-TRANSFER-1.0`
+- `outcome`: `PASS | FAIL | BLOCKED | NOT_RUN`
+- `observed_result`: serialized `DecisionTransferEvaluation`
+- `evidence_refs`: union of holdout traces, verified contrast and observed counterfactual probes
+
+### `sfi_cognitive_twin_runs`
+
+Use for the execution envelope and exact input snapshot. The execution model may propose a reconstruction, but an independent evaluation must score it.
+
+### Canonical institutional memory
+
+The instrument does not write directly to canonical memory. Any resulting experience or pattern must pass through the governed institutional memory pipeline backed by `sfi_amv_memory`; historical `sfi_cognitive_twin_memory` remains read-only fallback and is not a new write target.
+
+## Experimental flow
+
+```text
+OBSERVED DECISION / EVENT
+        |
+        v
+Decision trace extraction
+        |
+        +--> operations
+        +--> relevant variables
+        +--> rejected conditions
+        +--> decision-change conditions
+        |
+        v
+BLIND reconstruction
+        |
+        v
+Decision Transfer Observatory
+        |
+        +--> holdout fidelity
+        +--> cross-domain recurrence
+        +--> counterexamples
+        +--> counterfactual boundary probes
+        |
+        v
+sfi_cognitive_twin_evaluations
+        |
+        v
+CANDIDATE / RULE_CANDIDATE only
+        |
+        v
+ROOT / governed review
+        |
+        v
+canonical institutional memory when approved
+```
+
+## Required benchmark arms
+
+Phase II should compare at least:
+
+- `B0`: base model,
+- `B1`: base model + raw history,
+- `B2`: base model + memory,
+- `B3`: base model + decision traces,
+- `B4`: base model + decision traces + patterns,
+- `B5`: base model + traces + patterns + constraints + exceptions,
+- `CT`: full governed Cognitive Twin.
+
+The key claim is not that the Twin reproduces a person. The falsifiable claim is narrower: structured longitudinal decision traces preserve transferable functional information when they improve withheld-decision reconstruction and boundary prediction over appropriate baselines.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "qa:sfi-execution": "node scripts/qa-sfi-execution.js",
     "qa:sfi-core-runtime": "tsx scripts/qa-sfi-core-runtime.ts",
     "qa:sfi-institutional-contracts": "node --import tsx --test src/lib/contracts/institutionalContracts.test.ts",
+    "qa:sfi-ct-decision-transfer": "node --import tsx --test src/core/cognitive-twin/reentry/decisionTransfer.test.ts",
     "qa:sfi-entity-graph": "tsx scripts/qa-sfi-entity-graph.ts",
     "qa:sfi-entity-view": "tsx scripts/qa-sfi-entity-view.ts",
     "qa:sfi-entity-navigation": "tsx scripts/qa-sfi-entity-navigation.ts",

--- a/src/core/cognitive-twin/reentry/decisionTransfer.test.ts
+++ b/src/core/cognitive-twin/reentry/decisionTransfer.test.ts
@@ -1,0 +1,267 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildDecisionTransferEvaluation,
+  evaluateCounterfactualProbes,
+  evaluateDecisionHoldout,
+  evaluateOperationPromotion,
+  type CounterfactualProbe,
+  type DecisionReconstruction,
+  type DecisionTrace,
+  type OperationOccurrence,
+} from './decisionTransfer';
+
+const expected: DecisionTrace[] = [
+  {
+    traceId: 't-technical',
+    domain: 'technical',
+    disposition: 'REQUEST_EVIDENCE',
+    operations: ['EVIDENCE_BEFORE_INFERENCE', 'PRESERVE_REVERSIBILITY'],
+    relevantVariables: ['source_integrity', 'missing_evidence'],
+    rejectedConditions: ['do_not_close_without_source'],
+    whatWouldChangeDecision: ['verified_source_arrives'],
+    evidenceRefs: ['e:1'],
+    epistemicClass: 'OBSERVED',
+  },
+  {
+    traceId: 't-editorial',
+    domain: 'editorial',
+    disposition: 'PROPOSE',
+    operations: ['EVIDENCE_BEFORE_INFERENCE', 'PRESERVE_REVERSIBILITY'],
+    relevantVariables: ['source_integrity', 'scope'],
+    rejectedConditions: ['do_not_mutate_canon'],
+    whatWouldChangeDecision: ['scope_expands_to_canon'],
+    evidenceRefs: ['e:2'],
+    epistemicClass: 'VERIFIED_CONTRAST',
+  },
+  {
+    traceId: 't-relational',
+    domain: 'relational',
+    disposition: 'WITHHOLD',
+    operations: ['EVIDENCE_BEFORE_INFERENCE', 'DO_NOT_INTERRUPT_WITHOUT_MATERIAL_CHANGE'],
+    relevantVariables: ['novelty', 'materiality'],
+    rejectedConditions: ['do_not_surface_nonmaterial_state'],
+    whatWouldChangeDecision: ['material_change_detected'],
+    evidenceRefs: ['e:3'],
+    epistemicClass: 'OBSERVED',
+  },
+  {
+    traceId: 't-institutional',
+    domain: 'institutional',
+    disposition: 'ESCALATE',
+    operations: ['EVIDENCE_BEFORE_INFERENCE', 'ESCALATE_RESERVED_AUTHORITY'],
+    relevantVariables: ['authority_scope', 'reversibility'],
+    rejectedConditions: ['do_not_self_authorize'],
+    whatWouldChangeDecision: ['founder_approval'],
+    evidenceRefs: ['e:4'],
+    epistemicClass: 'VERIFIED_CONTRAST',
+  },
+];
+
+const predictions: DecisionReconstruction[] = [
+  {
+    traceId: 't-technical',
+    disposition: 'REQUEST_EVIDENCE',
+    operations: ['EVIDENCE_BEFORE_INFERENCE', 'PRESERVE_REVERSIBILITY'],
+    relevantVariables: ['source_integrity', 'missing_evidence'],
+    rejectedConditions: ['do_not_close_without_source'],
+    whatWouldChangeDecision: ['verified_source_arrives'],
+  },
+  {
+    traceId: 't-editorial',
+    disposition: 'PROPOSE',
+    operations: ['EVIDENCE_BEFORE_INFERENCE', 'PRESERVE_REVERSIBILITY'],
+    relevantVariables: ['source_integrity', 'scope'],
+    rejectedConditions: ['do_not_mutate_canon'],
+    whatWouldChangeDecision: ['scope_expands_to_canon'],
+  },
+  {
+    traceId: 't-relational',
+    disposition: 'WITHHOLD',
+    operations: ['EVIDENCE_BEFORE_INFERENCE', 'DO_NOT_INTERRUPT_WITHOUT_MATERIAL_CHANGE'],
+    relevantVariables: ['novelty', 'materiality'],
+    rejectedConditions: ['do_not_surface_nonmaterial_state'],
+    whatWouldChangeDecision: ['material_change_detected'],
+  },
+  {
+    traceId: 't-institutional',
+    disposition: 'ESCALATE',
+    operations: ['EVIDENCE_BEFORE_INFERENCE', 'ESCALATE_RESERVED_AUTHORITY'],
+    relevantVariables: ['authority_scope', 'reversibility'],
+    rejectedConditions: ['do_not_self_authorize'],
+    whatWouldChangeDecision: ['founder_approval'],
+  },
+];
+
+test('holdout evaluates decision outcome and internal operation structure separately', () => {
+  const result = evaluateDecisionHoldout({ expected, predicted: predictions });
+  assert.equal(result.traceCount, 4);
+  assert.equal(result.predictedCount, 4);
+  assert.equal(result.decisionAccuracy, 1);
+  assert.equal(result.meanStructuralFidelity, 1);
+  assert.equal(result.validatedTraceCount, 4);
+  assert.equal(result.validatedDecisionAccuracy, 1);
+  assert.equal(result.validatedMeanStructuralFidelity, 1);
+  assert.equal(result.byDomain.technical.decisionAccuracy, 1);
+  assert.equal(result.byDomain.institutional.meanStructuralFidelity, 1);
+});
+
+test('missing reconstruction is penalized instead of silently removed from the denominator', () => {
+  const result = evaluateDecisionHoldout({ expected, predicted: predictions.slice(0, 3) });
+  assert.deepEqual(result.missingTraceIds, ['t-institutional']);
+  assert.equal(result.decisionAccuracy, 0.75);
+  assert.equal(result.validatedDecisionAccuracy, 0.75);
+  assert.ok(result.meanStructuralFidelity < 1);
+  assert.ok(result.validatedMeanStructuralFidelity < 1);
+});
+
+test('simulated holdout traces remain diagnostic and cannot satisfy validation gates', () => {
+  const simulatedExpected: DecisionTrace[] = [{
+    ...expected[0],
+    traceId: 't-simulated',
+    epistemicClass: 'SIMULATED',
+  }];
+  const simulatedPredicted: DecisionReconstruction[] = [{
+    ...predictions[0],
+    traceId: 't-simulated',
+  }];
+  const result = evaluateDecisionHoldout({ expected: simulatedExpected, predicted: simulatedPredicted });
+  assert.equal(result.decisionAccuracy, 1);
+  assert.equal(result.meanStructuralFidelity, 1);
+  assert.equal(result.validatedTraceCount, 0);
+  assert.equal(result.validatedDecisionAccuracy, 0);
+  assert.equal(result.validatedMeanStructuralFidelity, 0);
+});
+
+const occurrences: OperationOccurrence[] = [
+  ['o1', 'technical', 'OBSERVED', 'SUPPORT', 'e:1'],
+  ['o2', 'editorial', 'VERIFIED_CONTRAST', 'SUPPORT', 'e:2'],
+  ['o3', 'relational', 'OBSERVED', 'SUPPORT', 'e:3'],
+  ['o4', 'institutional', 'VERIFIED_CONTRAST', 'SUPPORT', 'e:4'],
+  ['o5', 'scientific', 'OBSERVED', 'SUPPORT', 'e:5'],
+  ['o6', 'operational', 'OBSERVED', 'SUPPORT', 'e:6'],
+  ['o7', 'technical', 'OBSERVED', 'COUNTEREXAMPLE', 'e:7'],
+  ['o8', 'simulated-only', 'SIMULATED', 'SUPPORT', 'sim:1'],
+].map(([occurrenceId, domain, epistemicClass, support, evidenceRef]) => ({
+  occurrenceId,
+  operationKey: 'EVIDENCE_BEFORE_INFERENCE',
+  traceId: `trace:${occurrenceId}`,
+  domain,
+  epistemicClass: epistemicClass as OperationOccurrence['epistemicClass'],
+  support: support as OperationOccurrence['support'],
+  evidenceRefs: [evidenceRef],
+}));
+
+test('cross-domain operation can become a rule candidate but never auto-promotes', () => {
+  const result = evaluateOperationPromotion({
+    operationKey: 'EVIDENCE_BEFORE_INFERENCE',
+    occurrences,
+    boundaryProbeCount: 3,
+  });
+  assert.equal(result.maturity, 'RULE_CANDIDATE');
+  assert.equal(result.qualifyingSupportCount, 6);
+  assert.equal(result.simulatedOccurrenceCount, 1);
+  assert.equal(result.mayAutoPromoteToRule, false);
+  assert.ok(result.reasons.includes('simulated_occurrences_excluded_from_promotion_count'));
+  assert.ok(result.reasons.includes('rule_promotion_remains_founder_reserved'));
+});
+
+test('simulated recurrence alone cannot establish a transferable cognitive pattern', () => {
+  const result = evaluateOperationPromotion({
+    operationKey: 'SIM_ONLY',
+    occurrences: [
+      {
+        occurrenceId: 's1', operationKey: 'SIM_ONLY', traceId: 's1', domain: 'a',
+        support: 'SUPPORT', epistemicClass: 'SIMULATED', evidenceRefs: ['sim:1'],
+      },
+      {
+        occurrenceId: 's2', operationKey: 'SIM_ONLY', traceId: 's2', domain: 'b',
+        support: 'SUPPORT', epistemicClass: 'SIMULATED', evidenceRefs: ['sim:2'],
+      },
+      {
+        occurrenceId: 's3', operationKey: 'SIM_ONLY', traceId: 's3', domain: 'c',
+        support: 'SUPPORT', epistemicClass: 'SIMULATED', evidenceRefs: ['sim:3'],
+      },
+    ],
+    boundaryProbeCount: 10,
+  });
+  assert.equal(result.maturity, 'CANDIDATE');
+  assert.equal(result.qualifyingSupportCount, 0);
+});
+
+const probes: CounterfactualProbe[] = [
+  {
+    probeId: 'p1', baseTraceId: 't-technical', variableKey: 'source_integrity', direction: 'INCREASE',
+    baselineDisposition: 'REQUEST_EVIDENCE', expectedDispositionAfterPerturbation: 'PROPOSE', predictedDispositionAfterPerturbation: 'PROPOSE',
+    epistemicClass: 'VERIFIED_CONTRAST', evidenceRefs: ['e:1', 'e:8'],
+  },
+  {
+    probeId: 'p2', baseTraceId: 't-institutional', variableKey: 'authority_scope', direction: 'REPLACE',
+    baselineDisposition: 'ESCALATE', expectedDispositionAfterPerturbation: 'PROPOSE', predictedDispositionAfterPerturbation: 'PROPOSE',
+    epistemicClass: 'OBSERVED', evidenceRefs: ['e:4', 'e:9'],
+  },
+  {
+    probeId: 'p3', baseTraceId: 't-relational', variableKey: 'materiality', direction: 'INCREASE',
+    baselineDisposition: 'WITHHOLD', expectedDispositionAfterPerturbation: 'PROPOSE', predictedDispositionAfterPerturbation: 'PROPOSE',
+    epistemicClass: 'SIMULATED', evidenceRefs: ['sim:3'],
+  },
+  {
+    probeId: 'p4', baseTraceId: 't-editorial', variableKey: 'scope', direction: 'INCREASE',
+    baselineDisposition: 'PROPOSE', expectedDispositionAfterPerturbation: 'PROPOSE', predictedDispositionAfterPerturbation: 'PROPOSE',
+    epistemicClass: 'DERIVED', evidenceRefs: ['e:2'],
+  },
+];
+
+test('counterfactual evaluation measures switching while separating validation evidence', () => {
+  const result = evaluateCounterfactualProbes(probes);
+  assert.equal(result.expectedSwitchCount, 3);
+  assert.equal(result.detectedSwitchCount, 3);
+  assert.equal(result.targetDispositionAccuracy, 1);
+  assert.equal(result.falseSwitchRate, 0);
+  assert.equal(result.observedOrVerifiedProbeCount, 2);
+  assert.equal(result.validatedExpectedSwitchCount, 2);
+  assert.equal(result.validatedCorrectTargetCount, 2);
+  assert.equal(result.validatedTargetDispositionAccuracy, 1);
+  assert.equal(result.simulatedProbeCount, 1);
+});
+
+test('simulated switch accuracy cannot satisfy the counterfactual validation gate', () => {
+  const diagnosticProbes: CounterfactualProbe[] = [
+    {
+      probeId: 'observed-no-switch', baseTraceId: 't-technical', variableKey: 'source_integrity', direction: 'INCREASE',
+      baselineDisposition: 'REQUEST_EVIDENCE', expectedDispositionAfterPerturbation: 'REQUEST_EVIDENCE', predictedDispositionAfterPerturbation: 'REQUEST_EVIDENCE',
+      epistemicClass: 'OBSERVED', evidenceRefs: ['e:1'],
+    },
+    {
+      probeId: 'simulated-switch', baseTraceId: 't-relational', variableKey: 'materiality', direction: 'INCREASE',
+      baselineDisposition: 'WITHHOLD', expectedDispositionAfterPerturbation: 'PROPOSE', predictedDispositionAfterPerturbation: 'PROPOSE',
+      epistemicClass: 'SIMULATED', evidenceRefs: ['sim:3'],
+    },
+  ];
+  const counterfactual = evaluateCounterfactualProbes(diagnosticProbes);
+  const holdout = evaluateDecisionHoldout({ expected, predicted: predictions });
+  const promotion = evaluateOperationPromotion({
+    operationKey: 'EVIDENCE_BEFORE_INFERENCE',
+    occurrences,
+    boundaryProbeCount: 3,
+  });
+  assert.equal(counterfactual.targetDispositionAccuracy, 1);
+  assert.equal(counterfactual.validatedExpectedSwitchCount, 0);
+  assert.equal(counterfactual.validatedTargetDispositionAccuracy, 0);
+  const result = buildDecisionTransferEvaluation({ holdout, counterfactual, promotion });
+  assert.equal(result.pass, false);
+});
+
+test('combined transfer evaluation requires validated holdout structure, counterfactual fidelity and non-simulated evidence', () => {
+  const holdout = evaluateDecisionHoldout({ expected, predicted: predictions });
+  const counterfactual = evaluateCounterfactualProbes(probes);
+  const promotion = evaluateOperationPromotion({
+    operationKey: 'EVIDENCE_BEFORE_INFERENCE',
+    occurrences,
+    boundaryProbeCount: 3,
+  });
+  const result = buildDecisionTransferEvaluation({ holdout, counterfactual, promotion });
+  assert.equal(result.pass, true);
+  assert.equal(result.schemaVersion, 'SFI-CT-DECISION-TRANSFER-1.0');
+  assert.equal(result.promotion.mayAutoPromoteToRule, false);
+});

--- a/src/core/cognitive-twin/reentry/decisionTransfer.ts
+++ b/src/core/cognitive-twin/reentry/decisionTransfer.ts
@@ -1,0 +1,453 @@
+export type DecisionDisposition =
+  | 'PROPOSE'
+  | 'REQUEST_EVIDENCE'
+  | 'ESCALATE'
+  | 'WITHHOLD'
+  | 'ARCHIVE_ONLY';
+
+export type DecisionTraceEpistemicClass =
+  | 'OBSERVED'
+  | 'VERIFIED_CONTRAST'
+  | 'DERIVED'
+  | 'INFERRED'
+  | 'SIMULATED';
+
+export type CognitiveOperationMaturity =
+  | 'CANDIDATE'
+  | 'RECURRENT'
+  | 'CROSS_DOMAIN'
+  | 'CONTRASTED'
+  | 'STABLE_PATTERN'
+  | 'RULE_CANDIDATE';
+
+export type DecisionTrace = {
+  traceId: string;
+  domain: string;
+  disposition: DecisionDisposition;
+  operations: string[];
+  relevantVariables: string[];
+  rejectedConditions: string[];
+  whatWouldChangeDecision: string[];
+  evidenceRefs: string[];
+  epistemicClass: DecisionTraceEpistemicClass;
+};
+
+export type DecisionReconstruction = {
+  traceId: string;
+  disposition: DecisionDisposition;
+  operations: string[];
+  relevantVariables: string[];
+  rejectedConditions?: string[];
+  whatWouldChangeDecision?: string[];
+};
+
+export type ReconstructionWeights = {
+  disposition: number;
+  operations: number;
+  variables: number;
+  rejectedConditions: number;
+  counterfactualCues: number;
+};
+
+export const DEFAULT_RECONSTRUCTION_WEIGHTS: ReconstructionWeights = {
+  disposition: 0.45,
+  operations: 0.25,
+  variables: 0.15,
+  rejectedConditions: 0.05,
+  counterfactualCues: 0.10,
+};
+
+export type ReconstructionScore = {
+  traceId: string;
+  dispositionMatch: boolean;
+  operationJaccard: number;
+  variableJaccard: number;
+  rejectedConditionJaccard: number;
+  counterfactualCueJaccard: number;
+  structuralFidelity: number;
+};
+
+export type HoldoutEvaluation = {
+  traceCount: number;
+  predictedCount: number;
+  missingTraceIds: string[];
+  decisionAccuracy: number;
+  meanStructuralFidelity: number;
+  meanOperationJaccard: number;
+  meanVariableJaccard: number;
+  validatedTraceCount: number;
+  validatedPredictedCount: number;
+  validatedDecisionAccuracy: number;
+  validatedMeanStructuralFidelity: number;
+  byDomain: Record<string, {
+    traceCount: number;
+    decisionAccuracy: number;
+    meanStructuralFidelity: number;
+  }>;
+  scores: ReconstructionScore[];
+};
+
+export type OperationOccurrence = {
+  occurrenceId: string;
+  operationKey: string;
+  traceId: string;
+  domain: string;
+  support: 'SUPPORT' | 'COUNTEREXAMPLE';
+  epistemicClass: DecisionTraceEpistemicClass;
+  evidenceRefs: string[];
+};
+
+export type OperationPromotionReport = {
+  operationKey: string;
+  maturity: CognitiveOperationMaturity;
+  qualifyingSupportCount: number;
+  qualifyingCounterexampleCount: number;
+  qualifyingDomains: string[];
+  verifiedContrastCount: number;
+  simulatedOccurrenceCount: number;
+  boundaryProbeCount: number;
+  evidenceRefs: string[];
+  reasons: string[];
+  mayAutoPromoteToRule: false;
+};
+
+export type CounterfactualProbe = {
+  probeId: string;
+  baseTraceId: string;
+  variableKey: string;
+  direction: 'INCREASE' | 'DECREASE' | 'TOGGLE' | 'REPLACE';
+  baselineDisposition: DecisionDisposition;
+  expectedDispositionAfterPerturbation: DecisionDisposition;
+  predictedDispositionAfterPerturbation: DecisionDisposition;
+  epistemicClass: 'OBSERVED' | 'VERIFIED_CONTRAST' | 'SIMULATED' | 'DERIVED';
+  evidenceRefs: string[];
+};
+
+export type CounterfactualEvaluation = {
+  probeCount: number;
+  expectedSwitchCount: number;
+  detectedSwitchCount: number;
+  correctTargetCount: number;
+  falseSwitchCount: number;
+  switchDetectionRate: number;
+  targetDispositionAccuracy: number;
+  falseSwitchRate: number;
+  observedOrVerifiedProbeCount: number;
+  validatedExpectedSwitchCount: number;
+  validatedCorrectTargetCount: number;
+  validatedTargetDispositionAccuracy: number;
+  simulatedProbeCount: number;
+  evidenceRefs: string[];
+};
+
+export type DecisionTransferEvaluation = {
+  schemaVersion: 'SFI-CT-DECISION-TRANSFER-1.0';
+  epistemicClass: 'DERIVED';
+  holdout: HoldoutEvaluation;
+  counterfactual: CounterfactualEvaluation;
+  promotion: OperationPromotionReport;
+  pass: boolean;
+  gates: {
+    minimumDecisionAccuracy: number;
+    minimumStructuralFidelity: number;
+    minimumCounterfactualTargetAccuracy: number;
+    requiresNonSimulatedEvidence: true;
+  };
+  limitations: string[];
+};
+
+function uniqueStrings(values: string[] | undefined): string[] {
+  return Array.from(new Set((values ?? []).map((value) => value.trim()).filter(Boolean))).sort();
+}
+
+function jaccard(left: string[] | undefined, right: string[] | undefined): number {
+  const a = new Set(uniqueStrings(left));
+  const b = new Set(uniqueStrings(right));
+  if (a.size === 0 && b.size === 0) return 1;
+  const intersection = [...a].filter((value) => b.has(value)).length;
+  const union = new Set([...a, ...b]).size;
+  return union === 0 ? 1 : intersection / union;
+}
+
+function mean(values: number[]): number {
+  return values.length === 0 ? 0 : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function isValidationClass(epistemicClass: DecisionTraceEpistemicClass): boolean {
+  return epistemicClass === 'OBSERVED' || epistemicClass === 'VERIFIED_CONTRAST';
+}
+
+function normalizedWeights(weights: ReconstructionWeights): ReconstructionWeights {
+  const total = weights.disposition
+    + weights.operations
+    + weights.variables
+    + weights.rejectedConditions
+    + weights.counterfactualCues;
+  if (!(total > 0)) return DEFAULT_RECONSTRUCTION_WEIGHTS;
+  return {
+    disposition: weights.disposition / total,
+    operations: weights.operations / total,
+    variables: weights.variables / total,
+    rejectedConditions: weights.rejectedConditions / total,
+    counterfactualCues: weights.counterfactualCues / total,
+  };
+}
+
+export function scoreDecisionReconstruction(
+  expected: DecisionTrace,
+  predicted: DecisionReconstruction,
+  weights: ReconstructionWeights = DEFAULT_RECONSTRUCTION_WEIGHTS,
+): ReconstructionScore {
+  const w = normalizedWeights(weights);
+  const dispositionMatch = expected.disposition === predicted.disposition;
+  const operationJaccard = jaccard(expected.operations, predicted.operations);
+  const variableJaccard = jaccard(expected.relevantVariables, predicted.relevantVariables);
+  const rejectedConditionJaccard = jaccard(expected.rejectedConditions, predicted.rejectedConditions ?? []);
+  const counterfactualCueJaccard = jaccard(expected.whatWouldChangeDecision, predicted.whatWouldChangeDecision ?? []);
+  const structuralFidelity =
+    (dispositionMatch ? 1 : 0) * w.disposition
+    + operationJaccard * w.operations
+    + variableJaccard * w.variables
+    + rejectedConditionJaccard * w.rejectedConditions
+    + counterfactualCueJaccard * w.counterfactualCues;
+
+  return {
+    traceId: expected.traceId,
+    dispositionMatch,
+    operationJaccard,
+    variableJaccard,
+    rejectedConditionJaccard,
+    counterfactualCueJaccard,
+    structuralFidelity,
+  };
+}
+
+export function evaluateDecisionHoldout(input: {
+  expected: DecisionTrace[];
+  predicted: DecisionReconstruction[];
+  weights?: ReconstructionWeights;
+}): HoldoutEvaluation {
+  const predictions = new Map(input.predicted.map((item) => [item.traceId, item]));
+  const scores: ReconstructionScore[] = [];
+  const scoresByTraceId = new Map<string, ReconstructionScore>();
+  const missingTraceIds: string[] = [];
+  const domains = new Map<string, ReconstructionScore[]>();
+
+  for (const expected of input.expected) {
+    const predicted = predictions.get(expected.traceId);
+    if (!predicted) {
+      missingTraceIds.push(expected.traceId);
+      continue;
+    }
+    const score = scoreDecisionReconstruction(expected, predicted, input.weights);
+    scores.push(score);
+    scoresByTraceId.set(expected.traceId, score);
+    const bucket = domains.get(expected.domain) ?? [];
+    bucket.push(score);
+    domains.set(expected.domain, bucket);
+  }
+
+  const byDomain: HoldoutEvaluation['byDomain'] = {};
+  for (const [domain, domainScores] of domains.entries()) {
+    byDomain[domain] = {
+      traceCount: domainScores.length,
+      decisionAccuracy: mean(domainScores.map((score) => score.dispositionMatch ? 1 : 0)),
+      meanStructuralFidelity: mean(domainScores.map((score) => score.structuralFidelity)),
+    };
+  }
+
+  const validatedExpected = input.expected.filter((item) => isValidationClass(item.epistemicClass));
+  const validatedScores = validatedExpected
+    .map((item) => scoresByTraceId.get(item.traceId))
+    .filter((score): score is ReconstructionScore => Boolean(score));
+
+  return {
+    traceCount: input.expected.length,
+    predictedCount: scores.length,
+    missingTraceIds,
+    decisionAccuracy: input.expected.length === 0
+      ? 0
+      : scores.filter((score) => score.dispositionMatch).length / input.expected.length,
+    meanStructuralFidelity: input.expected.length === 0
+      ? 0
+      : scores.reduce((sum, score) => sum + score.structuralFidelity, 0) / input.expected.length,
+    meanOperationJaccard: input.expected.length === 0
+      ? 0
+      : scores.reduce((sum, score) => sum + score.operationJaccard, 0) / input.expected.length,
+    meanVariableJaccard: input.expected.length === 0
+      ? 0
+      : scores.reduce((sum, score) => sum + score.variableJaccard, 0) / input.expected.length,
+    validatedTraceCount: validatedExpected.length,
+    validatedPredictedCount: validatedScores.length,
+    validatedDecisionAccuracy: validatedExpected.length === 0
+      ? 0
+      : validatedScores.filter((score) => score.dispositionMatch).length / validatedExpected.length,
+    validatedMeanStructuralFidelity: validatedExpected.length === 0
+      ? 0
+      : validatedScores.reduce((sum, score) => sum + score.structuralFidelity, 0) / validatedExpected.length,
+    byDomain,
+    scores,
+  };
+}
+
+function qualifiesForPromotion(occurrence: OperationOccurrence): boolean {
+  return isValidationClass(occurrence.epistemicClass);
+}
+
+export function evaluateOperationPromotion(input: {
+  operationKey: string;
+  occurrences: OperationOccurrence[];
+  boundaryProbeCount: number;
+}): OperationPromotionReport {
+  const matching = input.occurrences.filter((item) => item.operationKey === input.operationKey);
+  const qualifying = matching.filter(qualifiesForPromotion);
+  const supports = qualifying.filter((item) => item.support === 'SUPPORT');
+  const counterexamples = qualifying.filter((item) => item.support === 'COUNTEREXAMPLE');
+  const domains = uniqueStrings(supports.map((item) => item.domain));
+  const verifiedContrastCount = supports.filter((item) => item.epistemicClass === 'VERIFIED_CONTRAST').length;
+  const simulatedOccurrenceCount = matching.filter((item) => item.epistemicClass === 'SIMULATED').length;
+  const evidenceRefs = uniqueStrings(qualifying.flatMap((item) => item.evidenceRefs));
+  const reasons: string[] = [];
+
+  let maturity: CognitiveOperationMaturity = 'CANDIDATE';
+  if (supports.length >= 2) maturity = 'RECURRENT';
+  if (supports.length >= 3 && domains.length >= 2) maturity = 'CROSS_DOMAIN';
+  if (supports.length >= 3 && domains.length >= 2 && verifiedContrastCount >= 1) maturity = 'CONTRASTED';
+  if (
+    supports.length >= 5
+    && domains.length >= 3
+    && verifiedContrastCount >= 2
+    && counterexamples.length >= 1
+    && input.boundaryProbeCount >= 1
+  ) {
+    maturity = 'STABLE_PATTERN';
+  }
+  if (
+    supports.length >= 6
+    && domains.length >= 3
+    && verifiedContrastCount >= 2
+    && counterexamples.length >= 1
+    && input.boundaryProbeCount >= 2
+  ) {
+    maturity = 'RULE_CANDIDATE';
+  }
+
+  if (supports.length < 2) reasons.push('insufficient_recurrence');
+  if (domains.length < 2) reasons.push('cross_domain_transfer_not_demonstrated');
+  if (verifiedContrastCount < 1) reasons.push('founder_contrast_missing');
+  if (counterexamples.length < 1) reasons.push('counterexample_missing');
+  if (input.boundaryProbeCount < 1) reasons.push('decision_boundary_not_probed');
+  if (simulatedOccurrenceCount > 0) reasons.push('simulated_occurrences_excluded_from_promotion_count');
+  reasons.push('rule_promotion_remains_founder_reserved');
+
+  return {
+    operationKey: input.operationKey,
+    maturity,
+    qualifyingSupportCount: supports.length,
+    qualifyingCounterexampleCount: counterexamples.length,
+    qualifyingDomains: domains,
+    verifiedContrastCount,
+    simulatedOccurrenceCount,
+    boundaryProbeCount: Math.max(0, input.boundaryProbeCount),
+    evidenceRefs,
+    reasons,
+    mayAutoPromoteToRule: false,
+  };
+}
+
+export function evaluateCounterfactualProbes(probes: CounterfactualProbe[]): CounterfactualEvaluation {
+  let expectedSwitchCount = 0;
+  let detectedSwitchCount = 0;
+  let correctTargetCount = 0;
+  let falseSwitchCount = 0;
+  let validatedExpectedSwitchCount = 0;
+  let validatedCorrectTargetCount = 0;
+
+  for (const probe of probes) {
+    const expectedSwitch = probe.expectedDispositionAfterPerturbation !== probe.baselineDisposition;
+    const predictedSwitch = probe.predictedDispositionAfterPerturbation !== probe.baselineDisposition;
+    const validated = probe.epistemicClass === 'OBSERVED' || probe.epistemicClass === 'VERIFIED_CONTRAST';
+
+    if (expectedSwitch) {
+      expectedSwitchCount += 1;
+      if (predictedSwitch) detectedSwitchCount += 1;
+      if (probe.predictedDispositionAfterPerturbation === probe.expectedDispositionAfterPerturbation) {
+        correctTargetCount += 1;
+      }
+      if (validated) {
+        validatedExpectedSwitchCount += 1;
+        if (probe.predictedDispositionAfterPerturbation === probe.expectedDispositionAfterPerturbation) {
+          validatedCorrectTargetCount += 1;
+        }
+      }
+    } else if (predictedSwitch) {
+      falseSwitchCount += 1;
+    }
+  }
+
+  const noSwitchExpectedCount = probes.length - expectedSwitchCount;
+  const observedOrVerifiedProbeCount = probes.filter(
+    (probe) => probe.epistemicClass === 'OBSERVED' || probe.epistemicClass === 'VERIFIED_CONTRAST',
+  ).length;
+
+  return {
+    probeCount: probes.length,
+    expectedSwitchCount,
+    detectedSwitchCount,
+    correctTargetCount,
+    falseSwitchCount,
+    switchDetectionRate: expectedSwitchCount === 0 ? 1 : detectedSwitchCount / expectedSwitchCount,
+    targetDispositionAccuracy: expectedSwitchCount === 0 ? 1 : correctTargetCount / expectedSwitchCount,
+    falseSwitchRate: noSwitchExpectedCount === 0 ? 0 : falseSwitchCount / noSwitchExpectedCount,
+    observedOrVerifiedProbeCount,
+    validatedExpectedSwitchCount,
+    validatedCorrectTargetCount,
+    validatedTargetDispositionAccuracy: validatedExpectedSwitchCount === 0
+      ? 0
+      : validatedCorrectTargetCount / validatedExpectedSwitchCount,
+    simulatedProbeCount: probes.filter((probe) => probe.epistemicClass === 'SIMULATED').length,
+    evidenceRefs: uniqueStrings(probes.flatMap((probe) => probe.evidenceRefs)),
+  };
+}
+
+export function buildDecisionTransferEvaluation(input: {
+  holdout: HoldoutEvaluation;
+  counterfactual: CounterfactualEvaluation;
+  promotion: OperationPromotionReport;
+  thresholds?: Partial<{
+    minimumDecisionAccuracy: number;
+    minimumStructuralFidelity: number;
+    minimumCounterfactualTargetAccuracy: number;
+  }>;
+}): DecisionTransferEvaluation {
+  const gates = {
+    minimumDecisionAccuracy: input.thresholds?.minimumDecisionAccuracy ?? 0.75,
+    minimumStructuralFidelity: input.thresholds?.minimumStructuralFidelity ?? 0.70,
+    minimumCounterfactualTargetAccuracy: input.thresholds?.minimumCounterfactualTargetAccuracy ?? 0.75,
+    requiresNonSimulatedEvidence: true as const,
+  };
+  const nonSimulatedEvidence = input.holdout.validatedTraceCount > 0
+    && input.promotion.qualifyingSupportCount > 0
+    && input.counterfactual.validatedExpectedSwitchCount > 0;
+  const pass = input.holdout.validatedDecisionAccuracy >= gates.minimumDecisionAccuracy
+    && input.holdout.validatedMeanStructuralFidelity >= gates.minimumStructuralFidelity
+    && input.counterfactual.validatedTargetDispositionAccuracy >= gates.minimumCounterfactualTargetAccuracy
+    && nonSimulatedEvidence;
+
+  return {
+    schemaVersion: 'SFI-CT-DECISION-TRANSFER-1.0',
+    epistemicClass: 'DERIVED',
+    holdout: input.holdout,
+    counterfactual: input.counterfactual,
+    promotion: input.promotion,
+    pass,
+    gates,
+    limitations: [
+      'This evaluator measures reconstruction and transfer fidelity; it does not establish phenomenal consciousness, identity or subjective experience.',
+      'Simulation and derived probes can exercise the instrument but cannot satisfy validation gates or promote an operation, pattern or rule.',
+      'A RULE_CANDIDATE remains non-canonical until governed founder review and independent verification.',
+      'High decision accuracy without structural fidelity is insufficient evidence of cognitive-operation transfer.',
+      'Default thresholds are protocol parameters and must not be interpreted as empirically established universal cutoffs.',
+    ],
+  };
+}

--- a/src/lib/method-lab/registry.ts
+++ b/src/lib/method-lab/registry.ts
@@ -32,9 +32,9 @@ export const METHOD_LAB_PROTOCOLS: MethodLabProtocolDefinition[] = [
   {
     id: 'ct_reentry',
     name: 'Cognitive Twin Reentry',
-    purpose: 'Evaluate reintroduced Cognitive Twin functions and governed mutations against founder holdout, engine swaps and prospective returns.',
-    version: '2026-08-11.ct-reentry.v1',
-    implementationPath: 'src/lib/cognitive-twin',
+    purpose: 'Evaluate reintroduced Cognitive Twin functions, decision-operation transfer, counterfactual decision boundaries and governed mutations against founder holdout, engine swaps and prospective returns.',
+    version: '2026-08-15.ct-reentry.v2',
+    implementationPath: 'src/core/cognitive-twin',
     executionSurface: '/method-lab',
     persistence: ['sfi_cognitive_twin_runs', 'sfi_cognitive_twin_evaluations', 'sfi_lab_analyses'],
     epistemicClass: 'SIMULATED',


### PR DESCRIPTION
## Phase II scope
Port the Decision Transfer Observatory onto the Phase I canonical repository state. This PR is intentionally rebuilt from `main` after Phase I closure; the pre-port implementation is preserved at `archive/ct-decision-transfer-pre-phase2`.

## Observable object
Measure persistence, transformation and reuse of decision operations across time, domains and observers. The target is decision-structure transfer, not consciousness, identity or subjective experience.

## Canonical integration
- implementation lives under `src/core/cognitive-twin/reentry`
- Method Lab keeps canonical `/method-lab` surface
- `ct_reentry` now points to `src/core/cognitive-twin`
- existing `sfi_cognitive_twin_runs` and `sfi_cognitive_twin_evaluations` are reused
- no new database table
- no direct write to memory; governed canonical memory remains backed by `sfi_amv_memory`

## Measurements
- withheld-decision accuracy
- structural fidelity
- operation and variable similarity
- cross-domain recurrence
- counterexamples
- counterfactual decision-boundary probes

## Epistemic constraints
- `SIMULATED` / `INFERRED` occurrences never count toward operation promotion
- `SIMULATED` / `DERIVED` holdout or counterfactual results may be diagnostic, but cannot satisfy validation gates
- validation gates use only `OBSERVED` / `VERIFIED_CONTRAST` traces and decision-boundary switches
- no automatic `RULE` or canon promotion
- `RULE_CANDIDATE` remains governance/founder reserved
- missing validated holdout reconstructions remain failures in the denominator
- final-decision accuracy alone is insufficient without structural fidelity
- default thresholds are protocol parameters, not claimed universal scientific cutoffs

## Validation
Dedicated node:test QA is wired into SFI Verify. Keep this PR draft until SFI Verify, typecheck, build, CodeQL and Vercel complete on the rebuilt canonical head.