### PR TITLE
Freeze SFI Cognitive Spine architecture

### DIFF
--- a/docs/architecture/cognitive-spine/ADR-SFI-CT-SPINE-001.md
+++ b/docs/architecture/cognitive-spine/ADR-SFI-CT-SPINE-001.md
@@ -1,0 +1,158 @@
+# ADR-SFI-CT-SPINE-001 — SFI Cognitive Spine
+
+Status: FROZEN FOR IMPLEMENTATION
+Version: 1.0
+Date: 2026-08-16
+
+## Decision
+
+System Friction Institute (SFI) will treat the institutional Cognitive Twin as a longitudinal cognitive spine, not as a sovereign store, universal middleware, or source of truth.
+
+The Cognitive Spine is defined as a temporal graph of immutable cognitive-state snapshots and explicit transitions derived reproducibly from institutional canonical records and already-assessed epistemic relationships.
+
+`SFI-CT = (S, Δ, L)`
+
+- `S`: immutable cognitive-state snapshots.
+- `Δ`: explicit state-transition records.
+- `L`: lineage across records, epistemic assessments, snapshots, executions, decisions, interventions, and returns.
+
+## Constitutional separations
+
+```text
+RECORD ≠ EVIDENCE
+EVIDENCE / EPISTEMIC ASSESSMENT ≠ COGNITIVE STATE
+COGNITIVE STATE ≠ COGNITIVE EXECUTION
+COGNITIVE EXECUTION ≠ GOVERNANCE
+GOVERNANCE ≠ TRUTH
+ARTIFACT IDENTITY ≠ SEMANTIC IDENTITY
+CT AVAILABLE ≠ CT CONSUMED
+```
+
+## Architectural flow
+
+```text
+WORLD
+  ↓
+OBSERVATION
+  ↓
+CANONICAL EVENT PLANE
+  ↓
+EPISTEMIC RELATION / POLICY PLANE
+  ↓
+COGNITIVE STATE PROJECTOR
+  ↓
+IMMUTABLE COGNITIVE SNAPSHOT
+  ├─ CT AVAILABLE
+  └─ CT CONSUMED? yes / no
+          ↓
+COGNITIVE EXECUTION
+          ↓
+DECISION TRACE
+          ↓
+ROOT
+  governance authority
+          ↓
+INTERVENTION
+          ↓
+WORLD
+          ↓
+OBSERVED RETURN
+          ↓
+CANONICAL EVENT
+          ↓
+NEXT COGNITIVE STATE
+```
+
+## Parts that conform the whole
+
+The architecture is composed of ten distinct parts. They may share infrastructure, but their responsibilities must not collapse.
+
+### 1. Observation adapters
+Capture observations or returns from Field, Studio, WorldSpect, Laboratory, external providers, manual institutional intake, or other governed surfaces. They do not establish truth merely by observing.
+
+### 2. Canonical Event Plane
+Holds admissible institutional records of what was observed, declared, executed, decided, returned, invalidated, or otherwise recorded. A canonical event is not automatically evidence for a claim.
+
+### 3. Epistemic Relation / Policy Plane
+Owns epistemic judgment: classification, admissibility, claim-evidence relationships, independence, invalidation, and policy-versioned epistemic status. This plane exists outside the Cognitive State Projector.
+
+### 4. Cognitive State Projector
+A deterministic operator that reads already-assessed state and performs temporal cutoff, reference resolution, ancestry resolution, deduplication, visibility filtering, deterministic derived summaries, canonical serialization, hashing, and sealing. It must not create new epistemic judgments.
+
+### 5. Cognitive State Snapshot + Temporal Graph
+Stores or materializes immutable `CT-vN` semantic states and transition records. Snapshot identity is semantic and reproducible; artifact metadata may differ across reconstructions.
+
+### 6. Cognitive Execution Consumers
+Runtime, Field, Studio, Laboratory, Atlas, Library, WorldSpect, or future processes may consume a sealed snapshot through an explicit projection profile. Consumption is selective and traceable, never assumed.
+
+### 7. Decision Trace
+Records which snapshot was available, whether it was consumed, the profile used, the execution/model/template context, operations, alternatives, proposal, and provenance needed for reconstruction.
+
+### 8. ROOT Governance Boundary
+ROOT retains institutional governance authority over approvals, freezes, interventions, and reserved actions. ROOT cannot promote epistemic class by decree, manufacture independence, erase lineage, or convert governance into truth.
+
+### 9. Intervention / Return Loop
+Authorized actions re-enter the world. Their observed returns become new canonical records through the normal observation and epistemic process before they can affect a future snapshot.
+
+### 10. Person → Institution Gate + Verification
+Person-level Cognitive Twins can submit candidate contributions, but personal cognitive content never becomes institutional state by inheritance. Cognitive Provenance Reconstruction Tests (CPRT-A and CPRT-B) are required to prove state reconstruction and decision provenance.
+
+## Runtime and deployment decision
+
+The Cognitive Spine is runtime-agnostic. Its semantic core must not depend on Vercel, Next.js request lifecycle, or any single hosted provider.
+
+Required execution topology:
+
+```text
+PURE CORE
+contracts · canonical serialization · projector · hashing · CPRT logic
+        │
+        ├── LOCAL / OFFLINE CLI OR RESEARCH WORKER
+        ├── LONG-RUNNING OWN WORKER / SERVER
+        └── VERCEL THIN API / UI ADAPTERS
+```
+
+Vercel may expose UI, authenticated APIs, lightweight orchestration, and bounded serverless jobs. It is not the constitutional execution substrate of the Spine.
+
+Long-running reconstruction, large historical replays, experimental batches, local-model execution, provider-heavy jobs, or tasks requiring filesystem/GPU/process persistence should be runnable outside Vercel from the same contracts.
+
+The canonical semantic result must be identical regardless of execution substrate when the contractual inputs are identical.
+
+## Experimental isolation
+
+Operational SFI-CT may evolve continuously. A registered experiment must consume a frozen snapshot, projector version, policy version, schema version, profile, source cutoff, and semantic hash.
+
+```text
+SFI-CT LIVE: v144 → v145 → v146 ...
+EXP-001:     CT-v143 🔒
+```
+
+An experiment never silently consumes the live SFI-CT state.
+
+## Person CT boundary
+
+`PERSON_CT ≠ SFI-CT`.
+
+Personal cognitive content enters institutional state only through an explicit intake path with provenance, epistemic assessment, admissibility, evidence relations where applicable, and governance where required.
+
+## Implementation gates
+
+```text
+NO RUNTIME CONSUMPTION UNTIL CPRT-A = PASS.
+NO "SFI COGNITIVE SPINE INTEGRATED" UNTIL CPRT-B = PASS.
+```
+
+## Reopening criteria
+
+This frozen decision may be reopened only for:
+
+1. Contradiction in the contract.
+2. Demonstrated non-reproducibility.
+3. Epistemic leak.
+4. Security or integrity defect.
+
+Implementation convenience is not a reopening criterion.
+
+## Explicit non-decisions
+
+This ADR does not declare SFI-CT conscious, autonomous, sovereign, infallible, or equivalent to a person-level twin. It does not require all SFI operations to consume CT context. It does not require Vercel for state reconstruction or execution. It does not create a new source of truth.

