### PR TITLE
Phase II: materialize blind Decision Transfer context from canonical history

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Verify blind decision reconstruction protocol
         run: npx tsx scripts/qa-sfi-decision-transfer-blind.ts
 
+      - name: Verify canonical Decision Transfer context materialization
+        run: npx tsx scripts/qa-sfi-decision-transfer-context.ts
+
       - name: Verify canonical evidence identity
         run: node --import tsx --test src/lib/evidence/canonicalEvidence.test.ts
 

--- a/scripts/qa-sfi-decision-transfer-context.ts
+++ b/scripts/qa-sfi-decision-transfer-context.ts
@@ -7,9 +7,13 @@ function assert(condition: unknown, message: string): asserts condition {
 }
 
 const materializerPath = 'src/core/cognitive-twin/reentry/decisionTransferContext.ts';
+const integrityPath = 'src/core/cognitive-twin/reentry/decisionTransferContextIntegrity.ts';
 const routePath = 'src/app/api/root/method-lab/decision-transfer/blind/route.ts';
-assert(fs.existsSync(materializerPath), 'materializer_missing');
+for (const file of [materializerPath, integrityPath, routePath]) {
+  assert(fs.existsSync(path.join(process.cwd(), file)), `missing:${file}`);
+}
 const materializer = read(materializerPath);
