### PR TITLE
Phase II: operational Decision Transfer Observatory in Method Lab

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Verify Cognitive Twin decision transfer observatory
         run: npm run qa:sfi-ct-decision-transfer
 
+      - name: Verify Decision Transfer operational wiring
+        run: npx tsx scripts/qa-sfi-decision-transfer-operational.ts
+
       - name: Verify canonical evidence identity
         run: node --import tsx --test src/lib/evidence/canonicalEvidence.test.ts
 

--- a/scripts/qa-sfi-decision-transfer-operational.ts
+++ b/scripts/qa-sfi-decision-transfer-operational.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function read(relative: string) {
+  return fs.readFileSync(path.join(process.cwd(), relative), 'utf8');
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`SFI_DECISION_TRANSFER_OPERATIONAL_QA:${message}`);
+}
+
+const runPath = 'src/core/cognitive-twin/reentry/decisionTransferRun.ts';
+const routePath = 'src/app/api/root/method-lab/decision-transfer/route.ts';
+const readModelPath = 'src/lib/method-lab/readModel.ts';
+const componentPath = 'src/components/root/method-lab/DecisionTransferObservatory.tsx';
+const pagePath = 'src/app/method-lab/page.tsx';
+
+for (const file of [runPath, routePath, readModelPath, componentPath, pagePath]) {
+  assert(fs.existsSync(path.join(process.cwd(), file)), `missing:${file}`);
+}
+
+const run = read(runPath);
+const route = read(routePath);
+const readModel = read(readModelPath);
+const component = read(componentPath);
+const page = read(pagePath);
+
+assert(route.includes("requireRootActor('root.method-lab.decision-transfer.evaluate')"), 'route_must_require_root_actor');
+assert(route.includes('auditRootAction'), 'route_must_audit_mutation');
+assert(route.includes('executeDecisionTransferEvaluation'), 'route_must_use_canonical_evaluator');
+assert(route.includes('ZodError'), 'route_must_return_structured_input_failure');
+
+for (const table of ['sfi_cognitive_twin_runs', 'sfi_cognitive_twin_evaluations', 'sfi_lab_analyses']) {
+  assert(run.includes(`from('${table}')`), `missing_persistence:${table}`);
+}
+assert(run.includes("status: 'CLOSED'"), 'evaluation_run_must_close_explicitly');
+assert(run.includes("role: 'DECISION_TRANSFER_EVALUATOR'"), 'run_role_missing');
+assert(run.includes("holdoutPolicy: 'TARGET_DECISION_MUST_BE_EXCLUDED_FROM_RECONSTRUCTION_CONTEXT_UNTIL_REVEAL'"), 'holdout_contamination_guard_missing');
+assert(run.includes("evaluationStage: 'POST_REVEAL_SCORING'"), 'post_reveal_stage_missing');
+assert(run.includes("outcome === 'BLOCKED'"), 'blocked_state_missing');
+assert(run.includes('compensateInsert'), 'partial_persistence_compensation_missing');
+assert(!run.includes('recordCognitiveTwinExperience'), 'decision_transfer_must_not_write_memory_automatically');
+assert(!run.includes("from('sfi_amv_memory')"), 'decision_transfer_must_not_write_canonical_memory');
+assert(!run.includes("from('sfi_cognitive_twin_memory')"), 'decision_transfer_must_not_write_historical_memory');
+
+assert(readModel.includes(".like('test_key', 'decision_transfer:%')"), 'read_model_must_surface_persisted_evaluations');
+assert(readModel.includes("ct_reentry: ['sfi_amv_memory'"), 'ct_reentry_must_probe_canonical_memory');
+assert(!readModel.includes("ct_reentry: ['sfi_cognitive_twin_memory'"), 'historical_memory_must_not_be_canonical_dependency');
+assert(readModel.includes('decisionTransfer'), 'read_model_summary_missing');
+assert(readModel.includes('validatedDecisionAccuracy'), 'validated_holdout_metric_missing');
+assert(readModel.includes('validatedTargetDispositionAccuracy'), 'validated_counterfactual_metric_missing');
+
+assert(component.includes("fetch('/api/root/method-lab/decision-transfer'"), 'ui_execution_route_missing');
+assert(component.includes('Transferencia decisional observable'), 'ui_observable_object_missing');
+assert(component.includes('AUTO-PROMOTION'), 'ui_authority_boundary_missing');
+assert(component.includes('no se precargan datos ficticios') || component.includes('No se precargan datos ficticios'), 'ui_must_not_seed_fake_experiment');
+assert(page.includes('<DecisionTransferObservatory initial={state.decisionTransfer} />'), 'method_lab_must_render_observatory');
+
+console.log(JSON.stringify({
+  ok: true,
+  gate: 'SFI_DECISION_TRANSFER_OPERATIONAL',
+  canonicalRoute: '/api/root/method-lab/decision-transfer',
+  canonicalSurface: '/method-lab',
+  persistence: ['sfi_cognitive_twin_runs', 'sfi_cognitive_twin_evaluations', 'sfi_lab_analyses'],
+  memoryMutation: false,
+  autoPromotion: false,
+}, null, 2));