--- a/docs/architecture/cognitive-spine/SFI-CT-CPRT-1.0.md
+++ b/docs/architecture/cognitive-spine/SFI-CT-CPRT-1.0.md
@@ -1,0 +1,193 @@
+# SFI-CT-CPRT-1.0
+
+Status: FROZEN
+Version: 1.0
+Date: 2026-08-16
+
+## Purpose
+
+Define the Cognitive Provenance Reconstruction Tests (CPRT) that determine whether the System Friction Institute (SFI) Cognitive Spine is reproducible and whether its use in cognitive execution is provenance-complete.
+
+Two tests are mandatory and distinct.
+
+---
+
+# CPRT-A — Cognitive State Reconstruction
+
+## Question
+
+Given a historical cognitive-state snapshot, can SFI reconstruct exactly the institutionally admissible information universe and produce the identical semantic snapshot hash?
+
+## Required reconstruction inputs
+
+```text
+source manifest
+source hashes
+source cutoff
+epistemic state / assessed relationships
+projector version
+policy version
+projection profile
+schema version
+canonical serialization rules
+```
+
+## Required assertions
+
+```text
+PROJECTOR VERSION       PASS
+POLICY VERSION          PASS
+SOURCE CUTOFF           PASS
+SOURCE MANIFEST         PASS
+SOURCE HASHES           PASS
+EPISTEMIC STATE         PASS
+PROJECTION PROFILE      PASS
+SCHEMA VERSION          PASS
+CANONICAL SERIALIZATION PASS
+SNAPSHOT RECONSTRUCTED  PASS
+SNAPSHOT HASH MATCH     PASS
+```
+
+## Deterministic equality
+
+```text
+same canonical source manifest
++ same source hashes
++ same source cutoff
++ same epistemic state
++ same projector version
++ same policy version
++ same projection profile
++ same schema version
++ same canonical serialization
+=
+same semantic snapshotHash
+```
+
+## Cross-substrate requirement
+
+At minimum, CPRT-A must be executable without Vercel. The reference implementation must be runnable from a local or persistent-worker context.
+
+A valid cross-substrate test should be able to compare, where infrastructure is available:
+
+```text
+LOCAL RESULT HASH
+WORKER RESULT HASH
+VERCEL-ADAPTER RESULT HASH
+```
+
+All must match for identical contractual inputs.
+
+## Gate
+
+```text
+NO RUNTIME CONSUMPTION UNTIL CPRT-A = PASS.
+```
+
+Passing CPRT-A declares:
+
+`STATE INFRASTRUCTURE READY`
+
+It does not declare the Cognitive Spine integrated into institutional cognition.
+
+---
+
+# CPRT-B — Decision Provenance Reconstruction
+
+## Question
+
+Given a historical cognitive execution or institutional decision path, can SFI reconstruct which cognitive state was available, whether it was consumed, how execution proceeded, what governance occurred, what intervention followed, what return was observed, and how the next state changed?
+
+## Required reconstruction chain
+
+```text
+T-2 projector / policy / schema / profile versions
+T-1 canonical source cutoff
+T0  cognitive snapshot
+T1  observations available
+T2  admissible evidence / epistemic relations
+T3  memory visible
+T4  active hypotheses
+T5  constraints / rules / exceptions / freezes
+T6  cognitive operations executed
+T7  alternatives / rejection conditions
+T8  proposal produced
+T9  ROOT decision
+T10 intervention / action
+T11 observed return
+T12 next-state transition / delta
+```
+
+## Required provenance assertions
+
+```text
+SNAPSHOT AVAILABLE      PASS
+SNAPSHOT CONSUMED FLAG  PASS
+SNAPSHOT HASH           PASS
+PROJECTION PROFILE      PASS
+EXECUTION ID            PASS
+MODEL / SUBSTRATE INFO  PASS when applicable
+PROMPT / TEMPLATE HASH  PASS when applicable
+OPERATIONS              PASS
+ALTERNATIVES            PASS
+PROPOSAL                PASS
+ROOT ACTION             PASS
+INTERVENTION            PASS
+RETURN                  PASS
+TRANSITION              PASS
+ANCESTRY                PASS
+EPISTEMIC CLASSES       PASS
+HASH CHAIN              PASS
+```
+
+## Reproducibility distinction
+
+`STATE REPRODUCIBILITY` is mandatory.
+
+`MODEL OUTPUT REPRODUCIBILITY` is a separate property and depends on the model substrate, model version, parameters, prompt/template, seed support, and execution environment.
+
+CPRT-B must not fail state provenance merely because a probabilistic model cannot reproduce byte-identical text years later, provided the exact historical execution output and its provenance were preserved.
+
+## Failure classification
+
+A failed reconstruction must be classified rather than narratively repaired.
+
+Allowed high-level classes:
+
+- `STATE_FAILURE`
+- `EXECUTION_FAILURE`
+- `GOVERNANCE_CHOICE`
+- `INTERVENTION_FAILURE`
+- `WORLD_MODEL_MISMATCH`
+- `RETURN_OBSERVATION_FAILURE`
+- `PROVENANCE_GAP`
+- `SECURITY_INTEGRITY_FAILURE`
+
+A provenance gap is preserved as debt. It is not filled retrospectively with an inferred story.
+
+## Gate
+
+```text
+NO "SFI COGNITIVE SPINE INTEGRATED" UNTIL CPRT-B = PASS.
+```
+
+Passing CPRT-B declares:
+
+`COGNITIVE SPINE INTEGRATED`
+
+only for the implementation scope actually covered by the test.
+
+---
+
+# Sampling and regression
+
+Once implemented, CPRT should support both:
+
+1. deterministic fixture-based regression tests; and
+2. reconstruction of randomly selected historical decisions with sufficient preserved provenance.
+
+A future continuous audit may sample historical decisions periodically, but the semantic test logic must remain runnable locally and must not depend on Vercel cron infrastructure.
+
+# Non-goals
+
+CPRT does not prove that SFI's beliefs are true, that a model reasoned correctly, or that an intervention was optimal. It proves reconstruction, semantic identity, and provenance completeness within the declared contract.

