### PR TITLE
Phase II: prove revealed target occurred after frozen context cutoff

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Verify canonical Decision Transfer context materialization
         run: npx tsx scripts/qa-sfi-decision-transfer-context.ts
 
+      - name: Verify post-cutoff Decision Transfer target timing
+        run: npx tsx scripts/qa-sfi-decision-transfer-target-timing.ts
+
       - name: Verify canonical evidence identity
         run: node --import tsx --test src/lib/evidence/canonicalEvidence.test.ts
 

--- a/scripts/qa-sfi-decision-transfer-target-timing.ts
+++ b/scripts/qa-sfi-decision-transfer-target-timing.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function read(relative: string) { return fs.readFileSync(path.join(process.cwd(), relative), 'utf8'); }
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`SFI_DECISION_TRANSFER_TARGET_TIMING_QA:${message}`);
+}
+
+const timingPath = 'src/core/cognitive-twin/reentry/decisionTransferTargetTiming.ts';
+const revealRoutePath = 'src/app/api/root/method-lab/decision-transfer/reveal/route.ts';
+assert(fs.existsSync(timingPath), 'timing_verifier_missing');
+const timing = read(timingPath);
+const revealRoute = read(revealRoutePath);
+
+assert(timing.includes("protocol) !== 'SFI-DT-CONTEXT-MATERIALIZATION-1.0'"), 'canonical_context_receipt_contract_gate_missing');
+assert(timing.includes("source) !== 'CANONICAL_MATERIALIZED'"), 'canonical_context_source_gate_missing');
+assert(timing.includes("text(receipt.targetTraceId) !== input.target.traceId"), 'receipt_target_binding_missing');
+assert(timing.includes('DT_TARGET_TIMING_RECEIPT_INTEGRITY_MISMATCH'), 'receipt_hash_integrity_gate_missing');
+assert(timing.includes('sha256(canonicalJson(receiptBase))'), 'receipt_rehash_missing');
+assert(timing.includes("const ROOT_EVIDENCE_PREFIX = 'root_evidence_entries:'"), 'canonical_target_evidence_ref_prefix_missing');
+assert(timing.includes('targetRefMatchesEvidenceId'), 'explicit_target_evidence_binding_missing');
+assert(timing.includes("from('root_evidence_entries')"), 'root_target_evidence_read_missing');
+assert(timing.includes("from('epistemic_events')"), 'target_epistemic_event_read_missing');
+assert(timing.includes("text(event.epistemic_class) !== 'observed'"), 'target_event_must_be_observed');
+assert(timing.includes('occurredMs <= cutoffMs'), 'target_event_must_be_strictly_after_cutoff');
+assert(timing.includes('DT_TARGET_TIMING_NO_POST_CUTOFF_OBSERVED_EVIDENCE'), 'post_cutoff_observed_evidence_required');
+assert(timing.includes("status: 'NOT_APPLICABLE_MANUAL_CONTEXT'"), 'manual_context_compatibility_boundary_missing');
+assert(timing.includes("protocol: 'SFI-DT-TARGET-TIMING-1.0'"), 'target_timing_receipt_protocol_missing');
+assert(timing.includes('proofHash: sha256(canonicalJson(proofBase))'), 'target_timing_proof_hash_missing');
+
+for (const forbidden of ["from('sfi_amv_memory')", "from('sfi_cognitive_twin_memory')", 'recordCognitiveTwinExperience']) {
+  assert(!timing.includes(forbidden), `timing_verifier_must_not_mutate_or_read_memory:${forbidden}`);
+}
+
+assert(revealRoute.includes('verifyBlindDecisionContextIntegrity(input.blindRunId)'), 'selected_context_integrity_gate_missing');
+assert(revealRoute.includes('verifyRevealedTargetAfterContextCutoff'), 'target_timing_gate_missing');
+const timingIndex = revealRoute.indexOf('verifyRevealedTargetAfterContextCutoff({');
+const revealIndex = revealRoute.indexOf('executeBlindDecisionReveal(input');
+assert(timingIndex >= 0 && revealIndex > timingIndex, 'target_timing_gate_must_precede_reveal_and_scoring');
+assert(revealRoute.includes('targetTimingProofHash'), 'target_timing_audit_hash_missing');
+assert(revealRoute.includes('verifiedTargetObservationEvidenceIds'), 'verified_target_evidence_audit_missing');
+assert(revealRoute.includes('earliestObservedTargetAt'), 'target_observed_time_audit_missing');
+
+console.log(JSON.stringify({
+  ok: true,
+  gate: 'SFI_DECISION_TRANSFER_TARGET_TIMING',
+  protocol: 'SFI-DT-TARGET-TIMING-1.0',
+  canonicalContextRequiresPostCutoffTargetProof: true,
+  targetEvidenceClass: 'OBSERVED',
+  targetEvidenceTimeRelation: 'occurred_at > cutoffAt',
+  manualContextCompatibility: 'NOT_APPLICABLE',
+  memoryMutation: false,
+}, null, 2));