--- a/src/app/api/root/method-lab/decision-transfer/route.ts
+++ b/src/app/api/root/method-lab/decision-transfer/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { ZodError } from 'zod';
+import { auditRootAction, requireRootActor } from '@/lib/root/server';
+import {
+  executeDecisionTransferEvaluation,
+  parseDecisionTransferRunInput,
+} from '@/core/cognitive-twin/reentry/decisionTransferRun';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+export async function POST(request: Request) {
+  const gate = await requireRootActor('root.method-lab.decision-transfer.evaluate');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  try {
+    const raw = await request.json();
+    const input = parseDecisionTransferRunInput(raw);
+    const result = await executeDecisionTransferEvaluation(input, gate.ctx.user.id);
+    const audit = await auditRootAction({
+      actorId: gate.ctx.user.id,
+      action: 'method_lab.decision_transfer.evaluated',
+      target: result.evaluationId,
+      payload: {
+        taskId: result.taskId,
+        runId: result.runId,
+        evaluationId: result.evaluationId,
+        labAnalysisId: result.labAnalysisId,
+        operationKey: result.operationKey,
+        provider: result.provider,
+        model: result.model,
+        outcome: result.outcome,
+        evidenceRefs: result.evidenceRefs,
+        epistemicClass: 'DERIVED',
+        promotionAllowed: false,
+      },
+      request,
+    });
+    if (!audit.ok) return NextResponse.json(audit, { status: 500 });
+    return NextResponse.json({ ...result, audit }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    const invalidInput = error instanceof ZodError;
+    const details = invalidInput
+      ? error.issues.map((issue) => `${issue.path.join('.') || 'root'}:${issue.message}`).join('; ')
+      : error instanceof Error ? error.message : String(error);
+    return NextResponse.json({
+      ok: false,
+      error: invalidInput ? 'decision_transfer_input_invalid' : 'decision_transfer_evaluation_failed',
+      details,
+    }, { status: invalidInput ? 400 : 503 });
+  }
+}

--- a/src/app/method-lab/page.tsx
+++ b/src/app/method-lab/page.tsx
@@ -1,6 +1,7 @@
 import { requireRootObserverPage } from '@/lib/root/server';
 import { readMethodLabState } from '@/lib/method-lab/readModel';
 import { MethodLabConsole } from '@/components/root/method-lab/MethodLabConsole';
+import { DecisionTransferObservatory } from '@/components/root/method-lab/DecisionTransferObservatory';
 import { CognitiveLabConsole } from '@/components/root/cognitive-lab/CognitiveLabConsole';
 
 export const dynamic = 'force-dynamic';
@@ -12,6 +13,7 @@ export default async function MethodLabPage() {
   return (
     <>
       <MethodLabConsole state={state} />
+      <DecisionTransferObservatory initial={state.decisionTransfer} />
       <CognitiveLabConsole />
       <style>{`
         .crl-launch{border-color:#425a6d!important;background:#0d1923!important;color:#ddc58d!important;box-shadow:0 12px 35px rgba(0,0,0,.38)!important}

--- a/src/components/root/method-lab/DecisionTransferObservatory.tsx
+++ b/src/components/root/method-lab/DecisionTransferObservatory.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useState } from 'react';
+import type { MethodLabState } from '@/lib/method-lab/readModel';
+
+type DecisionTransferState = MethodLabState['decisionTransfer'];
+type RunResponse = {
+  ok?: boolean;
+  error?: string;
+  details?: string;
+  taskId?: string;
+  runId?: string;
+  evaluationId?: string;
+  labAnalysisId?: string;
+  operationKey?: string;
+  provider?: string;
+  model?: string;
+  outcome?: string;
+  claimBoundary?: string;
+  evaluation?: {
+    pass?: boolean;
+    holdout?: { validatedDecisionAccuracy?: number; validatedMeanStructuralFidelity?: number; validatedTraceCount?: number };
+    counterfactual?: { validatedTargetDispositionAccuracy?: number; validatedExpectedSwitchCount?: number };
+    promotion?: { maturity?: string; qualifyingSupportCount?: number; qualifyingCounterexampleCount?: number; mayAutoPromoteToRule?: boolean };
+  };
+};
+
+function pct(value: number | null | undefined) {
+  return typeof value === 'number' && Number.isFinite(value) ? `${(value * 100).toFixed(1)}%` : '—';
+}
+
+export function DecisionTransferObservatory({ initial }: { initial: DecisionTransferState }) {
+  const [state, setState] = useState(initial);
+  const [payload, setPayload] = useState('');
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<RunResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    const response = await fetch('/api/root/method-lab', { credentials: 'include', cache: 'no-store' });
+    const body = await response.json().catch(() => null) as { ok?: boolean; lab?: MethodLabState } | null;
+    if (response.ok && body?.ok && body.lab?.decisionTransfer) setState(body.lab.decisionTransfer);
+  }
+
+  async function evaluate() {
+    if (!payload.trim() || running) return;
+    setRunning(true);
+    setError(null);
+    setResult(null);
+    try {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(payload);
+      } catch {
+        throw new Error('El envelope no es JSON válido.');
+      }
+      const response = await fetch('/api/root/method-lab/decision-transfer', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(parsed),
+      });
+      const body = await response.json().catch(() => null) as RunResponse | null;
+      if (!response.ok || !body?.ok) throw new Error(body?.details ?? body?.error ?? `HTTP ${response.status}`);
+      setResult(body);
+      await refresh();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'DECISION_TRANSFER_EVALUATION_FAILED');
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  const latest = state.latest;
+
+  return (
+    <section className="dto-root" aria-labelledby="dto-title">
+      <header className="dto-header">
+        <div>
+          <span>PHASE II · DECISION TRANSFER OBSERVATORY</span>
+          <h2 id="dto-title">Transferencia decisional observable.</h2>
+          <p>Compara una reconstrucción retenida contra la decisión revelada y separa acierto final, fidelidad estructural, frontera contrafactual y madurez operacional. Un PASS sigue siendo una medición derivada; no promueve memoria, regla ni autoridad.</p>
+        </div>
+        <div className="dto-state" data-status={state.status}>
+          <small>ESTADO</small>
+          <strong>{state.status}</strong>
+        </div>
+      </header>
+
+      <div className="dto-metrics">
+        <article><small>EVALUACIONES</small><strong>{state.totalEvaluations}</strong></article>
+        <article><small>PASS</small><strong>{state.passCount}</strong></article>
+        <article><small>FAIL</small><strong>{state.failCount}</strong></article>
+        <article><small>BLOCKED</small><strong>{state.blockedCount}</strong></article>
+        <article><small>FIDELIDAD ESTRUCTURAL</small><strong>{pct(latest?.structuralFidelity)}</strong></article>
+        <article><small>CONTRAFACTUAL</small><strong>{pct(latest?.counterfactualAccuracy)}</strong></article>
+      </div>
+
+      <div className="dto-rules">
+        <article><span>VALIDACIÓN</span><p>{state.validationRule}</p></article>
+        <article><span>AUTORIDAD</span><p>{state.authorityRule}</p></article>
+      </div>
+
+      {latest ? (
+        <article className="dto-latest">
+          <div className="dto-latest-head">
+            <div><span>ÚLTIMA EVALUACIÓN</span><h3>{latest.operationKey || 'OPERACIÓN NO DECLARADA'}</h3></div>
+            <b data-outcome={latest.outcome}>{latest.outcome}</b>
+          </div>
+          <div className="dto-latest-grid">
+            <div><small>PROVIDER / MODEL</small><strong>{latest.provider} / {latest.model}</strong></div>
+            <div><small>DECISIÓN</small><strong>{pct(latest.decisionAccuracy)}</strong></div>
+            <div><small>ESTRUCTURA</small><strong>{pct(latest.structuralFidelity)}</strong></div>
+            <div><small>OPERACIONES</small><strong>{pct(latest.operationSimilarity)}</strong></div>
+            <div><small>VARIABLES</small><strong>{pct(latest.variableSimilarity)}</strong></div>
+            <div><small>FRONTERA</small><strong>{pct(latest.counterfactualAccuracy)}</strong></div>
+            <div><small>TRAZAS VALIDADAS</small><strong>{latest.validatedTraceCount ?? 0}</strong></div>
+            <div><small>SWITCHES VALIDADOS</small><strong>{latest.validatedBoundarySwitchCount ?? 0}</strong></div>
+            <div><small>MADUREZ</small><strong>{latest.maturity ?? 'CANDIDATE'}</strong></div>
+            <div><small>DOMINIOS</small><strong>{latest.qualifyingDomains.length || 0}</strong></div>
+            <div><small>CONTRAEJEMPLOS</small><strong>{latest.counterexampleCount ?? 0}</strong></div>
+            <div><small>AUTO-PROMOTION</small><strong>{latest.mayAutoPromoteToRule ? 'INVALID STATE' : 'NO'}</strong></div>
+          </div>
+        </article>
+      ) : (
+        <div className="dto-empty">AÚN NO EXISTE UNA EVALUACIÓN DECISION_TRANSFER PERSISTIDA. EL ESTADO VACÍO ES EXPLÍCITO.</div>
+      )}
+
+      <div className="dto-run">
+        <div>
+          <span>ROOT · POST-REVEAL SCORING</span>
+          <h3>Evaluar un experimento preparado.</h3>
+          <p>El envelope debe contener trazas y referencias reales del experimento. Esta superficie no fabrica ejemplos ni llama a un modelo para conseguir un PASS. La reconstrucción debe haberse producido con la decisión objetivo retenida.</p>
+          <details>
+            <summary>CONTRATO DE ENTRADA</summary>
+            <pre>{`{
+  "provider": "...",
+  "model": "...",
+  "operationKey": "...",
+  "expected": [DecisionTrace],
+  "predicted": [DecisionReconstruction],
+  "occurrences": [OperationOccurrence],
+  "counterfactualProbes": [CounterfactualProbe],
+  "boundaryProbeCount": 0,
+  "thresholds": { ... } // opcional
+}`}</pre>
+          </details>
+        </div>
+        <div className="dto-form">
+          <label>EXPERIMENT ENVELOPE · JSON
+            <textarea value={payload} onChange={(event) => setPayload(event.target.value)} placeholder="Pegue aquí el envelope construido a partir de un experimento real. No se precargan datos ficticios." spellCheck={false} />
+          </label>
+          <button type="button" disabled={running || !payload.trim()} onClick={() => void evaluate()}>{running ? 'EVALUANDO…' : 'EVALUAR Y PERSISTIR'}</button>
+        </div>
+      </div>
+
+      {result?.ok ? (
+        <div className="dto-result">
+          <strong>{result.outcome}</strong>
+          <span>{result.operationKey}</span>
+          <small>evaluation {result.evaluationId}</small>
+          <small>run {result.runId}</small>
+          <small>lab {result.labAnalysisId}</small>
+          <p>{result.claimBoundary}</p>
+        </div>
+      ) : null}
+      {error ? <div className="dto-error">{error}</div> : null}
+      {state.warning ? <div className="dto-error">{state.warning}</div> : null}
+
+      {state.recent.length ? (
+        <details className="dto-history">
+          <summary>HISTORIAL RECIENTE · {state.recent.length}</summary>
+          <div>
+            {state.recent.map((item) => (
+              <article key={item.id}>
+                <b>{item.outcome}</b><span>{item.operationKey}</span><small>{item.provider}/{item.model}</small><small>{item.executedAt ?? 'sin timestamp'}</small><em>{pct(item.structuralFidelity)}</em>
+              </article>
+            ))}
+          </div>
+        </details>
+      ) : null}
+
+      <style jsx>{`
+        .dto-root{background:#071018;color:#e8edf0;border-top:1px solid #33495c;border-bottom:1px solid #33495c;padding:28px 30px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}.dto-header{display:flex;justify-content:space-between;gap:30px;align-items:flex-start}.dto-header>div:first-child{max-width:920px}.dto-header span,.dto-rules span,.dto-run>div>span,.dto-latest-head span{font-size:8px;letter-spacing:.16em;color:#c8aa6d}.dto-header h2{font:400 clamp(28px,3vw,42px)/1 Georgia,serif;color:#f4f6f7;margin:8px 0 11px}.dto-header p,.dto-run p{font:13px/1.6 Georgia,serif;color:#91a0ac;margin:0}.dto-state{border:1px solid #33495c;background:#0c1822;padding:12px 15px;min-width:130px}.dto-state small,.dto-metrics small,.dto-latest-grid small{display:block;font-size:7px;letter-spacing:.12em;color:#8195a3}.dto-state strong{display:block;margin-top:7px;color:#d8c38e;font-size:10px}.dto-state[data-status=OBSERVED] strong{color:#9fbea9}.dto-state[data-status=DEGRADED] strong{color:#d19380}.dto-metrics{display:grid;grid-template-columns:repeat(6,1fr);gap:1px;background:#2c4253;margin:18px 0}.dto-metrics article{background:#0b161f;padding:12px}.dto-metrics strong{display:block;margin-top:7px;font-size:15px;color:#e7d3a1}.dto-rules{display:grid;grid-template-columns:1fr 1fr;gap:8px}.dto-rules article{border:1px solid #263a4a;background:#0c1720;padding:14px}.dto-rules p{margin:7px 0 0;font:11px/1.55 Georgia,serif;color:#98a6af}.dto-latest{border:1px solid #33495c;background:#0b161f;padding:17px;margin-top:14px}.dto-latest-head{display:flex;justify-content:space-between;gap:20px;align-items:flex-start}.dto-latest-head h3,.dto-run h3{font:400 22px Georgia,serif;color:#f0f3f5;margin:6px 0 0}.dto-latest-head b{border:1px solid #526778;padding:7px 10px;font-size:8px;color:#9aaab5}.dto-latest-head b[data-outcome=PASS]{color:#9fbea9;border-color:#526e5e}.dto-latest-head b[data-outcome=FAIL]{color:#d19380;border-color:#744e47}.dto-latest-head b[data-outcome=BLOCKED]{color:#d4bd83;border-color:#6f6041}.dto-latest-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:7px;margin-top:15px}.dto-latest-grid>div{border-top:1px solid #263a4a;padding-top:8px;min-width:0}.dto-latest-grid strong{display:block;margin-top:6px;font-size:9px;color:#c5d0d6;overflow-wrap:anywhere}.dto-empty{border:1px dashed #33495c;color:#7f92a1;padding:16px;margin-top:14px;font-size:9px;letter-spacing:.06em}.dto-run{display:grid;grid-template-columns:minmax(300px,.8fr) minmax(420px,1.2fr);gap:22px;border:1px solid #33495c;background:#0c1720;padding:18px;margin-top:14px}.dto-run details{margin-top:13px;border-top:1px solid #2c4253;padding-top:9px}.dto-run summary,.dto-history summary{font-size:8px;color:#c8aa6d;cursor:pointer}.dto-run pre{white-space:pre-wrap;color:#8fa2b0;font-size:8px;line-height:1.55}.dto-form{display:grid;gap:10px}.dto-form label{display:grid;gap:6px;color:#8195a3;font-size:8px;letter-spacing:.1em}.dto-form textarea{min-height:260px;width:100%;box-sizing:border-box;resize:vertical;border:1px solid #3a5265;background:#081119;color:#e7ecef;padding:11px;font:9px/1.55 ui-monospace,monospace}.dto-form button{border:1px solid #b69759;background:#c2a464;color:#081119;padding:10px 12px;font:700 9px ui-monospace,monospace;letter-spacing:.08em;cursor:pointer}.dto-form button:disabled{opacity:.4}.dto-result,.dto-error{border:1px solid #31495a;background:#0b161f;padding:12px 14px;margin-top:10px;font-size:9px}.dto-result{display:flex;gap:12px;align-items:center;flex-wrap:wrap}.dto-result strong{color:#a9c5b3}.dto-result span{color:#e7d3a1}.dto-result small{color:#8193a0}.dto-result p{width:100%;margin:4px 0 0;color:#91a0ac;font:11px/1.5 Georgia,serif}.dto-error{border-color:#64443f;color:#d19380;background:#160f0f}.dto-history{margin-top:13px;border-top:1px solid #2c4253;padding-top:10px}.dto-history>div{display:grid;gap:4px;margin-top:9px}.dto-history article{display:grid;grid-template-columns:70px 1.2fr 1fr 1fr 70px;gap:10px;border-bottom:1px solid #1f303d;padding:7px 0;align-items:center}.dto-history b{font-size:8px;color:#d8c38e}.dto-history span{font-size:8px;color:#c5d0d6}.dto-history small{font-size:7px;color:#788a97;overflow-wrap:anywhere}.dto-history em{font-size:8px;color:#a9c5b3;font-style:normal;text-align:right}@media(max-width:900px){.dto-root{padding:22px 16px}.dto-header{display:grid}.dto-state{width:max-content}.dto-metrics{grid-template-columns:repeat(2,1fr)}.dto-rules,.dto-run{grid-template-columns:1fr}.dto-latest-grid{grid-template-columns:repeat(2,1fr)}.dto-history article{grid-template-columns:60px 1fr}.dto-history article small,.dto-history article em{display:none}}`}</style>
+    </section>
+  );
+}

--- a/src/core/cognitive-twin/reentry/decisionTransferRun.ts
+++ b/src/core/cognitive-twin/reentry/decisionTransferRun.ts
@@ -1,0 +1,239 @@
+import 'server-only';
+
+import { createHash, randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import {
+  buildDecisionTransferEvaluation,
+  evaluateCounterfactualProbes,
+  evaluateDecisionHoldout,
+  evaluateOperationPromotion,
+  type DecisionTransferEvaluation,
+} from './decisionTransfer';
+
+const dispositionSchema = z.enum(['PROPOSE', 'REQUEST_EVIDENCE', 'ESCALATE', 'WITHHOLD', 'ARCHIVE_ONLY']);
+const epistemicClassSchema = z.enum(['OBSERVED', 'VERIFIED_CONTRAST', 'DERIVED', 'INFERRED', 'SIMULATED']);
+
+const decisionTraceSchema = z.object({
+  traceId: z.string().trim().min(1).max(240),
+  domain: z.string().trim().min(1).max(160),
+  disposition: dispositionSchema,
+  operations: z.array(z.string().trim().min(1).max(240)).max(100),
+  relevantVariables: z.array(z.string().trim().min(1).max(240)).max(100),
+  rejectedConditions: z.array(z.string().trim().min(1).max(500)).max(100),
+  whatWouldChangeDecision: z.array(z.string().trim().min(1).max(500)).max(100),
+  evidenceRefs: z.array(z.string().trim().min(1).max(500)).max(500),
+  epistemicClass: epistemicClassSchema,
+}).strict();
+
+const reconstructionSchema = z.object({
+  traceId: z.string().trim().min(1).max(240),
+  disposition: dispositionSchema,
+  operations: z.array(z.string().trim().min(1).max(240)).max(100),
+  relevantVariables: z.array(z.string().trim().min(1).max(240)).max(100),
+  rejectedConditions: z.array(z.string().trim().min(1).max(500)).max(100).optional(),
+  whatWouldChangeDecision: z.array(z.string().trim().min(1).max(500)).max(100).optional(),
+}).strict();
+
+const occurrenceSchema = z.object({
+  occurrenceId: z.string().trim().min(1).max(240),
+  operationKey: z.string().trim().min(1).max(240),
+  traceId: z.string().trim().min(1).max(240),
+  domain: z.string().trim().min(1).max(160),
+  support: z.enum(['SUPPORT', 'COUNTEREXAMPLE']),
+  epistemicClass: epistemicClassSchema,
+  evidenceRefs: z.array(z.string().trim().min(1).max(500)).max(500),
+}).strict();
+
+const probeSchema = z.object({
+  probeId: z.string().trim().min(1).max(240),
+  baseTraceId: z.string().trim().min(1).max(240),
+  variableKey: z.string().trim().min(1).max(240),
+  direction: z.enum(['INCREASE', 'DECREASE', 'TOGGLE', 'REPLACE']),
+  baselineDisposition: dispositionSchema,
+  expectedDispositionAfterPerturbation: dispositionSchema,
+  predictedDispositionAfterPerturbation: dispositionSchema,
+  epistemicClass: z.enum(['OBSERVED', 'VERIFIED_CONTRAST', 'SIMULATED', 'DERIVED']),
+  evidenceRefs: z.array(z.string().trim().min(1).max(500)).max(500),
+}).strict();
+
+const thresholdSchema = z.number().finite().min(0).max(1);
+
+export const decisionTransferRunInputSchema = z.object({
+  provider: z.string().trim().min(1).max(120),
+  model: z.string().trim().min(1).max(240),
+  operationKey: z.string().trim().min(1).max(240),
+  expected: z.array(decisionTraceSchema).min(1).max(500),
+  predicted: z.array(reconstructionSchema).max(500),
+  occurrences: z.array(occurrenceSchema).max(2000),
+  counterfactualProbes: z.array(probeSchema).max(1000),
+  boundaryProbeCount: z.number().int().min(0).max(100000),
+  thresholds: z.object({
+    minimumDecisionAccuracy: thresholdSchema.optional(),
+    minimumStructuralFidelity: thresholdSchema.optional(),
+    minimumCounterfactualTargetAccuracy: thresholdSchema.optional(),
+  }).strict().optional(),
+}).strict();
+
+export type DecisionTransferRunInput = z.infer<typeof decisionTransferRunInputSchema>;
+
+type EvaluationOutcome = 'PASS' | 'FAIL' | 'BLOCKED';
+
+function hash(value: unknown) {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+function unique(values: string[]) {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).sort();
+}
+
+function classifyOutcome(evaluation: DecisionTransferEvaluation): EvaluationOutcome {
+  const validationReady = evaluation.holdout.validatedTraceCount > 0
+    && evaluation.promotion.qualifyingSupportCount > 0
+    && evaluation.counterfactual.validatedExpectedSwitchCount > 0;
+  if (!validationReady) return 'BLOCKED';
+  return evaluation.pass ? 'PASS' : 'FAIL';
+}
+
+async function compensateInsert(table: 'sfi_cognitive_twin_runs' | 'sfi_cognitive_twin_evaluations', id: string | null) {
+  if (!id) return;
+  const db = createServiceSupabaseClient();
+  await db.from(table).delete().eq('id', id);
+}
+
+export function parseDecisionTransferRunInput(value: unknown): DecisionTransferRunInput {
+  return decisionTransferRunInputSchema.parse(value);
+}
+
+export async function executeDecisionTransferEvaluation(input: DecisionTransferRunInput, actorId: string) {
+  const holdout = evaluateDecisionHoldout({ expected: input.expected, predicted: input.predicted });
+  const counterfactual = evaluateCounterfactualProbes(input.counterfactualProbes);
+  const promotion = evaluateOperationPromotion({
+    operationKey: input.operationKey,
+    occurrences: input.occurrences,
+    boundaryProbeCount: input.boundaryProbeCount,
+  });
+  const evaluation = buildDecisionTransferEvaluation({
+    holdout,
+    counterfactual,
+    promotion,
+    thresholds: input.thresholds,
+  });
+  const outcome = classifyOutcome(evaluation);
+  const evidenceRefs = unique([
+    ...input.expected.flatMap((item) => item.evidenceRefs),
+    ...input.occurrences.flatMap((item) => item.evidenceRefs),
+    ...input.counterfactualProbes.flatMap((item) => item.evidenceRefs),
+  ]);
+  const taskId = `DT-${randomUUID()}`;
+  const startedAt = new Date().toISOString();
+  const finishedAt = startedAt;
+  const inputHash = hash(input);
+  const db = createServiceSupabaseClient();
+
+  const runInsert = await db.from('sfi_cognitive_twin_runs').insert({
+    task_id: taskId,
+    contract_version: evaluation.schemaVersion,
+    provider: input.provider,
+    model: input.model,
+    role: 'DECISION_TRANSFER_EVALUATOR',
+    status: 'CLOSED',
+    objective: `Evaluate withheld decision reconstruction and decision-boundary transfer for ${input.operationKey}.`,
+    input_snapshot: {
+      ...input,
+      inputHash,
+      holdoutPolicy: 'TARGET_DECISION_MUST_BE_EXCLUDED_FROM_RECONSTRUCTION_CONTEXT_UNTIL_REVEAL',
+      evaluationStage: 'POST_REVEAL_SCORING',
+    },
+    output_envelope: {
+      operationKey: input.operationKey,
+      outcome,
+      evaluation,
+      inputHash,
+    },
+    evidence_refs: evidenceRefs,
+    limitations: evaluation.limitations,
+    started_at: startedAt,
+    finished_at: finishedAt,
+  }).select('id').single();
+  if (runInsert.error || !runInsert.data?.id) {
+    throw new Error(`DECISION_TRANSFER_RUN_PERSIST_FAILED:${runInsert.error?.message ?? 'unknown'}`);
+  }
+  const runId = String(runInsert.data.id);
+
+  const evaluationInsert = await db.from('sfi_cognitive_twin_evaluations').insert({
+    provider: input.provider,
+    model: input.model,
+    test_key: `decision_transfer:${input.operationKey}`,
+    test_version: evaluation.schemaVersion,
+    outcome,
+    observed_result: {
+      operationKey: input.operationKey,
+      taskId,
+      runId,
+      inputHash,
+      evaluation,
+    },
+    evidence_refs: evidenceRefs,
+    executor: actorId,
+  }).select('id').single();
+  if (evaluationInsert.error || !evaluationInsert.data?.id) {
+    await compensateInsert('sfi_cognitive_twin_runs', runId);
+    throw new Error(`DECISION_TRANSFER_EVALUATION_PERSIST_FAILED:${evaluationInsert.error?.message ?? 'unknown'}`);
+  }
+  const evaluationId = String(evaluationInsert.data.id);
+
+  const labInsert = await db.from('sfi_lab_analyses').insert({
+    mode: 'ct_reentry',
+    source: `sfi_cognitive_twin_evaluations:${evaluationId}`,
+    data_mode: 'DERIVED',
+    systems: ['cognitive_twin', 'decision_transfer_observatory', input.provider, input.model],
+    variables: unique([
+      'decision_accuracy',
+      'structural_fidelity',
+      'operation_similarity',
+      'variable_similarity',
+      'counterfactual_target_accuracy',
+      input.operationKey,
+    ]),
+    limitations: evaluation.limitations,
+    recommendations: outcome === 'BLOCKED'
+      ? ['Collect OBSERVED or VERIFIED_CONTRAST holdout traces, qualifying operation support and at least one observed/verified decision-boundary switch before validation.']
+      : ['Compare this evaluation against declared baseline arms before making any transfer claim or governed promotion request.'],
+    raw_analysis: {
+      protocol: 'decision_transfer',
+      schemaVersion: evaluation.schemaVersion,
+      operationKey: input.operationKey,
+      taskId,
+      runId,
+      evaluationId,
+      provider: input.provider,
+      model: input.model,
+      outcome,
+      inputHash,
+      epistemicClass: 'DERIVED',
+      evaluation,
+      promotionAllowed: false,
+    },
+  }).select('id').single();
+  if (labInsert.error || !labInsert.data?.id) {
+    await compensateInsert('sfi_cognitive_twin_evaluations', evaluationId);
+    await compensateInsert('sfi_cognitive_twin_runs', runId);
+    throw new Error(`DECISION_TRANSFER_LAB_PROJECTION_FAILED:${labInsert.error?.message ?? 'unknown'}`);
+  }
+
+  return {
+    ok: true as const,
+    taskId,
+    runId,
+    evaluationId,
+    labAnalysisId: String(labInsert.data.id),
+    operationKey: input.operationKey,
+    provider: input.provider,
+    model: input.model,
+    outcome,
+    evaluation,
+    evidenceRefs,
+    claimBoundary: 'This result is a governed DERIVED evaluation. SIMULATED/DERIVED inputs may remain diagnostic but cannot satisfy validation gates, promote a rule, mutate canonical memory or expand authority.',
+  };
+}

--- a/src/lib/method-lab/readModel.ts
+++ b/src/lib/method-lab/readModel.ts
@@ -111,7 +111,7 @@ export async function readMethodLabState() {
     const warnings = [
       ...(Array.isArray(latest?.limitations) ? latest.limitations.map(String) : []),
       ...missingDependencies.map((item) => `${item.table}:${item.error ?? 'unavailable'}`),
-      ...(definition.id === 'ct_reentry' ? ['CT reentry is implemented as governed longitudinal provenance. GATED means no Method Lab evaluation row has yet validated it; Decision Transfer PASS remains a DERIVED measurement and does not imply individuation, subjective experience or automatic rule promotion.'] : []),
+      ...(definition.id === 'ct_reentry' ? ['CT reentry is implemented as governed longitudinal provenance. GATED means no Method Lab evaluation row has yet validated it; it does not mean individuation is demonstrated. Decision Transfer PASS remains a DERIVED measurement and does not imply subjective experience or automatic rule promotion.'] : []),
       ...(definition.id === 'cognitive_relational_lab' ? ['CRL protocol-specific migration remains experimental; persisted session state is not canonical memory or proof of individuation.'] : []),
       ...(tableWarning ? [`sfi_lab_analyses:${tableWarning}`] : []),
     ];

--- a/src/lib/method-lab/readModel.ts
+++ b/src/lib/method-lab/readModel.ts
@@ -21,7 +21,7 @@ const IMPLEMENTATION_GATES: Record<MethodLabProtocolId, () => boolean> = {
 const PROTOCOL_DEPENDENCIES: Record<MethodLabProtocolId, string[]> = {
   chronos_olympics: [],
   cognitive_relational_lab: ['sfi_cognitive_lab_sessions', 'sfi_cognitive_lab_events', 'sfi_cognitive_lab_analyses'],
-  ct_reentry: ['sfi_cognitive_twin_memory', 'sfi_cognitive_twin_decisions', 'sfi_cognitive_twin_model_registry', 'sfi_cognitive_twin_evaluations', 'sfi_cognitive_twin_runs'],
+  ct_reentry: ['sfi_amv_memory', 'sfi_cognitive_twin_decisions', 'sfi_cognitive_twin_model_registry', 'sfi_cognitive_twin_evaluations', 'sfi_cognitive_twin_runs'],
   sociotechnical_simulation: ['root_evidence_entries', 'epistemic_events', 'field_cases', 'sfi_graph_nodes'],
   economic_simulation: ['root_evidence_entries', 'epistemic_events', 'field_cases', 'world_source_observations'],
 };
@@ -31,6 +31,14 @@ function text(value: unknown, fallback = '') {
 }
 function row(value: unknown): Row {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function numeric(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : [];
 }
 
 async function probeDependencies() {
@@ -43,17 +51,55 @@ async function probeDependencies() {
   return new Map(results.map((item) => [item.table, item]));
 }
 
+function summarizeDecisionTransfer(item: Row) {
+  const observed = row(item.observed_result);
+  const evaluation = row(observed.evaluation ?? item.observed_result);
+  const holdout = row(evaluation.holdout);
+  const counterfactual = row(evaluation.counterfactual);
+  const promotion = row(evaluation.promotion);
+  const testKey = text(item.test_key);
+  return {
+    id: text(item.id),
+    provider: text(item.provider, 'UNKNOWN'),
+    model: text(item.model, 'UNKNOWN'),
+    operationKey: text(observed.operationKey) || (testKey.startsWith('decision_transfer:') ? testKey.slice('decision_transfer:'.length) : testKey),
+    testVersion: text(item.test_version),
+    outcome: text(item.outcome, 'NOT_RUN'),
+    executedAt: text(item.executed_at) || null,
+    executor: text(item.executor) || null,
+    evidenceRefs: strings(item.evidence_refs),
+    decisionAccuracy: numeric(holdout.validatedDecisionAccuracy ?? holdout.decisionAccuracy),
+    structuralFidelity: numeric(holdout.validatedMeanStructuralFidelity ?? holdout.meanStructuralFidelity),
+    operationSimilarity: numeric(holdout.meanOperationJaccard),
+    variableSimilarity: numeric(holdout.meanVariableJaccard),
+    counterfactualAccuracy: numeric(counterfactual.validatedTargetDispositionAccuracy ?? counterfactual.targetDispositionAccuracy),
+    validatedTraceCount: numeric(holdout.validatedTraceCount),
+    validatedBoundarySwitchCount: numeric(counterfactual.validatedExpectedSwitchCount),
+    maturity: text(promotion.maturity) || null,
+    qualifyingSupportCount: numeric(promotion.qualifyingSupportCount),
+    counterexampleCount: numeric(promotion.qualifyingCounterexampleCount),
+    qualifyingDomains: strings(promotion.qualifyingDomains),
+    mayAutoPromoteToRule: promotion.mayAutoPromoteToRule === true,
+  };
+}
+
 export async function readMethodLabState() {
   const db = createServiceSupabaseClient();
-  const [analyses, dependencyState] = await Promise.all([
+  const [analyses, decisionTransferEvaluations, dependencyState] = await Promise.all([
     db.from('sfi_lab_analyses')
       .select('id,mode,source,data_mode,limitations,raw_analysis,created_at')
       .order('created_at', { ascending: false })
       .limit(200),
+    db.from('sfi_cognitive_twin_evaluations')
+      .select('id,provider,model,test_key,test_version,outcome,observed_result,evidence_refs,executed_at,executor')
+      .like('test_key', 'decision_transfer:%')
+      .order('executed_at', { ascending: false })
+      .limit(100),
     probeDependencies(),
   ]);
 
   const tableWarning = analyses.error ? analyses.error.message : null;
+  const decisionTransferWarning = decisionTransferEvaluations.error ? decisionTransferEvaluations.error.message : null;
   const rows = (analyses.data ?? []) as Row[];
   const protocols = METHOD_LAB_PROTOCOLS.map((definition) => {
     const relevant = rows.filter((item) => text(item.mode) === definition.id);
@@ -65,7 +111,7 @@ export async function readMethodLabState() {
     const warnings = [
       ...(Array.isArray(latest?.limitations) ? latest.limitations.map(String) : []),
       ...missingDependencies.map((item) => `${item.table}:${item.error ?? 'unavailable'}`),
-      ...(definition.id === 'ct_reentry' ? ['CT reentry is implemented as governed longitudinal provenance. GATED means no Method Lab evaluation row has yet validated it; it does not mean individuation is demonstrated.'] : []),
+      ...(definition.id === 'ct_reentry' ? ['CT reentry is governed longitudinal provenance. Decision Transfer evaluations are DERIVED measurements; even PASS does not imply individuation, subjective experience or automatic rule promotion.'] : []),
       ...(definition.id === 'cognitive_relational_lab' ? ['CRL protocol-specific migration remains experimental; persisted session state is not canonical memory or proof of individuation.'] : []),
       ...(tableWarning ? [`sfi_lab_analyses:${tableWarning}`] : []),
     ];
@@ -81,31 +127,47 @@ export async function readMethodLabState() {
       runCount: relevant.length,
       lastRunAt: text(latest?.created_at) || null,
       lastRunId: text(latest?.id) || null,
-      lastValidationLevel: text(raw.validationLevel) || null,
-      lastResultHash: text(raw.resultHash) || null,
+      lastValidationLevel: text(raw.validationLevel) || text(raw.epistemicClass) || null,
+      lastResultHash: text(raw.resultHash) || text(raw.inputHash) || null,
       dependencies,
       missingDependencies: missingDependencies.map((item) => item.table),
       warnings,
     };
   });
 
+  const decisionTransferRows = ((decisionTransferEvaluations.data ?? []) as Row[]).map(summarizeDecisionTransfer);
+  const decisionTransfer = {
+    status: decisionTransferWarning ? 'DEGRADED' as const : decisionTransferRows.length ? 'OBSERVED' as const : 'GATED' as const,
+    totalEvaluations: decisionTransferRows.length,
+    passCount: decisionTransferRows.filter((item) => item.outcome === 'PASS').length,
+    failCount: decisionTransferRows.filter((item) => item.outcome === 'FAIL').length,
+    blockedCount: decisionTransferRows.filter((item) => item.outcome === 'BLOCKED').length,
+    latest: decisionTransferRows[0] ?? null,
+    recent: decisionTransferRows.slice(0, 12),
+    warning: decisionTransferWarning,
+    validationRule: 'Only OBSERVED / VERIFIED_CONTRAST traces and observed/verified decision-boundary switches can satisfy validation gates. SIMULATED / DERIVED results remain diagnostic.',
+    authorityRule: 'PASS is an evaluation outcome, not a RULE, canon mutation, memory promotion or authority grant.',
+  };
+
   const llmProviders = getLlmProviderStatus();
 
   return {
     generatedAt: new Date().toISOString(),
     contractVersion: METHOD_LAB_CONTRACT_VERSION,
-    status: tableWarning || protocols.some((item) => item.status === 'DEGRADED')
+    status: tableWarning || decisionTransferWarning || protocols.some((item) => item.status === 'DEGRADED')
       ? 'DEGRADED'
       : protocols.some((item) => item.status === 'OPERATIONAL')
         ? 'OPERATIONAL'
         : 'GATED',
-    sharedPersistence: 'sfi_lab_analyses',
-    epistemicRule: 'Every laboratory output remains SIMULATED until a later observed return supports a stronger validation state.',
+    sharedPersistence: 'sfi_lab_analyses + governed protocol stores',
+    epistemicRule: 'Every laboratory output preserves its epistemic class. Simulation may exercise an instrument but cannot validate its own claim.',
     promotionRule: 'No protocol can mutate canonical state or promote its own result; ROOT/ACP evaluates promotion requests.',
     llmProviders,
     protocols,
+    decisionTransfer,
     warnings: [
       ...(tableWarning ? [`sfi_lab_analyses:${tableWarning}`] : []),
+      ...(decisionTransferWarning ? [`sfi_cognitive_twin_evaluations:${decisionTransferWarning}`] : []),
       ...protocols.flatMap((item) => item.missingDependencies.map((table) => `${item.id}:${table}`)),
     ],
   };

--- a/src/lib/method-lab/readModel.ts
+++ b/src/lib/method-lab/readModel.ts
@@ -111,7 +111,7 @@ export async function readMethodLabState() {
     const warnings = [
       ...(Array.isArray(latest?.limitations) ? latest.limitations.map(String) : []),
       ...missingDependencies.map((item) => `${item.table}:${item.error ?? 'unavailable'}`),
-      ...(definition.id === 'ct_reentry' ? ['CT reentry is governed longitudinal provenance. Decision Transfer evaluations are DERIVED measurements; even PASS does not imply individuation, subjective experience or automatic rule promotion.'] : []),
+      ...(definition.id === 'ct_reentry' ? ['CT reentry is implemented as governed longitudinal provenance. GATED means no Method Lab evaluation row has yet validated it; Decision Transfer PASS remains a DERIVED measurement and does not imply individuation, subjective experience or automatic rule promotion.'] : []),
       ...(definition.id === 'cognitive_relational_lab' ? ['CRL protocol-specific migration remains experimental; persisted session state is not canonical memory or proof of individuation.'] : []),
       ...(tableWarning ? [`sfi_lab_analyses:${tableWarning}`] : []),
     ];


### PR DESCRIPTION
## Scope
Make the Phase II Decision Transfer Observatory operational inside the existing canonical `/method-lab` surface.

## Runtime
- adds governed POST `/api/root/method-lab/decision-transfer`
- requires ROOT actor and writes a ROOT audit event
- validates experiment envelopes with Zod
- evaluates withheld-decision reconstruction, structural fidelity, operation recurrence and observed/verified counterfactual boundary switches
- persists the evaluation into existing `sfi_cognitive_twin_runs`, `sfi_cognitive_twin_evaluations` and `sfi_lab_analyses`
- uses compensating deletes if multi-store persistence does not complete

## Site
- adds `DecisionTransferObservatory` inside `/method-lab`; no new Lab or parallel public surface
- shows PASS / FAIL / BLOCKED, validated structural fidelity, counterfactual accuracy, maturity, domains and counterexamples
- explicitly exposes empty state instead of fabricated example results
- accepts a prepared post-reveal experiment envelope for governed scoring

## Epistemic / authority boundaries
- observed/verified evidence only can satisfy validation gates
- simulated/derived data remains diagnostic
- target decision must remain withheld from reconstruction context until reveal
- evaluation is post-reveal scoring, not reconstruction itself
- no direct write to `sfi_amv_memory` or historical CT memory
- no `recordCognitiveTwinExperience`
- PASS does not promote a rule, mutate canon or expand authority

## Canonical dependency correction
`ct_reentry` now probes `sfi_amv_memory` as canonical memory dependency instead of treating historical `sfi_cognitive_twin_memory` as canonical.

## QA
Adds `qa-sfi-decision-transfer-operational.ts` to SFI Verify to enforce route governance, persistence, holdout contamination guard, canonical-memory dependency and absence of automatic memory/canon mutation.