--- a/docs/architecture/cognitive-spine/SFI-CT-INVARIANTS-1.0.md
+++ b/docs/architecture/cognitive-spine/SFI-CT-INVARIANTS-1.0.md
@@ -1,0 +1,118 @@
+# SFI-CT-INVARIANTS-1.0
+
+Status: FROZEN
+Version: 1.0
+Date: 2026-08-16
+
+These invariants are constitutional constraints for the System Friction Institute (SFI) Cognitive Spine.
+
+## I-01 — The world is not a canonical store
+
+The world, an observation, and an institutional record are distinct objects.
+
+`WORLD ≠ OBSERVATION ≠ CANONICAL RECORD ≠ CT PROJECTION`
+
+## I-02 — Canonical record is not reality
+
+A canonical record represents an admissible institutional record under stated conditions. Its existence does not make its content an ontological truth.
+
+## I-03 — Event is not evidence
+
+A canonical event is not automatically evidence for a claim. Evidence status depends on explicit epistemic assessment and relationships.
+
+## I-04 — Canonical sources exist outside CT
+
+The Cognitive Twin (CT) may reference and project canonical sources. It does not own them and cannot rewrite their historical meaning by projection.
+
+## I-05 — CT state is a projection, not a second canonical store
+
+A cognitive snapshot is a versioned, reproducible projection of already-assessed institutional state under an explicit cutoff, projector, policy, profile, schema, and canonical serialization.
+
+## I-06 — Projector creates no new epistemic judgments
+
+The Cognitive State Projector may select, resolve, deduplicate, summarize deterministically, serialize, hash, and seal. It may not independently decide that a record is observed, verified, independent, invalid, or stronger evidence than previously assessed.
+
+## I-07 — CT consumption is explicit
+
+`CT AVAILABLE ≠ CT CONSUMED`.
+
+A cognitive execution that consumes CT must record the snapshot identifier, semantic hash, projection profile, and consumption flag. Operations may deliberately run blinded or without CT context.
+
+## I-08 — Repetition does not create evidence
+
+Repeated storage, rendering, summarization, or reuse of the same ancestral information does not increase the count of independent evidence.
+
+## I-09 — Derivation does not upgrade epistemic class or independence
+
+A derivative object cannot upgrade the epistemic class, admissibility, support, or independence of its own ancestral sources merely by derivation.
+
+## I-10 — Ancestral self-validation is prohibited
+
+No snapshot or derivative descendant may independently validate its own ancestral claim.
+
+`NO DERIVATIVE DESCENDANT CAN INDEPENDENTLY VALIDATE ITS OWN ANCESTRAL CLAIM.`
+
+## I-11 — ROOT governs action, not truth
+
+ROOT has institutional governance authority. ROOT may authorize, reject, defer, freeze, approve interventions, and apply reserved governance actions. ROOT may not create observational independence, erase provenance, rewrite lineage history, or promote epistemic class by decree.
+
+`GOVERNANCE AUTHORITY ≠ EPISTEMIC AUTHORITY`
+
+## I-12 — Personal state is not institutional state by inheritance
+
+`PERSON_CT ≠ SFI-CT`.
+
+Personal cognitive content must pass through institutional intake and the ordinary epistemic/governance path before it can become an admissible institutional record used by a future SFI-CT snapshot.
+
+`PERSONAL COGNITIVE CONTENT DOES NOT BECOME INSTITUTIONAL STATE BY INHERITANCE.`
+
+## I-13 — Live operational CT is distinct from frozen experimental CT
+
+Operational SFI-CT may advance. A registered experiment must remain bound to its declared frozen snapshot and exact versions/cutoff/profile/hash unless the protocol explicitly permits otherwise.
+
+## I-14 — Artifact identity is distinct from semantic identity
+
+A snapshot or transition may be reconstructed into a new physical artifact at a later time. Audit metadata may differ, but identical contractual semantic content must yield the identical semantic hash.
+
+## I-15 — Same semantic inputs produce the same snapshot hash
+
+The following equality is contractual:
+
+```text
+same canonical source manifest
++ same source hashes
++ same source cutoff
++ same epistemic state
++ same projector version
++ same policy version
++ same projection profile
++ same schema version
++ same canonical serialization
+=
+same semantic snapshotHash
+```
+
+No runtime-specific metadata may alter semantic identity.
+
+## I-16 — Source, epistemic, cognitive, and governance deltas remain distinct
+
+The transition system must preserve four non-equivalent delta classes:
+
+- SOURCE DELTA — available canonical records changed.
+- EPISTEMIC DELTA — admissibility, classification, independence, support, invalidation, or claim relationships changed.
+- COGNITIVE STATE DELTA — the projected institutional cognitive state changed.
+- GOVERNANCE DELTA — a governed decision, authorization, restriction, freeze, or governed canon state changed.
+
+A change in one does not imply a change in the others.
+
+## I-17 — Transition inputs are not causal claims
+
+Transition records may identify admitted inputs and computationally attributable transition inputs. They must not use `causedBy` unless a separate valid causal relation has actually been established.
+
+## I-18 — Execution substrate does not define semantic state
+
+The same contractual inputs must produce the same semantic snapshot whether the projector runs locally, in a persistent worker, or behind a Vercel adapter. Hosting substrate is operational metadata, not part of epistemic or semantic identity.
+
+## Failure rule
+
+Any implementation that violates an invariant must fail explicitly, degrade explicitly, or be rejected. It must never silently reinterpret the invariant.

