### PR TITLE
CI: run Studio audio gates in parallel with core SFI Verify

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: npm install --no-audit --no-fund
 
+      - name: Verify SFI Verify parallel topology
+        run: npx tsx scripts/qa-sfi-verify-parallelism.ts
+
       - name: Check domain boundaries
         run: npm run check:boundaries
 
@@ -108,18 +111,6 @@ jobs:
             exit "$status"
           fi
 
-      - name: Verify Studio audio smoke path
-        run: npm run qa:studio-audio
-
-      - name: Verify Studio loudness
-        run: npm run qa:sfi-studio-loudness
-
-      - name: Verify Studio rhythm
-        run: npm run qa:sfi-studio-rhythm
-
-      - name: Verify Studio harmony
-        run: npm run qa:sfi-studio-harmony
-
       - name: Typecheck
         id: typecheck
         shell: bash
@@ -141,3 +132,32 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  audio:
+    name: Verify Studio audio gates
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Verify Studio audio smoke path
+        run: npm run qa:studio-audio
+
+      - name: Verify Studio loudness
+        run: npm run qa:sfi-studio-loudness
+
+      - name: Verify Studio rhythm
+        run: npm run qa:sfi-studio-rhythm
+
+      - name: Verify Studio harmony
+        run: npm run qa:sfi-studio-harmony

--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Verify SFI boundaries and build

--- a/scripts/qa-sfi-verify-parallelism.ts
+++ b/scripts/qa-sfi-verify-parallelism.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const workflow = readFileSync('.github/workflows/sfi-verify.yml', 'utf8');
+
+const verifyStart = workflow.indexOf('\n  verify:\n');
+const audioStart = workflow.indexOf('\n  audio:\n');
+assert.ok(verifyStart >= 0, 'SFI Verify core job is missing.');
+assert.ok(audioStart > verifyStart, 'SFI Verify audio job must exist independently after core job.');
+
+const core = workflow.slice(verifyStart, audioStart);
+const audio = workflow.slice(audioStart);
+
+for (const command of [
+  'npm run qa:studio-audio',
+  'npm run qa:sfi-studio-loudness',
+  'npm run qa:sfi-studio-rhythm',
+  'npm run qa:sfi-studio-harmony',
+]) {
+  assert.ok(audio.includes(command), `Audio job lost required gate: ${command}`);
+  assert.ok(!core.includes(command), `Audio gate must not remain serialized in core job: ${command}`);
+}
+
+assert.match(core, /npm run typecheck/, 'Core job must retain TypeScript validation.');
+assert.match(core, /npm run build/, 'Core job must retain production build.');
+assert.match(core, /qa-sfi-decision-transfer-target-timing\.ts/, 'Core job must retain latest Decision Transfer timing gate.');
+assert.match(audio, /name: Verify Studio audio gates/, 'Audio job must remain visibly named, not hidden as an optimization helper.');
+assert.match(core, /npm install --no-audit --no-fund/, 'Core job must install dependencies independently.');
+assert.match(audio, /npm install --no-audit --no-fund/, 'Audio job must install dependencies independently.');
+assert.doesNotMatch(core, /^\s+needs:/m, 'Core verification must not wait on audio.');
+assert.doesNotMatch(audio, /^\s+needs:/m, 'Audio verification must not wait on core.');
+assert.doesNotMatch(audio, /^\s+if:/m, 'Audio gates must run on every SFI Verify invocation; this optimization is parallelism, not skipping.');
+
+console.log(JSON.stringify({
+  ok: true,
+  gate: 'SFI_VERIFY_PARALLEL_TOPOLOGY',
+  coreAndAudioParallel: true,
+  audioGateCount: 4,
+  pathSkipping: false,
+  typecheckRetained: true,
+  buildRetained: true,
+}, null, 2));

--- a/scripts/qa-sfi-verify-parallelism.ts
+++ b/scripts/qa-sfi-verify-parallelism.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 
 const workflow = readFileSync('.github/workflows/sfi-verify.yml', 'utf8');
 
+assert.match(workflow, /\npermissions:\n\s+contents: read\n/, 'SFI Verify must explicitly limit GITHUB_TOKEN to contents: read.');
+
 const verifyStart = workflow.indexOf('\n  verify:\n');
 const audioStart = workflow.indexOf('\n  audio:\n');
 assert.ok(verifyStart >= 0, 'SFI Verify core job is missing.');
@@ -37,6 +39,7 @@ console.log(JSON.stringify({
   coreAndAudioParallel: true,
   audioGateCount: 4,
   pathSkipping: false,
+  tokenPermissions: 'contents:read',
   typecheckRetained: true,
   buildRetained: true,
 }, null, 2));


### PR DESCRIPTION
## Scope
Reduce SFI Verify wall-clock latency without removing, conditionally skipping, or weakening any validation gate.

## Change
`SFI Verify` is split into two independent jobs that start in parallel:

- `Verify SFI boundaries and build`: all existing architecture, MIHM, Cognitive Twin, Decision Transfer, evidence, Studio functional QA, typecheck and production build.
- `Verify Studio audio gates`: the same four audio gates previously serialized before typecheck/build:
  - `qa:studio-audio`
  - `qa:sfi-studio-loudness`
  - `qa:sfi-studio-rhythm`
  - `qa:sfi-studio-harmony`

Both jobs independently checkout, setup Node and install dependencies. There is no `needs:` relationship and no path-based `if:` skipping.

## Safety
Adds `qa-sfi-verify-parallelism.ts`, executed by the core job, which fails if:
- either job disappears;
- any of the four audio gates disappears;
- an audio gate returns to the serialized core job;
- typecheck/build are removed from core;
- the latest Decision Transfer timing gate disappears;
- either job is made dependent on the other;
- the audio job gains a conditional `if:` path skip.

This is a scheduling optimization only. Gate coverage remains unchanged.