--- a/src/app/api/root/method-lab/decision-transfer/reveal/route.ts
+++ b/src/app/api/root/method-lab/decision-transfer/reveal/route.ts
@@ -36,6 +36,9 @@ export async function POST(request: Request) {
       targetObservationEvidenceIds,
     });
     const result = await executeBlindDecisionReveal(input, gate.ctx.user.id);
+    const verifiedTargetEvidenceIds = targetTiming.required
+      ? targetTiming.evidence.map((item) => item.evidenceId)
+      : [];
     const audit = await auditRootAction({
       actorId: gate.ctx.user.id,
       action: 'method_lab.decision_transfer.blind_target_revealed',
@@ -56,9 +59,9 @@ export async function POST(request: Request) {
         targetTimingVerified: targetTiming.verified,
         targetTimingStatus: targetTiming.status,
         targetTimingProofHash: targetTiming.required ? targetTiming.proofHash : null,
-        targetObservedAfter: targetTiming.required ? targetTiming.cutoffAt : null,
+        contextCutoffAt: targetTiming.required ? targetTiming.cutoffAt : null,
         earliestObservedTargetAt: targetTiming.required ? targetTiming.earliestObservedTargetAt : null,
-        targetObservationEvidenceIds,
+        verifiedTargetObservationEvidenceIds: verifiedTargetEvidenceIds,
       },
       request,
     });

--- a/src/app/api/root/method-lab/decision-transfer/reveal/route.ts
+++ b/src/app/api/root/method-lab/decision-transfer/reveal/route.ts
@@ -6,10 +6,20 @@ import {
   parseBlindDecisionRevealInput,
 } from '@/core/cognitive-twin/reentry/blindDecisionReconstruction';
 import { verifyBlindDecisionContextIntegrity } from '@/core/cognitive-twin/reentry/blindDecisionIntegrity';