--- a/docs/architecture/cognitive-spine/SFI-CT-PERSON-INSTITUTION-GATE-1.0.md
+++ b/docs/architecture/cognitive-spine/SFI-CT-PERSON-INSTITUTION-GATE-1.0.md
@@ -1,0 +1,120 @@
+# SFI-CT-PERSON-INSTITUTION-GATE-1.0
+
+Status: FROZEN
+Version: 1.0
+Date: 2026-08-16
+
+## Constitutional rule
+
+`PERSON_CT ≠ SFI-CT`.
+
+**Personal cognitive content does not become institutional state by inheritance.**
+
+A person-level Cognitive Twin may represent regularities, candidate memories, decisions, dispositions, or modelled cognitive structure of a person. Those representations are not automatically positions, knowledge, evidence, policy, or memory of System Friction Institute (SFI).
+
+## Required transition
+
+```text
+PERSON_CT
+   ↓
+candidate contribution
+   ↓
+institutional intake
+   ↓
+provenance capture
+   ↓
+epistemic assessment
+   ↓
+admissibility / evidence relationships
+   ↓
+governance where required
+   ↓
+CANONICAL EVENT / RECORD
+   ↓
+possible future SFI-CT projection
+```
+
+The forbidden shortcut is:
+
+```text
+PERSON_CT REPRESENTS X
+        ↓
+SFI-CT REPRESENTS X
+```
+
+by inheritance alone.
+
+## Candidate contribution contract
+
+A candidate contribution should be representable with fields equivalent to:
+
+```ts
+type PersonCtInstitutionCandidate = {
+  candidateId: string
+  personCtId: string
+  sourceSnapshotId?: string
+  sourceSnapshotHash?: string
+  contentRef: string
+  contributionKind: string
+  provenanceRefs: string[]
+  declaredEpistemicClass?: string
+  submittedAt: string
+  requestedInstitutionalUse?: string
+}
+```
+
+The candidate is an intake object, not an institutional truth claim.
+
+## Intake outcomes
+
+Institutional intake must result in one explicit outcome:
+
+- `REJECTED`
+- `RECORDED_NON_EVIDENTIARY`
+- `ADMITTED_AS_CANDIDATE`
+- `ADMITTED_WITH_EPISTEMIC_RELATION`
+- `BLOCKED_PENDING_EVIDENCE`
+- `REQUIRES_GOVERNANCE`
+
+Exact implementation enums may differ, but the semantics must preserve the distinction between recording a contribution and accepting its content as institutionally supported.
+
+## Founder-specific constraint
+
+Founder provenance does not bypass this gate. A founder-level or ROOT-level person CT does not become SFI institutional state merely because the represented person holds institutional authority.
+
+`GOVERNANCE AUTHORITY ≠ EPISTEMIC INHERITANCE`
+
+## Independence constraint
+
+Multiple derivatives of one person-level representation do not become independent institutional evidence by being copied into multiple surfaces, summaries, runs, or artifacts.
+
+Ancestry must remain resolvable through the gate.
+
+## Governance constraint
+
+ROOT may authorize the institutional use of a candidate where policy permits, but ROOT cannot transform a personal inference into an observation, create source independence, or erase person-level provenance.
+
+## SFI-CT projection constraint
+
+The Cognitive State Projector may only include a person-derived institutional record when that record has already passed through the institutional intake/epistemic path and is visible under the active projection profile.
+
+The projector never performs the gate implicitly.
+
+## Experimental constraint
+
+Person-level Cognitive Twins used as experimental treatment objects must remain isolatable from SFI-CT live state. A frozen experimental person-CT snapshot cannot silently inherit subsequent institutional state.
+
+## Auditability
+
+For every person-derived institutional object, SFI must be able to reconstruct:
+
+```text
+person CT origin
+candidate contribution
+institutional intake outcome
+epistemic assessment
+canonical record, if any
+future snapshot inclusion, if any
+```
+
+If this chain cannot be reconstructed, the object must be marked with a provenance gap rather than narratively assumed to be institutionally valid.

