### PR TITLE
Phase II: sealed blind decision reconstruction before reveal

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Verify Decision Transfer operational wiring
         run: npx tsx scripts/qa-sfi-decision-transfer-operational.ts
 
+      - name: Verify blind decision reconstruction protocol
+        run: npx tsx scripts/qa-sfi-decision-transfer-blind.ts
+
       - name: Verify canonical evidence identity
         run: node --import tsx --test src/lib/evidence/canonicalEvidence.test.ts
 

--- a/scripts/qa-sfi-decision-transfer-blind.ts
+++ b/scripts/qa-sfi-decision-transfer-blind.ts
@@ -10,17 +10,19 @@ function assert(condition: unknown, message: string): asserts condition {
 
 const runtimePath = 'src/core/cognitive-twin/reentry/blindDecisionReconstruction.ts';
 const commitmentPath = 'src/core/cognitive-twin/reentry/decisionCommitment.ts';
+const integrityPath = 'src/core/cognitive-twin/reentry/blindDecisionIntegrity.ts';
 const blindRoutePath = 'src/app/api/root/method-lab/decision-transfer/blind/route.ts';
 const revealRoutePath = 'src/app/api/root/method-lab/decision-transfer/reveal/route.ts';
 const componentPath = 'src/components/root/method-lab/BlindDecisionExperiment.tsx';
 const pagePath = 'src/app/method-lab/page.tsx';
 
-for (const file of [runtimePath, commitmentPath, blindRoutePath, revealRoutePath, componentPath, pagePath]) {
+for (const file of [runtimePath, commitmentPath, integrityPath, blindRoutePath, revealRoutePath, componentPath, pagePath]) {
   assert(fs.existsSync(path.join(process.cwd(), file)), `missing:${file}`);
 }
 
 const runtime = read(runtimePath);
 const commitment = read(commitmentPath);
+const integrity = read(integrityPath);
 const blindRoute = read(blindRoutePath);
 const revealRoute = read(revealRoutePath);
 const component = read(componentPath);
@@ -30,6 +32,8 @@ assert(blindRoute.includes("requireRootActor('root.method-lab.decision-transfer.
 assert(revealRoute.includes("requireRootActor('root.method-lab.decision-transfer.reveal')"), 'reveal_route_root_gate_missing');
 assert(blindRoute.includes('auditRootAction'), 'blind_route_audit_missing');
 assert(revealRoute.includes('auditRootAction'), 'reveal_route_audit_missing');
+assert(revealRoute.includes('verifyBlindDecisionContextIntegrity(input.blindRunId)'), 'frozen_context_integrity_gate_missing');
+assert(revealRoute.indexOf('verifyBlindDecisionContextIntegrity(input.blindRunId)') < revealRoute.indexOf('executeBlindDecisionReveal(input'), 'context_integrity_must_precede_reveal');
 
 const blindSchema = runtime.slice(runtime.indexOf('export const blindDecisionRunInputSchema'), runtime.indexOf('const predictionSchema'));
 assert(blindSchema.includes('targetCommitmentSha256'), 'blind_input_commitment_missing');
@@ -47,6 +51,12 @@ assert(runtime.includes('predictionHash'), 'prediction_integrity_hash_missing');
 assert(runtime.includes('selectedContextHash'), 'context_integrity_hash_missing');
 assert(runtime.includes('contextPoolHash'), 'context_pool_hash_missing');
 
+assert(integrity.includes("contract_version !== 'SFI-CT-BLIND-DECISION-1.0'"), 'blind_contract_integrity_missing');
+assert(integrity.includes("role !== 'DECISION_TRANSFER_BLIND_RECONSTRUCTOR'"), 'blind_role_integrity_missing');
+assert(integrity.includes("status !== 'EVIDENCE_PENDING'"), 'blind_status_integrity_missing');
+assert(integrity.includes("throw new Error('BLIND_CONTEXT_INTEGRITY_MISMATCH')"), 'selected_context_hash_verification_missing');
+assert(integrity.includes('sha256(canonicalJson(snapshot.selectedContext))'), 'selected_context_rehash_missing');
+
 const commitmentCheckIndex = runtime.indexOf("if (revealedCommitment !== commitment) throw new Error('BLIND_REVEAL_COMMITMENT_MISMATCH')");
 const evaluationIndex = runtime.indexOf('executeDecisionTransferEvaluation({');
 assert(commitmentCheckIndex >= 0, 'commitment_verification_missing');
@@ -60,6 +70,7 @@ assert(commitment.includes('Object.keys(record)') && commitment.includes('.sort(
 
 for (const forbidden of ["from('sfi_amv_memory')", "from('sfi_cognitive_twin_memory')", 'recordCognitiveTwinExperience']) {
   assert(!runtime.includes(forbidden), `blind_runtime_must_not_mutate_memory:${forbidden}`);
+  assert(!integrity.includes(forbidden), `blind_integrity_must_not_mutate_memory:${forbidden}`);
 }
 
 assert(component.includes("crypto.subtle.digest('SHA-256'"), 'target_commitment_must_be_created_client_side');
@@ -74,6 +85,7 @@ console.log(JSON.stringify({
   commitment: 'SFI-DT-TARGET-COMMITMENT-1.0',
   predictionStatusBeforeReveal: 'EVIDENCE_PENDING',
   blindTargetTransmission: false,
+  frozenContextReverifiedBeforeReveal: true,
   memoryMutation: false,
   autoPromotion: false,
   routes: [

--- a/scripts/qa-sfi-decision-transfer-blind.ts
+++ b/scripts/qa-sfi-decision-transfer-blind.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function read(relative: string) {
+  return fs.readFileSync(path.join(process.cwd(), relative), 'utf8');
+}
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`SFI_DECISION_TRANSFER_BLIND_QA:${message}`);
+}
+
+const runtimePath = 'src/core/cognitive-twin/reentry/blindDecisionReconstruction.ts';
+const commitmentPath = 'src/core/cognitive-twin/reentry/decisionCommitment.ts';
+const blindRoutePath = 'src/app/api/root/method-lab/decision-transfer/blind/route.ts';
+const revealRoutePath = 'src/app/api/root/method-lab/decision-transfer/reveal/route.ts';
+const componentPath = 'src/components/root/method-lab/BlindDecisionExperiment.tsx';
+const pagePath = 'src/app/method-lab/page.tsx';
+
+for (const file of [runtimePath, commitmentPath, blindRoutePath, revealRoutePath, componentPath, pagePath]) {
+  assert(fs.existsSync(path.join(process.cwd(), file)), `missing:${file}`);
+}
+
+const runtime = read(runtimePath);
+const commitment = read(commitmentPath);
+const blindRoute = read(blindRoutePath);
+const revealRoute = read(revealRoutePath);
+const component = read(componentPath);
+const page = read(pagePath);
+
+assert(blindRoute.includes("requireRootActor('root.method-lab.decision-transfer.blind')"), 'blind_route_root_gate_missing');
+assert(revealRoute.includes("requireRootActor('root.method-lab.decision-transfer.reveal')"), 'reveal_route_root_gate_missing');
+assert(blindRoute.includes('auditRootAction'), 'blind_route_audit_missing');
+assert(revealRoute.includes('auditRootAction'), 'reveal_route_audit_missing');
+
+const blindSchema = runtime.slice(runtime.indexOf('export const blindDecisionRunInputSchema'), runtime.indexOf('const predictionSchema'));
+assert(blindSchema.includes('targetCommitmentSha256'), 'blind_input_commitment_missing');
+assert(!blindSchema.includes('target: targetTraceSchema'), 'blind_input_must_not_receive_target');
+assert(!blindSchema.includes('commitmentSalt'), 'blind_input_must_not_receive_reveal_salt');
+assert(runtime.includes("status: 'EVIDENCE_PENDING'"), 'blind_run_must_freeze_before_reveal');
+assert(runtime.includes("role: 'DECISION_TRANSFER_BLIND_RECONSTRUCTOR'"), 'blind_run_role_missing');
+assert(runtime.includes("protocolBoundary: 'TARGET_DECISION_ABSENT_UNTIL_COMMITMENT_VERIFIED_REVEAL'"), 'pre_reveal_boundary_missing');
+assert(runtime.includes('BLIND_CONTEXT_CONTAINS_TARGET_TRACE'), 'target_trace_leak_guard_missing');
+assert(runtime.includes('BLIND_CONTEXT_TARGET_KEY_FORBIDDEN'), 'target_key_leak_guard_missing');
+assert(runtime.includes('BLIND_PROVIDER_FALLBACK_REJECTED'), 'strict_provider_guard_missing');
+assert(runtime.includes("fallbackResult: '{}'"), 'provider_router_fallback_must_be_non_evidentiary');
+assert(runtime.includes('if (!llm.ok) throw'), 'degraded_llm_must_not_create_fake_prediction');
+assert(runtime.includes('predictionHash'), 'prediction_integrity_hash_missing');
+assert(runtime.includes('selectedContextHash'), 'context_integrity_hash_missing');
+assert(runtime.includes('contextPoolHash'), 'context_pool_hash_missing');
+
+const commitmentCheckIndex = runtime.indexOf("if (revealedCommitment !== commitment) throw new Error('BLIND_REVEAL_COMMITMENT_MISMATCH')");
+const evaluationIndex = runtime.indexOf('executeDecisionTransferEvaluation({');
+assert(commitmentCheckIndex >= 0, 'commitment_verification_missing');
+assert(evaluationIndex > commitmentCheckIndex, 'evaluation_must_happen_after_commitment_verification');
+assert(runtime.includes(".update({ status: 'VERIFYING' })"), 'reveal_lock_missing');
+assert(runtime.includes(".eq('status', 'EVIDENCE_PENDING')"), 'reveal_compare_and_set_missing');
+assert(runtime.includes("status: 'CLOSED'"), 'blind_run_close_missing');
+
+assert(commitment.includes("protocol: 'SFI-DT-TARGET-COMMITMENT-1.0'"), 'commitment_protocol_version_missing');
+assert(commitment.includes('Object.keys(record)') && commitment.includes('.sort()'), 'commitment_must_use_canonical_key_order');
+
+for (const forbidden of ["from('sfi_amv_memory')", "from('sfi_cognitive_twin_memory')", 'recordCognitiveTwinExperience']) {
+  assert(!runtime.includes(forbidden), `blind_runtime_must_not_mutate_memory:${forbidden}`);
+}
+
+assert(component.includes("crypto.subtle.digest('SHA-256'"), 'target_commitment_must_be_created_client_side');
+assert(component.includes("fetch('/api/root/method-lab/decision-transfer/blind'"), 'blind_ui_endpoint_missing');
+assert(component.includes("fetch('/api/root/method-lab/decision-transfer/reveal'"), 'reveal_ui_endpoint_missing');
+assert(component.includes('No se enviará durante la reconstrucción ciega'), 'ui_target_nontransmission_boundary_missing');
+assert(page.includes('<BlindDecisionExperiment />'), 'method_lab_blind_surface_missing');
+
+console.log(JSON.stringify({
+  ok: true,
+  gate: 'SFI_DECISION_TRANSFER_BLIND',
+  commitment: 'SFI-DT-TARGET-COMMITMENT-1.0',
+  predictionStatusBeforeReveal: 'EVIDENCE_PENDING',
+  blindTargetTransmission: false,
+  memoryMutation: false,
+  autoPromotion: false,
+  routes: [
+    '/api/root/method-lab/decision-transfer/blind',
+    '/api/root/method-lab/decision-transfer/reveal',
+  ],
+}, null, 2));

--- a/src/app/api/root/method-lab/decision-transfer/blind/route.ts
+++ b/src/app/api/root/method-lab/decision-transfer/blind/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { ZodError } from 'zod';
+import { auditRootAction, requireRootActor } from '@/lib/root/server';
+import {
+  executeBlindDecisionReconstruction,
+  parseBlindDecisionRunInput,
+} from '@/core/cognitive-twin/reentry/blindDecisionReconstruction';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+export async function POST(request: Request) {
+  const gate = await requireRootActor('root.method-lab.decision-transfer.blind');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  try {
+    const raw = await request.json();
+    const input = parseBlindDecisionRunInput(raw);
+    const result = await executeBlindDecisionReconstruction(input);
+    const audit = await auditRootAction({
+      actorId: gate.ctx.user.id,
+      action: 'method_lab.decision_transfer.blind_reconstruction_created',
+      target: result.runId,
+      payload: {
+        taskId: result.taskId,
+        experimentId: result.experimentId,
+        arm: result.arm,
+        provider: result.provider,
+        model: result.model,
+        targetTraceId: result.targetTraceId,
+        targetCommitmentSha256: result.targetCommitmentSha256,
+        selectedContextHash: result.selectedContextHash,
+        predictionHash: result.predictionHash,
+        epistemicClass: 'INFERRED',
+        targetRevealed: false,
+      },
+      request,
+    });
+    if (!audit.ok) return NextResponse.json({ ok: false, error: 'blind_reconstruction_audit_failed', runId: result.runId, audit }, { status: 500 });
+    return NextResponse.json({ ...result, audit }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    const invalidInput = error instanceof ZodError;
+    const details = invalidInput
+      ? error.issues.map((issue) => `${issue.path.join('.') || 'root'}:${issue.message}`).join('; ')
+      : error instanceof Error ? error.message : String(error);
+    const status = invalidInput || details.startsWith('BLIND_CONTEXT_') ? 400
+      : details.startsWith('BLIND_PROVIDER_') || details.startsWith('BLIND_LLM_') ? 503
+        : details.startsWith('BLIND_PREDICTION_') ? 502
+          : 503;
+    return NextResponse.json({
+      ok: false,
+      error: invalidInput ? 'blind_decision_input_invalid' : 'blind_decision_reconstruction_failed',
+      details,
+    }, { status });
+  }
+}

--- a/src/app/api/root/method-lab/decision-transfer/reveal/route.ts
+++ b/src/app/api/root/method-lab/decision-transfer/reveal/route.ts
@@ -5,6 +5,7 @@ import {
   executeBlindDecisionReveal,
   parseBlindDecisionRevealInput,
 } from '@/core/cognitive-twin/reentry/blindDecisionReconstruction';
+import { verifyBlindDecisionContextIntegrity } from '@/core/cognitive-twin/reentry/blindDecisionIntegrity';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -17,6 +18,7 @@ export async function POST(request: Request) {
   try {
     const raw = await request.json();
     const input = parseBlindDecisionRevealInput(raw);
+    const contextIntegrity = await verifyBlindDecisionContextIntegrity(input.blindRunId);
     const result = await executeBlindDecisionReveal(input, gate.ctx.user.id);
     const audit = await auditRootAction({
       actorId: gate.ctx.user.id,
@@ -28,24 +30,26 @@ export async function POST(request: Request) {
         arm: result.arm,
         predictionHash: result.predictionHash,
         targetCommitmentSha256: result.targetCommitmentSha256,
+        selectedContextHash: contextIntegrity.selectedContextHash,
         evaluationId: result.evaluation.evaluationId,
         evaluationRunId: result.evaluation.runId,
         outcome: result.evaluation.outcome,
         commitmentVerified: true,
+        contextIntegrityVerified: true,
       },
       request,
     });
     if (!audit.ok) return NextResponse.json({ ok: false, error: 'blind_reveal_audit_failed', result, audit }, { status: 500 });
-    return NextResponse.json({ ...result, audit }, { headers: { 'Cache-Control': 'no-store' } });
+    return NextResponse.json({ ...result, contextIntegrity, audit }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {
     const invalidInput = error instanceof ZodError;
     const details = invalidInput
       ? error.issues.map((issue) => `${issue.path.join('.') || 'root'}:${issue.message}`).join('; ')
       : error instanceof Error ? error.message : String(error);
     const status = invalidInput ? 400
-      : details.includes('COMMITMENT_MISMATCH') || details.includes('TRACE_ID_MISMATCH') || details.includes('DOMAIN_MISMATCH') ? 409
+      : details.includes('COMMITMENT_MISMATCH') || details.includes('TRACE_ID_MISMATCH') || details.includes('DOMAIN_MISMATCH') || details.includes('INTEGRITY_MISMATCH') ? 409
         : details.includes('NOT_FOUND') ? 404
-          : details.includes('NOT_REVEALABLE') || details.includes('LOCK_FAILED') ? 409
+          : details.includes('NOT_REVEALABLE') || details.includes('LOCK_FAILED') || details.includes('CONTRACT_MISMATCH') || details.includes('ROLE_MISMATCH') ? 409
             : 503;
     return NextResponse.json({
       ok: false,

--- a/src/app/api/root/method-lab/decision-transfer/reveal/route.ts
+++ b/src/app/api/root/method-lab/decision-transfer/reveal/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { ZodError } from 'zod';
+import { auditRootAction, requireRootActor } from '@/lib/root/server';
+import {
+  executeBlindDecisionReveal,
+  parseBlindDecisionRevealInput,
+} from '@/core/cognitive-twin/reentry/blindDecisionReconstruction';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+export async function POST(request: Request) {
+  const gate = await requireRootActor('root.method-lab.decision-transfer.reveal');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  try {
+    const raw = await request.json();
+    const input = parseBlindDecisionRevealInput(raw);
+    const result = await executeBlindDecisionReveal(input, gate.ctx.user.id);
+    const audit = await auditRootAction({
+      actorId: gate.ctx.user.id,
+      action: 'method_lab.decision_transfer.blind_target_revealed',
+      target: result.blindRunId,
+      payload: {
+        blindTaskId: result.blindTaskId,
+        experimentId: result.experimentId,
+        arm: result.arm,
+        predictionHash: result.predictionHash,
+        targetCommitmentSha256: result.targetCommitmentSha256,
+        evaluationId: result.evaluation.evaluationId,
+        evaluationRunId: result.evaluation.runId,
+        outcome: result.evaluation.outcome,
+        commitmentVerified: true,
+      },
+      request,
+    });
+    if (!audit.ok) return NextResponse.json({ ok: false, error: 'blind_reveal_audit_failed', result, audit }, { status: 500 });
+    return NextResponse.json({ ...result, audit }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    const invalidInput = error instanceof ZodError;
+    const details = invalidInput
+      ? error.issues.map((issue) => `${issue.path.join('.') || 'root'}:${issue.message}`).join('; ')
+      : error instanceof Error ? error.message : String(error);
+    const status = invalidInput ? 400
+      : details.includes('COMMITMENT_MISMATCH') || details.includes('TRACE_ID_MISMATCH') || details.includes('DOMAIN_MISMATCH') ? 409
+        : details.includes('NOT_FOUND') ? 404
+          : details.includes('NOT_REVEALABLE') || details.includes('LOCK_FAILED') ? 409
+            : 503;
+    return NextResponse.json({
+      ok: false,
+      error: invalidInput ? 'blind_reveal_input_invalid' : 'blind_decision_reveal_failed',
+      details,
+    }, { status });
+  }
+}

--- a/src/app/method-lab/page.tsx
+++ b/src/app/method-lab/page.tsx
@@ -2,6 +2,7 @@ import { requireRootObserverPage } from '@/lib/root/server';
 import { readMethodLabState } from '@/lib/method-lab/readModel';
 import { MethodLabConsole } from '@/components/root/method-lab/MethodLabConsole';
 import { DecisionTransferObservatory } from '@/components/root/method-lab/DecisionTransferObservatory';
+import { BlindDecisionExperiment } from '@/components/root/method-lab/BlindDecisionExperiment';
 import { CognitiveLabConsole } from '@/components/root/cognitive-lab/CognitiveLabConsole';
 
 export const dynamic = 'force-dynamic';
@@ -14,6 +15,7 @@ export default async function MethodLabPage() {
     <>
       <MethodLabConsole state={state} />
       <DecisionTransferObservatory initial={state.decisionTransfer} />
+      <BlindDecisionExperiment />
       <CognitiveLabConsole />
       <style>{`
         .crl-launch{border-color:#425a6d!important;background:#0d1923!important;color:#ddc58d!important;box-shadow:0 12px 35px rgba(0,0,0,.38)!important}

--- a/src/components/root/method-lab/BlindDecisionExperiment.tsx
+++ b/src/components/root/method-lab/BlindDecisionExperiment.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { decisionTraceCommitmentMaterial } from '@/core/cognitive-twin/reentry/decisionCommitment';
+import type { DecisionTrace } from '@/core/cognitive-twin/reentry/decisionTransfer';
+
+type Arm = 'B0_BASE' | 'B1_RAW_HISTORY' | 'B2_MEMORY' | 'B3_CDT' | 'B4_PATTERNS' | 'B5_RULE_STRUCTURE' | 'CT_FULL';
+
+type BlindRunResult = {
+  ok?: boolean;
+  runId?: string;
+  taskId?: string;
+  experimentId?: string;
+  arm?: Arm;
+  provider?: string;
+  model?: string;
+  targetTraceId?: string;
+  targetCommitmentSha256?: string;
+  selectedContextHash?: string;
+  predictionHash?: string;
+  prediction?: Record<string, unknown>;
+  details?: string;
+  error?: string;
+};
+
+type RevealResult = {
+  ok?: boolean;
+  status?: string;
+  blindRunId?: string;
+  predictionHash?: string;
+  evaluation?: {
+    outcome?: string;
+    evaluationId?: string;
+    runId?: string;
+    evaluation?: {
+      holdout?: { validatedDecisionAccuracy?: number; validatedMeanStructuralFidelity?: number };
+      counterfactual?: { validatedTargetDispositionAccuracy?: number };
+      promotion?: { maturity?: string };
+    };
+  };
+  details?: string;
+  error?: string;
+};
+
+const ARMS: Array<{ id: Arm; label: string }> = [
+  { id: 'B0_BASE', label: 'B0 · BASE' },
+  { id: 'B1_RAW_HISTORY', label: 'B1 · + RAW HISTORY' },
+  { id: 'B2_MEMORY', label: 'B2 · + MEMORY' },
+  { id: 'B3_CDT', label: 'B3 · + CDT' },
+  { id: 'B4_PATTERNS', label: 'B4 · + PATTERNS' },
+  { id: 'B5_RULE_STRUCTURE', label: 'B5 · + RULE STRUCTURE' },
+  { id: 'CT_FULL', label: 'CT · FULL GOVERNED CONTEXT' },
+];
+
+function randomSalt() {
+  const bytes = new Uint8Array(24);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function sha256(value: string) {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function pct(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? `${(value * 100).toFixed(1)}%` : '—';
+}
+
+export function BlindDecisionExperiment() {
+  const [experimentId, setExperimentId] = useState('');
+  const [arm, setArm] = useState<Arm>('B0_BASE');
+  const [provider, setProvider] = useState('');
+  const [targetJson, setTargetJson] = useState('');
+  const [contextJson, setContextJson] = useState('');
+  const [salt, setSalt] = useState('');
+  const [commitment, setCommitment] = useState('');
+  const [blind, setBlind] = useState<BlindRunResult | null>(null);
+  const [operationKey, setOperationKey] = useState('');
+  const [revealExtrasJson, setRevealExtrasJson] = useState('');
+  const [reveal, setReveal] = useState<RevealResult | null>(null);
+  const [busy, setBusy] = useState<'commit' | 'blind' | 'reveal' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const target = useMemo(() => {
+    if (!targetJson.trim()) return null;
+    try { return JSON.parse(targetJson) as DecisionTrace; } catch { return null; }
+  }, [targetJson]);
+
+  async function commitTarget() {
+    setBusy('commit');
+    setError(null);
+    setBlind(null);
+    setReveal(null);
+    try {
+      if (!target) throw new Error('La traza objetivo no es JSON válido.');
+      const nextSalt = randomSalt();
+      const nextCommitment = await sha256(decisionTraceCommitmentMaterial(target, nextSalt));
+      setSalt(nextSalt);
+      setCommitment(nextCommitment);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'TARGET_COMMITMENT_FAILED');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function runBlind() {
+    setBusy('blind');
+    setError(null);
+    setReveal(null);
+    try {
+      if (!target || !commitment || !salt) throw new Error('Primero comprometa localmente la traza objetivo.');
+      if (!experimentId.trim()) throw new Error('EXPERIMENT ID requerido.');
+      let contextPool: unknown;
+      try { contextPool = JSON.parse(contextJson); } catch { throw new Error('CONTEXT POOL no es JSON válido.'); }
+      const response = await fetch('/api/root/method-lab/decision-transfer/blind', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          experimentId: experimentId.trim(),
+          targetTraceId: target.traceId,
+          targetDomain: target.domain,
+          targetCommitmentSha256: commitment,
+          arm,
+          contextPool,
+          ...(provider ? { preferredProvider: provider, strictProvider: true } : {}),
+          maxTokens: 1000,
+        }),
+      });
+      const body = await response.json().catch(() => null) as BlindRunResult | null;
+      if (!response.ok || !body?.ok) throw new Error(body?.details ?? body?.error ?? `HTTP ${response.status}`);
+      setBlind(body);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'BLIND_RECONSTRUCTION_FAILED');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function revealTarget() {
+    setBusy('reveal');
+    setError(null);
+    try {
+      if (!blind?.runId || !target || !salt) throw new Error('No existe una reconstrucción ciega sellada para revelar.');
+      if (!operationKey.trim()) throw new Error('OPERATION KEY requerido para el contraste.');
+      let extras: Record<string, unknown>;
+      try { extras = JSON.parse(revealExtrasJson) as Record<string, unknown>; } catch { throw new Error('REVEAL EXTRAS no es JSON válido.'); }
+      const response = await fetch('/api/root/method-lab/decision-transfer/reveal', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          blindRunId: blind.runId,
+          target,
+          commitmentSalt: salt,
+          operationKey: operationKey.trim(),
+          occurrences: Array.isArray(extras.occurrences) ? extras.occurrences : [],
+          counterfactualProbes: Array.isArray(extras.counterfactualProbes) ? extras.counterfactualProbes : [],
+          boundaryProbeCount: typeof extras.boundaryProbeCount === 'number' ? extras.boundaryProbeCount : 0,
+          ...(extras.thresholds && typeof extras.thresholds === 'object' ? { thresholds: extras.thresholds } : {}),
+        }),
+      });
+      const body = await response.json().catch(() => null) as RevealResult | null;
+      if (!response.ok || !body?.ok) throw new Error(body?.details ?? body?.error ?? `HTTP ${response.status}`);
+      setReveal(body);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'BLIND_REVEAL_FAILED');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <section className="bde-root" aria-labelledby="bde-title">
+      <header>
+        <div>
+          <span>PHASE II · SEALED HOLDOUT</span>
+          <h2 id="bde-title">Reconstrucción ciega antes del reveal.</h2>
+          <p>La decisión objetivo se compromete en el navegador. El endpoint ciego recibe sólo su hash, congela el contexto exacto y persiste la predicción antes de que ROOT pueda revelar y puntuar la decisión observada.</p>
+        </div>
+        <b>{blind ? 'EVIDENCE_PENDING' : 'UNSEALED'}</b>
+      </header>
+
+      <div className="bde-grid">
+        <article>
+          <h3>01 · TARGET COMMITMENT</h3>
+          <label>EXPERIMENT ID<input value={experimentId} onChange={(event) => setExperimentId(event.target.value)} placeholder="DT-EXP-..." /></label>
+          <label>OBSERVED TARGET TRACE · LOCAL ONLY<textarea value={targetJson} onChange={(event) => { setTargetJson(event.target.value); setCommitment(''); setSalt(''); setBlind(null); setReveal(null); }} placeholder="Pegue la DecisionTrace observada. No se enviará durante la reconstrucción ciega." /></label>
+          <button type="button" disabled={busy !== null || !targetJson.trim()} onClick={() => void commitTarget()}>{busy === 'commit' ? 'SELLANDO…' : 'COMMIT TARGET LOCALLY'}</button>
+          {commitment ? <div className="bde-seal"><small>SHA-256</small><code>{commitment}</code><small>SALT LOCAL · reservado hasta reveal</small></div> : null}
+        </article>
+
+        <article>
+          <h3>02 · BLIND RUN</h3>
+          <div className="bde-two">
+            <label>ARM<select value={arm} onChange={(event) => setArm(event.target.value as Arm)}>{ARMS.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}</select></label>
+            <label>STRICT PROVIDER<select value={provider} onChange={(event) => setProvider(event.target.value)}><option value="">ROUTER / RECORD ACTUAL</option><option value="openai">OPENAI</option><option value="anthropic">ANTHROPIC</option><option value="gemini">GEMINI</option><option value="groq">GROQ</option><option value="ollama">OLLAMA</option><option value="huggingface">HUGGING FACE</option></select></label>
+          </div>
+          <label>CONTEXT POOL · JSON<textarea value={contextJson} onChange={(event) => setContextJson(event.target.value)} placeholder={'{"currentCase":{"situation":"...","evidence":[],"constraints":[]},"rawHistory":[],"memory":[],"decisionTraces":[],"patterns":[],"rules":[]}'}/></label>
+          <button type="button" disabled={busy !== null || !commitment || !contextJson.trim()} onClick={() => void runBlind()}>{busy === 'blind' ? 'RECONSTRUYENDO…' : 'RUN BLIND RECONSTRUCTION'}</button>
+          {blind?.ok ? <div className="bde-result"><strong>{blind.arm} · {blind.provider}/{blind.model}</strong><small>run {blind.runId}</small><small>context {blind.selectedContextHash}</small><small>prediction {blind.predictionHash}</small><pre>{JSON.stringify(blind.prediction, null, 2)}</pre></div> : null}
+        </article>
+
+        <article>
+          <h3>03 · COMMITMENT-VERIFIED REVEAL</h3>
+          <label>OPERATION KEY<input value={operationKey} onChange={(event) => setOperationKey(event.target.value)} placeholder="EVIDENCE_BEFORE_INFERENCE" /></label>
+          <label>REVEAL EXTRAS · JSON<textarea value={revealExtrasJson} onChange={(event) => setRevealExtrasJson(event.target.value)} placeholder={'{"occurrences":[],"counterfactualProbes":[],"boundaryProbeCount":0}'}/></label>
+          <button type="button" disabled={busy !== null || !blind?.runId || !operationKey.trim()} onClick={() => void revealTarget()}>{busy === 'reveal' ? 'VERIFICANDO…' : 'VERIFY COMMITMENT + REVEAL'}</button>
+          {reveal?.ok ? <div className="bde-result"><strong>{reveal.evaluation?.outcome ?? reveal.status}</strong><small>evaluation {reveal.evaluation?.evaluationId}</small><small>decision {pct(reveal.evaluation?.evaluation?.holdout?.validatedDecisionAccuracy)}</small><small>structure {pct(reveal.evaluation?.evaluation?.holdout?.validatedMeanStructuralFidelity)}</small><small>counterfactual {pct(reveal.evaluation?.evaluation?.counterfactual?.validatedTargetDispositionAccuracy)}</small><small>maturity {reveal.evaluation?.evaluation?.promotion?.maturity ?? '—'}</small></div> : null}
+        </article>
+      </div>
+
+      <div className="bde-boundary"><strong>INTEGRITY BOUNDARY</strong><span>El commitment prueba que el target revelado es el mismo target comprometido antes de la predicción. No prueba por sí solo que texto libre incluido en el contexto no haya filtrado semánticamente la respuesta; por eso cada run conserva contexto y hashes para auditoría.</span></div>
+      {error ? <div className="bde-error">{error}</div> : null}
+
+      <style jsx>{`
+        .bde-root{background:#071018;color:#e8edf0;border-bottom:1px solid #33495c;padding:28px 30px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}.bde-root>header{display:flex;justify-content:space-between;gap:24px;align-items:flex-start}.bde-root header>div{max-width:920px}.bde-root header span{font-size:8px;letter-spacing:.16em;color:#c8aa6d}.bde-root h2{font:400 clamp(27px,3vw,40px)/1 Georgia,serif;margin:8px 0 11px;color:#f4f6f7}.bde-root header p{font:13px/1.6 Georgia,serif;color:#91a0ac;margin:0}.bde-root header>b{border:1px solid #425a6d;padding:9px 11px;font-size:8px;color:#d8c38e}.bde-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:18px}.bde-grid>article{border:1px solid #2c4253;background:#0b161f;padding:15px;display:flex;flex-direction:column;gap:10px}.bde-grid h3{font-size:9px;letter-spacing:.08em;color:#d8c38e;margin:0}.bde-grid label{display:grid;gap:5px;color:#8195a3;font-size:7px;letter-spacing:.1em}.bde-grid input,.bde-grid select,.bde-grid textarea{box-sizing:border-box;width:100%;border:1px solid #3a5265;background:#081119;color:#e7ecef;padding:9px;font:9px/1.5 ui-monospace,monospace}.bde-grid textarea{min-height:180px;resize:vertical}.bde-grid button{border:1px solid #b69759;background:#c2a464;color:#081119;padding:10px;font:700 8px ui-monospace,monospace;letter-spacing:.08em;cursor:pointer}.bde-grid button:disabled{opacity:.4}.bde-two{display:grid;grid-template-columns:1fr 1fr;gap:7px}.bde-seal,.bde-result{border:1px solid #31495a;background:#081119;padding:10px;display:grid;gap:6px}.bde-seal small,.bde-result small{font-size:7px;color:#8193a0}.bde-seal code{font-size:7px;color:#a9c5b3;overflow-wrap:anywhere}.bde-result strong{font-size:8px;color:#a9c5b3}.bde-result pre{white-space:pre-wrap;overflow-wrap:anywhere;font-size:8px;line-height:1.5;color:#c5d0d6;margin:4px 0 0}.bde-boundary{display:grid;grid-template-columns:160px 1fr;gap:16px;border:1px solid #3a4d5c;background:#0c1720;padding:13px;margin-top:10px}.bde-boundary strong{font-size:8px;color:#c8aa6d}.bde-boundary span{font:11px/1.55 Georgia,serif;color:#91a0ac}.bde-error{border:1px solid #64443f;background:#160f0f;color:#d19380;padding:11px;margin-top:9px;font-size:8px}@media(max-width:1050px){.bde-grid{grid-template-columns:1fr}.bde-root{padding:22px 16px}.bde-root>header{display:grid}.bde-boundary{grid-template-columns:1fr}}`}</style>
+    </section>
+  );
+}

--- a/src/core/cognitive-twin/reentry/blindDecisionIntegrity.ts
+++ b/src/core/cognitive-twin/reentry/blindDecisionIntegrity.ts
@@ -1,0 +1,44 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { canonicalJson } from './decisionCommitment';
+
+function sha256(value: string) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+export async function verifyBlindDecisionContextIntegrity(blindRunId: string) {
+  const db = createServiceSupabaseClient();
+  const read = await db.from('sfi_cognitive_twin_runs')
+    .select('id,contract_version,role,status,input_snapshot')
+    .eq('id', blindRunId)
+    .maybeSingle();
+
+  if (read.error || !read.data) {
+    throw new Error(`BLIND_RUN_NOT_FOUND:${read.error?.message ?? blindRunId}`);
+  }
+  if (read.data.contract_version !== 'SFI-CT-BLIND-DECISION-1.0') {
+    throw new Error(`BLIND_RUN_CONTRACT_MISMATCH:${read.data.contract_version ?? 'missing'}`);
+  }
+  if (read.data.role !== 'DECISION_TRANSFER_BLIND_RECONSTRUCTOR') {
+    throw new Error(`BLIND_RUN_ROLE_MISMATCH:${read.data.role ?? 'missing'}`);
+  }
+  if (read.data.status !== 'EVIDENCE_PENDING') {
+    throw new Error(`BLIND_RUN_NOT_REVEALABLE:${read.data.status}`);
+  }
+
+  const snapshot = read.data.input_snapshot && typeof read.data.input_snapshot === 'object' && !Array.isArray(read.data.input_snapshot)
+    ? read.data.input_snapshot as Record<string, unknown>
+    : {};
+  const selectedContextHash = typeof snapshot.selectedContextHash === 'string' ? snapshot.selectedContextHash : '';
+  if (!selectedContextHash || !('selectedContext' in snapshot)) {
+    throw new Error('BLIND_CONTEXT_INTEGRITY_METADATA_MISSING');
+  }
+  const actualHash = sha256(canonicalJson(snapshot.selectedContext));
+  if (actualHash !== selectedContextHash) {
+    throw new Error('BLIND_CONTEXT_INTEGRITY_MISMATCH');
+  }
+
+  return { ok: true as const, selectedContextHash };
+}

--- a/src/core/cognitive-twin/reentry/blindDecisionReconstruction.ts
+++ b/src/core/cognitive-twin/reentry/blindDecisionReconstruction.ts
@@ -1,0 +1,434 @@
+import 'server-only';
+
+import { createHash, randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import { runLlmTask, type LlmProviderId } from '@/lib/ai/providerRouter';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { canonicalJson, decisionTraceCommitmentMaterial } from './decisionCommitment';
+import { executeDecisionTransferEvaluation } from './decisionTransferRun';
+
+const dispositionSchema = z.enum(['PROPOSE', 'REQUEST_EVIDENCE', 'ESCALATE', 'WITHHOLD', 'ARCHIVE_ONLY']);
+const epistemicClassSchema = z.enum(['OBSERVED', 'VERIFIED_CONTRAST', 'DERIVED', 'INFERRED', 'SIMULATED']);
+const providerSchema = z.enum(['openai', 'anthropic', 'gemini', 'groq', 'ollama', 'huggingface']);
+
+export const decisionTransferArmSchema = z.enum([
+  'B0_BASE',
+  'B1_RAW_HISTORY',
+  'B2_MEMORY',
+  'B3_CDT',
+  'B4_PATTERNS',
+  'B5_RULE_STRUCTURE',
+  'CT_FULL',
+]);
+export type DecisionTransferArm = z.infer<typeof decisionTransferArmSchema>;
+
+const evidenceItemSchema = z.object({
+  ref: z.string().trim().min(1).max(500),
+  summary: z.string().trim().min(1).max(8000),
+  epistemicClass: epistemicClassSchema,
+}).strict();
+
+const currentCaseSchema = z.object({
+  situation: z.string().trim().min(5).max(16000),
+  priorState: z.string().trim().max(12000).optional(),
+  evidence: z.array(evidenceItemSchema).max(120),
+  constraints: z.array(z.string().trim().min(1).max(1200)).max(120).default([]),
+}).strict();
+
+const rawHistorySchema = z.object({
+  ref: z.string().trim().min(1).max(500),
+  content: z.string().trim().min(1).max(12000),
+  evidenceRefs: z.array(z.string().trim().min(1).max(500)).max(100).default([]),
+}).strict();
+
+const memoryItemSchema = z.object({
+  key: z.string().trim().min(1).max(500),
+  content: z.unknown(),
+  status: z.string().trim().min(1).max(80),
+  evidenceRefs: z.array(z.string().trim().min(1).max(500)).max(100).default([]),
+}).strict();
+
+const historicalTraceSchema = z.object({
+  traceId: z.string().trim().min(1).max(240),
+  domain: z.string().trim().min(1).max(160),
+  disposition: dispositionSchema,
+  operations: z.array(z.string().trim().min(1).max(240)).max(100),
+  relevantVariables: z.array(z.string().trim().min(1).max(240)).max(100),
+  rejectedConditions: z.array(z.string().trim().min(1).max(500)).max(100),
+  whatWouldChangeDecision: z.array(z.string().trim().min(1).max(500)).max(100),
+  evidenceRefs: z.array(z.string().trim().min(1).max(500)).max(300),
+  epistemicClass: epistemicClassSchema,
+}).strict();
+
+const patternSchema = z.object({
+  key: z.string().trim().min(1).max(500),
+  maturity: z.string().trim().min(1).max(100),
+  operations: z.array(z.string().trim().min(1).max(240)).max(100).default([]),
+  domains: z.array(z.string().trim().min(1).max(160)).max(100).default([]),
+  evidenceRefs: z.array(z.string().trim().min(1).max(500)).max(300).default([]),
+}).strict();
+
+const ruleSchema = z.object({
+  key: z.string().trim().min(1).max(500),
+  statement: z.string().trim().min(1).max(4000),
+  constraints: z.array(z.string().trim().min(1).max(1200)).max(100).default([]),
+  exceptions: z.array(z.string().trim().min(1).max(1200)).max(100).default([]),
+  evidenceRefs: z.array(z.string().trim().min(1).max(500)).max(300).default([]),
+}).strict();
+
+const contextPoolSchema = z.object({
+  currentCase: currentCaseSchema,
+  rawHistory: z.array(rawHistorySchema).max(120).default([]),
+  memory: z.array(memoryItemSchema).max(120).default([]),
+  decisionTraces: z.array(historicalTraceSchema).max(120).default([]),
+  patterns: z.array(patternSchema).max(120).default([]),
+  rules: z.array(ruleSchema).max(120).default([]),
+  operatingMode: z.record(z.string(), z.unknown()).optional(),
+}).strict();
+
+export const blindDecisionRunInputSchema = z.object({
+  experimentId: z.string().trim().min(1).max(240),
+  targetTraceId: z.string().trim().min(1).max(240),
+  targetDomain: z.string().trim().min(1).max(160),
+  targetCommitmentSha256: z.string().regex(/^[0-9a-f]{64}$/i),
+  arm: decisionTransferArmSchema,
+  contextPool: contextPoolSchema,
+  preferredProvider: providerSchema.optional(),
+  strictProvider: z.boolean().default(true),
+  maxTokens: z.number().int().min(200).max(2500).default(1000),
+}).strict();
+export type BlindDecisionRunInput = z.infer<typeof blindDecisionRunInputSchema>;
+
+const predictionSchema = z.object({
+  traceId: z.string().trim().min(1).max(240),
+  disposition: dispositionSchema,
+  operations: z.array(z.string().trim().min(1).max(240)).max(100),
+  relevantVariables: z.array(z.string().trim().min(1).max(240)).max(100),
+  rejectedConditions: z.array(z.string().trim().min(1).max(500)).max(100).default([]),
+  whatWouldChangeDecision: z.array(z.string().trim().min(1).max(500)).max(100).default([]),
+  confidence: z.number().finite().min(0).max(1).nullable().default(null),
+}).strict();
+
+const occurrenceSchema = z.object({
+  occurrenceId: z.string().trim().min(1).max(240),
+  operationKey: z.string().trim().min(1).max(240),
+  traceId: z.string().trim().min(1).max(240),
+  domain: z.string().trim().min(1).max(160),
+  support: z.enum(['SUPPORT', 'COUNTEREXAMPLE']),
+  epistemicClass: epistemicClassSchema,
+  evidenceRefs: z.array(z.string().trim().min(1).max(500)).max(500),
+}).strict();
+
+const counterfactualProbeSchema = z.object({
+  probeId: z.string().trim().min(1).max(240),
+  baseTraceId: z.string().trim().min(1).max(240),
+  variableKey: z.string().trim().min(1).max(240),
+  direction: z.enum(['INCREASE', 'DECREASE', 'TOGGLE', 'REPLACE']),
+  baselineDisposition: dispositionSchema,
+  expectedDispositionAfterPerturbation: dispositionSchema,
+  predictedDispositionAfterPerturbation: dispositionSchema,
+  epistemicClass: z.enum(['OBSERVED', 'VERIFIED_CONTRAST', 'SIMULATED', 'DERIVED']),
+  evidenceRefs: z.array(z.string().trim().min(1).max(500)).max(500),
+}).strict();
+
+const targetTraceSchema = historicalTraceSchema;
+const thresholdSchema = z.number().finite().min(0).max(1);
+
+export const blindDecisionRevealInputSchema = z.object({
+  blindRunId: z.string().uuid(),
+  target: targetTraceSchema,
+  commitmentSalt: z.string().min(16).max(256),
+  operationKey: z.string().trim().min(1).max(240),
+  occurrences: z.array(occurrenceSchema).max(2000),
+  counterfactualProbes: z.array(counterfactualProbeSchema).max(1000),
+  boundaryProbeCount: z.number().int().min(0).max(100000),
+  thresholds: z.object({
+    minimumDecisionAccuracy: thresholdSchema.optional(),
+    minimumStructuralFidelity: thresholdSchema.optional(),
+    minimumCounterfactualTargetAccuracy: thresholdSchema.optional(),
+  }).strict().optional(),
+}).strict();
+export type BlindDecisionRevealInput = z.infer<typeof blindDecisionRevealInputSchema>;
+
+const FORBIDDEN_CONTEXT_KEYS = new Set([
+  'targetDisposition',
+  'expectedDisposition',
+  'observedDisposition',
+  'groundTruthDisposition',
+  'targetDecision',
+  'expectedDecision',
+  'observedDecision',
+  'groundTruth',
+  'answerKey',
+  'revealedTarget',
+]);
+
+function sha256(value: string) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function unique(values: string[]) {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).sort();
+}
+
+function inspectForbiddenKeys(value: unknown, path = 'contextPool') {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => inspectForbiddenKeys(item, `${path}[${index}]`));
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (FORBIDDEN_CONTEXT_KEYS.has(key)) throw new Error(`BLIND_CONTEXT_TARGET_KEY_FORBIDDEN:${path}.${key}`);
+    inspectForbiddenKeys(child, `${path}.${key}`);
+  }
+}
+
+function selectedContext(input: BlindDecisionRunInput) {
+  const source = input.contextPool;
+  const selected: Record<string, unknown> = { currentCase: source.currentCase };
+  if (input.arm !== 'B0_BASE') selected.rawHistory = source.rawHistory;
+  if (['B2_MEMORY', 'B3_CDT', 'B4_PATTERNS', 'B5_RULE_STRUCTURE', 'CT_FULL'].includes(input.arm)) selected.memory = source.memory;
+  if (['B3_CDT', 'B4_PATTERNS', 'B5_RULE_STRUCTURE', 'CT_FULL'].includes(input.arm)) selected.decisionTraces = source.decisionTraces;
+  if (['B4_PATTERNS', 'B5_RULE_STRUCTURE', 'CT_FULL'].includes(input.arm)) selected.patterns = source.patterns;
+  if (['B5_RULE_STRUCTURE', 'CT_FULL'].includes(input.arm)) selected.rules = source.rules;
+  if (input.arm === 'CT_FULL' && source.operatingMode) selected.operatingMode = source.operatingMode;
+  return selected;
+}
+
+function selectedEvidenceRefs(context: Record<string, unknown>): string[] {
+  const refs: string[] = [];
+  const walk = (value: unknown) => {
+    if (Array.isArray(value)) return value.forEach(walk);
+    if (!value || typeof value !== 'object') return;
+    const record = value as Record<string, unknown>;
+    if (typeof record.ref === 'string') refs.push(record.ref);
+    if (Array.isArray(record.evidenceRefs)) refs.push(...record.evidenceRefs.filter((item): item is string => typeof item === 'string'));
+    Object.values(record).forEach(walk);
+  };
+  walk(context);
+  return unique(refs);
+}
+
+function parsePrediction(raw: string, targetTraceId: string) {
+  const fenced = raw.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '');
+  const start = fenced.indexOf('{');
+  const end = fenced.lastIndexOf('}');
+  if (start < 0 || end <= start) throw new Error('BLIND_PREDICTION_JSON_MISSING');
+  let value: unknown;
+  try {
+    value = JSON.parse(fenced.slice(start, end + 1));
+  } catch {
+    throw new Error('BLIND_PREDICTION_JSON_INVALID');
+  }
+  const parsed = predictionSchema.parse(value);
+  if (parsed.traceId !== targetTraceId) throw new Error('BLIND_PREDICTION_TRACE_ID_MISMATCH');
+  return parsed;
+}
+
+function buildPrompt(input: BlindDecisionRunInput, context: Record<string, unknown>) {
+  return [
+    `EXPERIMENT: ${input.experimentId}`,
+    `TREATMENT ARM: ${input.arm}`,
+    `TARGET TRACE ID: ${input.targetTraceId}`,
+    `TARGET DOMAIN: ${input.targetDomain}`,
+    '',
+    'The observed target decision has been cryptographically committed but is NOT available to you. Reconstruct the decision from the supplied pre-reveal context only.',
+    'Do not infer an answer from experiment labels, IDs or hidden-answer assumptions. Do not invent facts. If evidence is insufficient, that uncertainty must be reflected in disposition/operations/confidence.',
+    '',
+    'PRE-REVEAL CONTEXT:',
+    JSON.stringify(context, null, 2),
+    '',
+    'Return ONLY one JSON object with exactly this shape:',
+    JSON.stringify({
+      traceId: input.targetTraceId,
+      disposition: 'PROPOSE | REQUEST_EVIDENCE | ESCALATE | WITHHOLD | ARCHIVE_ONLY',
+      operations: ['operation_key'],
+      relevantVariables: ['variable_key'],
+      rejectedConditions: ['condition'],
+      whatWouldChangeDecision: ['condition'],
+      confidence: 0.0,
+    }, null, 2),
+  ].join('\n');
+}
+
+export function parseBlindDecisionRunInput(value: unknown): BlindDecisionRunInput {
+  const parsed = blindDecisionRunInputSchema.parse(value);
+  inspectForbiddenKeys(parsed.contextPool);
+  if (parsed.contextPool.decisionTraces.some((trace) => trace.traceId === parsed.targetTraceId)) {
+    throw new Error('BLIND_CONTEXT_CONTAINS_TARGET_TRACE');
+  }
+  return parsed;
+}
+
+export function parseBlindDecisionRevealInput(value: unknown): BlindDecisionRevealInput {
+  return blindDecisionRevealInputSchema.parse(value);
+}
+
+export async function executeBlindDecisionReconstruction(input: BlindDecisionRunInput) {
+  const context = selectedContext(input);
+  const contextHash = sha256(canonicalJson(context));
+  const contextPoolHash = sha256(canonicalJson(input.contextPool));
+  const evidenceRefs = selectedEvidenceRefs(context);
+  const llm = await runLlmTask({
+    task: 'prediction',
+    system: 'You are the SFI blind decision reconstructor. The target outcome is withheld. Reconstruct only from supplied context. Return JSON only. Never claim subjective experience or identity. Never turn model output into evidence.',
+    prompt: buildPrompt(input, context),
+    fallbackResult: '{}',
+    preferredProvider: input.preferredProvider as LlmProviderId | undefined,
+    maxTokens: input.maxTokens,
+  });
+  if (!llm.ok) throw new Error(`BLIND_LLM_PROVIDER_UNAVAILABLE:${llm.warnings.join(' · ')}`);
+  if (input.preferredProvider && input.strictProvider && llm.provider !== input.preferredProvider) {
+    throw new Error(`BLIND_PROVIDER_FALLBACK_REJECTED:${input.preferredProvider}->${llm.provider}`);
+  }
+  const prediction = parsePrediction(llm.result, input.targetTraceId);
+  const predictionHash = sha256(canonicalJson(prediction));
+  const taskId = `DT-BLIND-${randomUUID()}`;
+  const startedAt = new Date().toISOString();
+  const db = createServiceSupabaseClient();
+  const insert = await db.from('sfi_cognitive_twin_runs').insert({
+    task_id: taskId,
+    contract_version: 'SFI-CT-BLIND-DECISION-1.0',
+    provider: llm.provider,
+    model: llm.model,
+    role: 'DECISION_TRANSFER_BLIND_RECONSTRUCTOR',
+    status: 'EVIDENCE_PENDING',
+    objective: `Blindly reconstruct ${input.targetTraceId} under treatment arm ${input.arm} before target reveal.`,
+    input_snapshot: {
+      experimentId: input.experimentId,
+      targetTraceId: input.targetTraceId,
+      targetDomain: input.targetDomain,
+      targetCommitmentSha256: input.targetCommitmentSha256.toLowerCase(),
+      arm: input.arm,
+      selectedContext: context,
+      selectedContextHash: contextHash,
+      contextPoolHash,
+      strictProvider: input.strictProvider,
+      preferredProvider: input.preferredProvider ?? null,
+      protocolBoundary: 'TARGET_DECISION_ABSENT_UNTIL_COMMITMENT_VERIFIED_REVEAL',
+    },
+    output_envelope: {
+      prediction,
+      predictionHash,
+      provider: llm.provider,
+      model: llm.model,
+      usage: llm.usage,
+      latencyMs: llm.latency_ms,
+      warnings: llm.warnings,
+      epistemicClass: 'INFERRED',
+      revealed: false,
+    },
+    evidence_refs: evidenceRefs,
+    limitations: [
+      'Cryptographic commitment proves the revealed target matches the pre-run commitment; it cannot prove that free-text context was semantically uncontaminated.',
+      'The reconstruction is INFERRED and is not evidence, memory, canon or authority.',
+      'Provider/model identity is persisted so treatment arms can be compared without silently mixing engines.',
+    ],
+    started_at: startedAt,
+  }).select('id').single();
+  if (insert.error || !insert.data?.id) throw new Error(`BLIND_RUN_PERSIST_FAILED:${insert.error?.message ?? 'unknown'}`);
+
+  return {
+    ok: true as const,
+    runId: String(insert.data.id),
+    taskId,
+    experimentId: input.experimentId,
+    arm: input.arm,
+    provider: llm.provider,
+    model: llm.model,
+    targetTraceId: input.targetTraceId,
+    targetDomain: input.targetDomain,
+    targetCommitmentSha256: input.targetCommitmentSha256.toLowerCase(),
+    selectedContextHash: contextHash,
+    predictionHash,
+    prediction,
+    evidenceRefs,
+    epistemicClass: 'INFERRED' as const,
+    status: 'EVIDENCE_PENDING' as const,
+  };
+}
+
+export async function executeBlindDecisionReveal(input: BlindDecisionRevealInput, actorId: string) {
+  const db = createServiceSupabaseClient();
+  const read = await db.from('sfi_cognitive_twin_runs')
+    .select('id,task_id,contract_version,provider,model,role,status,input_snapshot,output_envelope,evidence_refs,started_at')
+    .eq('id', input.blindRunId)
+    .eq('role', 'DECISION_TRANSFER_BLIND_RECONSTRUCTOR')
+    .maybeSingle();
+  if (read.error || !read.data) throw new Error(`BLIND_RUN_NOT_FOUND:${read.error?.message ?? input.blindRunId}`);
+  if (read.data.status !== 'EVIDENCE_PENDING') throw new Error(`BLIND_RUN_NOT_REVEALABLE:${read.data.status}`);
+
+  const snapshot = (read.data.input_snapshot ?? {}) as Record<string, unknown>;
+  const output = (read.data.output_envelope ?? {}) as Record<string, unknown>;
+  const targetTraceId = typeof snapshot.targetTraceId === 'string' ? snapshot.targetTraceId : '';
+  const targetDomain = typeof snapshot.targetDomain === 'string' ? snapshot.targetDomain : '';
+  const commitment = typeof snapshot.targetCommitmentSha256 === 'string' ? snapshot.targetCommitmentSha256.toLowerCase() : '';
+  if (input.target.traceId !== targetTraceId) throw new Error('BLIND_REVEAL_TRACE_ID_MISMATCH');
+  if (input.target.domain !== targetDomain) throw new Error('BLIND_REVEAL_DOMAIN_MISMATCH');
+  const revealedCommitment = sha256(decisionTraceCommitmentMaterial(input.target, input.commitmentSalt));
+  if (revealedCommitment !== commitment) throw new Error('BLIND_REVEAL_COMMITMENT_MISMATCH');
+  const prediction = predictionSchema.parse(output.prediction);
+  const predictionHash = sha256(canonicalJson(prediction));
+  if (predictionHash !== output.predictionHash) throw new Error('BLIND_PREDICTION_INTEGRITY_MISMATCH');
+
+  const lock = await db.from('sfi_cognitive_twin_runs')
+    .update({ status: 'VERIFYING' })
+    .eq('id', input.blindRunId)
+    .eq('status', 'EVIDENCE_PENDING')
+    .select('id')
+    .maybeSingle();
+  if (lock.error || !lock.data) throw new Error(`BLIND_REVEAL_LOCK_FAILED:${lock.error?.message ?? 'concurrent_or_already_revealed'}`);
+
+  try {
+    const evaluation = await executeDecisionTransferEvaluation({
+      provider: typeof read.data.provider === 'string' ? read.data.provider : 'unknown',
+      model: typeof read.data.model === 'string' ? read.data.model : 'unknown',
+      operationKey: input.operationKey,
+      expected: [{ ...input.target, evidenceRefs: unique([...input.target.evidenceRefs, `blind-run:${input.blindRunId}`]) }],
+      predicted: [prediction],
+      occurrences: input.occurrences,
+      counterfactualProbes: input.counterfactualProbes,
+      boundaryProbeCount: input.boundaryProbeCount,
+      thresholds: input.thresholds,
+    }, actorId);
+
+    const revealedAt = new Date().toISOString();
+    const finalize = await db.from('sfi_cognitive_twin_runs').update({
+      status: 'CLOSED',
+      finished_at: revealedAt,
+      output_envelope: {
+        ...output,
+        revealed: true,
+        reveal: {
+          revealedAt,
+          targetCommitmentSha256: revealedCommitment,
+          targetHash: sha256(canonicalJson(input.target)),
+          evaluationId: evaluation.evaluationId,
+          evaluationRunId: evaluation.runId,
+          outcome: evaluation.outcome,
+        },
+      },
+    }).eq('id', input.blindRunId).eq('status', 'VERIFYING');
+    if (finalize.error) {
+      throw new Error(`BLIND_REVEAL_FINALIZE_FAILED:${finalize.error.message}:evaluation=${evaluation.evaluationId}`);
+    }
+
+    return {
+      ok: true as const,
+      blindRunId: input.blindRunId,
+      blindTaskId: String(read.data.task_id),
+      experimentId: typeof snapshot.experimentId === 'string' ? snapshot.experimentId : null,
+      arm: typeof snapshot.arm === 'string' ? snapshot.arm : null,
+      prediction,
+      predictionHash,
+      targetCommitmentSha256: revealedCommitment,
+      evaluation,
+      status: 'CLOSED' as const,
+    };
+  } catch (error) {
+    if (!(error instanceof Error && error.message.startsWith('BLIND_REVEAL_FINALIZE_FAILED:'))) {
+      await db.from('sfi_cognitive_twin_runs').update({ status: 'EVIDENCE_PENDING' }).eq('id', input.blindRunId).eq('status', 'VERIFYING');
+    }
+    throw error;
+  }
+}

--- a/src/core/cognitive-twin/reentry/decisionCommitment.ts
+++ b/src/core/cognitive-twin/reentry/decisionCommitment.ts
@@ -1,0 +1,28 @@
+import type { DecisionTrace } from './decisionTransfer';
+
+function canonicalValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .filter((key) => record[key] !== undefined)
+        .map((key) => [key, canonicalValue(record[key])]),
+    );
+  }
+  if (typeof value === 'number' && !Number.isFinite(value)) return null;
+  return value;
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalValue(value));
+}
+
+export function decisionTraceCommitmentMaterial(target: DecisionTrace, salt: string): string {
+  return canonicalJson({
+    protocol: 'SFI-DT-TARGET-COMMITMENT-1.0',
+    salt,
+    target,
+  });
+}


### PR DESCRIPTION
## Scope
Add the missing pre-reveal half of the Phase II Decision Transfer experiment. A target DecisionTrace is committed locally with SHA-256, the server receives only the commitment and pre-reveal context, the LLM reconstruction is frozen/persisted, and only then can ROOT reveal the target and invoke the existing Decision Transfer scorer.

## Protocol
- treatment arms: B0 base, B1 raw history, B2 memory, B3 CDT, B4 patterns, B5 rule structure, CT full
- target commitment protocol: `SFI-DT-TARGET-COMMITMENT-1.0`
- browser computes commitment and retains salt until reveal
- blind endpoint never receives the target trace or reveal salt
- exact selected context, context-pool hash, prediction and prediction hash are frozen in `sfi_cognitive_twin_runs`
- blind run remains `EVIDENCE_PENDING` until commitment-verified reveal
- reveal uses compare-and-set `EVIDENCE_PENDING -> VERIFYING` to prevent duplicate concurrent scoring
- prediction integrity and target commitment are verified before evaluation

## Routes
- POST `/api/root/method-lab/decision-transfer/blind`
- POST `/api/root/method-lab/decision-transfer/reveal`
Both require ROOT actor and write ROOT audit events.

## Site
Adds `BlindDecisionExperiment` inside the existing `/method-lab` surface. No new Lab or public surface. The target remains local during the blind run; the interface shows commitment, frozen run/context/prediction hashes, actual provider/model, and reveal result.

## Anti-leakage / epistemic boundaries
- blind input schema contains commitment, trace id/domain and context pool, never target decision
- known target/answer-key field names are rejected recursively
- historical decisionTraces cannot include the target trace id
- strict provider mode rejects silent provider fallback
- degraded/no-provider output cannot become a fake prediction
- blind reconstruction is `INFERRED`, not evidence
- no memory write, canon mutation or automatic rule promotion
- commitment proves target immutability across reveal; it does not prove free-text context was semantically uncontaminated, so exact context is persisted for audit

## QA
Adds `qa-sfi-decision-transfer-blind.ts` to SFI Verify to enforce the non-transmission boundary, commitment-before-evaluation ordering, provider integrity, prediction/context hashing, compare-and-set reveal lock, no memory mutation and Method Lab integration.