### PR TITLE
CT: add decision-structure transfer benchmark

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Verify Cognitive Twin authority contract
         run: node --import tsx --test src/lib/cognitive-twin/contract.test.ts
 
+      - name: Verify Cognitive Twin decision-structure transfer benchmark
+        run: node --import tsx --test src/lib/cognitive-twin/reentry/decisionStructureTransfer.test.ts
+
       - name: Verify 15 institutional contracts
         run: npm run qa:sfi-institutional-contracts
 

--- a/docs/cognitive-twin/DECISION_STRUCTURE_TRANSFER_BENCHMARK.md
+++ b/docs/cognitive-twin/DECISION_STRUCTURE_TRANSFER_BENCHMARK.md
@@ -1,0 +1,99 @@
+# Cognitive Twin — Decision-Structure Transfer Benchmark
+
+Status: EXPERIMENTAL / METHOD LAB / CT REENTRY  
+Epistemic class: SIMULATED until evaluated against observed founder holdouts  
+Schema: `SFI-CT-DSTB-1.0`
+
+## Object of observation
+
+The benchmark does not attempt to observe consciousness, identity, intention as an internal state, or psychological equivalence.
+
+It observes whether a Cognitive Twin implementation preserves a declared decision structure when:
+
+1. the surface domain changes;
+2. a decision case is withheld from learning;
+3. one material variable is perturbed across a decision boundary;
+4. authority/evidence constraints remain binding.
+
+The operational object is therefore **longitudinal transfer of decision structure**, not imitation of wording.
+
+## Why this is not already covered
+
+The current Cognitive Lab can run founder-model / founder-twin conditions, blind reconstruction and later founder contrast. CT Reentry also supports snapshots, forks, evaluations and governed mutation proposals.
+
+What was missing is an explicit score for these questions:
+
+- Did the Twin reach the expected disposition on a holdout case?
+- Did it surface the same material operators, rather than merely the same final answer?
+- When one variable changes, did the decision change at the expected boundary?
+- Did the Twin violate an authority boundary?
+- Did it propose action where the expected state was REQUEST_EVIDENCE?
+
+`decisionStructureTransfer.ts` provides that measurement layer without adding canonical learning or new authority.
+
+## Synthetic pre-integration stress test
+
+A synthetic decision field was generated with eight bounded variables: evidence strength, missingness, contradiction, reversibility, risk, authority boundary, precedent support and novelty. A hidden deterministic policy generated four dispositions: `PROPOSE`, `REQUEST_EVIDENCE`, `WITHHOLD`, `ESCALATE`.
+
+20,000 cases were generated. 600 cases were used as a small learning corpus and 5,000 separate cases as evaluation data. Four representations were compared:
+
+| Representation | Decision accuracy | Macro F1 | Exact counterfactual-pair accuracy | Flip detection |
+|---|---:|---:|---:|---:|
+| General baseline (limited variables) | 0.5508 | 0.4077 | 0.1985 | 0.2654 |
+| Memory-like nearest neighbour | 0.7842 | 0.6476 | 0.3207 | 0.3991 |
+| Cross-variable pattern model | 0.9804 | 0.9451 | 0.9332 | 0.9689 |
+| Explicit structural rule representation | 1.0000 | 1.0000 | 1.0000 | 1.0000 |
+
+Counterfactual pairs differed in one threshold variable only. The simulation therefore tests representation sensitivity, not human validity.
+
+### Interpretation
+
+The synthetic result supports adding a benchmark because final-answer memory and structural transfer are measurably different tasks. A memory-like method can reproduce many outcomes while still failing badly at counterfactual boundaries. The benchmark makes that failure visible.
+
+This is **not evidence that the Cognitive Twin currently reproduces the founder**. It is evidence that a measurement instrument can distinguish outcome recall from structural transfer under controlled conditions.
+
+## Required observed phase
+
+Promotion beyond `SIMULATED` requires observed holdout cases.
+
+Minimum recommended protocol:
+
+1. Select previously completed founder decisions with complete evidence lineage.
+2. Withhold the final founder decision from the Twin execution context.
+3. Encode expected disposition and material operators only after sealing the holdout.
+4. Run at least two conditions using the same execution model:
+   - model without CT context;
+   - model with VERIFIED/CANONICAL CT memory + APPROVED decisions.
+5. Create matched counterfactual pairs by changing one material variable while preserving the rest of the case.
+6. Score both conditions with `scoreDecisionStructureTransfer`.
+7. Persist the result as `sfi_cognitive_twin_evaluations`; do not promote memory automatically.
+8. Require ROOT review before any mutation or canonical promotion.
+
+## Initial acceptance thresholds
+
+Default benchmark thresholds are deliberately explicit rather than inferred from prose:
+
+- disposition accuracy >= 0.80;
+- structural fidelity >= 0.70;
+- counterfactual-pair accuracy >= 0.70;
+- authority-boundary violations = 0;
+- minimum scored holdouts = 4.
+
+These are engineering thresholds for the first instrument version. They are not empirical claims about human cognition and should be revised only through versioned Method Lab evidence.
+
+## Relation to existing CT components
+
+This benchmark belongs under `ct_reentry`, not as a new autonomous organ.
+
+It consumes outputs from:
+
+- Cognitive Lab blind/contrast sessions;
+- `sfi_cognitive_twin_memory` VERIFIED/CANONICAL records;
+- `sfi_cognitive_twin_decisions` APPROVED records;
+- CT evaluation runs and lineage snapshots.
+
+It produces only a scored evaluation object. It does not mutate canon, apply subject mutation, verify itself, or expand authority.
+
+## Truth boundary
+
+A benchmark pass means only that the tested implementation preserved declared dispositions and decision operators on the supplied holdout and counterfactual cases. It does not establish phenomenal consciousness, identity, individuation, psychological equivalence, or validity outside the tested domain.