--- a/docs/architecture/cognitive-spine/SFI-CT-PROJECTION-PROFILES-1.0.md
+++ b/docs/architecture/cognitive-spine/SFI-CT-PROJECTION-PROFILES-1.0.md
@@ -1,0 +1,168 @@
+# SFI-CT-PROJECTION-PROFILES-1.0
+
+Status: FROZEN
+Version: 1.0
+Date: 2026-08-16
+
+## Purpose
+
+Define how a sealed System Friction Institute (SFI) cognitive snapshot may be exposed to different operational surfaces without making Cognitive Twin (CT) context mandatory or universal.
+
+`CT AVAILABLE ≠ CT CONSUMED`.
+
+A projection profile controls visibility over an already-produced immutable snapshot. It does not create new epistemic judgments and does not mutate the snapshot.
+
+## Profile contract
+
+Each profile must declare:
+
+```ts
+type CognitiveProjectionProfile = {
+  profileId: string
+  version: string
+  surface: string
+  allowedRefKinds: string[]
+  deniedRefKinds: string[]
+  fieldVisibilityRules: Record<string, unknown>
+  blindedByDefault: boolean
+  purpose: string
+}
+```
+
+A profile is versioned. Historical execution provenance must reference the exact profile version used.
+
+## Baseline profiles
+
+### ROOT_GOVERNANCE_CONTEXT_V1
+
+Purpose: provide governed institutional context for ROOT deliberation while preserving the distinction between epistemic state and governance authority.
+
+May expose, as permitted:
+- active hypotheses and statuses
+- contradictions
+- approved decisions and precedents
+- verification and return debt
+- freezes and blocked questions
+- relevant temporal deltas
+- provenance and uncertainty
+
+Must not allow ROOT to mutate epistemic class through the projection mechanism.
+
+### FIELD_CASE_CONTEXT_V1
+
+Purpose: expose only case-relevant prior institutional context where prior knowledge is operationally justified.
+
+Must support `ctSnapshotConsumed = false` for blinded observation modes.
+
+### FIELD_BLINDED_OBSERVATION_V1
+
+Purpose: explicitly prevent prior CT context from influencing capture when expectation contamination is a methodological risk.
+
+The snapshot may be recorded as available for provenance, but not exposed to the observer/execution.
+
+### STUDIO_OBJECT_CONTEXT_V1
+
+Purpose: expose object-specific temporal history, prior decisions, version relationships, approved relevant memory, and provenance without granting Studio authority over institutional truth.
+
+### LAB_EXPERIMENT_CONTEXT_V1
+
+Purpose: consume only the exact context declared by a protocol. Frozen experiments must bind to an exact snapshot hash, source cutoff, projector version, policy version, schema version, and profile version.
+
+No live CT advancement may silently enter a frozen experimental run.
+
+### LAB_BLINDED_V1
+
+Purpose: execute a protocol arm without CT context while retaining explicit provenance that an operational CT state existed but was not consumed.
+
+### WORLDSPECT_CONTEXT_V1
+
+Purpose: compare external observations/signals with prior institutional state without converting expectation into observation or evidence.
+
+### ATLAS_TEMPORAL_CONTEXT_V1
+
+Purpose: expose lineage, temporal transitions, and graph relationships needed to inspect trajectories. Atlas may represent relationships but does not promote their epistemic class.
+
+### LIBRARY_IMPACT_CONTEXT_V1
+
+Purpose: expose which formalized artifacts, decisions, or records are associated with later cognitive-state transitions. Association is not automatically causality.
+
+### RUNTIME_GENERAL_CONTEXT_V1
+
+Purpose: provide a bounded, shared snapshot-derived context to the Cognitive Runtime. All participating agents in one execution must receive the same sealed semantic cut unless a protocol explicitly declares differentiated visibility.
+
+The Runtime and individual agents must not independently query live CT state mid-execution to enrich the same run.
+
+## Consumption trace
+
+Every execution that can access CT must persist or emit an auditable record equivalent to:
+
+```ts
+type CtConsumptionTrace = {
+  ctSnapshotAvailable: string | null
+  ctSnapshotConsumed: boolean
+  snapshotHash?: string
+  projectionProfile?: string
+  profileVersion?: string
+  consumptionReason?: string
+}
+```
+
+## Selective consumption rule
+
+The Cognitive Spine is universally available where operationally connected and universally traceable, but selectively consumed.
+
+No surface is required to consume CT merely because CT exists.
+
+## Deployment independence
+
+Projection profiles are semantic configuration, not Vercel configuration. The same profile must be usable by:
+
+- local/offline CLI execution
+- a persistent institutional worker/server
+- batch experimental runners
+- local model/Ollama pipelines
+- Vercel API routes
+- UI clients consuming already-produced state
+
+A Vercel route may request or expose a projection. It must not become the only place where projection semantics exist.
+
+## Runtime placement guidance
+
+Recommended execution placement:
+
+```text
+LOCAL / OFFLINE
+- CPRT reconstruction
+- historical replay
+- experiment batches
+- local-model runs
+- development fixtures
+
+PERSISTENT WORKER / OWN SERVER
+- long-running projection/reconstruction
+- scheduled institutional processing
+- high-volume lineage resolution
+- provider-heavy cognitive execution
+
+VERCEL
+- UI
+- authentication / authorization edge
+- thin APIs
+- bounded orchestration
+- status / observability endpoints
+```
+
+This is an operational recommendation, not a semantic distinction. Identical contractual inputs must yield identical semantic outputs regardless of substrate.
+
+## Prohibitions
+
+A profile must not:
+
+- upgrade epistemic class
+- create evidence
+- invent independence
+- alter canonical records
+- mutate the sealed snapshot
+- grant a surface authority it does not otherwise possess
+- silently switch from frozen to live CT state
+- hide whether CT context was consumed