+import {
+  parseTargetObservationEvidenceIds,
+  verifyRevealedTargetAfterContextCutoff,
+} from '@/core/cognitive-twin/reentry/decisionTransferTargetTiming';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 export const maxDuration = 60;
+
+function withoutTimingExtension(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const { targetObservationEvidenceIds: _targetObservationEvidenceIds, ...reveal } = value as Record<string, unknown>;
+  return reveal;
+}
 
 export async function POST(request: Request) {
   const gate = await requireRootActor('root.method-lab.decision-transfer.reveal');
@@ -17,8 +27,14 @@ export async function POST(request: Request) {
 
   try {
     const raw = await request.json();
-    const input = parseBlindDecisionRevealInput(raw);
+    const targetObservationEvidenceIds = parseTargetObservationEvidenceIds(raw);
+    const input = parseBlindDecisionRevealInput(withoutTimingExtension(raw));
     const contextIntegrity = await verifyBlindDecisionContextIntegrity(input.blindRunId);
+    const targetTiming = await verifyRevealedTargetAfterContextCutoff({
+      blindRunId: input.blindRunId,
+      target: input.target,
+      targetObservationEvidenceIds,
+    });
     const result = await executeBlindDecisionReveal(input, gate.ctx.user.id);
     const audit = await auditRootAction({
       actorId: gate.ctx.user.id,
@@ -36,21 +52,32 @@ export async function POST(request: Request) {
         outcome: result.evaluation.outcome,
         commitmentVerified: true,
         contextIntegrityVerified: true,
+        targetTimingRequired: targetTiming.required,
+        targetTimingVerified: targetTiming.verified,
+        targetTimingStatus: targetTiming.status,
+        targetTimingProofHash: targetTiming.required ? targetTiming.proofHash : null,
+        targetObservedAfter: targetTiming.required ? targetTiming.cutoffAt : null,
+        earliestObservedTargetAt: targetTiming.required ? targetTiming.earliestObservedTargetAt : null,
+        targetObservationEvidenceIds,
       },
       request,
     });
     if (!audit.ok) return NextResponse.json({ ok: false, error: 'blind_reveal_audit_failed', result, audit }, { status: 500 });
-    return NextResponse.json({ ...result, contextIntegrity, audit }, { headers: { 'Cache-Control': 'no-store' } });
+    return NextResponse.json({ ...result, contextIntegrity, targetTiming, audit }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {
     const invalidInput = error instanceof ZodError;
     const details = invalidInput
       ? error.issues.map((issue) => `${issue.path.join('.') || 'root'}:${issue.message}`).join('; ')
       : error instanceof Error ? error.message : String(error);
+    const timingInfrastructureFailure = details.includes('DT_TARGET_TIMING_EVIDENCE_READ_FAILED')
+      || details.includes('DT_TARGET_TIMING_EVENT_READ_FAILED');
     const status = invalidInput ? 400
-      : details.includes('COMMITMENT_MISMATCH') || details.includes('TRACE_ID_MISMATCH') || details.includes('DOMAIN_MISMATCH') || details.includes('INTEGRITY_MISMATCH') ? 409
-        : details.includes('NOT_FOUND') ? 404
-          : details.includes('NOT_REVEALABLE') || details.includes('LOCK_FAILED') || details.includes('CONTRACT_MISMATCH') || details.includes('ROLE_MISMATCH') ? 409
-            : 503;
+      : timingInfrastructureFailure ? 503
+        : details.startsWith('DT_TARGET_TIMING_') ? 409
+          : details.includes('COMMITMENT_MISMATCH') || details.includes('TRACE_ID_MISMATCH') || details.includes('DOMAIN_MISMATCH') || details.includes('INTEGRITY_MISMATCH') ? 409
+            : details.includes('NOT_FOUND') ? 404
+              : details.includes('NOT_REVEALABLE') || details.includes('LOCK_FAILED') || details.includes('CONTRACT_MISMATCH') || details.includes('ROLE_MISMATCH') ? 409
+                : 503;
     return NextResponse.json({
       ok: false,
       error: invalidInput ? 'blind_reveal_input_invalid' : 'blind_decision_reveal_failed',

--- a/src/core/cognitive-twin/reentry/decisionTransferTargetTiming.ts
+++ b/src/core/cognitive-twin/reentry/decisionTransferTargetTiming.ts
@@ -1,0 +1,145 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { canonicalJson } from './decisionCommitment';
+import type { DecisionTrace } from './decisionTransfer';
+
+type Row = Record<string, unknown>;
+
+const targetObservationEvidenceIdsSchema = z.array(z.string().uuid()).max(120).default([]);
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+function sha256(value: string) {
+  return createHash('sha256').update(value).digest('hex');
+}
+function targetRefMatchesEvidenceId(ref: string, id: string) {
+  return ref === id || ref === `root_evidence_entries:${id}`;
+}
+
+export function parseTargetObservationEvidenceIds(value: unknown) {
+  const source = record(value);
+  return targetObservationEvidenceIdsSchema.parse(source.targetObservationEvidenceIds);
+}
+
+export async function verifyRevealedTargetAfterContextCutoff(input: {
+  blindRunId: string;
+  target: DecisionTrace;
+  targetObservationEvidenceIds: string[];
+}) {
+  const db = createServiceSupabaseClient();
+  const run = await db.from('sfi_cognitive_twin_runs')
+    .select('id,role,status,input_snapshot')
+    .eq('id', input.blindRunId)
+    .maybeSingle();
+  if (run.error || !run.data) throw new Error(`DT_TARGET_TIMING_RUN_NOT_FOUND:${run.error?.message ?? input.blindRunId}`);
+  if (run.data.role !== 'DECISION_TRANSFER_BLIND_RECONSTRUCTOR') {
+    throw new Error(`DT_TARGET_TIMING_ROLE_MISMATCH:${run.data.role ?? 'missing'}`);
+  }
+  if (run.data.status !== 'EVIDENCE_PENDING') {
+    throw new Error(`DT_TARGET_TIMING_RUN_NOT_REVEALABLE:${run.data.status ?? 'missing'}`);
+  }
+
+  const snapshot = record(run.data.input_snapshot);
+  const receipt = record(snapshot.contextMaterialization);
+  if (!Object.keys(receipt).length) {
+    return {
+      required: false as const,
+      status: 'NOT_APPLICABLE_MANUAL_CONTEXT' as const,
+      verified: false as const,
+      cutoffAt: null,
+      evidence: [],
+    };
+  }
+
+  if (text(receipt.protocol) !== 'SFI-DT-CONTEXT-MATERIALIZATION-1.0' || text(receipt.source) !== 'CANONICAL_MATERIALIZED') {
+    throw new Error('DT_TARGET_TIMING_CONTEXT_RECEIPT_CONTRACT_MISMATCH');
+  }
+  if (text(receipt.targetTraceId) !== input.target.traceId) {
+    throw new Error('DT_TARGET_TIMING_TARGET_TRACE_MISMATCH');
+  }
+
+  const storedReceiptHash = text(receipt.receiptHash);
+  if (!storedReceiptHash) throw new Error('DT_TARGET_TIMING_RECEIPT_HASH_MISSING');
+  const { receiptHash: _receiptHash, ...receiptBase } = receipt;
+  const actualReceiptHash = sha256(canonicalJson(receiptBase));
+  if (actualReceiptHash !== storedReceiptHash) throw new Error('DT_TARGET_TIMING_RECEIPT_INTEGRITY_MISMATCH');
+
+  const cutoffAt = text(receipt.cutoffAt);
+  const cutoffMs = cutoffAt ? new Date(cutoffAt).getTime() : Number.NaN;
+  if (!cutoffAt || !Number.isFinite(cutoffMs)) throw new Error('DT_TARGET_TIMING_CUTOFF_INVALID');
+
+  const evidenceIds = [...new Set(input.targetObservationEvidenceIds)];
+  if (!evidenceIds.length) throw new Error('DT_TARGET_TIMING_OBSERVED_EVIDENCE_REQUIRED');
+  for (const id of evidenceIds) {
+    if (!input.target.evidenceRefs.some((ref) => targetRefMatchesEvidenceId(ref, id))) {
+      throw new Error(`DT_TARGET_TIMING_EVIDENCE_NOT_BOUND_TO_TARGET:${id}`);
+    }
+  }
+
+  const evidenceRead = await db.from('root_evidence_entries')
+    .select('id,epistemic_event_id,created_at')
+    .in('id', evidenceIds);
+  if (evidenceRead.error) throw new Error(`DT_TARGET_TIMING_EVIDENCE_READ_FAILED:${evidenceRead.error.message}`);
+  const evidenceRows = (evidenceRead.data ?? []) as Row[];
+  const evidenceById = new Map(evidenceRows.map((item) => [String(item.id), item]));
+  const missingEvidenceIds = evidenceIds.filter((id) => !evidenceById.has(id));
+  if (missingEvidenceIds.length) throw new Error(`DT_TARGET_TIMING_EVIDENCE_NOT_FOUND:${missingEvidenceIds.join(',')}`);
+
+  const eventIds = evidenceIds.map((id) => text(evidenceById.get(id)?.epistemic_event_id));
+  if (eventIds.some((id) => !id)) throw new Error('DT_TARGET_TIMING_EPISTEMIC_EVENT_REQUIRED');
+  const concreteEventIds = eventIds.filter((id): id is string => Boolean(id));
+  const eventRead = await db.from('epistemic_events')
+    .select('event_id,epistemic_class,occurred_at,checksum,hash_self')
+    .in('event_id', concreteEventIds);
+  if (eventRead.error) throw new Error(`DT_TARGET_TIMING_EVENT_READ_FAILED:${eventRead.error.message}`);
+  const eventById = new Map(((eventRead.data ?? []) as Row[]).map((item) => [String(item.event_id), item]));
+
+  const proof = evidenceIds.map((id) => {
+    const evidence = evidenceById.get(id)!;
+    const eventId = text(evidence.epistemic_event_id)!;
+    const event = eventById.get(eventId);
+    if (!event) throw new Error(`DT_TARGET_TIMING_EVENT_NOT_FOUND:${eventId}`);
+    if (text(event.epistemic_class) !== 'observed') {
+      throw new Error(`DT_TARGET_TIMING_EVENT_NOT_OBSERVED:${eventId}:${text(event.epistemic_class) ?? 'missing'}`);
+    }
+    const occurredAt = text(event.occurred_at);
+    const occurredMs = occurredAt ? new Date(occurredAt).getTime() : Number.NaN;
+    if (!occurredAt || !Number.isFinite(occurredMs)) throw new Error(`DT_TARGET_TIMING_EVENT_TIME_INVALID:${eventId}`);
+    if (occurredMs <= cutoffMs) throw new Error(`DT_TARGET_TIMING_EVENT_NOT_AFTER_CUTOFF:${eventId}:${occurredAt}`);
+    return {
+      evidenceId: id,
+      eventId,
+      epistemicClass: 'OBSERVED' as const,
+      occurredAt,
+      checksum: text(event.checksum),
+      hashSelf: text(event.hash_self),
+    };
+  });
+
+  proof.sort((a, b) => a.occurredAt.localeCompare(b.occurredAt));
+  const proofBase = {
+    protocol: 'SFI-DT-TARGET-TIMING-1.0' as const,
+    blindRunId: input.blindRunId,
+    targetTraceId: input.target.traceId,
+    contextReceiptHash: storedReceiptHash,
+    cutoffAt,
+    earliestObservedTargetAt: proof[0].occurredAt,
+    evidence: proof,
+    boundary: 'Every designated target-observation evidence record is bound to the revealed target, classed OBSERVED, and occurred strictly after the frozen context cutoff.',
+  };
+
+  return {
+    required: true as const,
+    status: 'VERIFIED_POST_CUTOFF' as const,
+    verified: true as const,
+    ...proofBase,
+    proofHash: sha256(canonicalJson(proofBase)),
+  };
+}

--- a/src/core/cognitive-twin/reentry/decisionTransferTargetTiming.ts
+++ b/src/core/cognitive-twin/reentry/decisionTransferTargetTiming.ts
@@ -9,6 +9,7 @@ import type { DecisionTrace } from './decisionTransfer';
 type Row = Record<string, unknown>;
 
 const targetObservationEvidenceIdsSchema = z.array(z.string().uuid()).max(120).default([]);
+const ROOT_EVIDENCE_PREFIX = 'root_evidence_entries:';
 
 function record(value: unknown): Row {
   return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
@@ -20,7 +21,15 @@ function sha256(value: string) {
   return createHash('sha256').update(value).digest('hex');
 }
 function targetRefMatchesEvidenceId(ref: string, id: string) {
-  return ref === id || ref === `root_evidence_entries:${id}`;
+  return ref === id || ref === `${ROOT_EVIDENCE_PREFIX}${id}`;
+}
+function canonicalRootEvidenceIds(target: DecisionTrace) {
+  return target.evidenceRefs.flatMap((ref) => {
+    if (!ref.startsWith(ROOT_EVIDENCE_PREFIX)) return [];
+    const id = ref.slice(ROOT_EVIDENCE_PREFIX.length);
+    const parsed = z.string().uuid().safeParse(id);
+    return parsed.success ? [parsed.data] : [];
+  });
 }
 
 export function parseTargetObservationEvidenceIds(value: unknown) {
@@ -55,6 +64,7 @@ export async function verifyRevealedTargetAfterContextCutoff(input: {
       verified: false as const,
       cutoffAt: null,
       evidence: [],
+      rejectedCandidates: [],
     };
   }
 
@@ -75,12 +85,15 @@ export async function verifyRevealedTargetAfterContextCutoff(input: {
   const cutoffMs = cutoffAt ? new Date(cutoffAt).getTime() : Number.NaN;
   if (!cutoffAt || !Number.isFinite(cutoffMs)) throw new Error('DT_TARGET_TIMING_CUTOFF_INVALID');
 
-  const evidenceIds = [...new Set(input.targetObservationEvidenceIds)];
-  if (!evidenceIds.length) throw new Error('DT_TARGET_TIMING_OBSERVED_EVIDENCE_REQUIRED');
-  for (const id of evidenceIds) {
+  const explicitIds = [...new Set(input.targetObservationEvidenceIds)];
+  for (const id of explicitIds) {
     if (!input.target.evidenceRefs.some((ref) => targetRefMatchesEvidenceId(ref, id))) {
       throw new Error(`DT_TARGET_TIMING_EVIDENCE_NOT_BOUND_TO_TARGET:${id}`);
     }
+  }
+  const evidenceIds = explicitIds.length ? explicitIds : [...new Set(canonicalRootEvidenceIds(input.target))];
+  if (!evidenceIds.length) {
+    throw new Error('DT_TARGET_TIMING_OBSERVED_EVIDENCE_REQUIRED:bind at least one root_evidence_entries:<uuid> ref to the revealed target');
   }
 
   const evidenceRead = await db.from('root_evidence_entries')
@@ -90,38 +103,68 @@ export async function verifyRevealedTargetAfterContextCutoff(input: {
   const evidenceRows = (evidenceRead.data ?? []) as Row[];
   const evidenceById = new Map(evidenceRows.map((item) => [String(item.id), item]));
   const missingEvidenceIds = evidenceIds.filter((id) => !evidenceById.has(id));
-  if (missingEvidenceIds.length) throw new Error(`DT_TARGET_TIMING_EVIDENCE_NOT_FOUND:${missingEvidenceIds.join(',')}`);
+  if (explicitIds.length && missingEvidenceIds.length) {
+    throw new Error(`DT_TARGET_TIMING_EVIDENCE_NOT_FOUND:${missingEvidenceIds.join(',')}`);
+  }
 
-  const eventIds = evidenceIds.map((id) => text(evidenceById.get(id)?.epistemic_event_id));
-  if (eventIds.some((id) => !id)) throw new Error('DT_TARGET_TIMING_EPISTEMIC_EVENT_REQUIRED');
-  const concreteEventIds = eventIds.filter((id): id is string => Boolean(id));
+  const eventIds = evidenceIds
+    .map((id) => text(evidenceById.get(id)?.epistemic_event_id))
+    .filter((id): id is string => Boolean(id));
+  if (!eventIds.length) throw new Error('DT_TARGET_TIMING_EPISTEMIC_EVENT_REQUIRED');
   const eventRead = await db.from('epistemic_events')
     .select('event_id,epistemic_class,occurred_at,checksum,hash_self')
-    .in('event_id', concreteEventIds);
+    .in('event_id', eventIds);
   if (eventRead.error) throw new Error(`DT_TARGET_TIMING_EVENT_READ_FAILED:${eventRead.error.message}`);
   const eventById = new Map(((eventRead.data ?? []) as Row[]).map((item) => [String(item.event_id), item]));
 
-  const proof = evidenceIds.map((id) => {
-    const evidence = evidenceById.get(id)!;
-    const eventId = text(evidence.epistemic_event_id)!;
+  const proof: Array<{ evidenceId: string; eventId: string; epistemicClass: 'OBSERVED'; occurredAt: string; checksum: string | null; hashSelf: string | null }> = [];
+  const rejectedCandidates: Array<{ evidenceId: string; reason: string }> = [];
+  for (const id of evidenceIds) {
+    const evidence = evidenceById.get(id);
+    if (!evidence) {
+      rejectedCandidates.push({ evidenceId: id, reason: 'ROOT_EVIDENCE_NOT_FOUND' });
+      continue;
+    }
+    const eventId = text(evidence.epistemic_event_id);
+    if (!eventId) {
+      rejectedCandidates.push({ evidenceId: id, reason: 'EPISTEMIC_EVENT_MISSING' });
+      continue;
+    }
     const event = eventById.get(eventId);
-    if (!event) throw new Error(`DT_TARGET_TIMING_EVENT_NOT_FOUND:${eventId}`);
+    if (!event) {
+      rejectedCandidates.push({ evidenceId: id, reason: 'EPISTEMIC_EVENT_NOT_FOUND' });
+      continue;
+    }
     if (text(event.epistemic_class) !== 'observed') {
-      throw new Error(`DT_TARGET_TIMING_EVENT_NOT_OBSERVED:${eventId}:${text(event.epistemic_class) ?? 'missing'}`);
+      rejectedCandidates.push({ evidenceId: id, reason: `NOT_OBSERVED:${text(event.epistemic_class) ?? 'missing'}` });
+      continue;
     }
     const occurredAt = text(event.occurred_at);
     const occurredMs = occurredAt ? new Date(occurredAt).getTime() : Number.NaN;
-    if (!occurredAt || !Number.isFinite(occurredMs)) throw new Error(`DT_TARGET_TIMING_EVENT_TIME_INVALID:${eventId}`);
-    if (occurredMs <= cutoffMs) throw new Error(`DT_TARGET_TIMING_EVENT_NOT_AFTER_CUTOFF:${eventId}:${occurredAt}`);
-    return {
+    if (!occurredAt || !Number.isFinite(occurredMs)) {
+      rejectedCandidates.push({ evidenceId: id, reason: 'EVENT_TIME_INVALID' });
+      continue;
+    }
+    if (occurredMs <= cutoffMs) {
+      rejectedCandidates.push({ evidenceId: id, reason: `NOT_AFTER_CUTOFF:${occurredAt}` });
+      continue;
+    }
+    proof.push({
       evidenceId: id,
       eventId,
-      epistemicClass: 'OBSERVED' as const,
+      epistemicClass: 'OBSERVED',
       occurredAt,
       checksum: text(event.checksum),
       hashSelf: text(event.hash_self),
-    };
-  });
+    });
+  }
+
+  if (explicitIds.length && proof.length !== explicitIds.length) {
+    throw new Error(`DT_TARGET_TIMING_EXPLICIT_EVIDENCE_NOT_VERIFIED:${rejectedCandidates.map((item) => `${item.evidenceId}=${item.reason}`).join(',')}`);
+  }
+  if (!proof.length) {
+    throw new Error(`DT_TARGET_TIMING_NO_POST_CUTOFF_OBSERVED_EVIDENCE:${rejectedCandidates.map((item) => `${item.evidenceId}=${item.reason}`).join(',')}`);
+  }
 
   proof.sort((a, b) => a.occurredAt.localeCompare(b.occurredAt));
   const proofBase = {
@@ -132,7 +175,9 @@ export async function verifyRevealedTargetAfterContextCutoff(input: {
     cutoffAt,
     earliestObservedTargetAt: proof[0].occurredAt,
     evidence: proof,
-    boundary: 'Every designated target-observation evidence record is bound to the revealed target, classed OBSERVED, and occurred strictly after the frozen context cutoff.',
+    rejectedCandidates,
+    evidenceSelection: explicitIds.length ? 'EXPLICIT_TARGET_OBSERVATION_IDS' as const : 'AUTO_FROM_CANONICAL_TARGET_REFS' as const,
+    boundary: 'At least one root evidence reference bound to the revealed target resolves to an OBSERVED epistemic event that occurred strictly after the frozen context cutoff. Explicitly designated target-observation IDs must all satisfy the boundary.',
   };
 
   return {


### PR DESCRIPTION
## Scope
Close the temporal validity gap in canonical sealed Decision Transfer experiments. A materialized blind context is only scoreable after reveal when persisted target-bound evidence proves that the observed target occurred strictly after the frozen context cutoff.

## Timing proof
For `CANONICAL_MATERIALIZED` runs the reveal now:
- re-reads the blind run and its `SFI-DT-CONTEXT-MATERIALIZATION-1.0` receipt;
- re-hashes the receipt before trusting its cutoff;
- requires the receipt target trace to match the revealed target;
- resolves target observation evidence from canonical `root_evidence_entries:<uuid>` references already bound to the revealed DecisionTrace, or accepts optional explicitly designated evidence IDs;
- joins those records to `epistemic_events`;
- accepts proof only from events whose canonical epistemic class is exactly `observed` and whose `occurred_at` is strictly greater than `cutoffAt`;
- requires at least one qualifying post-cutoff observed event in automatic mode; explicitly designated target-observation IDs must all qualify;
- records a hashed `SFI-DT-TARGET-TIMING-1.0` proof with event hashes/checksums and earliest observed target time.

## Reveal order
The order is now:
1. validate request;
2. verify frozen selected-context integrity;
3. verify target timing against the materialization receipt and persisted observed evidence;
4. only then perform commitment verification and Decision Transfer scoring.

Thus a canonical experiment cannot score a revealed target whose temporal separation from the frozen context is unsupported.

## Compatibility / boundaries
- manual/advanced `MANUAL_CONTEXT_POOL` runs remain compatible and report timing proof as `NOT_APPLICABLE_MANUAL_CONTEXT`;
- supporting target refs that are pre-cutoff/non-observed do not invalidate automatic mode if another target-bound ref proves the post-cutoff observation; explicit IDs are strict;
- no new table or migration;
- no memory read/write;
- no canon/rule promotion;
- no inference is converted into observed evidence.

## Audit
ROOT audit records timing-required/verified status, proof hash, context cutoff, earliest observed target time and the verified target observation evidence IDs.

## QA
Adds `qa-sfi-decision-transfer-target-timing.ts` to SFI Verify. It enforces receipt integrity, target binding, canonical ROOT evidence resolution, `observed`-only proof, `occurred_at > cutoffAt`, execution before scoring, manual-context compatibility and no memory mutation.