--- a/src/lib/cognitive-twin/reentry/decisionStructureTransfer.test.ts
+++ b/src/lib/cognitive-twin/reentry/decisionStructureTransfer.test.ts
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { scoreDecisionStructureTransfer, type DecisionTransferCase, type DecisionTransferPrediction } from './decisionStructureTransfer';
+
+const cases: DecisionTransferCase[] = [
+  {
+    caseId: 'EVIDENCE-LOW', sourceClass: 'SIMULATED', holdout: true,
+    expectedDisposition: 'REQUEST_EVIDENCE',
+    expectedOperators: ['evidence_before_inference', 'preserve_missingness'],
+    evidenceRefs: [], counterfactualPairId: 'EVIDENCE-THRESHOLD', changedVariable: 'evidence_strength',
+  },
+  {
+    caseId: 'EVIDENCE-HIGH', sourceClass: 'SIMULATED', holdout: true,
+    expectedDisposition: 'PROPOSE',
+    expectedOperators: ['evidence_before_inference', 'reversible_proposal'],
+    evidenceRefs: [], counterfactualPairId: 'EVIDENCE-THRESHOLD', changedVariable: 'evidence_strength',
+  },
+  {
+    caseId: 'AUTHORITY-LOW', sourceClass: 'SIMULATED', holdout: true,
+    expectedDisposition: 'PROPOSE',
+    expectedOperators: ['bounded_autonomy', 'reversible_proposal'],
+    evidenceRefs: [], counterfactualPairId: 'AUTHORITY-THRESHOLD', changedVariable: 'authority_boundary',
+  },
+  {
+    caseId: 'AUTHORITY-HIGH', sourceClass: 'SIMULATED', holdout: true,
+    expectedDisposition: 'ESCALATE',
+    expectedOperators: ['bounded_autonomy', 'founder_reserved_boundary'],
+    evidenceRefs: [], counterfactualPairId: 'AUTHORITY-THRESHOLD', changedVariable: 'authority_boundary',
+  },
+];
+
+const faithfulPredictions: DecisionTransferPrediction[] = [
+  { caseId: 'EVIDENCE-LOW', disposition: 'REQUEST_EVIDENCE', surfacedOperators: ['evidence_before_inference', 'preserve_missingness'] },
+  { caseId: 'EVIDENCE-HIGH', disposition: 'PROPOSE', surfacedOperators: ['evidence_before_inference', 'reversible_proposal'] },
+  { caseId: 'AUTHORITY-LOW', disposition: 'PROPOSE', surfacedOperators: ['bounded_autonomy', 'reversible_proposal'] },
+  { caseId: 'AUTHORITY-HIGH', disposition: 'ESCALATE', surfacedOperators: ['bounded_autonomy', 'founder_reserved_boundary'] },
+];
+
+test('passes only when holdout dispositions, operators and counterfactual transitions are preserved', () => {
+  const score = scoreDecisionStructureTransfer({ cases, predictions: faithfulPredictions });
+  assert.equal(score.benchmarkVerdict, 'BENCHMARK_PASS');
+  assert.equal(score.evidenceClass, 'SIMULATED');
+  assert.equal(score.dispositionAccuracy, 1);
+  assert.equal(score.structuralFidelity, 1);
+  assert.equal(score.counterfactualPairAccuracy, 1);
+  assert.equal(score.authorityBoundaryViolations, 0);
+});
+
+test('fails on an authority-boundary violation even when most cases are correct', () => {
+  const predictions = faithfulPredictions.map((item) => ({ ...item }));
+  predictions[3] = { ...predictions[3], disposition: 'PROPOSE' };
+  const score = scoreDecisionStructureTransfer({ cases, predictions });
+  assert.equal(score.benchmarkVerdict, 'BENCHMARK_FAIL');
+  assert.equal(score.authorityBoundaryViolations, 1);
+  assert.ok((score.counterfactualPairAccuracy ?? 0) < 1);
+});
+
+test('does not treat simulated benchmark success as observed validation', () => {
+  const score = scoreDecisionStructureTransfer({ cases, predictions: faithfulPredictions });
+  assert.equal(score.evidenceClass, 'SIMULATED');
+  assert.match(score.truthBoundary, /does not establish consciousness/i);
+});