--- a/docs/architecture/cognitive-spine/SFI-CT-SNAPSHOT-CONTRACT-1.0.md
+++ b/docs/architecture/cognitive-spine/SFI-CT-SNAPSHOT-CONTRACT-1.0.md
@@ -1,0 +1,178 @@
+# SFI-CT-SNAPSHOT-CONTRACT-1.0
+
+Status: FROZEN
+Version: 1.0
+Date: 2026-08-16
+
+## Purpose
+
+Define the semantic and audit contract for an immutable System Friction Institute (SFI) Cognitive State Snapshot (`CT-vN`).
+
+A snapshot is not a canonical store and is not the Cognitive Twin as a whole. It is a reproducible computational projection of institutionally admissible state at a declared temporal cutoff.
+
+## Artifact envelope
+
+Operational metadata identifies the physical reconstruction or persisted artifact. It is not part of semantic identity unless explicitly promoted into the semantic payload by a future contract version.
+
+```ts
+type CognitiveSnapshotArtifact = {
+  snapshotId: string
+  createdAt: string
+  reconstructedAt?: string
+  runtimeMetadata?: {
+    runtime?: 'local' | 'worker' | 'vercel' | 'other'
+    runtimeJobId?: string
+    workerId?: string
+    requestId?: string
+  }
+  semanticPayload: CognitiveSnapshotSemanticPayload
+  snapshotHash: string
+}
+```
+
+## Semantic payload
+
+```ts
+type CognitiveSnapshotSemanticPayload = {
+  sourceCutoff: string
+  projectorVersion: string
+  policyVersion: string
+  projectionProfile: string
+  schemaVersion: string
+
+  eventRefs: string[]
+  evidenceRefs: string[]
+  hypothesisRefs: string[]
+  memoryRefs: string[]
+  decisionRefs: string[]
+  contradictionRefs: string[]
+  freezeRefs: string[]
+  questionRefs: string[]
+  personCtRefs: string[]
+
+  operatingMode: unknown
+  temporalState: unknown
+  verificationDebt: unknown
+  derivedState: unknown
+
+  sourceManifest: SourceManifestEntry[]
+  sourceHashes: SourceHashEntry[]
+  epistemicStateRefs: string[]
+  lineageRoot: string
+}
+
+type SourceManifestEntry = {
+  ref: string
+  sourceKind: string
+  sourceVersion?: string
+  sourceHash: string
+}
+
+type SourceHashEntry = {
+  ref: string
+  hash: string
+}
+```
+
+Exact implementation types may narrow `unknown` values, but they must not change the frozen semantics without a schema-version increment.
+
+## Semantic hash
+
+`snapshotHash` is computed from the canonical serialization of `semanticPayload` only.
+
+It MUST NOT depend on:
+
+- `snapshotId`
+- `createdAt`
+- `reconstructedAt`
+- `runtimeJobId`
+- `workerId`
+- `requestId`
+- random UUIDs
+- filesystem paths
+- array insertion order
+- JSON object key order
+- deployment provider
+
+## Canonical serialization
+
+Before hashing, the semantic payload must be canonically serialized.
+
+Required rules:
+
+1. Stable object-key ordering.
+2. Deterministic ordering for all semantically unordered reference arrays.
+3. Deterministic duplicate elimination.
+4. Timestamp normalization to the contractually defined UTC representation.
+5. Stable `null` versus absent-field semantics.
+6. Deterministic numeric representation.
+7. No random identifiers inside semantic content unless the identifier itself is a canonical referenced identity.
+8. No generation-time values inside semantic content unless they are source facts already present in the canonical manifest.
+9. Derived metrics must be deterministic functions of already-assessed state.
+10. Canonical serialization version must be covered by `schemaVersion` or another explicit version field before behavior can change.
+
+## Determinism requirement
+
+```text
+same canonical source manifest
++ same source hashes
++ same source cutoff
++ same epistemic state
++ same projector version
++ same policy version
++ same projection profile
++ same schema version
++ same canonical serialization
+=
+same semantic snapshotHash
+```
+
+This property must hold across local, persistent-worker, and Vercel execution substrates.
+
+## Projector prohibition
+
+The snapshot may contain deterministic summaries of already-assessed state. The projector must not create new epistemic judgments while producing them.
+
+Allowed examples:
+
+```text
+verificationDebt = 12
+activeContradictions = 4
+independentLineageRoots = 7
+```
+
+Forbidden example:
+
+```text
+7 referenced records exist
+therefore claim X becomes VERIFIED
+```
+
+## Availability and consumption
+
+Snapshot existence does not imply consumption.
+
+Any downstream execution that has access to a snapshot must be able to record:
+
+```ts
+{
+  ctSnapshotAvailable: string | null
+  ctSnapshotConsumed: boolean
+  snapshotHash?: string
+  projectionProfile?: string
+}
+```
+
+A blinded execution may deliberately set `ctSnapshotConsumed = false`.
+
+## Immutability
+
+A materialized snapshot is immutable. Corrections to sources or epistemic assessments produce a future snapshot or a reconstruction result under the original cutoff/version contract; they do not mutate the historic semantic payload in place.
+
+## Reconstruction
+
+A future reconstruction may have different artifact metadata but MUST yield the same `snapshotHash` when the semantic inputs and versioned rules are identical.
+
+## Failure behavior
+
+If required source hashes, cutoff semantics, epistemic state, projector version, policy version, profile, schema, or canonical serialization cannot be resolved, snapshot production must fail or emit an explicit non-final/incomplete status. It must not fabricate missing state.