+const integrity = read(integrityPath);
 const route = read(routePath);
 
 for (const table of [
@@ -40,15 +44,24 @@ assert(materializer.includes('contextMaterialization: receipt'), 'receipt_must_b
 assert(materializer.includes("role !== 'DECISION_TRANSFER_BLIND_RECONSTRUCTOR'"), 'receipt_bind_role_gate_missing');
 assert(materializer.includes("status !== 'EVIDENCE_PENDING'"), 'receipt_bind_status_gate_missing');
 
+assert(integrity.includes("role !== 'DECISION_TRANSFER_BLIND_RECONSTRUCTOR'"), 'receipt_verify_role_gate_missing');
+assert(integrity.includes("status !== 'EVIDENCE_PENDING'"), 'receipt_verify_status_gate_missing');
+assert(integrity.includes('DT_CONTEXT_BIND_VERIFY_RECEIPT_MISMATCH'), 'receipt_verify_hash_mismatch_guard_missing');
+assert(integrity.includes('snapshot.contextMaterialization'), 'receipt_verify_snapshot_read_missing');
+
 for (const forbidden of ["from('sfi_cognitive_twin_memory')", 'recordCognitiveTwinExperience', ".insert({\n    module: 'institutionalEventPipeline'"]) {
   assert(!materializer.includes(forbidden), `materializer_must_not_mutate_or_use_legacy_memory:${forbidden}`);
+  assert(!integrity.includes(forbidden), `integrity_must_not_mutate_or_use_legacy_memory:${forbidden}`);
 }
 
 assert(route.includes('parseMaterializedBlindDecisionRequest'), 'blind_route_materialized_parser_missing');
 assert(route.includes('materializeDecisionTransferContext'), 'blind_route_materializer_missing');
 assert(route.includes('bindDecisionTransferContextReceipt'), 'blind_route_receipt_binding_missing');
+assert(route.includes('verifyDecisionTransferContextReceiptBound'), 'blind_route_receipt_verification_missing');
+assert(route.indexOf('bindDecisionTransferContextReceipt') < route.lastIndexOf('verifyDecisionTransferContextReceiptBound'), 'receipt_verification_must_follow_binding');
 assert(route.includes("contextSource: materialized ? 'CANONICAL_MATERIALIZED' : 'MANUAL_CONTEXT_POOL'"), 'context_source_audit_missing');
 assert(route.includes('contextMaterializationReceiptHash'), 'receipt_hash_audit_missing');
+assert(route.includes('contextMaterializationVerified: Boolean(materialized)'), 'receipt_verified_audit_missing');
 
 console.log(JSON.stringify({
   ok: true,
@@ -61,4 +74,5 @@ console.log(JSON.stringify({
   legacyMemory: false,
   memoryMutation: false,
   targetExactIdExcluded: true,
+  receiptBindingVerified: true,
 }, null, 2));

--- a/scripts/qa-sfi-decision-transfer-context.ts
+++ b/scripts/qa-sfi-decision-transfer-context.ts
@@ -28,6 +28,21 @@ for (const table of [
 }
 
 assert(materializer.includes("contextSource: z.literal('CANONICAL_MATERIALIZED')"), 'canonical_context_contract_missing');
+assert(materializer.includes('function layersForArm'), 'arm_layer_selector_missing');
+assert(materializer.includes("rawHistory: arm !== 'B0_BASE'"), 'b0_must_not_query_raw_history');
+assert(materializer.includes("memory: ['B2_MEMORY', 'B3_CDT', 'B4_PATTERNS', 'B5_RULE_STRUCTURE', 'CT_FULL'].includes(arm)"), 'memory_arm_boundary_missing');
+assert(materializer.includes("decisionTraces: ['B3_CDT', 'B4_PATTERNS', 'B5_RULE_STRUCTURE', 'CT_FULL'].includes(arm)"), 'cdt_arm_boundary_missing');
+assert(materializer.includes("patterns: ['B4_PATTERNS', 'B5_RULE_STRUCTURE', 'CT_FULL'].includes(arm)"), 'pattern_arm_boundary_missing');
+assert(materializer.includes("rules: ['B5_RULE_STRUCTURE', 'CT_FULL'].includes(arm)"), 'rule_arm_boundary_missing');
+assert(materializer.includes("operatingMode: arm === 'CT_FULL'"), 'operating_mode_arm_boundary_missing');
+assert(materializer.includes('layers.rawHistory ? loadRawHistory'), 'raw_history_query_must_be_arm_conditional');
+assert(materializer.includes('layers.memory ? loadVerifiedMemory'), 'memory_query_must_be_arm_conditional');
+assert(materializer.includes('layers.decisionTraces || layers.patterns ? loadDecisionTransferHistory'), 'decision_history_query_must_be_arm_conditional');
+assert(materializer.includes('layers.rules ? loadApprovedRules'), 'rules_query_must_be_arm_conditional');
+assert(materializer.includes('layers.operatingMode ? loadOperatingMode'), 'operating_mode_query_must_be_arm_conditional');
+assert(materializer.includes('selectedLayers: layers'), 'receipt_must_record_selected_layers');
+assert(materializer.includes('lower-information arms do not depend on higher-information stores'), 'arm_dependency_boundary_must_be_declared');
+
 assert(materializer.includes(".lte('occurred_at', cutoffIso)"), 'raw_history_temporal_cutoff_missing');
 assert(materializer.includes(".lte('created_at', cutoffIso)"), 'created_at_temporal_cutoff_missing');
 assert(materializer.includes(".lte('approved_at', cutoffIso)"), 'approved_rule_temporal_cutoff_missing');
@@ -68,6 +83,7 @@ console.log(JSON.stringify({
   gate: 'SFI_DECISION_TRANSFER_CANONICAL_CONTEXT',
   protocol: 'SFI-DT-CONTEXT-MATERIALIZATION-1.0',
   temporalCutoff: 'QUERY_LEVEL',
+  treatmentDependencies: 'ARM_SELECTIVE',
   memory: 'VERIFIED_OR_CANONICAL_ONLY',
   decisionTraces: 'OBSERVED_OR_VERIFIED_CONTRAST_ONLY',
   rules: 'APPROVED_ONLY',

--- a/scripts/qa-sfi-decision-transfer-context.ts
+++ b/scripts/qa-sfi-decision-transfer-context.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function read(relative: string) { return fs.readFileSync(path.join(process.cwd(), relative), 'utf8'); }
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`SFI_DECISION_TRANSFER_CONTEXT_QA:${message}`);
+}
+
+const materializerPath = 'src/core/cognitive-twin/reentry/decisionTransferContext.ts';
+const routePath = 'src/app/api/root/method-lab/decision-transfer/blind/route.ts';
+assert(fs.existsSync(materializerPath), 'materializer_missing');
+const materializer = read(materializerPath);
+const route = read(routePath);
+
+for (const table of [
+  'root_evidence_entries',
+  'epistemic_events',
+  'sfi_cognitive_lab_events',
+  'sfi_amv_memory',
+  'sfi_cognitive_twin_runs',
+  'sfi_cognitive_twin_decisions',
+]) {
+  assert(materializer.includes(table), `canonical_source_missing:${table}`);
+}
+
+assert(materializer.includes("contextSource: z.literal('CANONICAL_MATERIALIZED')"), 'canonical_context_contract_missing');
+assert(materializer.includes(".lte('occurred_at', cutoffIso)"), 'raw_history_temporal_cutoff_missing');
+assert(materializer.includes(".lte('created_at', cutoffIso)"), 'created_at_temporal_cutoff_missing');
+assert(materializer.includes(".lte('approved_at', cutoffIso)"), 'approved_rule_temporal_cutoff_missing');
+assert(materializer.includes("verifiedMemoryStatuses = new Set(['VERIFIED', 'CANONICAL'])"), 'memory_must_be_verified_or_canonical');
+assert(materializer.includes("terminalMemoryStatuses = new Set(['REJECTED', 'OBSOLETE', 'FOUNDER_RESERVED'])"), 'terminal_memory_suppression_missing');
+assert(materializer.includes("['OBSERVED', 'VERIFIED_CONTRAST'].includes(trace.epistemicClass)"), 'decision_trace_validation_filter_missing');
+assert(materializer.includes(".eq('status', 'APPROVED')"), 'rules_must_be_approved');
+assert(materializer.includes("patternMaturities = new Set(['RECURRENT', 'CROSS_DOMAIN', 'CONTRASTED', 'STABLE_PATTERN', 'RULE_CANDIDATE'])"), 'persisted_pattern_maturity_filter_missing');
+assert(materializer.includes('DT_CONTEXT_TARGET_ID_LEAK_AFTER_MATERIALIZATION'), 'post_materialization_target_leak_guard_missing');
+assert(materializer.includes("protocol: 'SFI-DT-CONTEXT-MATERIALIZATION-1.0'"), 'materialization_receipt_protocol_missing');
+assert(materializer.includes('contextPoolHash'), 'materialized_context_hash_missing');
+assert(materializer.includes('receiptHash'), 'materialization_receipt_hash_missing');
+assert(materializer.includes('contextMaterialization: receipt'), 'receipt_must_bind_to_blind_run');
+assert(materializer.includes("role !== 'DECISION_TRANSFER_BLIND_RECONSTRUCTOR'"), 'receipt_bind_role_gate_missing');
+assert(materializer.includes("status !== 'EVIDENCE_PENDING'"), 'receipt_bind_status_gate_missing');
+
+for (const forbidden of ["from('sfi_cognitive_twin_memory')", 'recordCognitiveTwinExperience', ".insert({\n    module: 'institutionalEventPipeline'"]) {
+  assert(!materializer.includes(forbidden), `materializer_must_not_mutate_or_use_legacy_memory:${forbidden}`);
+}
+
+assert(route.includes('parseMaterializedBlindDecisionRequest'), 'blind_route_materialized_parser_missing');
+assert(route.includes('materializeDecisionTransferContext'), 'blind_route_materializer_missing');
+assert(route.includes('bindDecisionTransferContextReceipt'), 'blind_route_receipt_binding_missing');
+assert(route.includes("contextSource: materialized ? 'CANONICAL_MATERIALIZED' : 'MANUAL_CONTEXT_POOL'"), 'context_source_audit_missing');
+assert(route.includes('contextMaterializationReceiptHash'), 'receipt_hash_audit_missing');
+
+console.log(JSON.stringify({
+  ok: true,
+  gate: 'SFI_DECISION_TRANSFER_CANONICAL_CONTEXT',
+  protocol: 'SFI-DT-CONTEXT-MATERIALIZATION-1.0',
+  temporalCutoff: 'QUERY_LEVEL',
+  memory: 'VERIFIED_OR_CANONICAL_ONLY',
+  decisionTraces: 'OBSERVED_OR_VERIFIED_CONTRAST_ONLY',
+  rules: 'APPROVED_ONLY',
+  legacyMemory: false,
+  memoryMutation: false,
+  targetExactIdExcluded: true,
+}, null, 2));

--- a/src/app/api/root/method-lab/decision-transfer/blind/route.ts
+++ b/src/app/api/root/method-lab/decision-transfer/blind/route.ts
@@ -5,10 +5,20 @@ import {
   executeBlindDecisionReconstruction,
   parseBlindDecisionRunInput,
 } from '@/core/cognitive-twin/reentry/blindDecisionReconstruction';
+import {
+  bindDecisionTransferContextReceipt,
+  materializeDecisionTransferContext,
+  parseMaterializedBlindDecisionRequest,
+} from '@/core/cognitive-twin/reentry/decisionTransferContext';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 export const maxDuration = 60;
+
+function isCanonicalMaterializationRequest(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+    && (value as Record<string, unknown>).contextSource === 'CANONICAL_MATERIALIZED';
+}
 
 export async function POST(request: Request) {
   const gate = await requireRootActor('root.method-lab.decision-transfer.blind');
@@ -16,8 +26,13 @@ export async function POST(request: Request) {
 
   try {
     const raw = await request.json();
-    const input = parseBlindDecisionRunInput(raw);
+    const materialized = isCanonicalMaterializationRequest(raw)
+      ? await materializeDecisionTransferContext(parseMaterializedBlindDecisionRequest(raw))
+      : null;
+    const input = materialized?.blindInput ?? parseBlindDecisionRunInput(raw);
     const result = await executeBlindDecisionReconstruction(input);
+    if (materialized) await bindDecisionTransferContextReceipt(result.runId, materialized.receipt);
+
     const audit = await auditRootAction({
       actorId: gate.ctx.user.id,
       action: 'method_lab.decision_transfer.blind_reconstruction_created',
@@ -34,20 +49,31 @@ export async function POST(request: Request) {
         predictionHash: result.predictionHash,
         epistemicClass: 'INFERRED',
         targetRevealed: false,
+        contextSource: materialized ? 'CANONICAL_MATERIALIZED' : 'MANUAL_CONTEXT_POOL',
+        contextMaterializationReceiptHash: materialized?.receipt.receiptHash ?? null,
+        cutoffAt: materialized?.receipt.cutoffAt ?? null,
       },
       request,
     });
     if (!audit.ok) return NextResponse.json({ ok: false, error: 'blind_reconstruction_audit_failed', runId: result.runId, audit }, { status: 500 });
-    return NextResponse.json({ ...result, audit }, { headers: { 'Cache-Control': 'no-store' } });
+    return NextResponse.json({
+      ...result,
+      contextMaterialization: materialized?.receipt ?? null,
+      audit,
+    }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {
     const invalidInput = error instanceof ZodError;
     const details = invalidInput
       ? error.issues.map((issue) => `${issue.path.join('.') || 'root'}:${issue.message}`).join('; ')
       : error instanceof Error ? error.message : String(error);
-    const status = invalidInput || details.startsWith('BLIND_CONTEXT_') ? 400
-      : details.startsWith('BLIND_PROVIDER_') || details.startsWith('BLIND_LLM_') ? 503
-        : details.startsWith('BLIND_PREDICTION_') ? 502
-          : 503;
+    const contextInfrastructureFailure = details.includes('_READ_FAILED')
+      || details.startsWith('DT_CONTEXT_BIND_')
+      || details.startsWith('DT_CONTEXT_OPERATING_MODE_READ_FAILED');
+    const status = contextInfrastructureFailure ? 503
+      : invalidInput || details.startsWith('BLIND_CONTEXT_') || details.startsWith('DT_CONTEXT_') ? 400
+        : details.startsWith('BLIND_PROVIDER_') || details.startsWith('BLIND_LLM_') ? 503
+          : details.startsWith('BLIND_PREDICTION_') ? 502
+            : 503;
     return NextResponse.json({
       ok: false,
       error: invalidInput ? 'blind_decision_input_invalid' : 'blind_decision_reconstruction_failed',

--- a/src/app/api/root/method-lab/decision-transfer/blind/route.ts
+++ b/src/app/api/root/method-lab/decision-transfer/blind/route.ts
@@ -10,6 +10,7 @@ import {
   materializeDecisionTransferContext,
   parseMaterializedBlindDecisionRequest,
 } from '@/core/cognitive-twin/reentry/decisionTransferContext';
+import { verifyDecisionTransferContextReceiptBound } from '@/core/cognitive-twin/reentry/decisionTransferContextIntegrity';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -31,7 +32,10 @@ export async function POST(request: Request) {
       : null;
     const input = materialized?.blindInput ?? parseBlindDecisionRunInput(raw);
     const result = await executeBlindDecisionReconstruction(input);
-    if (materialized) await bindDecisionTransferContextReceipt(result.runId, materialized.receipt);
+    if (materialized) {
+      await bindDecisionTransferContextReceipt(result.runId, materialized.receipt);
+      await verifyDecisionTransferContextReceiptBound(result.runId, materialized.receipt.receiptHash);
+    }
 
     const audit = await auditRootAction({
       actorId: gate.ctx.user.id,
@@ -51,6 +55,7 @@ export async function POST(request: Request) {
         targetRevealed: false,
         contextSource: materialized ? 'CANONICAL_MATERIALIZED' : 'MANUAL_CONTEXT_POOL',
         contextMaterializationReceiptHash: materialized?.receipt.receiptHash ?? null,
+        contextMaterializationVerified: Boolean(materialized),
         cutoffAt: materialized?.receipt.cutoffAt ?? null,
       },
       request,

--- a/src/components/root/method-lab/BlindDecisionExperiment.tsx
+++ b/src/components/root/method-lab/BlindDecisionExperiment.tsx
@@ -5,6 +5,16 @@ import { decisionTraceCommitmentMaterial } from '@/core/cognitive-twin/reentry/d
 import type { DecisionTrace } from '@/core/cognitive-twin/reentry/decisionTransfer';
 
 type Arm = 'B0_BASE' | 'B1_RAW_HISTORY' | 'B2_MEMORY' | 'B3_CDT' | 'B4_PATTERNS' | 'B5_RULE_STRUCTURE' | 'CT_FULL';
+type ContextMode = 'CANONICAL_MATERIALIZED' | 'MANUAL_CONTEXT_POOL';
+
+type ContextReceipt = {
+  protocol?: string;
+  receiptHash?: string;
+  cutoffAt?: string;
+  contextPoolHash?: string;
+  sourceCounts?: Record<string, number>;
+  excludedExactTargetMatches?: number;
+};
 
 type BlindRunResult = {
   ok?: boolean;
@@ -19,6 +29,7 @@ type BlindRunResult = {
   selectedContextHash?: string;
   predictionHash?: string;
   prediction?: Record<string, unknown>;
+  contextMaterialization?: ContextReceipt | null;
   details?: string;
   error?: string;
 };
@@ -63,6 +74,12 @@ async function sha256(value: string) {
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
+function splitTokens(value: string) {
+  return [...new Set(value.split(/[\s,;]+/).map((item) => item.trim()).filter(Boolean))];
+}
+function splitLines(value: string) {
+  return [...new Set(value.split(/\r?\n/).map((item) => item.trim()).filter(Boolean))];
+}
 function pct(value: unknown) {
   return typeof value === 'number' && Number.isFinite(value) ? `${(value * 100).toFixed(1)}%` : '—';
 }
@@ -71,6 +88,12 @@ export function BlindDecisionExperiment() {
   const [experimentId, setExperimentId] = useState('');
   const [arm, setArm] = useState<Arm>('B0_BASE');
   const [provider, setProvider] = useState('');
+  const [contextMode, setContextMode] = useState<ContextMode>('CANONICAL_MATERIALIZED');
+  const [cutoffAt, setCutoffAt] = useState('');
+  const [caseSituation, setCaseSituation] = useState('');
+  const [casePriorState, setCasePriorState] = useState('');
+  const [caseEvidenceRefs, setCaseEvidenceRefs] = useState('');
+  const [caseConstraints, setCaseConstraints] = useState('');
   const [targetJson, setTargetJson] = useState('');
   const [contextJson, setContextJson] = useState('');
   const [salt, setSalt] = useState('');
@@ -86,6 +109,9 @@ export function BlindDecisionExperiment() {
     if (!targetJson.trim()) return null;
     try { return JSON.parse(targetJson) as DecisionTrace; } catch { return null; }
   }, [targetJson]);
+
+  const canonicalContextReady = Boolean(cutoffAt.trim() && caseSituation.trim() && splitTokens(caseEvidenceRefs).length);
+  const blindContextReady = contextMode === 'CANONICAL_MATERIALIZED' ? canonicalContextReady : Boolean(contextJson.trim());
 
   async function commitTarget() {
     setBusy('commit');
@@ -112,13 +138,33 @@ export function BlindDecisionExperiment() {
     try {
       if (!target || !commitment || !salt) throw new Error('Primero comprometa localmente la traza objetivo.');
       if (!experimentId.trim()) throw new Error('EXPERIMENT ID requerido.');
-      let contextPool: unknown;
-      try { contextPool = JSON.parse(contextJson); } catch { throw new Error('CONTEXT POOL no es JSON válido.'); }
-      const response = await fetch('/api/root/method-lab/decision-transfer/blind', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
+
+      let payload: Record<string, unknown>;
+      if (contextMode === 'CANONICAL_MATERIALIZED') {
+        if (!canonicalContextReady) throw new Error('CUTOFF, situación y EVIDENCE IDS persistidos son requeridos.');
+        const cutoff = new Date(cutoffAt);
+        if (!Number.isFinite(cutoff.getTime())) throw new Error('CUTOFF inválido.');
+        payload = {
+          contextSource: 'CANONICAL_MATERIALIZED',
+          experimentId: experimentId.trim(),
+          targetTraceId: target.traceId,
+          targetDomain: target.domain,
+          targetCommitmentSha256: commitment,
+          arm,
+          cutoffAt: cutoff.toISOString(),
+          currentCase: {
+            situation: caseSituation.trim(),
+            ...(casePriorState.trim() ? { priorState: casePriorState.trim() } : {}),
+            evidenceRefs: splitTokens(caseEvidenceRefs),
+            constraints: splitLines(caseConstraints),
+          },
+          ...(provider ? { preferredProvider: provider, strictProvider: true } : {}),
+          maxTokens: 1000,
+        };
+      } else {
+        let contextPool: unknown;
+        try { contextPool = JSON.parse(contextJson); } catch { throw new Error('CONTEXT POOL no es JSON válido.'); }
+        payload = {
           experimentId: experimentId.trim(),
           targetTraceId: target.traceId,
           targetDomain: target.domain,
@@ -127,7 +173,14 @@ export function BlindDecisionExperiment() {
           contextPool,
           ...(provider ? { preferredProvider: provider, strictProvider: true } : {}),
           maxTokens: 1000,
-        }),
+        };
+      }
+
+      const response = await fetch('/api/root/method-lab/decision-transfer/blind', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
       });
       const body = await response.json().catch(() => null) as BlindRunResult | null;
       if (!response.ok || !body?.ok) throw new Error(body?.details ?? body?.error ?? `HTTP ${response.status}`);
@@ -178,7 +231,7 @@ export function BlindDecisionExperiment() {
         <div>
           <span>PHASE II · SEALED HOLDOUT</span>
           <h2 id="bde-title">Reconstrucción ciega antes del reveal.</h2>
-          <p>La decisión objetivo se compromete en el navegador. El endpoint ciego recibe sólo su hash, congela el contexto exacto y persiste la predicción antes de que ROOT pueda revelar y puntuar la decisión observada.</p>
+          <p>El target se compromete localmente. Por defecto el servidor materializa el historial desde stores canónicos con un corte temporal explícito, congela el contexto exacto y persiste la predicción antes del reveal.</p>
         </div>
         <b>{blind ? 'EVIDENCE_PENDING' : 'UNSEALED'}</b>
       </header>
@@ -198,9 +251,24 @@ export function BlindDecisionExperiment() {
             <label>ARM<select value={arm} onChange={(event) => setArm(event.target.value as Arm)}>{ARMS.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}</select></label>
             <label>STRICT PROVIDER<select value={provider} onChange={(event) => setProvider(event.target.value)}><option value="">ROUTER / RECORD ACTUAL</option><option value="openai">OPENAI</option><option value="anthropic">ANTHROPIC</option><option value="gemini">GEMINI</option><option value="groq">GROQ</option><option value="ollama">OLLAMA</option><option value="huggingface">HUGGING FACE</option></select></label>
           </div>
-          <label>CONTEXT POOL · JSON<textarea value={contextJson} onChange={(event) => setContextJson(event.target.value)} placeholder={'{"currentCase":{"situation":"...","evidence":[],"constraints":[]},"rawHistory":[],"memory":[],"decisionTraces":[],"patterns":[],"rules":[]}'}/></label>
-          <button type="button" disabled={busy !== null || !commitment || !contextJson.trim()} onClick={() => void runBlind()}>{busy === 'blind' ? 'RECONSTRUYENDO…' : 'RUN BLIND RECONSTRUCTION'}</button>
-          {blind?.ok ? <div className="bde-result"><strong>{blind.arm} · {blind.provider}/{blind.model}</strong><small>run {blind.runId}</small><small>context {blind.selectedContextHash}</small><small>prediction {blind.predictionHash}</small><pre>{JSON.stringify(blind.prediction, null, 2)}</pre></div> : null}
+          <label>CONTEXT SOURCE<select value={contextMode} onChange={(event) => setContextMode(event.target.value as ContextMode)}><option value="CANONICAL_MATERIALIZED">CANONICAL · TEMPORALLY BOUNDED</option><option value="MANUAL_CONTEXT_POOL">MANUAL · ADVANCED / LEGACY</option></select></label>
+
+          {contextMode === 'CANONICAL_MATERIALIZED' ? <div className="bde-context">
+            <label>CUTOFF · BEFORE TARGET<input type="datetime-local" value={cutoffAt} onChange={(event) => setCutoffAt(event.target.value)} /></label>
+            <label>CURRENT CASE · SITUATION<textarea value={caseSituation} onChange={(event) => setCaseSituation(event.target.value)} placeholder="Situación conocida antes de la decisión objetivo." /></label>
+            <label>PRIOR STATE · OPTIONAL<textarea value={casePriorState} onChange={(event) => setCasePriorState(event.target.value)} placeholder="Estado inmediatamente anterior, sin resultado ni decisión objetivo." /></label>
+            <label>PERSISTED ROOT EVIDENCE IDS<textarea value={caseEvidenceRefs} onChange={(event) => setCaseEvidenceRefs(event.target.value)} placeholder="UUID-1, UUID-2…" /></label>
+            <label>CONSTRAINTS · ONE PER LINE<textarea value={caseConstraints} onChange={(event) => setCaseConstraints(event.target.value)} placeholder="Restricción observable 1\nRestricción observable 2" /></label>
+            <p>El servidor recupera B1–B5/CT desde historia anterior al cutoff; no se acepta historial manual en este modo.</p>
+          </div> : <label>CONTEXT POOL · JSON<textarea value={contextJson} onChange={(event) => setContextJson(event.target.value)} placeholder={'{"currentCase":{"situation":"...","evidence":[],"constraints":[]},"rawHistory":[],"memory":[],"decisionTraces":[],"patterns":[],"rules":[]}'}/></label>}
+
+          <button type="button" disabled={busy !== null || !commitment || !blindContextReady} onClick={() => void runBlind()}>{busy === 'blind' ? 'RECONSTRUYENDO…' : 'RUN BLIND RECONSTRUCTION'}</button>
+          {blind?.ok ? <div className="bde-result">
+            <strong>{blind.arm} · {blind.provider}/{blind.model}</strong>
+            <small>run {blind.runId}</small><small>context {blind.selectedContextHash}</small><small>prediction {blind.predictionHash}</small>
+            {blind.contextMaterialization ? <><small>receipt {blind.contextMaterialization.receiptHash}</small><small>cutoff {blind.contextMaterialization.cutoffAt}</small><small>sources {JSON.stringify(blind.contextMaterialization.sourceCounts)}</small><small>excluded exact target matches {blind.contextMaterialization.excludedExactTargetMatches ?? 0}</small></> : <small>manual context · no canonical materialization receipt</small>}
+            <pre>{JSON.stringify(blind.prediction, null, 2)}</pre>
+          </div> : null}
         </article>
 
         <article>
@@ -212,11 +280,11 @@ export function BlindDecisionExperiment() {
         </article>
       </div>
 
-      <div className="bde-boundary"><strong>INTEGRITY BOUNDARY</strong><span>El commitment prueba que el target revelado es el mismo target comprometido antes de la predicción. No prueba por sí solo que texto libre incluido en el contexto no haya filtrado semánticamente la respuesta; por eso cada run conserva contexto y hashes para auditoría.</span></div>
+      <div className="bde-boundary"><strong>INTEGRITY BOUNDARY</strong><span>El commitment fija el target; el receipt fija el contexto materializado y su cutoff. El materializador excluye IDs exactos del target y estado posterior al cutoff, pero la contaminación semántica todavía se audita sobre el contexto congelado. El cutoff declarado no prueba por sí solo la fecha del target revelado.</span></div>
       {error ? <div className="bde-error">{error}</div> : null}
 
       <style jsx>{`
-        .bde-root{background:#071018;color:#e8edf0;border-bottom:1px solid #33495c;padding:28px 30px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}.bde-root>header{display:flex;justify-content:space-between;gap:24px;align-items:flex-start}.bde-root header>div{max-width:920px}.bde-root header span{font-size:8px;letter-spacing:.16em;color:#c8aa6d}.bde-root h2{font:400 clamp(27px,3vw,40px)/1 Georgia,serif;margin:8px 0 11px;color:#f4f6f7}.bde-root header p{font:13px/1.6 Georgia,serif;color:#91a0ac;margin:0}.bde-root header>b{border:1px solid #425a6d;padding:9px 11px;font-size:8px;color:#d8c38e}.bde-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:18px}.bde-grid>article{border:1px solid #2c4253;background:#0b161f;padding:15px;display:flex;flex-direction:column;gap:10px}.bde-grid h3{font-size:9px;letter-spacing:.08em;color:#d8c38e;margin:0}.bde-grid label{display:grid;gap:5px;color:#8195a3;font-size:7px;letter-spacing:.1em}.bde-grid input,.bde-grid select,.bde-grid textarea{box-sizing:border-box;width:100%;border:1px solid #3a5265;background:#081119;color:#e7ecef;padding:9px;font:9px/1.5 ui-monospace,monospace}.bde-grid textarea{min-height:180px;resize:vertical}.bde-grid button{border:1px solid #b69759;background:#c2a464;color:#081119;padding:10px;font:700 8px ui-monospace,monospace;letter-spacing:.08em;cursor:pointer}.bde-grid button:disabled{opacity:.4}.bde-two{display:grid;grid-template-columns:1fr 1fr;gap:7px}.bde-seal,.bde-result{border:1px solid #31495a;background:#081119;padding:10px;display:grid;gap:6px}.bde-seal small,.bde-result small{font-size:7px;color:#8193a0}.bde-seal code{font-size:7px;color:#a9c5b3;overflow-wrap:anywhere}.bde-result strong{font-size:8px;color:#a9c5b3}.bde-result pre{white-space:pre-wrap;overflow-wrap:anywhere;font-size:8px;line-height:1.5;color:#c5d0d6;margin:4px 0 0}.bde-boundary{display:grid;grid-template-columns:160px 1fr;gap:16px;border:1px solid #3a4d5c;background:#0c1720;padding:13px;margin-top:10px}.bde-boundary strong{font-size:8px;color:#c8aa6d}.bde-boundary span{font:11px/1.55 Georgia,serif;color:#91a0ac}.bde-error{border:1px solid #64443f;background:#160f0f;color:#d19380;padding:11px;margin-top:9px;font-size:8px}@media(max-width:1050px){.bde-grid{grid-template-columns:1fr}.bde-root{padding:22px 16px}.bde-root>header{display:grid}.bde-boundary{grid-template-columns:1fr}}`}</style>
+        .bde-root{background:#071018;color:#e8edf0;border-bottom:1px solid #33495c;padding:28px 30px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}.bde-root>header{display:flex;justify-content:space-between;gap:24px;align-items:flex-start}.bde-root header>div{max-width:920px}.bde-root header span{font-size:8px;letter-spacing:.16em;color:#c8aa6d}.bde-root h2{font:400 clamp(27px,3vw,40px)/1 Georgia,serif;margin:8px 0 11px;color:#f4f6f7}.bde-root header p{font:13px/1.6 Georgia,serif;color:#91a0ac;margin:0}.bde-root header>b{border:1px solid #425a6d;padding:9px 11px;font-size:8px;color:#d8c38e}.bde-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:18px}.bde-grid>article{border:1px solid #2c4253;background:#0b161f;padding:15px;display:flex;flex-direction:column;gap:10px}.bde-grid h3{font-size:9px;letter-spacing:.08em;color:#d8c38e;margin:0}.bde-grid label{display:grid;gap:5px;color:#8195a3;font-size:7px;letter-spacing:.1em}.bde-grid input,.bde-grid select,.bde-grid textarea{box-sizing:border-box;width:100%;border:1px solid #3a5265;background:#081119;color:#e7ecef;padding:9px;font:9px/1.5 ui-monospace,monospace}.bde-grid textarea{min-height:120px;resize:vertical}.bde-grid button{border:1px solid #b69759;background:#c2a464;color:#081119;padding:10px;font:700 8px ui-monospace,monospace;letter-spacing:.08em;cursor:pointer}.bde-grid button:disabled{opacity:.4}.bde-two{display:grid;grid-template-columns:1fr 1fr;gap:7px}.bde-context{display:grid;gap:8px;border:1px solid #263a4a;padding:10px;background:#081119}.bde-context p{font:10px/1.5 Georgia,serif;color:#8193a0;margin:0}.bde-seal,.bde-result{border:1px solid #31495a;background:#081119;padding:10px;display:grid;gap:6px}.bde-seal small,.bde-result small{font-size:7px;color:#8193a0;overflow-wrap:anywhere}.bde-seal code{font-size:7px;color:#a9c5b3;overflow-wrap:anywhere}.bde-result strong{font-size:8px;color:#a9c5b3}.bde-result pre{white-space:pre-wrap;overflow-wrap:anywhere;font-size:8px;line-height:1.5;color:#c5d0d6;margin:4px 0 0}.bde-boundary{display:grid;grid-template-columns:160px 1fr;gap:16px;border:1px solid #3a4d5c;background:#0c1720;padding:13px;margin-top:10px}.bde-boundary strong{font-size:8px;color:#c8aa6d}.bde-boundary span{font:11px/1.55 Georgia,serif;color:#91a0ac}.bde-error{border:1px solid #64443f;background:#160f0f;color:#d19380;padding:11px;margin-top:9px;font-size:8px}@media(max-width:1050px){.bde-grid{grid-template-columns:1fr}.bde-root{padding:22px 16px}.bde-root>header{display:grid}.bde-boundary{grid-template-columns:1fr}}`}</style>
     </section>
   );
 }

--- a/src/core/cognitive-twin/reentry/decisionTransferContext.ts
+++ b/src/core/cognitive-twin/reentry/decisionTransferContext.ts
@@ -1,0 +1,398 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { canonicalJson } from './decisionCommitment';
+import {
+  decisionTransferArmSchema,
+  parseBlindDecisionRunInput,
+  type BlindDecisionRunInput,
+} from './blindDecisionReconstruction';
+
+const providerSchema = z.enum(['openai', 'anthropic', 'gemini', 'groq', 'ollama', 'huggingface']);
+const dispositionValues = new Set(['PROPOSE', 'REQUEST_EVIDENCE', 'ESCALATE', 'WITHHOLD', 'ARCHIVE_ONLY']);
+const traceClassValues = new Set(['OBSERVED', 'VERIFIED_CONTRAST', 'DERIVED', 'INFERRED', 'SIMULATED']);
+const terminalMemoryStatuses = new Set(['REJECTED', 'OBSOLETE', 'FOUNDER_RESERVED']);
+const verifiedMemoryStatuses = new Set(['VERIFIED', 'CANONICAL']);
+const patternMaturities = new Set(['RECURRENT', 'CROSS_DOMAIN', 'CONTRASTED', 'STABLE_PATTERN', 'RULE_CANDIDATE']);
+const PAGE_SIZE = 128;
+
+const currentCaseRequestSchema = z.object({
+  situation: z.string().trim().min(5).max(16000),
+  priorState: z.string().trim().max(12000).optional(),
+  evidenceRefs: z.array(z.string().uuid()).min(1).max(120),
+  constraints: z.array(z.string().trim().min(1).max(1200)).max(120).default([]),
+}).strict();
+
+export const materializedBlindDecisionRequestSchema = z.object({
+  contextSource: z.literal('CANONICAL_MATERIALIZED'),
+  experimentId: z.string().trim().min(1).max(240),
+  targetTraceId: z.string().trim().min(1).max(240),
+  targetDomain: z.string().trim().min(1).max(160),
+  targetCommitmentSha256: z.string().regex(/^[0-9a-f]{64}$/i),
+  arm: decisionTransferArmSchema,
+  cutoffAt: z.string().datetime({ offset: true }),
+  currentCase: currentCaseRequestSchema,
+  preferredProvider: providerSchema.optional(),
+  strictProvider: z.boolean().default(true),
+  maxTokens: z.number().int().min(200).max(2500).default(1000),
+}).strict();
+
+export type MaterializedBlindDecisionRequest = z.infer<typeof materializedBlindDecisionRequestSchema>;
+type Row = Record<string, unknown>;
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : [];
+}
+function sha256(value: string) {
+  return createHash('sha256').update(value).digest('hex');
+}
+function containsTarget(value: unknown, targetTraceId: string) {
+  try { return canonicalJson(value).includes(targetTraceId); } catch { return false; }
+}
+function memoryStatus(content: Row) {
+  const lifecycle = text(content.lifecycleStatus);
+  if (lifecycle === 'REJECTED' || lifecycle === 'OBSOLETE' || lifecycle === 'FOUNDER_RESERVED') return lifecycle;
+  if (lifecycle === 'INSTITUTIONALIZED') return 'CANONICAL';
+  if (lifecycle === 'REPRODUCIBLE') return 'VERIFIED';
+  const declared = text(content.memoryStatus) ?? text(content.status);
+  if (declared && ['CANDIDATE', 'VERIFIED', 'CANONICAL', 'REJECTED', 'OBSOLETE', 'FOUNDER_RESERVED'].includes(declared)) return declared;
+  return 'CANDIDATE';
+}
+function safeEpistemicClass(value: unknown) {
+  const normalized = text(value)?.toUpperCase();
+  if (normalized === 'OBSERVED') return 'OBSERVED' as const;
+  if (normalized === 'SIMULATED') return 'SIMULATED' as const;
+  if (normalized === 'INFERRED') return 'INFERRED' as const;
+  if (normalized === 'VERIFIED_CONTRAST') return 'VERIFIED_CONTRAST' as const;
+  return 'DERIVED' as const;
+}
+function normalizeTrace(value: unknown) {
+  const item = record(value);
+  const traceId = text(item.traceId);
+  const domain = text(item.domain);
+  const disposition = text(item.disposition);
+  const epistemicClass = text(item.epistemicClass);
+  if (!traceId || !domain || !disposition || !epistemicClass) return null;
+  if (!dispositionValues.has(disposition) || !traceClassValues.has(epistemicClass)) return null;
+  return {
+    traceId,
+    domain,
+    disposition,
+    operations: strings(item.operations),
+    relevantVariables: strings(item.relevantVariables),
+    rejectedConditions: strings(item.rejectedConditions),
+    whatWouldChangeDecision: strings(item.whatWouldChangeDecision),
+    evidenceRefs: strings(item.evidenceRefs),
+    epistemicClass,
+  };
+}
+
+async function loadCurrentCase(input: MaterializedBlindDecisionRequest, cutoffIso: string) {
+  const db = createServiceSupabaseClient();
+  const evidence = await db.from('root_evidence_entries')
+    .select('id,title,content,evidence_type,payload,epistemic_event_id,created_at')
+    .in('id', input.currentCase.evidenceRefs);
+  if (evidence.error) throw new Error(`DT_CONTEXT_CURRENT_EVIDENCE_READ_FAILED:${evidence.error.message}`);
+  const rows = (evidence.data ?? []) as Row[];
+  const byId = new Map(rows.map((item) => [String(item.id), item]));
+  const missing = input.currentCase.evidenceRefs.filter((id) => !byId.has(id));
+  if (missing.length) throw new Error(`DT_CONTEXT_CURRENT_EVIDENCE_MISSING:${missing.join(',')}`);
+  for (const item of rows) {
+    const createdAt = text(item.created_at);
+    if (!createdAt || createdAt > cutoffIso) throw new Error(`DT_CONTEXT_CURRENT_EVIDENCE_AFTER_CUTOFF:${String(item.id)}`);
+    if (containsTarget(item, input.targetTraceId)) throw new Error(`DT_CONTEXT_TARGET_ID_IN_CURRENT_EVIDENCE:${String(item.id)}`);
+  }
+
+  const eventIds = rows.map((item) => text(item.epistemic_event_id)).filter((value): value is string => Boolean(value));
+  const events = eventIds.length
+    ? await db.from('epistemic_events').select('event_id,epistemic_class,occurred_at').in('event_id', eventIds)
+    : { data: [], error: null };
+  if (events.error) throw new Error(`DT_CONTEXT_EPISTEMIC_EVENT_READ_FAILED:${events.error.message}`);
+  const eventMap = new Map(((events.data ?? []) as Row[]).map((item) => [String(item.event_id), item]));
+
+  return {
+    situation: input.currentCase.situation,
+    ...(input.currentCase.priorState ? { priorState: input.currentCase.priorState } : {}),
+    evidence: input.currentCase.evidenceRefs.map((id) => {
+      const item = byId.get(id)!;
+      const event = eventMap.get(String(item.epistemic_event_id ?? ''));
+      const observedAt = text(event?.occurred_at);
+      if (observedAt && observedAt > cutoffIso) throw new Error(`DT_CONTEXT_EPISTEMIC_EVENT_AFTER_CUTOFF:${id}`);
+      return {
+        ref: `root_evidence_entries:${id}`,
+        summary: [text(item.title), text(item.content)].filter(Boolean).join(' — ').slice(0, 8000),
+        epistemicClass: safeEpistemicClass(event?.epistemic_class),
+      };
+    }),
+    constraints: input.currentCase.constraints,
+  };
+}
+
+async function loadRawHistory(targetTraceId: string, cutoffIso: string) {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_cognitive_lab_events')
+    .select('id,session_id,event_kind,provenance,actor_key,relation_from,relation_to,payload,evidence_refs,source_ref,occurred_at,created_at')
+    .lte('occurred_at', cutoffIso)
+    .order('occurred_at', { ascending: false })
+    .limit(120);
+  if (result.error) throw new Error(`DT_CONTEXT_RAW_HISTORY_READ_FAILED:${result.error.message}`);
+  let excluded = 0;
+  const history = ((result.data ?? []) as Row[]).flatMap((item) => {
+    if (containsTarget(item, targetTraceId)) { excluded += 1; return []; }
+    const id = String(item.id);
+    return [{
+      ref: `cognitive-lab-event:${id}`,
+      content: canonicalJson({
+        eventKind: item.event_kind,
+        provenance: item.provenance,
+        actorKey: item.actor_key,
+        relationFrom: item.relation_from,
+        relationTo: item.relation_to,
+        payload: item.payload,
+        sourceRef: item.source_ref,
+        occurredAt: item.occurred_at,
+      }).slice(0, 12000),
+      evidenceRefs: strings(item.evidence_refs),
+    }];
+  }).reverse();
+  return { rows: history, excluded };
+}
+
+async function loadVerifiedMemory(targetTraceId: string, cutoffIso: string) {
+  const db = createServiceSupabaseClient();
+  const latestByKey = new Map<string, { key: string; content: unknown; status: string; evidenceRefs: string[] }>();
+  const seenKeys = new Set<string>();
+  let offset = 0;
+  let excluded = 0;
+  while (latestByKey.size < 120) {
+    const page = await db.from('sfi_amv_memory')
+      .select('id,module,memory_delta,created_at')
+      .eq('module', 'institutionalEventPipeline')
+      .not('memory_delta->raw->>memoryKey', 'is', null)
+      .lte('created_at', cutoffIso)
+      .order('created_at', { ascending: false })
+      .range(offset, offset + PAGE_SIZE - 1);
+    if (page.error) throw new Error(`DT_CONTEXT_MEMORY_READ_FAILED:${page.error.message}`);
+    const rows = (page.data ?? []) as Row[];
+    for (const item of rows) {
+      const delta = record(item.memory_delta);
+      const raw = record(delta.raw);
+      const key = text(raw.memoryKey);
+      if (!key || seenKeys.has(key)) continue;
+      seenKeys.add(key);
+      const content = record(raw.content);
+      const status = memoryStatus(content);
+      if (terminalMemoryStatuses.has(status) || !verifiedMemoryStatuses.has(status)) continue;
+      if (containsTarget(raw, targetTraceId)) { excluded += 1; continue; }
+      latestByKey.set(key, {
+        key,
+        content: raw.content ?? null,
+        status,
+        evidenceRefs: strings(raw.evidenceRefs),
+      });
+      if (latestByKey.size >= 120) break;
+    }
+    if (rows.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+  return { rows: [...latestByKey.values()], excluded };
+}
+
+async function loadDecisionTransferHistory(targetTraceId: string, cutoffIso: string) {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_cognitive_twin_runs')
+    .select('id,input_snapshot,output_envelope,evidence_refs,created_at')
+    .eq('role', 'DECISION_TRANSFER_EVALUATOR')
+    .lte('created_at', cutoffIso)
+    .order('created_at', { ascending: false })
+    .limit(120);
+  if (result.error) throw new Error(`DT_CONTEXT_DECISION_HISTORY_READ_FAILED:${result.error.message}`);
+  const traces = new Map<string, ReturnType<typeof normalizeTrace> extends infer T ? Exclude<T, null> : never>();
+  const patterns = new Map<string, { key: string; maturity: string; operations: string[]; domains: string[]; evidenceRefs: string[] }>();
+  let excluded = 0;
+  for (const run of (result.data ?? []) as Row[]) {
+    const snapshot = record(run.input_snapshot);
+    const expected = Array.isArray(snapshot.expected) ? snapshot.expected : [];
+    for (const rawTrace of expected) {
+      const trace = normalizeTrace(rawTrace);
+      if (!trace) continue;
+      if (trace.traceId === targetTraceId || containsTarget(trace, targetTraceId)) { excluded += 1; continue; }
+      if (!['OBSERVED', 'VERIFIED_CONTRAST'].includes(trace.epistemicClass)) continue;
+      if (!traces.has(trace.traceId)) traces.set(trace.traceId, trace);
+    }
+    const output = record(run.output_envelope);
+    const evaluation = record(output.evaluation);
+    const promotion = record(evaluation.promotion);
+    const key = text(promotion.operationKey) ?? text(output.operationKey);
+    const maturity = text(promotion.maturity);
+    if (!key || !maturity || !patternMaturities.has(maturity) || patterns.has(key)) continue;
+    if (containsTarget(promotion, targetTraceId)) { excluded += 1; continue; }
+    patterns.set(key, {
+      key,
+      maturity,
+      operations: [key],
+      domains: strings(promotion.qualifyingDomains),
+      evidenceRefs: strings(promotion.evidenceRefs),
+    });
+  }
+  return { traces: [...traces.values()].slice(0, 120), patterns: [...patterns.values()].slice(0, 120), excluded };
+}
+
+async function loadApprovedRules(targetTraceId: string, cutoffIso: string) {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_cognitive_twin_decisions')
+    .select('decision_id,situation,rejected_condition,correct_state,general_rule,required_evidence,evidence_refs,status,approved_at,created_at')
+    .eq('status', 'APPROVED')
+    .not('approved_at', 'is', null)
+    .lte('approved_at', cutoffIso)
+    .order('approved_at', { ascending: false })
+    .limit(120);
+  if (result.error) throw new Error(`DT_CONTEXT_RULES_READ_FAILED:${result.error.message}`);
+  let excluded = 0;
+  const rules = ((result.data ?? []) as Row[]).flatMap((item) => {
+    if (containsTarget(item, targetTraceId)) { excluded += 1; return []; }
+    const key = text(item.decision_id);
+    const statement = text(item.general_rule);
+    if (!key || !statement) return [];
+    const constraints = [...strings(item.required_evidence)];
+    const correctState = text(item.correct_state);
+    if (correctState) constraints.push(`correct_state:${correctState}`);
+    const rejected = text(item.rejected_condition);
+    return [{
+      key,
+      statement,
+      constraints,
+      exceptions: rejected ? [rejected] : [],
+      evidenceRefs: strings(item.evidence_refs),
+    }];
+  });
+  return { rows: rules, excluded };
+}
+
+async function loadOperatingMode(cutoffIso: string) {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_cognitive_twin_runs')
+    .select('role,status,created_at')
+    .lte('created_at', cutoffIso)
+    .order('created_at', { ascending: false })
+    .limit(500);
+  if (result.error) throw new Error(`DT_CONTEXT_OPERATING_MODE_READ_FAILED:${result.error.message}`);
+  const byRole: Record<string, number> = {};
+  const byStatus: Record<string, number> = {};
+  for (const item of (result.data ?? []) as Row[]) {
+    const role = text(item.role) ?? 'unknown';
+    const status = text(item.status) ?? 'unknown';
+    byRole[role] = (byRole[role] ?? 0) + 1;
+    byStatus[status] = (byStatus[status] ?? 0) + 1;
+  }
+  return { total: result.data?.length ?? 0, byRole, byStatus, cutoffAt: cutoffIso, sourceState: result.data?.length ? 'OBSERVED' : 'READY_EMPTY' };
+}
+
+export function parseMaterializedBlindDecisionRequest(value: unknown): MaterializedBlindDecisionRequest {
+  const parsed = materializedBlindDecisionRequestSchema.parse(value);
+  const cutoff = new Date(parsed.cutoffAt);
+  if (!Number.isFinite(cutoff.getTime())) throw new Error('DT_CONTEXT_CUTOFF_INVALID');
+  if (cutoff.getTime() > Date.now() + 60_000) throw new Error('DT_CONTEXT_CUTOFF_IN_FUTURE');
+  if (containsTarget(parsed.currentCase, parsed.targetTraceId)) throw new Error('DT_CONTEXT_TARGET_ID_IN_CURRENT_CASE');
+  return parsed;
+}
+
+export async function materializeDecisionTransferContext(input: MaterializedBlindDecisionRequest) {
+  const cutoffIso = new Date(input.cutoffAt).toISOString();
+  const [currentCase, rawHistory, memory, decisionHistory, rules, operatingMode] = await Promise.all([
+    loadCurrentCase(input, cutoffIso),
+    loadRawHistory(input.targetTraceId, cutoffIso),
+    loadVerifiedMemory(input.targetTraceId, cutoffIso),
+    loadDecisionTransferHistory(input.targetTraceId, cutoffIso),
+    loadApprovedRules(input.targetTraceId, cutoffIso),
+    loadOperatingMode(cutoffIso),
+  ]);
+  const contextPool = {
+    currentCase,
+    rawHistory: rawHistory.rows,
+    memory: memory.rows,
+    decisionTraces: decisionHistory.traces,
+    patterns: decisionHistory.patterns,
+    rules: rules.rows,
+    operatingMode,
+  };
+  if (containsTarget(contextPool, input.targetTraceId)) throw new Error('DT_CONTEXT_TARGET_ID_LEAK_AFTER_MATERIALIZATION');
+  const contextPoolHash = sha256(canonicalJson(contextPool));
+  const receiptBase = {
+    protocol: 'SFI-DT-CONTEXT-MATERIALIZATION-1.0' as const,
+    source: 'CANONICAL_MATERIALIZED' as const,
+    cutoffAt: cutoffIso,
+    targetTraceId: input.targetTraceId,
+    arm: input.arm,
+    contextPoolHash,
+    sourceCounts: {
+      currentEvidence: currentCase.evidence.length,
+      rawHistory: rawHistory.rows.length,
+      verifiedMemory: memory.rows.length,
+      decisionTraces: decisionHistory.traces.length,
+      patterns: decisionHistory.patterns.length,
+      approvedRules: rules.rows.length,
+      operatingModeRuns: operatingMode.total,
+    },
+    excludedExactTargetMatches: rawHistory.excluded + memory.excluded + decisionHistory.excluded + rules.excluded,
+    sourceTables: [
+      'root_evidence_entries',
+      'epistemic_events',
+      'sfi_cognitive_lab_events',
+      'sfi_amv_memory',
+      'sfi_cognitive_twin_runs',
+      'sfi_cognitive_twin_decisions',
+    ],
+    boundaries: [
+      'Every persisted historical query is bounded at or before cutoffAt.',
+      'Canonical memory uses the newest state per memory key as of cutoffAt and only VERIFIED/CANONICAL states are exposed.',
+      'Decision traces are recovered only from prior Decision Transfer evaluator inputs and only OBSERVED/VERIFIED_CONTRAST traces are exposed.',
+      'Patterns come only from prior persisted promotion reports with maturity RECURRENT or stronger; they are not promoted by materialization.',
+      'Rules come only from APPROVED Cognitive Twin decisions whose approved_at is at or before cutoffAt.',
+      'Exact target trace identifiers are excluded from every historical source. Semantic contamination still requires audit of the frozen context.',
+      'cutoffAt is a ROOT-declared pre-decision boundary; this materializer does not by itself prove the revealed target occurred after the cutoff.',
+    ],
+  };
+  const receipt = { ...receiptBase, receiptHash: sha256(canonicalJson(receiptBase)) };
+  const blindInput: BlindDecisionRunInput = parseBlindDecisionRunInput({
+    experimentId: input.experimentId,
+    targetTraceId: input.targetTraceId,
+    targetDomain: input.targetDomain,
+    targetCommitmentSha256: input.targetCommitmentSha256,
+    arm: input.arm,
+    contextPool,
+    ...(input.preferredProvider ? { preferredProvider: input.preferredProvider } : {}),
+    strictProvider: input.strictProvider,
+    maxTokens: input.maxTokens,
+  });
+  return { blindInput, contextPool, receipt };
+}
+
+export async function bindDecisionTransferContextReceipt(runId: string, receipt: Record<string, unknown>) {
+  const db = createServiceSupabaseClient();
+  const read = await db.from('sfi_cognitive_twin_runs')
+    .select('id,role,status,input_snapshot')
+    .eq('id', runId)
+    .maybeSingle();
+  if (read.error || !read.data) throw new Error(`DT_CONTEXT_BIND_RUN_NOT_FOUND:${read.error?.message ?? runId}`);
+  if (read.data.role !== 'DECISION_TRANSFER_BLIND_RECONSTRUCTOR' || read.data.status !== 'EVIDENCE_PENDING') {
+    throw new Error(`DT_CONTEXT_BIND_RUN_STATE_INVALID:${read.data.role}:${read.data.status}`);
+  }
+  const snapshot = record(read.data.input_snapshot);
+  const update = await db.from('sfi_cognitive_twin_runs').update({
+    input_snapshot: { ...snapshot, contextMaterialization: receipt },
+  }).eq('id', runId).eq('status', 'EVIDENCE_PENDING');
+  if (update.error) {
+    await db.from('sfi_cognitive_twin_runs').delete().eq('id', runId).eq('status', 'EVIDENCE_PENDING');
+    throw new Error(`DT_CONTEXT_BIND_FAILED:${update.error.message}`);
+  }
+  return { ok: true as const };
+}

--- a/src/core/cognitive-twin/reentry/decisionTransferContext.ts
+++ b/src/core/cognitive-twin/reentry/decisionTransferContext.ts
@@ -8,6 +8,7 @@ import {
   decisionTransferArmSchema,
   parseBlindDecisionRunInput,
   type BlindDecisionRunInput,
+  type DecisionTransferArm,
 } from './blindDecisionReconstruction';
 
 const providerSchema = z.enum(['openai', 'anthropic', 'gemini', 'groq', 'ollama', 'huggingface']);
@@ -41,6 +42,37 @@ export const materializedBlindDecisionRequestSchema = z.object({
 
 export type MaterializedBlindDecisionRequest = z.infer<typeof materializedBlindDecisionRequestSchema>;
 type Row = Record<string, unknown>;
+type NormalizedTrace = {
+  traceId: string;
+  domain: string;
+  disposition: string;
+  operations: string[];
+  relevantVariables: string[];
+  rejectedConditions: string[];
+  whatWouldChangeDecision: string[];
+  evidenceRefs: string[];
+  epistemicClass: string;
+};
+
+type LayerSelection = {
+  rawHistory: boolean;
+  memory: boolean;
+  decisionTraces: boolean;
+  patterns: boolean;
+  rules: boolean;
+  operatingMode: boolean;
+};
+
+function layersForArm(arm: DecisionTransferArm): LayerSelection {
+  return {
+    rawHistory: arm !== 'B0_BASE',
+    memory: ['B2_MEMORY', 'B3_CDT', 'B4_PATTERNS', 'B5_RULE_STRUCTURE', 'CT_FULL'].includes(arm),
+    decisionTraces: ['B3_CDT', 'B4_PATTERNS', 'B5_RULE_STRUCTURE', 'CT_FULL'].includes(arm),
+    patterns: ['B4_PATTERNS', 'B5_RULE_STRUCTURE', 'CT_FULL'].includes(arm),
+    rules: ['B5_RULE_STRUCTURE', 'CT_FULL'].includes(arm),
+    operatingMode: arm === 'CT_FULL',
+  };
+}
 
 function record(value: unknown): Row {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
@@ -74,7 +106,7 @@ function safeEpistemicClass(value: unknown) {
   if (normalized === 'VERIFIED_CONTRAST') return 'VERIFIED_CONTRAST' as const;
   return 'DERIVED' as const;
 }
-function normalizeTrace(value: unknown) {
+function normalizeTrace(value: unknown): NormalizedTrace | null {
   const item = record(value);
   const traceId = text(item.traceId);
   const domain = text(item.domain);
@@ -215,7 +247,7 @@ async function loadDecisionTransferHistory(targetTraceId: string, cutoffIso: str
     .order('created_at', { ascending: false })
     .limit(120);
   if (result.error) throw new Error(`DT_CONTEXT_DECISION_HISTORY_READ_FAILED:${result.error.message}`);
-  const traces = new Map<string, ReturnType<typeof normalizeTrace> extends infer T ? Exclude<T, null> : never>();
+  const traces = new Map<string, NormalizedTrace>();
   const patterns = new Map<string, { key: string; maturity: string; operations: string[]; domains: string[]; evidenceRefs: string[] }>();
   let excluded = 0;
   for (const run of (result.data ?? []) as Row[]) {
@@ -307,57 +339,66 @@ export function parseMaterializedBlindDecisionRequest(value: unknown): Materiali
 
 export async function materializeDecisionTransferContext(input: MaterializedBlindDecisionRequest) {
   const cutoffIso = new Date(input.cutoffAt).toISOString();
+  const layers = layersForArm(input.arm);
+  const emptyRows = { rows: [] as never[], excluded: 0 };
+  const emptyDecisionHistory = { traces: [] as NormalizedTrace[], patterns: [] as Array<{ key: string; maturity: string; operations: string[]; domains: string[]; evidenceRefs: string[] }>, excluded: 0 };
+  const emptyOperatingMode = { total: 0, byRole: {} as Record<string, number>, byStatus: {} as Record<string, number>, cutoffAt: cutoffIso, sourceState: 'NOT_SELECTED' };
+
   const [currentCase, rawHistory, memory, decisionHistory, rules, operatingMode] = await Promise.all([
     loadCurrentCase(input, cutoffIso),
-    loadRawHistory(input.targetTraceId, cutoffIso),
-    loadVerifiedMemory(input.targetTraceId, cutoffIso),
-    loadDecisionTransferHistory(input.targetTraceId, cutoffIso),
-    loadApprovedRules(input.targetTraceId, cutoffIso),
-    loadOperatingMode(cutoffIso),
+    layers.rawHistory ? loadRawHistory(input.targetTraceId, cutoffIso) : Promise.resolve(emptyRows),
+    layers.memory ? loadVerifiedMemory(input.targetTraceId, cutoffIso) : Promise.resolve(emptyRows),
+    layers.decisionTraces || layers.patterns ? loadDecisionTransferHistory(input.targetTraceId, cutoffIso) : Promise.resolve(emptyDecisionHistory),
+    layers.rules ? loadApprovedRules(input.targetTraceId, cutoffIso) : Promise.resolve(emptyRows),
+    layers.operatingMode ? loadOperatingMode(cutoffIso) : Promise.resolve(emptyOperatingMode),
   ]);
+
   const contextPool = {
     currentCase,
     rawHistory: rawHistory.rows,
     memory: memory.rows,
-    decisionTraces: decisionHistory.traces,
-    patterns: decisionHistory.patterns,
+    decisionTraces: layers.decisionTraces ? decisionHistory.traces : [],
+    patterns: layers.patterns ? decisionHistory.patterns : [],
     rules: rules.rows,
-    operatingMode,
+    ...(layers.operatingMode ? { operatingMode } : {}),
   };
   if (containsTarget(contextPool, input.targetTraceId)) throw new Error('DT_CONTEXT_TARGET_ID_LEAK_AFTER_MATERIALIZATION');
   const contextPoolHash = sha256(canonicalJson(contextPool));
+  const sourceTables = [
+    'root_evidence_entries',
+    'epistemic_events',
+    ...(layers.rawHistory ? ['sfi_cognitive_lab_events'] : []),
+    ...(layers.memory ? ['sfi_amv_memory'] : []),
+    ...(layers.decisionTraces || layers.patterns || layers.operatingMode ? ['sfi_cognitive_twin_runs'] : []),
+    ...(layers.rules ? ['sfi_cognitive_twin_decisions'] : []),
+  ];
   const receiptBase = {
     protocol: 'SFI-DT-CONTEXT-MATERIALIZATION-1.0' as const,
     source: 'CANONICAL_MATERIALIZED' as const,
     cutoffAt: cutoffIso,
     targetTraceId: input.targetTraceId,
     arm: input.arm,
+    selectedLayers: layers,
     contextPoolHash,
     sourceCounts: {
       currentEvidence: currentCase.evidence.length,
       rawHistory: rawHistory.rows.length,
       verifiedMemory: memory.rows.length,
-      decisionTraces: decisionHistory.traces.length,
-      patterns: decisionHistory.patterns.length,
+      decisionTraces: layers.decisionTraces ? decisionHistory.traces.length : 0,
+      patterns: layers.patterns ? decisionHistory.patterns.length : 0,
       approvedRules: rules.rows.length,
-      operatingModeRuns: operatingMode.total,
+      operatingModeRuns: layers.operatingMode ? operatingMode.total : 0,
     },
     excludedExactTargetMatches: rawHistory.excluded + memory.excluded + decisionHistory.excluded + rules.excluded,
-    sourceTables: [
-      'root_evidence_entries',
-      'epistemic_events',
-      'sfi_cognitive_lab_events',
-      'sfi_amv_memory',
-      'sfi_cognitive_twin_runs',
-      'sfi_cognitive_twin_decisions',
-    ],
+    sourceTables,
     boundaries: [
       'Every persisted historical query is bounded at or before cutoffAt.',
+      'Only context layers selected by the treatment arm are queried; lower-information arms do not depend on higher-information stores.',
       'Canonical memory uses the newest state per memory key as of cutoffAt and only VERIFIED/CANONICAL states are exposed.',
       'Decision traces are recovered only from prior Decision Transfer evaluator inputs and only OBSERVED/VERIFIED_CONTRAST traces are exposed.',
       'Patterns come only from prior persisted promotion reports with maturity RECURRENT or stronger; they are not promoted by materialization.',
       'Rules come only from APPROVED Cognitive Twin decisions whose approved_at is at or before cutoffAt.',
-      'Exact target trace identifiers are excluded from every historical source. Semantic contamination still requires audit of the frozen context.',
+      'Exact target trace identifiers are excluded from every queried historical source. Semantic contamination still requires audit of the frozen context.',
       'cutoffAt is a ROOT-declared pre-decision boundary; this materializer does not by itself prove the revealed target occurred after the cutoff.',
     ],
   };

--- a/src/core/cognitive-twin/reentry/decisionTransferContextIntegrity.ts
+++ b/src/core/cognitive-twin/reentry/decisionTransferContextIntegrity.ts
@@ -1,0 +1,34 @@
+import 'server-only';
+
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+export async function verifyDecisionTransferContextReceiptBound(runId: string, expectedReceiptHash: string) {
+  const db = createServiceSupabaseClient();
+  const read = await db.from('sfi_cognitive_twin_runs')
+    .select('id,role,status,input_snapshot')
+    .eq('id', runId)
+    .maybeSingle();
+
+  if (read.error || !read.data) {
+    throw new Error(`DT_CONTEXT_BIND_VERIFY_RUN_NOT_FOUND:${read.error?.message ?? runId}`);
+  }
+  if (read.data.role !== 'DECISION_TRANSFER_BLIND_RECONSTRUCTOR') {
+    throw new Error(`DT_CONTEXT_BIND_VERIFY_ROLE_MISMATCH:${read.data.role ?? 'missing'}`);
+  }
+  if (read.data.status !== 'EVIDENCE_PENDING') {
+    throw new Error(`DT_CONTEXT_BIND_VERIFY_STATE_MISMATCH:${read.data.status ?? 'missing'}`);
+  }
+
+  const snapshot = record(read.data.input_snapshot);
+  const receipt = record(snapshot.contextMaterialization);
+  const actualReceiptHash = typeof receipt.receiptHash === 'string' ? receipt.receiptHash : '';
+  if (!actualReceiptHash || actualReceiptHash !== expectedReceiptHash) {
+    throw new Error('DT_CONTEXT_BIND_VERIFY_RECEIPT_MISMATCH');
+  }
+
+  return { ok: true as const, receiptHash: actualReceiptHash };
+}


### PR DESCRIPTION
## Scope
Remove the normal dependency on a hand-assembled `contextPool` for sealed Decision Transfer experiments. The canonical mode now materializes historical context server-side from persisted SFI stores under an explicit pre-target cutoff, while the manual context path remains only as an advanced/legacy laboratory fallback.

## Treatment-isolated canonical sources
Each arm queries only the layers it is allowed to receive; lower-information arms do not depend on higher-information stores.
- B0 base: persisted current-case `root_evidence_entries` joined to `epistemic_events`
- B1: B0 + `sfi_cognitive_lab_events`
- B2: B1 + canonical `sfi_amv_memory`, newest state per key as-of cutoff, VERIFIED/CANONICAL only
- B3: B2 + prior `DECISION_TRANSFER_EVALUATOR` inputs, OBSERVED/VERIFIED_CONTRAST traces only
- B4: B3 + persisted prior Decision Transfer promotion reports at RECURRENT maturity or stronger
- B5: B4 + `sfi_cognitive_twin_decisions` with `status=APPROVED` and `approved_at <= cutoff`
- CT_FULL: B5 + observed role/status distribution from prior Cognitive Twin runs

## Temporal / leakage boundary
- persisted history queries apply cutoff at query level (`occurred_at`, `created_at`, or `approved_at`)
- current-case evidence is rejected if persisted after cutoff
- exact target trace id is rejected/excluded from every queried source and checked again on the fully materialized pool
- a receipt `SFI-DT-CONTEXT-MATERIALIZATION-1.0` freezes selected layers, source counts, cutoff, context-pool hash, exclusion count and source tables
- receipt is bound to the EVIDENCE_PENDING blind run and re-read/verified before the endpoint reports success
- the receipt explicitly does not claim that exact-id exclusion proves absence of semantic contamination, nor that a ROOT-declared cutoff proves the target occurred later

## Authority boundaries
- no new table or migration
- no write to `sfi_amv_memory` or historical CT memory
- no `recordCognitiveTwinExperience`
- no rule/canon promotion
- B4 reads prior persisted pattern maturity but materialization itself cannot increase maturity
- manual context remains available only as an explicit fallback and is identified in the ROOT audit

## Site
The existing `/method-lab` blind experiment defaults to `CANONICAL_MATERIALIZED`. ROOT supplies cutoff, pre-decision situation, persisted ROOT evidence IDs and constraints; the server supplies only the historical layers permitted by the selected treatment arm. The resulting receipt hash, cutoff, source counts, selected layers and exact-target exclusions remain auditable with the blind run.

## QA
Adds `qa-sfi-decision-transfer-context.ts` to SFI Verify, enforcing arm-selective dependencies, query-level temporal cutoffs, canonical memory status boundaries, observed/verified DecisionTrace filtering, approved-only rules, target exclusion, receipt binding verification, no legacy memory, no memory mutation and route auditability.