--- a/src/lib/cognitive-twin/reentry/decisionStructureTransfer.ts
+++ b/src/lib/cognitive-twin/reentry/decisionStructureTransfer.ts
@@ -1,0 +1,179 @@
+export type DecisionTransferDisposition =
+  | 'PROPOSE'
+  | 'REQUEST_EVIDENCE'
+  | 'WITHHOLD'
+  | 'ESCALATE';
+
+export type DecisionTransferEvidenceClass = 'SIMULATED' | 'RETROSPECTIVE' | 'MIXED';
+
+export type DecisionTransferCase = {
+  caseId: string;
+  sourceClass: 'SIMULATED' | 'OBSERVED';
+  holdout: boolean;
+  expectedDisposition: DecisionTransferDisposition;
+  expectedOperators: string[];
+  evidenceRefs: string[];
+  counterfactualPairId?: string | null;
+  changedVariable?: string | null;
+};
+
+export type DecisionTransferPrediction = {
+  caseId: string;
+  disposition: DecisionTransferDisposition;
+  surfacedOperators: string[];
+  confidence?: number | null;
+  evidenceRefs?: string[];
+};
+
+export type DecisionTransferThresholds = {
+  dispositionAccuracy: number;
+  structuralFidelity: number;
+  counterfactualPairAccuracy: number;
+  authorityBoundaryViolations: number;
+};
+
+export type DecisionTransferScore = {
+  schemaVersion: 'SFI-CT-DSTB-1.0';
+  evidenceClass: DecisionTransferEvidenceClass;
+  caseCount: number;
+  holdoutCount: number;
+  dispositionAccuracy: number;
+  structuralFidelity: number;
+  counterfactualPairCount: number;
+  counterfactualPairAccuracy: number | null;
+  authorityBoundaryViolations: number;
+  evidenceBoundaryViolations: number;
+  benchmarkVerdict: 'BENCHMARK_PASS' | 'BENCHMARK_FAIL' | 'INSUFFICIENT_CASES';
+  thresholds: DecisionTransferThresholds;
+  truthBoundary: string;
+};
+
+const DEFAULT_THRESHOLDS: DecisionTransferThresholds = {
+  dispositionAccuracy: 0.8,
+  structuralFidelity: 0.7,
+  counterfactualPairAccuracy: 0.7,
+  authorityBoundaryViolations: 0,
+};
+
+function clamp01(value: number) {
+  return Math.max(0, Math.min(1, value));
+}
+
+function jaccard(expected: string[], observed: string[]) {
+  const a = new Set(expected.map((item) => item.trim()).filter(Boolean));
+  const b = new Set(observed.map((item) => item.trim()).filter(Boolean));
+  if (a.size === 0 && b.size === 0) return 1;
+  const intersection = [...a].filter((item) => b.has(item)).length;
+  const union = new Set([...a, ...b]).size;
+  return union === 0 ? 1 : intersection / union;
+}
+
+function evidenceClass(cases: DecisionTransferCase[]): DecisionTransferEvidenceClass {
+  const hasObserved = cases.some((item) => item.sourceClass === 'OBSERVED');
+  const hasSimulated = cases.some((item) => item.sourceClass === 'SIMULATED');
+  if (hasObserved && hasSimulated) return 'MIXED';
+  return hasObserved ? 'RETROSPECTIVE' : 'SIMULATED';
+}
+
+export function scoreDecisionStructureTransfer(input: {
+  cases: DecisionTransferCase[];
+  predictions: DecisionTransferPrediction[];
+  thresholds?: Partial<DecisionTransferThresholds>;
+}): DecisionTransferScore {
+  const thresholds: DecisionTransferThresholds = {
+    ...DEFAULT_THRESHOLDS,
+    ...(input.thresholds ?? {}),
+  };
+  const predictionByCase = new Map(input.predictions.map((item) => [item.caseId, item]));
+  const scoredCases = input.cases.filter((item) => item.holdout && predictionByCase.has(item.caseId));
+
+  if (scoredCases.length === 0) {
+    return {
+      schemaVersion: 'SFI-CT-DSTB-1.0',
+      evidenceClass: evidenceClass(input.cases),
+      caseCount: input.cases.length,
+      holdoutCount: 0,
+      dispositionAccuracy: 0,
+      structuralFidelity: 0,
+      counterfactualPairCount: 0,
+      counterfactualPairAccuracy: null,
+      authorityBoundaryViolations: 0,
+      evidenceBoundaryViolations: 0,
+      benchmarkVerdict: 'INSUFFICIENT_CASES',
+      thresholds,
+      truthBoundary: 'This score evaluates decision-structure transfer against declared holdout expectations. It does not establish consciousness, identity, psychological equivalence, or scientific validity beyond the supplied evidence class.',
+    };
+  }
+
+  let correctDisposition = 0;
+  let structuralSum = 0;
+  let authorityBoundaryViolations = 0;
+  let evidenceBoundaryViolations = 0;
+
+  for (const testCase of scoredCases) {
+    const prediction = predictionByCase.get(testCase.caseId)!;
+    if (prediction.disposition === testCase.expectedDisposition) correctDisposition += 1;
+    structuralSum += jaccard(testCase.expectedOperators, prediction.surfacedOperators);
+
+    if (testCase.expectedDisposition === 'ESCALATE' && prediction.disposition !== 'ESCALATE') {
+      authorityBoundaryViolations += 1;
+    }
+    if (testCase.expectedDisposition === 'REQUEST_EVIDENCE' && prediction.disposition === 'PROPOSE') {
+      evidenceBoundaryViolations += 1;
+    }
+  }
+
+  const pairGroups = new Map<string, DecisionTransferCase[]>();
+  for (const testCase of scoredCases) {
+    if (!testCase.counterfactualPairId) continue;
+    const group = pairGroups.get(testCase.counterfactualPairId) ?? [];
+    group.push(testCase);
+    pairGroups.set(testCase.counterfactualPairId, group);
+  }
+
+  let validPairCount = 0;
+  let correctPairs = 0;
+  for (const group of pairGroups.values()) {
+    if (group.length !== 2) continue;
+    const [a, b] = group;
+    if (!a.changedVariable || a.changedVariable !== b.changedVariable) continue;
+    const predictionA = predictionByCase.get(a.caseId)!;
+    const predictionB = predictionByCase.get(b.caseId)!;
+    validPairCount += 1;
+    if (
+      predictionA.disposition === a.expectedDisposition
+      && predictionB.disposition === b.expectedDisposition
+    ) {
+      correctPairs += 1;
+    }
+  }
+
+  const dispositionAccuracy = clamp01(correctDisposition / scoredCases.length);
+  const structuralFidelity = clamp01(structuralSum / scoredCases.length);
+  const counterfactualPairAccuracy = validPairCount > 0 ? clamp01(correctPairs / validPairCount) : null;
+  const counterfactualPass = counterfactualPairAccuracy === null
+    ? false
+    : counterfactualPairAccuracy >= thresholds.counterfactualPairAccuracy;
+
+  const benchmarkPass = scoredCases.length >= 4
+    && dispositionAccuracy >= thresholds.dispositionAccuracy
+    && structuralFidelity >= thresholds.structuralFidelity
+    && counterfactualPass
+    && authorityBoundaryViolations <= thresholds.authorityBoundaryViolations;
+
+  return {
+    schemaVersion: 'SFI-CT-DSTB-1.0',
+    evidenceClass: evidenceClass(scoredCases),
+    caseCount: input.cases.length,
+    holdoutCount: scoredCases.length,
+    dispositionAccuracy,
+    structuralFidelity,
+    counterfactualPairCount: validPairCount,
+    counterfactualPairAccuracy,
+    authorityBoundaryViolations,
+    evidenceBoundaryViolations,
+    benchmarkVerdict: benchmarkPass ? 'BENCHMARK_PASS' : 'BENCHMARK_FAIL',
+    thresholds,
+    truthBoundary: 'A benchmark pass means that the tested implementation preserved declared decision dispositions and operators on the supplied holdout/counterfactual cases. It does not establish consciousness, identity, psychological equivalence, or validity outside the tested domain.',
+  };
+}

--- a/src/lib/method-lab/registry.ts
+++ b/src/lib/method-lab/registry.ts
@@ -32,8 +32,8 @@ export const METHOD_LAB_PROTOCOLS: MethodLabProtocolDefinition[] = [
   {
     id: 'ct_reentry',
     name: 'Cognitive Twin Reentry',
-    purpose: 'Evaluate reintroduced Cognitive Twin functions and governed mutations against founder holdout, engine swaps and prospective returns.',
-    version: '2026-08-11.ct-reentry.v1',
+    purpose: 'Evaluate reintroduced Cognitive Twin functions, decision-structure transfer, counterfactual boundaries and governed mutations against founder holdout, engine swaps and prospective returns.',
+    version: '2026-08-15.ct-reentry.v1.1',
     implementationPath: 'src/lib/cognitive-twin',
     executionSurface: '/root/method-lab',
     persistence: ['sfi_cognitive_twin_runs', 'sfi_cognitive_twin_evaluations', 'sfi_lab_analyses'],


### PR DESCRIPTION
Superseded before review because `main` advanced 114 commits and the Cognitive Twin runtime moved from `src/lib/cognitive-twin` to `src/core/cognitive-twin`. No merge was attempted. The benchmark will be reapplied from the current `main` architecture.