--- a/docs/architecture/cognitive-spine/SFI-CT-TRANSITION-CONTRACT-1.0.md
+++ b/docs/architecture/cognitive-spine/SFI-CT-TRANSITION-CONTRACT-1.0.md
@@ -1,0 +1,154 @@
+# SFI-CT-TRANSITION-CONTRACT-1.0
+
+Status: FROZEN
+Version: 1.0
+Date: 2026-08-16
+
+## Purpose
+
+Define the semantic contract for an explicit transition between two immutable System Friction Institute (SFI) cognitive-state snapshots.
+
+A transition records how the projected institutional state changed under declared admitted inputs and versioned rules. It does not assert causal relations unless an independent causal relation has been established elsewhere.
+
+## Artifact envelope
+
+```ts
+type CognitiveTransitionArtifact = {
+  transitionId: string
+  createdAt: string
+  runtimeMetadata?: {
+    runtime?: 'local' | 'worker' | 'vercel' | 'other'
+    runtimeJobId?: string
+    workerId?: string
+    requestId?: string
+  }
+  semanticPayload: CognitiveTransitionSemanticPayload
+  transitionHash: string
+}
+```
+
+## Semantic transition payload
+
+```ts
+type CognitiveTransitionSemanticPayload = {
+  fromSnapshotHash: string
+  toSnapshotHash: string
+
+  transitionInputs: string[]
+  admittedSourceRefs: string[]
+  admittedEpistemicRefs: string[]
+
+  sourceDelta: DeltaRecord
+  epistemicDelta: DeltaRecord
+  cognitiveStateDelta: DeltaRecord
+  governanceDelta: DeltaRecord
+
+  addedRefs: string[]
+  removedRefs: string[]
+  changedRefs: string[]
+  unchangedCriticalRefs: string[]
+
+  projectorVersion: string
+  policyVersion: string
+  schemaVersion: string
+}
+
+type DeltaRecord = {
+  changed: boolean
+  refs: string[]
+  summary?: string
+}
+```
+
+## Four non-equivalent deltas
+
+### SOURCE DELTA
+Canonical records available to the projection changed.
+
+### EPISTEMIC DELTA
+Admissibility, classification, independence, support, invalidation, or claim-evidence relationships changed.
+
+### COGNITIVE STATE DELTA
+The deterministic institutional projection changed.
+
+### GOVERNANCE DELTA
+A governed decision, authorization, restriction, freeze, or governed canon state changed.
+
+No delta implies another.
+
+Examples:
+
+```text
+SOURCE DELTA          YES
+EPISTEMIC DELTA       NO
+COGNITIVE STATE DELTA NO
+GOVERNANCE DELTA      NO
+```
+
+A new record entered, but it did not change assessed knowledge or the projected state.
+
+```text
+SOURCE DELTA          NO
+EPISTEMIC DELTA       YES
+COGNITIVE STATE DELTA YES
+GOVERNANCE DELTA      NO
+```
+
+No new record arrived, but an existing relation was invalidated, re-assessed, or otherwise changed under the epistemic plane.
+
+## Causality prohibition
+
+The transition contract must use terms such as:
+
+- `transitionInputs`
+- `admittedSourceRefs`
+- `admittedEpistemicRefs`
+- `associatedDelta`
+- `attributableComputationalInputs`
+
+It must not use `causedBy` unless the referenced relation is separately supported as a causal relation.
+
+`ENTERED TRANSITION ≠ CAUSED CHANGE IN THE WORLD`
+
+## Semantic hash
+
+`transitionHash` is computed from canonical serialization of `semanticPayload` only.
+
+It must not depend on artifact metadata such as `transitionId`, `createdAt`, job identifiers, worker identifiers, request identifiers, filesystem location, or deployment substrate.
+
+At minimum, the semantic identity covers:
+
+```text
+fromSnapshotHash
+toSnapshotHash
+transitionInputs
+admittedSourceRefs
+admittedEpistemicRefs
+sourceDelta
+epistemicDelta
+cognitiveStateDelta
+governanceDelta
+addedRefs
+removedRefs
+changedRefs
+unchangedCriticalRefs
+projectorVersion
+policyVersion
+schemaVersion
+```
+
+## Canonical serialization
+
+All semantically unordered arrays are sorted deterministically and deduplicated. Object keys, timestamps, null semantics, and numeric representation follow the same canonical serialization rules as the snapshot contract.
+
+## Immutability
+
+A sealed transition record is immutable. Corrections produce a new transition artifact or a reconstruction under the original contract; they do not silently rewrite a prior semantic transition.
+
+## Reconstruction requirement
+
+Given the same `fromSnapshotHash`, `toSnapshotHash`, admitted inputs, four delta records, versions, schema, and canonical serialization, reconstruction must yield the same `transitionHash` independent of whether it runs locally, on a persistent worker, or behind Vercel.
+
+## Failure behavior
+
+If either snapshot hash cannot be resolved, required admitted inputs are missing, or the four delta classes cannot be represented without collapsing semantics, the transition must fail or be marked explicitly incomplete. Narrative gap-filling is prohibited.


### PR DESCRIPTION
## What changed

Freezes the constitutional architecture for the System Friction Institute Cognitive Spine before any runtime integration.

Adds:

- `ADR-SFI-CT-SPINE-001.md`
- `SFI-CT-INVARIANTS-1.0.md`
- `SFI-CT-SNAPSHOT-CONTRACT-1.0.md`
- `SFI-CT-TRANSITION-CONTRACT-1.0.md`
- `SFI-CT-PROJECTION-PROFILES-1.0.md`
- `SFI-CT-PERSON-INSTITUTION-GATE-1.0.md`
- `SFI-CT-CPRT-1.0.md`

## Architectural decision

The institutional Cognitive Twin is a longitudinal cognitive spine, not a source of truth, sovereign store, or mandatory middleware.

The contract separates record, epistemic assessment, cognitive state, cognitive execution, governance, and truth; defines deterministic immutable snapshots and transitions; preserves explicit `CT AVAILABLE != CT CONSUMED`; separates PERSON_CT from SFI-CT; and introduces CPRT-A/CPRT-B as integration gates.

## Deployment boundary

The semantic core is explicitly runtime-agnostic. It must be runnable locally/offline or on a persistent worker; Vercel is a thin API/UI/orchestration substrate where appropriate, not a constitutional dependency of the Cognitive Spine.

## Scope

Documentation/contract freeze only. No runtime behavior, database schema, API route, cron, Supabase, Vercel deployment, or Cognitive Runtime consumption is changed in this PR.

## Next implementation gates

1. Snapshot schema and deterministic canonical serialization.
2. Deterministic projector.
3. CPRT-A: same semantic inputs -> same snapshot hash.
4. Only after CPRT-A passes, selective runtime consumption.
5. CPRT-B before claiming `SFI COGNITIVE SPINE INTEGRATED`.
