### PR TITLE
Implement SFI Cognitive Spine state infrastructure

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -1,0 +1,36 @@
+name: SFI Cognitive Spine
+
+on:
+  pull_request:
+    paths:
+      - 'src/core/cognitive-spine/**'
+      - 'scripts/cognitive-spine/**'
+      - 'docs/architecture/cognitive-spine/**'
+      - '.github/workflows/sfi-cognitive-spine.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/core/cognitive-spine/**'
+      - 'scripts/cognitive-spine/**'
+      - 'docs/architecture/cognitive-spine/**'
+      - '.github/workflows/sfi-cognitive-spine.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  cprt-a:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Typecheck
+        run: npm run typecheck
+      - name: CPRT-A deterministic state reconstruction
+        run: node --import tsx --test src/core/cognitive-spine/cprt/cprtA.test.ts

--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 jobs:
-  cprt-a:
+  pre-runtime:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -34,3 +34,5 @@ jobs:
         run: npm run typecheck
       - name: CPRT-A deterministic state reconstruction
         run: node --import tsx --test src/core/cognitive-spine/cprt/cprtA.test.ts
+      - name: Pre-runtime boundaries and transition semantics
+        run: node --import tsx --test src/core/cognitive-spine/cprt/preRuntime.test.ts

--- a/scripts/cognitive-spine/reconstruct-snapshot.ts
+++ b/scripts/cognitive-spine/reconstruct-snapshot.ts
@@ -1,0 +1,53 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import type { CognitiveStateProjectionInput } from '../../src/core/cognitive-spine/contracts/snapshot';
+import {
+  materializeCognitiveSnapshot,
+  projectCognitiveState,
+  semanticSnapshotHash,
+} from '../../src/core/cognitive-spine/projector/cognitiveStateProjector';
+
+function argumentValue(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] ?? null : null;
+}
+
+async function main() {
+  const inputPath = argumentValue('--input');
+  if (!inputPath) {
+    throw new Error('Usage: npm run sfi:ct:reconstruct -- --input <projection-input.json> [--snapshot-id <id>]');
+  }
+
+  const absolutePath = resolve(process.cwd(), inputPath);
+  const raw = await readFile(absolutePath, 'utf8');
+  const input = JSON.parse(raw) as CognitiveStateProjectionInput;
+  const semanticPayload = projectCognitiveState(input);
+  const snapshotHash = semanticSnapshotHash(semanticPayload);
+  const snapshotId = argumentValue('--snapshot-id') ?? `CT-${snapshotHash.slice(0, 12)}`;
+  const now = new Date().toISOString();
+  const snapshot = materializeCognitiveSnapshot(input, {
+    snapshotId,
+    createdAt: now,
+    runtimeMetadata: { runner: 'local-cli' },
+  });
+
+  process.stdout.write(`${JSON.stringify({
+    status: 'PASS',
+    input: absolutePath,
+    snapshotId: snapshot.snapshotId,
+    snapshotHash: snapshot.snapshotHash,
+    sourceCutoff: snapshot.semanticPayload.sourceCutoff,
+    projectorVersion: snapshot.semanticPayload.projectorVersion,
+    policyVersion: snapshot.semanticPayload.policyVersion,
+    projectionProfile: snapshot.semanticPayload.projectionProfile,
+    sourceCount: snapshot.semanticPayload.derivedState.sourceCount,
+    semanticPayload: snapshot.semanticPayload,
+  }, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`SFI_COGNITIVE_SPINE_RECONSTRUCTION_FAILED:${message}\n`);
+  process.exitCode = 1;
+});

--- a/src/core/cognitive-spine/contracts/consumptionTrace.ts
+++ b/src/core/cognitive-spine/contracts/consumptionTrace.ts
@@ -9,6 +9,8 @@ export type CognitiveContextConsumptionTrace = {
   consumedSnapshotId: string | null;
   consumedSnapshotHash: string | null;
   projectionProfile: string | null;
+  profileVersion: string | null;
+  consumptionReason: string | null;
   blindedObservation: boolean;
   recordedAt: string;
 };
@@ -21,6 +23,8 @@ export type CognitiveContextConsumptionInput = {
   consumedSnapshotId?: string | null;
   consumedSnapshotHash?: string | null;
   projectionProfile?: string | null;
+  profileVersion?: string | null;
+  consumptionReason?: string | null;
   blindedObservation?: boolean;
   recordedAt: string;
 };

--- a/src/core/cognitive-spine/contracts/consumptionTrace.ts
+++ b/src/core/cognitive-spine/contracts/consumptionTrace.ts
@@ -1,0 +1,26 @@
+export const CT_CONSUMPTION_TRACE_SCHEMA_VERSION = 'SFI-CT-CONTEXT-CONSUMPTION-1.0' as const;
+
+export type CognitiveContextConsumptionTrace = {
+  schemaVersion: typeof CT_CONSUMPTION_TRACE_SCHEMA_VERSION;
+  executionId: string;
+  ctSnapshotAvailable: string | null;
+  ctSnapshotHashAvailable: string | null;
+  ctSnapshotConsumed: boolean;
+  consumedSnapshotId: string | null;
+  consumedSnapshotHash: string | null;
+  projectionProfile: string | null;
+  blindedObservation: boolean;
+  recordedAt: string;
+};
+
+export type CognitiveContextConsumptionInput = {
+  executionId: string;
+  ctSnapshotAvailable?: string | null;
+  ctSnapshotHashAvailable?: string | null;
+  ctSnapshotConsumed: boolean;
+  consumedSnapshotId?: string | null;
+  consumedSnapshotHash?: string | null;
+  projectionProfile?: string | null;
+  blindedObservation?: boolean;
+  recordedAt: string;
+};

--- a/src/core/cognitive-spine/contracts/personInstitutionGate.ts
+++ b/src/core/cognitive-spine/contracts/personInstitutionGate.ts
@@ -1,0 +1,34 @@
+export const PERSON_INSTITUTION_GATE_SCHEMA_VERSION = 'SFI-CT-PERSON-INSTITUTION-GATE-1.0' as const;
+
+export type InstitutionalIntakeDisposition = 'ADMITTED' | 'REJECTED' | 'PENDING';
+
+/**
+ * Input supplied by the institutional intake / epistemic plane.
+ * The gate does not decide admissibility or epistemic class itself.
+ */
+export type PersonCognitiveContributionIntake = {
+  schemaVersion: typeof PERSON_INSTITUTION_GATE_SCHEMA_VERSION;
+  contributionRef: string;
+  personCtRef: string;
+  representationRef: string;
+  contributionHash: string;
+  intakeRef: string;
+  disposition: InstitutionalIntakeDisposition;
+  canonicalRecordRef?: string;
+  epistemicAssessmentRef?: string;
+  governanceRef?: string;
+  assessedAt: string;
+};
+
+export type PersonInstitutionGateResult = {
+  schemaVersion: typeof PERSON_INSTITUTION_GATE_SCHEMA_VERSION;
+  contributionRef: string;
+  personCtRef: string;
+  intakeRef: string;
+  disposition: InstitutionalIntakeDisposition;
+  institutionalStateEligible: boolean;
+  canonicalRecordRef: string | null;
+  epistemicAssessmentRef: string | null;
+  governanceRef: string | null;
+  reasons: string[];
+};

--- a/src/core/cognitive-spine/contracts/snapshot.ts
+++ b/src/core/cognitive-spine/contracts/snapshot.ts
@@ -39,6 +39,7 @@ export type CognitiveSpineSourceRecord = {
   kind: CognitiveSpineRefKind;
   recordedAt: string;
   sourceHash: string;
+  sourceVersion?: string;
   epistemicAssessmentRef?: string;
   epistemicClass?: AssessedEpistemicClass;
   ancestryRoots?: string[];
@@ -57,12 +58,38 @@ export type CognitiveSpineDerivedState = {
   debt: Record<CognitiveDebtType, number>;
 };
 
+export type CognitiveSpineOperatingMode = {
+  modeRef: string | null;
+};
+
+export type CognitiveSpineTemporalState = {
+  sourceCutoff: string;
+  visibleRecordCount: number;
+};
+
+export type CognitiveSpineVerificationDebt = {
+  absolute: number;
+  byType: Record<CognitiveDebtType, number>;
+};
+
+export type CognitiveSpineSourceManifestEntry = {
+  ref: string;
+  sourceKind: CognitiveSpineRefKind;
+  sourceVersion: string | null;
+  sourceHash: string;
+};
+
+export type CognitiveSpineSourceHashEntry = {
+  ref: string;
+  hash: string;
+};
+
 export type CognitiveSpineSemanticPayload = {
-  schemaVersion: typeof COGNITIVE_SPINE_SNAPSHOT_SCHEMA_VERSION;
   sourceCutoff: string;
   projectorVersion: string;
   policyVersion: string;
   projectionProfile: string;
+  schemaVersion: typeof COGNITIVE_SPINE_SNAPSHOT_SCHEMA_VERSION;
 
   eventRefs: string[];
   evidenceRefs: string[];
@@ -74,19 +101,15 @@ export type CognitiveSpineSemanticPayload = {
   questionRefs: string[];
   personCtRefs: string[];
 
-  epistemicAssessmentRefs: string[];
-  sourceManifest: Array<{
-    ref: string;
-    kind: CognitiveSpineRefKind;
-    sourceHash: string;
-    epistemicAssessmentRef: string | null;
-    epistemicClass: AssessedEpistemicClass | null;
-    ancestryRoots: string[];
-    invalidated: boolean;
-    debtType: CognitiveDebtType | null;
-  }>;
+  operatingMode: CognitiveSpineOperatingMode;
+  temporalState: CognitiveSpineTemporalState;
+  verificationDebt: CognitiveSpineVerificationDebt;
   derivedState: CognitiveSpineDerivedState;
-  lineageRoots: string[];
+
+  sourceManifest: CognitiveSpineSourceManifestEntry[];
+  sourceHashes: CognitiveSpineSourceHashEntry[];
+  epistemicStateRefs: string[];
+  lineageRoot: string;
 };
 
 /**
@@ -109,6 +132,7 @@ export type CognitiveStateProjectionInput = {
   projectorVersion: string;
   policyVersion: string;
   projectionProfile: string;
+  operatingModeRef?: string | null;
   records: CognitiveSpineSourceRecord[];
 };
 

--- a/src/core/cognitive-spine/contracts/snapshot.ts
+++ b/src/core/cognitive-spine/contracts/snapshot.ts
@@ -1,0 +1,120 @@
+export const COGNITIVE_SPINE_SNAPSHOT_SCHEMA_VERSION = 'SFI-CT-SNAPSHOT-1.0' as const;
+
+export type CognitiveSpineRefKind =
+  | 'EVENT'
+  | 'EVIDENCE'
+  | 'HYPOTHESIS'
+  | 'MEMORY'
+  | 'DECISION'
+  | 'CONTRADICTION'
+  | 'FREEZE'
+  | 'QUESTION'
+  | 'PERSON_CT';
+
+export type AssessedEpistemicClass =
+  | 'OBSERVED'
+  | 'DECLARED'
+  | 'VERIFIED_CONTRAST'
+  | 'DERIVED'
+  | 'INFERRED'
+  | 'SIMULATED'
+  | 'PROJECTED'
+  | 'INVALIDATED';
+
+export type CognitiveDebtType =
+  | 'VERIFICATION'
+  | 'CONTRADICTION'
+  | 'RETURN'
+  | 'PROVENANCE'
+  | 'EXPERIMENTAL'
+  | 'STALE_KNOWLEDGE';
+
+/**
+ * A source record is already canonicalized and, where epistemically relevant,
+ * already assessed before it reaches the projector. The projector must not
+ * create or upgrade epistemic judgments.
+ */
+export type CognitiveSpineSourceRecord = {
+  ref: string;
+  kind: CognitiveSpineRefKind;
+  recordedAt: string;
+  sourceHash: string;
+  epistemicAssessmentRef?: string;
+  epistemicClass?: AssessedEpistemicClass;
+  ancestryRoots?: string[];
+  visibilityProfiles?: string[];
+  invalidated?: boolean;
+  debtType?: CognitiveDebtType;
+};
+
+export type CognitiveSpineDerivedState = {
+  sourceCount: number;
+  assessedSourceCount: number;
+  invalidatedSourceCount: number;
+  independentLineageRootCount: number;
+  contradictionCount: number;
+  questionCount: number;
+  debt: Record<CognitiveDebtType, number>;
+};
+
+export type CognitiveSpineSemanticPayload = {
+  schemaVersion: typeof COGNITIVE_SPINE_SNAPSHOT_SCHEMA_VERSION;
+  sourceCutoff: string;
+  projectorVersion: string;
+  policyVersion: string;
+  projectionProfile: string;
+
+  eventRefs: string[];
+  evidenceRefs: string[];
+  hypothesisRefs: string[];
+  memoryRefs: string[];
+  decisionRefs: string[];
+  contradictionRefs: string[];
+  freezeRefs: string[];
+  questionRefs: string[];
+  personCtRefs: string[];
+
+  epistemicAssessmentRefs: string[];
+  sourceManifest: Array<{
+    ref: string;
+    kind: CognitiveSpineRefKind;
+    sourceHash: string;
+    epistemicAssessmentRef: string | null;
+    epistemicClass: AssessedEpistemicClass | null;
+    ancestryRoots: string[];
+    invalidated: boolean;
+    debtType: CognitiveDebtType | null;
+  }>;
+  derivedState: CognitiveSpineDerivedState;
+  lineageRoots: string[];
+};
+
+/**
+ * artifact identity != semantic identity
+ *
+ * snapshotId / timestamps / runtimeMetadata identify a material artifact.
+ * snapshotHash identifies only semanticPayload.
+ */
+export type CognitiveSpineSnapshot = {
+  snapshotId: string;
+  createdAt: string;
+  reconstructedAt?: string;
+  semanticPayload: CognitiveSpineSemanticPayload;
+  snapshotHash: string;
+  runtimeMetadata?: Record<string, string | number | boolean | null>;
+};
+
+export type CognitiveStateProjectionInput = {
+  sourceCutoff: string;
+  projectorVersion: string;
+  policyVersion: string;
+  projectionProfile: string;
+  records: CognitiveSpineSourceRecord[];
+};
+
+export type CognitiveSnapshotEnvelopeInput = {
+  snapshotId: string;
+  createdAt: string;
+  reconstructedAt?: string;
+  runtimeMetadata?: Record<string, string | number | boolean | null>;
+};

--- a/src/core/cognitive-spine/contracts/transition.ts
+++ b/src/core/cognitive-spine/contracts/transition.ts
@@ -1,0 +1,47 @@
+export const COGNITIVE_SPINE_TRANSITION_SCHEMA_VERSION = 'SFI-CT-TRANSITION-1.0' as const;
+
+export type CognitiveSpineDeltaSummary = {
+  changed: boolean;
+  addedRefs: string[];
+  removedRefs: string[];
+  changedRefs: string[];
+  unchangedCriticalRefs: string[];
+};
+
+export type CognitiveSpineSemanticTransitionPayload = {
+  schemaVersion: typeof COGNITIVE_SPINE_TRANSITION_SCHEMA_VERSION;
+  fromSnapshotHash: string;
+  toSnapshotHash: string;
+  transitionInputs: string[];
+  admittedEpistemicRefs: string[];
+
+  sourceDelta: CognitiveSpineDeltaSummary;
+  epistemicDelta: CognitiveSpineDeltaSummary;
+  cognitiveStateDelta: CognitiveSpineDeltaSummary;
+  governanceDelta: CognitiveSpineDeltaSummary;
+
+  projectorVersion: string;
+  policyVersion: string;
+  snapshotSchemaVersion: string;
+};
+
+/**
+ * The transition envelope records artifact execution metadata. transitionHash
+ * covers semanticPayload only. No `causedBy` field exists by design.
+ */
+export type CognitiveSpineTransition = {
+  transitionId: string;
+  createdAt: string;
+  semanticPayload: CognitiveSpineSemanticTransitionPayload;
+  transitionHash: string;
+  runtimeMetadata?: Record<string, string | number | boolean | null>;
+};
+
+export type CognitiveSpineTransitionInput = {
+  transitionId: string;
+  createdAt: string;
+  transitionInputs: string[];
+  admittedEpistemicRefs: string[];
+  unchangedCriticalRefs?: string[];
+  runtimeMetadata?: Record<string, string | number | boolean | null>;
+};

--- a/src/core/cognitive-spine/cprt/cprtA.test.ts
+++ b/src/core/cognitive-spine/cprt/cprtA.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  materializeCognitiveSnapshot,
+  projectCognitiveState,
+  semanticSnapshotHash,
+} from '../projector/cognitiveStateProjector';
+import {
+  CPRT_A_PROFILE,
+  cprtAProjectionInputA,
+  cprtAProjectionInputB,
+} from './fixture';
+
+test('CPRT-A: semantically identical inputs produce the same snapshot hash', () => {
+  const leftPayload = projectCognitiveState(cprtAProjectionInputA());
+  const rightPayload = projectCognitiveState(cprtAProjectionInputB());
+
+  assert.deepEqual(leftPayload, rightPayload);
+  assert.equal(semanticSnapshotHash(leftPayload), semanticSnapshotHash(rightPayload));
+  assert.match(semanticSnapshotHash(leftPayload), /^[a-f0-9]{64}$/);
+});
+
+test('CPRT-A: artifact identity does not alter semantic identity', () => {
+  const input = cprtAProjectionInputA();
+  const left = materializeCognitiveSnapshot(input, {
+    snapshotId: 'CT-fixture-left',
+    createdAt: '2026-08-16T07:40:00.000Z',
+    runtimeMetadata: { runner: 'local' },
+  });
+  const right = materializeCognitiveSnapshot(input, {
+    snapshotId: 'CT-fixture-right',
+    createdAt: '2031-04-02T10:11:12.000Z',
+    reconstructedAt: '2031-04-02T10:11:12.000Z',
+    runtimeMetadata: { runner: 'future-worker', requestId: 'different' },
+  });
+
+  assert.notEqual(left.snapshotId, right.snapshotId);
+  assert.equal(left.snapshotHash, right.snapshotHash);
+  assert.deepEqual(left.semanticPayload, right.semanticPayload);
+});
+
+test('CPRT-A: temporal cutoff and visibility profile are applied deterministically', () => {
+  const payload = projectCognitiveState(cprtAProjectionInputA());
+
+  assert.deepEqual(payload.eventRefs, ['EV-001']);
+  assert.deepEqual(payload.evidenceRefs, ['EVID-001']);
+  assert.deepEqual(payload.hypothesisRefs, ['H-001']);
+  assert.deepEqual(payload.questionRefs, ['Q-001']);
+  assert.equal(payload.projectionProfile, CPRT_A_PROFILE);
+  assert.equal(payload.derivedState.sourceCount, 4);
+  assert.equal(payload.derivedState.debt.VERIFICATION, 1);
+  assert.equal(payload.derivedState.independentLineageRootCount, 3);
+});
+
+test('CPRT-A: evidence must arrive with prior epistemic assessment', () => {
+  const input = cprtAProjectionInputA();
+  input.records.push({
+    ref: 'EVID-UNASSESSED',
+    kind: 'EVIDENCE',
+    recordedAt: '2026-08-16T07:20:00.000Z',
+    sourceHash: 'f'.repeat(64),
+  });
+
+  assert.throws(
+    () => projectCognitiveState(input),
+    /COGNITIVE_SPINE_UNASSESSED_EVIDENCE:EVID-UNASSESSED/,
+  );
+});
+
+test('CPRT-A: semantic policy or projector changes alter semantic identity', () => {
+  const baseline = cprtAProjectionInputA();
+  const changedPolicy = { ...cprtAProjectionInputA(), policyVersion: 'E2' };
+  const changedProjector = { ...cprtAProjectionInputA(), projectorVersion: 'P2' };
+
+  const baselineHash = semanticSnapshotHash(projectCognitiveState(baseline));
+  assert.notEqual(baselineHash, semanticSnapshotHash(projectCognitiveState(changedPolicy)));
+  assert.notEqual(baselineHash, semanticSnapshotHash(projectCognitiveState(changedProjector)));
+});

--- a/src/core/cognitive-spine/cprt/cprtA.test.ts
+++ b/src/core/cognitive-spine/cprt/cprtA.test.ts
@@ -12,7 +12,8 @@ import {
   cprtAProjectionInputB,
 } from './fixture';
 
-const CPRT_A_EXPECTED_HASH = 'da6ca1abf93679b429c5f44d5d0e524a0fbd3ec02ee081e48dca9fd09d1c9b22';
+const CPRT_A_EXPECTED_HASH = '8c10f1f8b70833b2e4584a53684248e213e955bcff46003255eefdfd49be66fb';
+const CPRT_A_EXPECTED_LINEAGE_ROOT = '64586008fa8de2ea17d541d52f48eb2a2d2fff5d0b32bdeb4af1e53f56e83302';
 
 test('CPRT-A: semantically identical inputs produce the same snapshot hash', () => {
   const leftPayload = projectCognitiveState(cprtAProjectionInputA());
@@ -45,17 +46,23 @@ test('CPRT-A: artifact identity does not alter semantic identity', () => {
   assert.deepEqual(left.semanticPayload, right.semanticPayload);
 });
 
-test('CPRT-A: temporal cutoff and visibility profile are applied deterministically', () => {
+test('CPRT-A: frozen semantic payload materializes every contract field', () => {
   const payload = projectCognitiveState(cprtAProjectionInputA());
 
   assert.deepEqual(payload.eventRefs, ['EV-001']);
   assert.deepEqual(payload.evidenceRefs, ['EVID-001']);
   assert.deepEqual(payload.hypothesisRefs, ['H-001']);
   assert.deepEqual(payload.questionRefs, ['Q-001']);
+  assert.deepEqual(payload.epistemicStateRefs, ['EA-001', 'EA-002', 'EA-003']);
   assert.equal(payload.projectionProfile, CPRT_A_PROFILE);
+  assert.equal(payload.temporalState.visibleRecordCount, 4);
+  assert.equal(payload.verificationDebt.absolute, 1);
   assert.equal(payload.derivedState.sourceCount, 4);
   assert.equal(payload.derivedState.debt.VERIFICATION, 1);
   assert.equal(payload.derivedState.independentLineageRootCount, 3);
+  assert.equal(payload.sourceManifest.length, 4);
+  assert.equal(payload.sourceHashes.length, 4);
+  assert.equal(payload.lineageRoot, CPRT_A_EXPECTED_LINEAGE_ROOT);
 });
 
 test('CPRT-A: evidence must arrive with prior epistemic assessment', () => {
@@ -73,12 +80,14 @@ test('CPRT-A: evidence must arrive with prior epistemic assessment', () => {
   );
 });
 
-test('CPRT-A: semantic policy or projector changes alter semantic identity', () => {
+test('CPRT-A: semantic policy, projector or operating-mode ref changes semantic identity', () => {
   const baseline = cprtAProjectionInputA();
   const changedPolicy = { ...cprtAProjectionInputA(), policyVersion: 'E2' };
   const changedProjector = { ...cprtAProjectionInputA(), projectorVersion: 'P2' };
+  const changedOperatingMode = { ...cprtAProjectionInputA(), operatingModeRef: 'MODE-001' };
 
   const baselineHash = semanticSnapshotHash(projectCognitiveState(baseline));
   assert.notEqual(baselineHash, semanticSnapshotHash(projectCognitiveState(changedPolicy)));
   assert.notEqual(baselineHash, semanticSnapshotHash(projectCognitiveState(changedProjector)));
+  assert.notEqual(baselineHash, semanticSnapshotHash(projectCognitiveState(changedOperatingMode)));
 });

--- a/src/core/cognitive-spine/cprt/cprtA.test.ts
+++ b/src/core/cognitive-spine/cprt/cprtA.test.ts
@@ -12,13 +12,17 @@ import {
   cprtAProjectionInputB,
 } from './fixture';
 
+const CPRT_A_EXPECTED_HASH = 'da6ca1abf93679b429c5f44d5d0e524a0fbd3ec02ee081e48dca9fd09d1c9b22';
+
 test('CPRT-A: semantically identical inputs produce the same snapshot hash', () => {
   const leftPayload = projectCognitiveState(cprtAProjectionInputA());
   const rightPayload = projectCognitiveState(cprtAProjectionInputB());
+  const leftHash = semanticSnapshotHash(leftPayload);
+  const rightHash = semanticSnapshotHash(rightPayload);
 
   assert.deepEqual(leftPayload, rightPayload);
-  assert.equal(semanticSnapshotHash(leftPayload), semanticSnapshotHash(rightPayload));
-  assert.match(semanticSnapshotHash(leftPayload), /^[a-f0-9]{64}$/);
+  assert.equal(leftHash, rightHash);
+  assert.equal(leftHash, CPRT_A_EXPECTED_HASH);
 });
 
 test('CPRT-A: artifact identity does not alter semantic identity', () => {
@@ -37,6 +41,7 @@ test('CPRT-A: artifact identity does not alter semantic identity', () => {
 
   assert.notEqual(left.snapshotId, right.snapshotId);
   assert.equal(left.snapshotHash, right.snapshotHash);
+  assert.equal(left.snapshotHash, CPRT_A_EXPECTED_HASH);
   assert.deepEqual(left.semanticPayload, right.semanticPayload);
 });
 

--- a/src/core/cognitive-spine/cprt/fixture.ts
+++ b/src/core/cognitive-spine/cprt/fixture.ts
@@ -1,0 +1,93 @@
+import type { CognitiveStateProjectionInput } from '../contracts/snapshot';
+
+const A = 'a'.repeat(64);
+const B = 'b'.repeat(64);
+const C = 'c'.repeat(64);
+const D = 'd'.repeat(64);
+const E = 'e'.repeat(64);
+
+export const CPRT_A_PROFILE = 'CPRT_A_V1';
+
+export function cprtAProjectionInputA(): CognitiveStateProjectionInput {
+  return {
+    sourceCutoff: '2026-08-16T07:30:00.000Z',
+    projectorVersion: 'P1',
+    policyVersion: 'E1',
+    projectionProfile: CPRT_A_PROFILE,
+    records: [
+      {
+        ref: 'EVID-001',
+        kind: 'EVIDENCE',
+        recordedAt: '2026-08-16T07:00:00.000Z',
+        sourceHash: A,
+        epistemicAssessmentRef: 'EA-001',
+        epistemicClass: 'OBSERVED',
+        ancestryRoots: ['ROOT-B', 'ROOT-A', 'ROOT-A'],
+        visibilityProfiles: [CPRT_A_PROFILE],
+      },
+      {
+        ref: 'EV-001',
+        kind: 'EVENT',
+        recordedAt: '2026-08-16T06:59:00.000Z',
+        sourceHash: B,
+        ancestryRoots: ['ROOT-A'],
+      },
+      {
+        ref: 'H-001',
+        kind: 'HYPOTHESIS',
+        recordedAt: '2026-08-16T07:05:00.000Z',
+        sourceHash: C,
+        epistemicAssessmentRef: 'EA-002',
+        epistemicClass: 'INFERRED',
+        ancestryRoots: ['ROOT-A'],
+      },
+      {
+        ref: 'Q-001',
+        kind: 'QUESTION',
+        recordedAt: '2026-08-16T07:06:00.000Z',
+        sourceHash: D,
+        epistemicAssessmentRef: 'EA-003',
+        epistemicClass: 'DERIVED',
+        ancestryRoots: ['ROOT-C'],
+        debtType: 'VERIFICATION',
+      },
+      {
+        ref: 'EV-FUTURE',
+        kind: 'EVENT',
+        recordedAt: '2026-08-16T07:31:00.000Z',
+        sourceHash: E,
+      },
+      {
+        ref: 'EV-HIDDEN',
+        kind: 'EVENT',
+        recordedAt: '2026-08-16T07:10:00.000Z',
+        sourceHash: E,
+        visibilityProfiles: ['OTHER_PROFILE'],
+      },
+    ],
+  };
+}
+
+export function cprtAProjectionInputB(): CognitiveStateProjectionInput {
+  const base = cprtAProjectionInputA();
+  const evidence = base.records.find((record) => record.ref === 'EVID-001');
+  if (!evidence) throw new Error('CPRT_A_FIXTURE_MISSING_EVIDENCE');
+
+  return {
+    ...base,
+    sourceCutoff: '2026-08-16T01:30:00-06:00',
+    records: [
+      ...base.records.slice().reverse().map((record) => record.ref === 'EVID-001'
+        ? {
+            ...record,
+            recordedAt: '2026-08-16T01:00:00-06:00',
+            ancestryRoots: ['ROOT-A', 'ROOT-B'],
+          }
+        : record),
+      {
+        ...evidence,
+        ancestryRoots: ['ROOT-B', 'ROOT-A', 'ROOT-A'],
+      },
+    ],
+  };
+}

--- a/src/core/cognitive-spine/cprt/preRuntime.test.ts
+++ b/src/core/cognitive-spine/cprt/preRuntime.test.ts
@@ -64,6 +64,27 @@ test('CT AVAILABLE is distinct from CT CONSUMED', () => {
   assert.equal(trace.ctSnapshotAvailable, 'CT-v145');
   assert.equal(trace.ctSnapshotConsumed, false);
   assert.equal(trace.consumedSnapshotId, null);
+  assert.equal(trace.profileVersion, null);
+});
+
+test('consumed CT context records profile version and reason', () => {
+  const trace = buildCognitiveContextConsumptionTrace({
+    executionId: 'RUN-002',
+    ctSnapshotAvailable: 'CT-v145',
+    ctSnapshotHashAvailable: 'a'.repeat(64),
+    ctSnapshotConsumed: true,
+    consumedSnapshotId: 'CT-v145',
+    consumedSnapshotHash: 'a'.repeat(64),
+    projectionProfile: 'RUNTIME_GENERAL_CONTEXT_V1',
+    profileVersion: '1.0',
+    consumptionReason: 'bounded institutional runtime context',
+    recordedAt: '2026-08-16T07:32:30.000Z',
+  });
+
+  assert.equal(trace.ctSnapshotConsumed, true);
+  assert.equal(trace.projectionProfile, 'RUNTIME_GENERAL_CONTEXT_V1');
+  assert.equal(trace.profileVersion, '1.0');
+  assert.equal(trace.consumptionReason, 'bounded institutional runtime context');
 });
 
 test('blinded observation cannot consume CT context', () => {
@@ -75,6 +96,8 @@ test('blinded observation cannot consume CT context', () => {
     consumedSnapshotId: 'CT-v145',
     consumedSnapshotHash: 'a'.repeat(64),
     projectionProfile: 'FIELD_CASE_CONTEXT_V2',
+    profileVersion: '2.0',
+    consumptionReason: 'invalid blinded consumption attempt',
     blindedObservation: true,
     recordedAt: '2026-08-16T07:33:00.000Z',
   }), /COGNITIVE_SPINE_BLINDED_OBSERVATION_CANNOT_CONSUME_CT/);

--- a/src/core/cognitive-spine/cprt/preRuntime.test.ts
+++ b/src/core/cognitive-spine/cprt/preRuntime.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { PERSON_INSTITUTION_GATE_SCHEMA_VERSION } from '../contracts/personInstitutionGate';
+import { evaluatePersonInstitutionGate } from '../gates/personInstitutionGate';
+import { materializeCognitiveSnapshot } from '../projector/cognitiveStateProjector';
+import { buildCognitiveContextConsumptionTrace } from '../trace/consumptionTrace';
+import { buildCognitiveSpineTransition } from '../transitions/buildTransition';
+import { cprtAProjectionInputA } from './fixture';
+
+function baseSnapshot() {
+  return materializeCognitiveSnapshot(cprtAProjectionInputA(), {
+    snapshotId: 'CT-v1',
+    createdAt: '2026-08-16T07:40:00.000Z',
+  });
+}
+
+test('PERSON_CT content is not institutionally eligible by inheritance', () => {
+  const pending = evaluatePersonInstitutionGate({
+    schemaVersion: PERSON_INSTITUTION_GATE_SCHEMA_VERSION,
+    contributionRef: 'PC-001',
+    personCtRef: 'CT-A01',
+    representationRef: 'REP-001',
+    contributionHash: 'a'.repeat(64),
+    intakeRef: 'INTAKE-001',
+    disposition: 'PENDING',
+    assessedAt: '2026-08-16T07:30:00.000Z',
+  });
+
+  assert.equal(pending.institutionalStateEligible, false);
+  assert.ok(pending.reasons.includes('intake_pending'));
+  assert.ok(pending.reasons.includes('canonical_record_missing'));
+  assert.ok(pending.reasons.includes('epistemic_assessment_missing'));
+});
+
+test('PERSON_CT contribution becomes eligible only after admitted canonical intake and assessment', () => {
+  const admitted = evaluatePersonInstitutionGate({
+    schemaVersion: PERSON_INSTITUTION_GATE_SCHEMA_VERSION,
+    contributionRef: 'PC-001',
+    personCtRef: 'CT-A01',
+    representationRef: 'REP-001',
+    contributionHash: 'a'.repeat(64),
+    intakeRef: 'INTAKE-002',
+    disposition: 'ADMITTED',
+    canonicalRecordRef: 'EV-PERSON-001',
+    epistemicAssessmentRef: 'EA-PERSON-001',
+    governanceRef: 'ROOT-D-001',
+    assessedAt: '2026-08-16T07:31:00.000Z',
+  });
+
+  assert.equal(admitted.institutionalStateEligible, true);
+  assert.deepEqual(admitted.reasons, []);
+});
+
+test('CT AVAILABLE is distinct from CT CONSUMED', () => {
+  const trace = buildCognitiveContextConsumptionTrace({
+    executionId: 'RUN-001',
+    ctSnapshotAvailable: 'CT-v145',
+    ctSnapshotHashAvailable: 'a'.repeat(64),
+    ctSnapshotConsumed: false,
+    recordedAt: '2026-08-16T07:32:00.000Z',
+  });
+
+  assert.equal(trace.ctSnapshotAvailable, 'CT-v145');
+  assert.equal(trace.ctSnapshotConsumed, false);
+  assert.equal(trace.consumedSnapshotId, null);
+});
+
+test('blinded observation cannot consume CT context', () => {
+  assert.throws(() => buildCognitiveContextConsumptionTrace({
+    executionId: 'RUN-BLIND-001',
+    ctSnapshotAvailable: 'CT-v145',
+    ctSnapshotHashAvailable: 'a'.repeat(64),
+    ctSnapshotConsumed: true,
+    consumedSnapshotId: 'CT-v145',
+    consumedSnapshotHash: 'a'.repeat(64),
+    projectionProfile: 'FIELD_CASE_CONTEXT_V2',
+    blindedObservation: true,
+    recordedAt: '2026-08-16T07:33:00.000Z',
+  }), /COGNITIVE_SPINE_BLINDED_OBSERVATION_CANNOT_CONSUME_CT/);
+});
+
+test('epistemic delta can occur without source delta', () => {
+  const from = baseSnapshot();
+  const nextInput = cprtAProjectionInputA();
+  nextInput.records = nextInput.records.map((record) => record.ref === 'H-001'
+    ? { ...record, epistemicClass: 'INVALIDATED' as const, invalidated: true }
+    : record);
+  const to = materializeCognitiveSnapshot(nextInput, {
+    snapshotId: 'CT-v2',
+    createdAt: '2026-08-16T07:41:00.000Z',
+  });
+
+  const transition = buildCognitiveSpineTransition(from, to, {
+    transitionId: 'TR-001',
+    createdAt: '2026-08-16T07:42:00.000Z',
+    transitionInputs: ['EA-INVALIDATE-H-001'],
+    admittedEpistemicRefs: ['EA-INVALIDATE-H-001'],
+    unchangedCriticalRefs: ['EVID-001'],
+  });
+
+  assert.equal(transition.semanticPayload.sourceDelta.changed, false);
+  assert.equal(transition.semanticPayload.epistemicDelta.changed, true);
+  assert.deepEqual(transition.semanticPayload.epistemicDelta.changedRefs, ['H-001']);
+  assert.equal(transition.semanticPayload.cognitiveStateDelta.changed, true);
+  assert.equal(transition.semanticPayload.governanceDelta.changed, false);
+});
+
+test('transition semantic hash is independent from transition artifact metadata', () => {
+  const from = baseSnapshot();
+  const nextInput = cprtAProjectionInputA();
+  nextInput.records.push({
+    ref: 'ROOT-D-002',
+    kind: 'DECISION',
+    recordedAt: '2026-08-16T07:20:00.000Z',
+    sourceHash: '9'.repeat(64),
+    epistemicAssessmentRef: 'EA-ROOT-D-002',
+    epistemicClass: 'DECLARED',
+  });
+  const to = materializeCognitiveSnapshot(nextInput, {
+    snapshotId: 'CT-v2-governance',
+    createdAt: '2026-08-16T07:41:00.000Z',
+  });
+
+  const left = buildCognitiveSpineTransition(from, to, {
+    transitionId: 'TR-left',
+    createdAt: '2026-08-16T07:42:00.000Z',
+    transitionInputs: ['ROOT-D-002'],
+    admittedEpistemicRefs: ['EA-ROOT-D-002'],
+    runtimeMetadata: { runner: 'local' },
+  });
+  const right = buildCognitiveSpineTransition(from, to, {
+    transitionId: 'TR-right',
+    createdAt: '2031-04-02T10:11:12.000Z',
+    transitionInputs: ['ROOT-D-002'],
+    admittedEpistemicRefs: ['EA-ROOT-D-002'],
+    runtimeMetadata: { runner: 'worker' },
+  });
+
+  assert.equal(left.semanticPayload.sourceDelta.changed, true);
+  assert.equal(left.semanticPayload.governanceDelta.changed, true);
+  assert.equal(left.transitionHash, right.transitionHash);
+});

--- a/src/core/cognitive-spine/cprt/preRuntime.test.ts
+++ b/src/core/cognitive-spine/cprt/preRuntime.test.ts
@@ -80,11 +80,16 @@ test('blinded observation cannot consume CT context', () => {
   }), /COGNITIVE_SPINE_BLINDED_OBSERVATION_CANNOT_CONSUME_CT/);
 });
 
-test('epistemic delta can occur without source delta', () => {
+test('epistemic delta can occur without source delta when assessment identity changes', () => {
   const from = baseSnapshot();
   const nextInput = cprtAProjectionInputA();
   nextInput.records = nextInput.records.map((record) => record.ref === 'H-001'
-    ? { ...record, epistemicClass: 'INVALIDATED' as const, invalidated: true }
+    ? {
+        ...record,
+        epistemicAssessmentRef: 'EA-INVALIDATE-H-001',
+        epistemicClass: 'INVALIDATED' as const,
+        invalidated: true,
+      }
     : record);
   const to = materializeCognitiveSnapshot(nextInput, {
     snapshotId: 'CT-v2',
@@ -101,7 +106,8 @@ test('epistemic delta can occur without source delta', () => {
 
   assert.equal(transition.semanticPayload.sourceDelta.changed, false);
   assert.equal(transition.semanticPayload.epistemicDelta.changed, true);
-  assert.deepEqual(transition.semanticPayload.epistemicDelta.changedRefs, ['H-001']);
+  assert.deepEqual(transition.semanticPayload.epistemicDelta.addedRefs, ['EA-INVALIDATE-H-001']);
+  assert.deepEqual(transition.semanticPayload.epistemicDelta.removedRefs, ['EA-002']);
   assert.equal(transition.semanticPayload.cognitiveStateDelta.changed, true);
   assert.equal(transition.semanticPayload.governanceDelta.changed, false);
 });

--- a/src/core/cognitive-spine/gates/personInstitutionGate.ts
+++ b/src/core/cognitive-spine/gates/personInstitutionGate.ts
@@ -1,0 +1,66 @@
+import {
+  PERSON_INSTITUTION_GATE_SCHEMA_VERSION,
+  type PersonCognitiveContributionIntake,
+  type PersonInstitutionGateResult,
+} from '../contracts/personInstitutionGate';
+import { normalizeTimestamp } from '../serialization/canonicalSerialize';
+
+function requireNonEmpty(value: string, label: string): string {
+  if (!value || value.trim() !== value) {
+    throw new Error(`COGNITIVE_SPINE_INVALID_${label}:${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+/**
+ * Personal cognitive content does not become institutional state by inheritance.
+ *
+ * This function only enforces that an upstream institutional intake has already
+ * admitted the contribution and attached both a canonical institutional record
+ * and an epistemic assessment. It does not perform that assessment itself.
+ */
+export function evaluatePersonInstitutionGate(
+  input: PersonCognitiveContributionIntake,
+): PersonInstitutionGateResult {
+  if (input.schemaVersion !== PERSON_INSTITUTION_GATE_SCHEMA_VERSION) {
+    throw new Error(`COGNITIVE_SPINE_PERSON_GATE_SCHEMA_MISMATCH:${input.schemaVersion}`);
+  }
+
+  requireNonEmpty(input.contributionRef, 'CONTRIBUTION_REF');
+  requireNonEmpty(input.personCtRef, 'PERSON_CT_REF');
+  requireNonEmpty(input.representationRef, 'REPRESENTATION_REF');
+  requireNonEmpty(input.contributionHash, 'CONTRIBUTION_HASH');
+  requireNonEmpty(input.intakeRef, 'INTAKE_REF');
+  normalizeTimestamp(input.assessedAt);
+
+  const canonicalRecordRef = input.canonicalRecordRef
+    ? requireNonEmpty(input.canonicalRecordRef, 'CANONICAL_RECORD_REF')
+    : null;
+  const epistemicAssessmentRef = input.epistemicAssessmentRef
+    ? requireNonEmpty(input.epistemicAssessmentRef, 'ASSESSMENT_REF')
+    : null;
+  const governanceRef = input.governanceRef
+    ? requireNonEmpty(input.governanceRef, 'GOVERNANCE_REF')
+    : null;
+
+  const reasons: string[] = [];
+  if (input.disposition !== 'ADMITTED') reasons.push(`intake_${input.disposition.toLowerCase()}`);
+  if (!canonicalRecordRef) reasons.push('canonical_record_missing');
+  if (!epistemicAssessmentRef) reasons.push('epistemic_assessment_missing');
+
+  return {
+    schemaVersion: PERSON_INSTITUTION_GATE_SCHEMA_VERSION,
+    contributionRef: input.contributionRef,
+    personCtRef: input.personCtRef,
+    intakeRef: input.intakeRef,
+    disposition: input.disposition,
+    institutionalStateEligible:
+      input.disposition === 'ADMITTED'
+      && Boolean(canonicalRecordRef)
+      && Boolean(epistemicAssessmentRef),
+    canonicalRecordRef,
+    epistemicAssessmentRef,
+    governanceRef,
+    reasons,
+  };
+}

--- a/src/core/cognitive-spine/projector/cognitiveStateProjector.ts
+++ b/src/core/cognitive-spine/projector/cognitiveStateProjector.ts
@@ -64,6 +64,9 @@ function normalizeRecord(record: CognitiveSpineSourceRecord): CognitiveSpineSour
   const ref = requireNonEmpty(record.ref, 'REF');
   const sourceHash = requireNonEmpty(record.sourceHash, 'SOURCE_HASH');
   const recordedAt = normalizeTimestamp(record.recordedAt);
+  const sourceVersion = record.sourceVersion === undefined
+    ? undefined
+    : requireNonEmpty(record.sourceVersion, 'SOURCE_VERSION');
   const epistemicAssessmentRef = record.epistemicAssessmentRef === undefined
     ? undefined
     : requireNonEmpty(record.epistemicAssessmentRef, 'ASSESSMENT_REF');
@@ -77,6 +80,7 @@ function normalizeRecord(record: CognitiveSpineSourceRecord): CognitiveSpineSour
     kind: record.kind,
     recordedAt,
     sourceHash,
+    sourceVersion,
     epistemicAssessmentRef,
     epistemicClass: record.epistemicClass,
     ancestryRoots: sortedUnique(record.ancestryRoots ?? []),
@@ -86,17 +90,13 @@ function normalizeRecord(record: CognitiveSpineSourceRecord): CognitiveSpineSour
   };
 }
 
-/**
- * Canonical comparison payload for duplicate source refs. Optional fields are
- * represented explicitly as null so the strict semantic serializer never has
- * to silently discard undefined values.
- */
 function deduplicationSignature(record: CognitiveSpineSourceRecord) {
   return {
     ref: record.ref,
     kind: record.kind,
     recordedAt: record.recordedAt,
     sourceHash: record.sourceHash,
+    sourceVersion: record.sourceVersion ?? null,
     epistemicAssessmentRef: record.epistemicAssessmentRef ?? null,
     epistemicClass: record.epistemicClass ?? null,
     ancestryRoots: record.ancestryRoots ?? [],
@@ -157,6 +157,9 @@ export function projectCognitiveState(input: CognitiveStateProjectionInput): Cog
   const projectorVersion = requireNonEmpty(input.projectorVersion, 'PROJECTOR_VERSION');
   const policyVersion = requireNonEmpty(input.policyVersion, 'POLICY_VERSION');
   const projectionProfile = requireNonEmpty(input.projectionProfile, 'PROJECTION_PROFILE');
+  const operatingModeRef = input.operatingModeRef
+    ? requireNonEmpty(input.operatingModeRef, 'OPERATING_MODE_REF')
+    : null;
 
   const records = deduplicateRecords(input.records)
     .filter((record) => record.recordedAt <= sourceCutoff)
@@ -185,27 +188,33 @@ export function projectCognitiveState(input: CognitiveStateProjectionInput): Cog
   }
 
   const lineageRoots = sortedUnique(records.flatMap((record) => record.ancestryRoots ?? []));
-  const epistemicAssessmentRefs = sortedUnique(records
+  const epistemicStateRefs = sortedUnique(records
     .map((record) => record.epistemicAssessmentRef)
     .filter((value): value is string => Boolean(value)));
 
   const sourceManifest = records.map((record) => ({
     ref: record.ref,
-    kind: record.kind,
+    sourceKind: record.kind,
+    sourceVersion: record.sourceVersion ?? null,
     sourceHash: record.sourceHash,
-    epistemicAssessmentRef: record.epistemicAssessmentRef ?? null,
-    epistemicClass: record.epistemicClass ?? null,
-    ancestryRoots: sortedUnique(record.ancestryRoots ?? []),
-    invalidated: Boolean(record.invalidated),
-    debtType: record.debtType ?? null,
   }));
+  const sourceHashes = sourceManifest.map((entry) => ({ ref: entry.ref, hash: entry.sourceHash }));
+  const derivedState = {
+    sourceCount: records.length,
+    assessedSourceCount: records.filter((record) => Boolean(record.epistemicAssessmentRef)).length,
+    invalidatedSourceCount: records.filter((record) => Boolean(record.invalidated)).length,
+    independentLineageRootCount: lineageRoots.length,
+    contradictionCount: refBuckets.contradictionRefs.length,
+    questionCount: refBuckets.questionRefs.length,
+    debt,
+  };
 
   return {
-    schemaVersion: COGNITIVE_SPINE_SNAPSHOT_SCHEMA_VERSION,
     sourceCutoff,
     projectorVersion,
     policyVersion,
     projectionProfile,
+    schemaVersion: COGNITIVE_SPINE_SNAPSHOT_SCHEMA_VERSION,
     eventRefs: sortedUnique(refBuckets.eventRefs),
     evidenceRefs: sortedUnique(refBuckets.evidenceRefs),
     hypothesisRefs: sortedUnique(refBuckets.hypothesisRefs),
@@ -215,18 +224,20 @@ export function projectCognitiveState(input: CognitiveStateProjectionInput): Cog
     freezeRefs: sortedUnique(refBuckets.freezeRefs),
     questionRefs: sortedUnique(refBuckets.questionRefs),
     personCtRefs: sortedUnique(refBuckets.personCtRefs),
-    epistemicAssessmentRefs,
-    sourceManifest,
-    derivedState: {
-      sourceCount: records.length,
-      assessedSourceCount: records.filter((record) => Boolean(record.epistemicAssessmentRef)).length,
-      invalidatedSourceCount: records.filter((record) => Boolean(record.invalidated)).length,
-      independentLineageRootCount: lineageRoots.length,
-      contradictionCount: refBuckets.contradictionRefs.length,
-      questionCount: refBuckets.questionRefs.length,
-      debt,
+    operatingMode: { modeRef: operatingModeRef },
+    temporalState: {
+      sourceCutoff,
+      visibleRecordCount: records.length,
     },
-    lineageRoots,
+    verificationDebt: {
+      absolute: debt.VERIFICATION,
+      byType: { ...debt },
+    },
+    derivedState,
+    sourceManifest,
+    sourceHashes,
+    epistemicStateRefs,
+    lineageRoot: canonicalSha256(lineageRoots),
   };
 }
 

--- a/src/core/cognitive-spine/projector/cognitiveStateProjector.ts
+++ b/src/core/cognitive-spine/projector/cognitiveStateProjector.ts
@@ -86,6 +86,26 @@ function normalizeRecord(record: CognitiveSpineSourceRecord): CognitiveSpineSour
   };
 }
 
+/**
+ * Canonical comparison payload for duplicate source refs. Optional fields are
+ * represented explicitly as null so the strict semantic serializer never has
+ * to silently discard undefined values.
+ */
+function deduplicationSignature(record: CognitiveSpineSourceRecord) {
+  return {
+    ref: record.ref,
+    kind: record.kind,
+    recordedAt: record.recordedAt,
+    sourceHash: record.sourceHash,
+    epistemicAssessmentRef: record.epistemicAssessmentRef ?? null,
+    epistemicClass: record.epistemicClass ?? null,
+    ancestryRoots: record.ancestryRoots ?? [],
+    visibilityProfiles: record.visibilityProfiles ?? [],
+    invalidated: Boolean(record.invalidated),
+    debtType: record.debtType ?? null,
+  };
+}
+
 function deduplicateRecords(records: CognitiveSpineSourceRecord[]): CognitiveSpineSourceRecord[] {
   const byRef = new Map<string, CognitiveSpineSourceRecord>();
 
@@ -97,7 +117,7 @@ function deduplicateRecords(records: CognitiveSpineSourceRecord[]): CognitiveSpi
       continue;
     }
 
-    if (canonicalSerialize(previous) !== canonicalSerialize(record)) {
+    if (canonicalSerialize(deduplicationSignature(previous)) !== canonicalSerialize(deduplicationSignature(record))) {
       throw new Error(`COGNITIVE_SPINE_CONFLICTING_SOURCE_REF:${record.ref}`);
     }
   }

--- a/src/core/cognitive-spine/projector/cognitiveStateProjector.ts
+++ b/src/core/cognitive-spine/projector/cognitiveStateProjector.ts
@@ -1,0 +1,243 @@
+import {
+  COGNITIVE_SPINE_SNAPSHOT_SCHEMA_VERSION,
+  type CognitiveDebtType,
+  type CognitiveSnapshotEnvelopeInput,
+  type CognitiveSpineRefKind,
+  type CognitiveSpineSemanticPayload,
+  type CognitiveSpineSnapshot,
+  type CognitiveSpineSourceRecord,
+  type CognitiveStateProjectionInput,
+} from '../contracts/snapshot';
+import {
+  canonicalSerialize,
+  canonicalSha256,
+  normalizeTimestamp,
+  sortedUnique,
+} from '../serialization/canonicalSerialize';
+
+const DEBT_TYPES: CognitiveDebtType[] = [
+  'VERIFICATION',
+  'CONTRADICTION',
+  'RETURN',
+  'PROVENANCE',
+  'EXPERIMENTAL',
+  'STALE_KNOWLEDGE',
+];
+
+const REF_FIELD_BY_KIND: Record<CognitiveSpineRefKind, keyof Pick<
+  CognitiveSpineSemanticPayload,
+  | 'eventRefs'
+  | 'evidenceRefs'
+  | 'hypothesisRefs'
+  | 'memoryRefs'
+  | 'decisionRefs'
+  | 'contradictionRefs'
+  | 'freezeRefs'
+  | 'questionRefs'
+  | 'personCtRefs'
+>> = {
+  EVENT: 'eventRefs',
+  EVIDENCE: 'evidenceRefs',
+  HYPOTHESIS: 'hypothesisRefs',
+  MEMORY: 'memoryRefs',
+  DECISION: 'decisionRefs',
+  CONTRADICTION: 'contradictionRefs',
+  FREEZE: 'freezeRefs',
+  QUESTION: 'questionRefs',
+  PERSON_CT: 'personCtRefs',
+};
+
+function requireNonEmpty(value: string, label: string): string {
+  if (!value || value.trim() !== value) {
+    throw new Error(`COGNITIVE_SPINE_INVALID_${label}:${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function normalizeRecord(record: CognitiveSpineSourceRecord): CognitiveSpineSourceRecord {
+  const ref = requireNonEmpty(record.ref, 'REF');
+  const sourceHash = requireNonEmpty(record.sourceHash, 'SOURCE_HASH');
+  const recordedAt = normalizeTimestamp(record.recordedAt);
+  const epistemicAssessmentRef = record.epistemicAssessmentRef === undefined
+    ? undefined
+    : requireNonEmpty(record.epistemicAssessmentRef, 'ASSESSMENT_REF');
+
+  if (record.kind === 'EVIDENCE' && (!epistemicAssessmentRef || !record.epistemicClass)) {
+    throw new Error(`COGNITIVE_SPINE_UNASSESSED_EVIDENCE:${ref}`);
+  }
+
+  return {
+    ref,
+    kind: record.kind,
+    recordedAt,
+    sourceHash,
+    epistemicAssessmentRef,
+    epistemicClass: record.epistemicClass,
+    ancestryRoots: sortedUnique(record.ancestryRoots ?? []),
+    visibilityProfiles: sortedUnique(record.visibilityProfiles ?? []),
+    invalidated: Boolean(record.invalidated || record.epistemicClass === 'INVALIDATED'),
+    debtType: record.debtType,
+  };
+}
+
+function deduplicateRecords(records: CognitiveSpineSourceRecord[]): CognitiveSpineSourceRecord[] {
+  const byRef = new Map<string, CognitiveSpineSourceRecord>();
+
+  for (const rawRecord of records) {
+    const record = normalizeRecord(rawRecord);
+    const previous = byRef.get(record.ref);
+    if (!previous) {
+      byRef.set(record.ref, record);
+      continue;
+    }
+
+    if (canonicalSerialize(previous) !== canonicalSerialize(record)) {
+      throw new Error(`COGNITIVE_SPINE_CONFLICTING_SOURCE_REF:${record.ref}`);
+    }
+  }
+
+  return [...byRef.values()].sort((left, right) => {
+    const kindOrder = left.kind.localeCompare(right.kind);
+    return kindOrder !== 0 ? kindOrder : left.ref.localeCompare(right.ref);
+  });
+}
+
+function visibleUnderProfile(record: CognitiveSpineSourceRecord, profile: string): boolean {
+  const profiles = record.visibilityProfiles ?? [];
+  return profiles.length === 0 || profiles.includes('*') || profiles.includes(profile);
+}
+
+function emptyDebt(): Record<CognitiveDebtType, number> {
+  return {
+    VERIFICATION: 0,
+    CONTRADICTION: 0,
+    RETURN: 0,
+    PROVENANCE: 0,
+    EXPERIMENTAL: 0,
+    STALE_KNOWLEDGE: 0,
+  };
+}
+
+/**
+ * Deterministically projects already-canonical, already-assessed source records
+ * into a semantic cognitive-state payload.
+ *
+ * This function MUST NOT create new epistemic judgments. It may only select,
+ * resolve, deduplicate and summarize classifications supplied by the preceding
+ * epistemic relation/policy plane.
+ */
+export function projectCognitiveState(input: CognitiveStateProjectionInput): CognitiveSpineSemanticPayload {
+  const sourceCutoff = normalizeTimestamp(input.sourceCutoff);
+  const projectorVersion = requireNonEmpty(input.projectorVersion, 'PROJECTOR_VERSION');
+  const policyVersion = requireNonEmpty(input.policyVersion, 'POLICY_VERSION');
+  const projectionProfile = requireNonEmpty(input.projectionProfile, 'PROJECTION_PROFILE');
+
+  const records = deduplicateRecords(input.records)
+    .filter((record) => record.recordedAt <= sourceCutoff)
+    .filter((record) => visibleUnderProfile(record, projectionProfile));
+
+  const refs: Record<keyof typeof REF_FIELD_BY_KIND extends never ? never : string, string[]> = {};
+  const refBuckets: Record<
+    | 'eventRefs'
+    | 'evidenceRefs'
+    | 'hypothesisRefs'
+    | 'memoryRefs'
+    | 'decisionRefs'
+    | 'contradictionRefs'
+    | 'freezeRefs'
+    | 'questionRefs'
+    | 'personCtRefs',
+    string[]
+  > = {
+    eventRefs: [],
+    evidenceRefs: [],
+    hypothesisRefs: [],
+    memoryRefs: [],
+    decisionRefs: [],
+    contradictionRefs: [],
+    freezeRefs: [],
+    questionRefs: [],
+    personCtRefs: [],
+  };
+
+  const debt = emptyDebt();
+  for (const record of records) {
+    refBuckets[REF_FIELD_BY_KIND[record.kind]].push(record.ref);
+    if (record.debtType) debt[record.debtType] += 1;
+  }
+  void refs;
+
+  for (const debtType of DEBT_TYPES) {
+    debt[debtType] = Math.max(0, debt[debtType]);
+  }
+
+  const lineageRoots = sortedUnique(records.flatMap((record) => record.ancestryRoots ?? []));
+  const epistemicAssessmentRefs = sortedUnique(records
+    .map((record) => record.epistemicAssessmentRef)
+    .filter((value): value is string => Boolean(value)));
+
+  const sourceManifest = records.map((record) => ({
+    ref: record.ref,
+    kind: record.kind,
+    sourceHash: record.sourceHash,
+    epistemicAssessmentRef: record.epistemicAssessmentRef ?? null,
+    epistemicClass: record.epistemicClass ?? null,
+    ancestryRoots: sortedUnique(record.ancestryRoots ?? []),
+    invalidated: Boolean(record.invalidated),
+    debtType: record.debtType ?? null,
+  }));
+
+  return {
+    schemaVersion: COGNITIVE_SPINE_SNAPSHOT_SCHEMA_VERSION,
+    sourceCutoff,
+    projectorVersion,
+    policyVersion,
+    projectionProfile,
+    eventRefs: sortedUnique(refBuckets.eventRefs),
+    evidenceRefs: sortedUnique(refBuckets.evidenceRefs),
+    hypothesisRefs: sortedUnique(refBuckets.hypothesisRefs),
+    memoryRefs: sortedUnique(refBuckets.memoryRefs),
+    decisionRefs: sortedUnique(refBuckets.decisionRefs),
+    contradictionRefs: sortedUnique(refBuckets.contradictionRefs),
+    freezeRefs: sortedUnique(refBuckets.freezeRefs),
+    questionRefs: sortedUnique(refBuckets.questionRefs),
+    personCtRefs: sortedUnique(refBuckets.personCtRefs),
+    epistemicAssessmentRefs,
+    sourceManifest,
+    derivedState: {
+      sourceCount: records.length,
+      assessedSourceCount: records.filter((record) => Boolean(record.epistemicAssessmentRef)).length,
+      invalidatedSourceCount: records.filter((record) => Boolean(record.invalidated)).length,
+      independentLineageRootCount: lineageRoots.length,
+      contradictionCount: refBuckets.contradictionRefs.length,
+      questionCount: refBuckets.questionRefs.length,
+      debt,
+    },
+    lineageRoots,
+  };
+}
+
+export function semanticSnapshotHash(payload: CognitiveSpineSemanticPayload): string {
+  return canonicalSha256(payload);
+}
+
+export function sealCognitiveSnapshot(
+  semanticPayload: CognitiveSpineSemanticPayload,
+  envelope: CognitiveSnapshotEnvelopeInput,
+): CognitiveSpineSnapshot {
+  return {
+    snapshotId: requireNonEmpty(envelope.snapshotId, 'SNAPSHOT_ID'),
+    createdAt: normalizeTimestamp(envelope.createdAt),
+    ...(envelope.reconstructedAt ? { reconstructedAt: normalizeTimestamp(envelope.reconstructedAt) } : {}),
+    semanticPayload,
+    snapshotHash: semanticSnapshotHash(semanticPayload),
+    ...(envelope.runtimeMetadata ? { runtimeMetadata: envelope.runtimeMetadata } : {}),
+  };
+}
+
+export function materializeCognitiveSnapshot(
+  input: CognitiveStateProjectionInput,
+  envelope: CognitiveSnapshotEnvelopeInput,
+): CognitiveSpineSnapshot {
+  return sealCognitiveSnapshot(projectCognitiveState(input), envelope);
+}

--- a/src/core/cognitive-spine/projector/cognitiveStateProjector.ts
+++ b/src/core/cognitive-spine/projector/cognitiveStateProjector.ts
@@ -24,8 +24,7 @@ const DEBT_TYPES: CognitiveDebtType[] = [
   'STALE_KNOWLEDGE',
 ];
 
-const REF_FIELD_BY_KIND: Record<CognitiveSpineRefKind, keyof Pick<
-  CognitiveSpineSemanticPayload,
+type RefBucketKey =
   | 'eventRefs'
   | 'evidenceRefs'
   | 'hypothesisRefs'
@@ -34,8 +33,9 @@ const REF_FIELD_BY_KIND: Record<CognitiveSpineRefKind, keyof Pick<
   | 'contradictionRefs'
   | 'freezeRefs'
   | 'questionRefs'
-  | 'personCtRefs'
->> = {
+  | 'personCtRefs';
+
+const REF_FIELD_BY_KIND: Record<CognitiveSpineRefKind, RefBucketKey> = {
   EVENT: 'eventRefs',
   EVIDENCE: 'evidenceRefs',
   HYPOTHESIS: 'hypothesisRefs',
@@ -52,6 +52,12 @@ function requireNonEmpty(value: string, label: string): string {
     throw new Error(`COGNITIVE_SPINE_INVALID_${label}:${JSON.stringify(value)}`);
   }
   return value;
+}
+
+function lexicalCompare(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
 }
 
 function normalizeRecord(record: CognitiveSpineSourceRecord): CognitiveSpineSourceRecord {
@@ -97,8 +103,8 @@ function deduplicateRecords(records: CognitiveSpineSourceRecord[]): CognitiveSpi
   }
 
   return [...byRef.values()].sort((left, right) => {
-    const kindOrder = left.kind.localeCompare(right.kind);
-    return kindOrder !== 0 ? kindOrder : left.ref.localeCompare(right.ref);
+    const kindOrder = lexicalCompare(left.kind, right.kind);
+    return kindOrder !== 0 ? kindOrder : lexicalCompare(left.ref, right.ref);
   });
 }
 
@@ -136,19 +142,7 @@ export function projectCognitiveState(input: CognitiveStateProjectionInput): Cog
     .filter((record) => record.recordedAt <= sourceCutoff)
     .filter((record) => visibleUnderProfile(record, projectionProfile));
 
-  const refs: Record<keyof typeof REF_FIELD_BY_KIND extends never ? never : string, string[]> = {};
-  const refBuckets: Record<
-    | 'eventRefs'
-    | 'evidenceRefs'
-    | 'hypothesisRefs'
-    | 'memoryRefs'
-    | 'decisionRefs'
-    | 'contradictionRefs'
-    | 'freezeRefs'
-    | 'questionRefs'
-    | 'personCtRefs',
-    string[]
-  > = {
+  const refBuckets: Record<RefBucketKey, string[]> = {
     eventRefs: [],
     evidenceRefs: [],
     hypothesisRefs: [],
@@ -165,7 +159,6 @@ export function projectCognitiveState(input: CognitiveStateProjectionInput): Cog
     refBuckets[REF_FIELD_BY_KIND[record.kind]].push(record.ref);
     if (record.debtType) debt[record.debtType] += 1;
   }
-  void refs;
 
   for (const debtType of DEBT_TYPES) {
     debt[debtType] = Math.max(0, debt[debtType]);

--- a/src/core/cognitive-spine/serialization/canonicalSerialize.ts
+++ b/src/core/cognitive-spine/serialization/canonicalSerialize.ts
@@ -1,0 +1,77 @@
+import { createHash } from 'node:crypto';
+
+type PlainObject = Record<string, unknown>;
+
+function isPlainObject(value: object): value is PlainObject {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function encode(value: unknown, path: string): string {
+  if (value === null) return 'null';
+
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`COGNITIVE_SPINE_NON_FINITE_NUMBER:${path}`);
+    }
+    return JSON.stringify(Object.is(value, -0) ? 0 : value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item, index) => encode(item, `${path}[${index}]`)).join(',')}]`;
+  }
+
+  if (typeof value === 'object') {
+    if (!isPlainObject(value)) {
+      throw new Error(`COGNITIVE_SPINE_NON_PLAIN_OBJECT:${path}`);
+    }
+
+    const keys = Object.keys(value).sort();
+    return `{${keys.map((key) => {
+      const child = value[key];
+      if (typeof child === 'undefined') {
+        throw new Error(`COGNITIVE_SPINE_UNDEFINED_VALUE:${path}.${key}`);
+      }
+      return `${JSON.stringify(key)}:${encode(child, `${path}.${key}`)}`;
+    }).join(',')}}`;
+  }
+
+  throw new Error(`COGNITIVE_SPINE_UNSUPPORTED_VALUE:${path}:${typeof value}`);
+}
+
+/**
+ * Canonical serializer for semantic hashing.
+ *
+ * Object keys are sorted. Array order is preserved because some arrays are
+ * ordered semantic structures; set-like arrays must be normalized before they
+ * reach this function. Undefined, non-finite numbers, functions, symbols,
+ * bigint values and non-plain objects are rejected rather than silently
+ * coerced.
+ */
+export function canonicalSerialize(value: unknown): string {
+  return encode(value, '$');
+}
+
+export function canonicalSha256(value: unknown): string {
+  return createHash('sha256').update(canonicalSerialize(value), 'utf8').digest('hex');
+}
+
+export function normalizeTimestamp(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`COGNITIVE_SPINE_INVALID_TIMESTAMP:${value}`);
+  }
+  return parsed.toISOString();
+}
+
+export function sortedUnique(values: readonly string[]): string[] {
+  return Array.from(new Set(values.map((value) => {
+    if (value.trim() !== value || value.length === 0) {
+      throw new Error(`COGNITIVE_SPINE_INVALID_REF:${JSON.stringify(value)}`);
+    }
+    return value;
+  }))).sort();
+}

--- a/src/core/cognitive-spine/serialization/canonicalSerialize.ts
+++ b/src/core/cognitive-spine/serialization/canonicalSerialize.ts
@@ -2,22 +2,32 @@ import { createHash } from 'node:crypto';
 
 type PlainObject = Record<string, unknown>;
 
+const ISO_TIMESTAMP_WITH_ZONE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
 function isPlainObject(value: object): value is PlainObject {
   const prototype = Object.getPrototypeOf(value);
   return prototype === Object.prototype || prototype === null;
 }
 
+function jsonScalar(value: string | number): string {
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) {
+    throw new Error('COGNITIVE_SPINE_JSON_SCALAR_ENCODING_FAILED');
+  }
+  return encoded;
+}
+
 function encode(value: unknown, path: string): string {
   if (value === null) return 'null';
 
-  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'string') return jsonScalar(value);
   if (typeof value === 'boolean') return value ? 'true' : 'false';
 
   if (typeof value === 'number') {
     if (!Number.isFinite(value)) {
       throw new Error(`COGNITIVE_SPINE_NON_FINITE_NUMBER:${path}`);
     }
-    return JSON.stringify(Object.is(value, -0) ? 0 : value);
+    return jsonScalar(Object.is(value, -0) ? 0 : value);
   }
 
   if (Array.isArray(value)) {
@@ -35,7 +45,7 @@ function encode(value: unknown, path: string): string {
       if (typeof child === 'undefined') {
         throw new Error(`COGNITIVE_SPINE_UNDEFINED_VALUE:${path}.${key}`);
       }
-      return `${JSON.stringify(key)}:${encode(child, `${path}.${key}`)}`;
+      return `${jsonScalar(key)}:${encode(child, `${path}.${key}`)}`;
     }).join(',')}}`;
   }
 
@@ -59,7 +69,14 @@ export function canonicalSha256(value: unknown): string {
   return createHash('sha256').update(canonicalSerialize(value), 'utf8').digest('hex');
 }
 
+/**
+ * Only offset-aware ISO timestamps are admissible. This prevents host timezone
+ * or locale from changing the semantic cutoff during reconstruction.
+ */
 export function normalizeTimestamp(value: string): string {
+  if (!ISO_TIMESTAMP_WITH_ZONE.test(value)) {
+    throw new Error(`COGNITIVE_SPINE_TIMESTAMP_REQUIRES_EXPLICIT_ZONE:${value}`);
+  }
   const parsed = new Date(value);
   if (Number.isNaN(parsed.getTime())) {
     throw new Error(`COGNITIVE_SPINE_INVALID_TIMESTAMP:${value}`);

--- a/src/core/cognitive-spine/trace/consumptionTrace.ts
+++ b/src/core/cognitive-spine/trace/consumptionTrace.ts
@@ -24,6 +24,8 @@ export function buildCognitiveContextConsumptionTrace(
   const consumedId = normalizedOptional(input.consumedSnapshotId, 'CONSUMED_SNAPSHOT_ID');
   const consumedHash = normalizedOptional(input.consumedSnapshotHash, 'CONSUMED_SNAPSHOT_HASH');
   const projectionProfile = normalizedOptional(input.projectionProfile, 'PROJECTION_PROFILE');
+  const profileVersion = normalizedOptional(input.profileVersion, 'PROFILE_VERSION');
+  const consumptionReason = normalizedOptional(input.consumptionReason, 'CONSUMPTION_REASON');
   const blindedObservation = Boolean(input.blindedObservation);
 
   if (Boolean(availableId) !== Boolean(availableHash)) {
@@ -35,8 +37,8 @@ export function buildCognitiveContextConsumptionTrace(
   }
 
   if (input.ctSnapshotConsumed) {
-    if (!consumedId || !consumedHash || !projectionProfile) {
-      throw new Error('COGNITIVE_SPINE_CONSUMPTION_REQUIRES_SNAPSHOT_HASH_AND_PROFILE');
+    if (!consumedId || !consumedHash || !projectionProfile || !profileVersion || !consumptionReason) {
+      throw new Error('COGNITIVE_SPINE_CONSUMPTION_REQUIRES_SNAPSHOT_HASH_PROFILE_VERSION_AND_REASON');
     }
     if (!availableId || !availableHash) {
       throw new Error('COGNITIVE_SPINE_CONSUMED_SNAPSHOT_MUST_HAVE_BEEN_AVAILABLE');
@@ -44,7 +46,7 @@ export function buildCognitiveContextConsumptionTrace(
     if (consumedId !== availableId || consumedHash !== availableHash) {
       throw new Error('COGNITIVE_SPINE_CONSUMED_SNAPSHOT_MUST_MATCH_AVAILABLE_SNAPSHOT');
     }
-  } else if (consumedId || consumedHash || projectionProfile) {
+  } else if (consumedId || consumedHash || projectionProfile || profileVersion || consumptionReason) {
     throw new Error('COGNITIVE_SPINE_NON_CONSUMPTION_MUST_NOT_DECLARE_CONSUMED_CONTEXT');
   }
 
@@ -57,6 +59,8 @@ export function buildCognitiveContextConsumptionTrace(
     consumedSnapshotId: consumedId,
     consumedSnapshotHash: consumedHash,
     projectionProfile,
+    profileVersion,
+    consumptionReason,
     blindedObservation,
     recordedAt: normalizeTimestamp(input.recordedAt),
   };

--- a/src/core/cognitive-spine/trace/consumptionTrace.ts
+++ b/src/core/cognitive-spine/trace/consumptionTrace.ts
@@ -1,0 +1,63 @@
+import {
+  CT_CONSUMPTION_TRACE_SCHEMA_VERSION,
+  type CognitiveContextConsumptionInput,
+  type CognitiveContextConsumptionTrace,
+} from '../contracts/consumptionTrace';
+import { normalizeTimestamp } from '../serialization/canonicalSerialize';
+
+function normalizedOptional(value: string | null | undefined, label: string): string | null {
+  if (value === null || value === undefined) return null;
+  if (!value || value.trim() !== value) {
+    throw new Error(`COGNITIVE_SPINE_INVALID_${label}:${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+export function buildCognitiveContextConsumptionTrace(
+  input: CognitiveContextConsumptionInput,
+): CognitiveContextConsumptionTrace {
+  const executionId = normalizedOptional(input.executionId, 'EXECUTION_ID');
+  if (!executionId) throw new Error('COGNITIVE_SPINE_EXECUTION_ID_REQUIRED');
+
+  const availableId = normalizedOptional(input.ctSnapshotAvailable, 'AVAILABLE_SNAPSHOT_ID');
+  const availableHash = normalizedOptional(input.ctSnapshotHashAvailable, 'AVAILABLE_SNAPSHOT_HASH');
+  const consumedId = normalizedOptional(input.consumedSnapshotId, 'CONSUMED_SNAPSHOT_ID');
+  const consumedHash = normalizedOptional(input.consumedSnapshotHash, 'CONSUMED_SNAPSHOT_HASH');
+  const projectionProfile = normalizedOptional(input.projectionProfile, 'PROJECTION_PROFILE');
+  const blindedObservation = Boolean(input.blindedObservation);
+
+  if (Boolean(availableId) !== Boolean(availableHash)) {
+    throw new Error('COGNITIVE_SPINE_AVAILABLE_SNAPSHOT_ID_HASH_PAIR_REQUIRED');
+  }
+
+  if (blindedObservation && input.ctSnapshotConsumed) {
+    throw new Error('COGNITIVE_SPINE_BLINDED_OBSERVATION_CANNOT_CONSUME_CT');
+  }
+
+  if (input.ctSnapshotConsumed) {
+    if (!consumedId || !consumedHash || !projectionProfile) {
+      throw new Error('COGNITIVE_SPINE_CONSUMPTION_REQUIRES_SNAPSHOT_HASH_AND_PROFILE');
+    }
+    if (!availableId || !availableHash) {
+      throw new Error('COGNITIVE_SPINE_CONSUMED_SNAPSHOT_MUST_HAVE_BEEN_AVAILABLE');
+    }
+    if (consumedId !== availableId || consumedHash !== availableHash) {
+      throw new Error('COGNITIVE_SPINE_CONSUMED_SNAPSHOT_MUST_MATCH_AVAILABLE_SNAPSHOT');
+    }
+  } else if (consumedId || consumedHash || projectionProfile) {
+    throw new Error('COGNITIVE_SPINE_NON_CONSUMPTION_MUST_NOT_DECLARE_CONSUMED_CONTEXT');
+  }
+
+  return {
+    schemaVersion: CT_CONSUMPTION_TRACE_SCHEMA_VERSION,
+    executionId,
+    ctSnapshotAvailable: availableId,
+    ctSnapshotHashAvailable: availableHash,
+    ctSnapshotConsumed: input.ctSnapshotConsumed,
+    consumedSnapshotId: consumedId,
+    consumedSnapshotHash: consumedHash,
+    projectionProfile,
+    blindedObservation,
+    recordedAt: normalizeTimestamp(input.recordedAt),
+  };
+}

--- a/src/core/cognitive-spine/transitions/buildTransition.ts
+++ b/src/core/cognitive-spine/transitions/buildTransition.ts
@@ -66,7 +66,7 @@ function sourceDelta(
   const changedRefs = sortedUnique(beforeRefs.filter((ref) => {
     const left = before.get(ref);
     const right = after.get(ref);
-    return Boolean(left && right && left.sourceHash !== right.sourceHash);
+    return Boolean(left && right && canonicalSerialize(left) !== canonicalSerialize(right));
   }));
   return {
     changed: membership.addedRefs.length > 0 || membership.removedRefs.length > 0 || changedRefs.length > 0,
@@ -76,37 +76,20 @@ function sourceDelta(
   };
 }
 
-function epistemicSignature(entry: ManifestEntry) {
-  return {
-    epistemicAssessmentRef: entry.epistemicAssessmentRef,
-    epistemicClass: entry.epistemicClass,
-    ancestryRoots: entry.ancestryRoots,
-    invalidated: entry.invalidated,
-    debtType: entry.debtType,
-  };
-}
-
 function epistemicDelta(
-  before: Map<string, ManifestEntry>,
-  after: Map<string, ManifestEntry>,
-  critical: string[],
+  from: CognitiveSpineSnapshot,
+  to: CognitiveSpineSnapshot,
 ): CognitiveSpineDeltaSummary {
-  const sharedRefs = [...before.keys()].filter((ref) => after.has(ref));
-  const changedRefs = sortedUnique(sharedRefs.filter((ref) => {
-    const left = before.get(ref);
-    const right = after.get(ref);
-    return Boolean(left && right && canonicalSerialize(epistemicSignature(left)) !== canonicalSerialize(epistemicSignature(right)));
-  }));
-  const membership = setDelta([...before.keys()], [...after.keys()]);
-  const assessmentRelevantAdded = membership.addedRefs.filter((ref) => Boolean(after.get(ref)?.epistemicAssessmentRef));
-  const assessmentRelevantRemoved = membership.removedRefs.filter((ref) => Boolean(before.get(ref)?.epistemicAssessmentRef));
-
+  const before = from.semanticPayload.epistemicStateRefs;
+  const after = to.semanticPayload.epistemicStateRefs;
+  const membership = setDelta(before, after);
+  const beforeSet = new Set(before);
+  const afterSet = new Set(after);
   return {
-    changed: changedRefs.length > 0 || assessmentRelevantAdded.length > 0 || assessmentRelevantRemoved.length > 0,
-    addedRefs: sortedUnique(assessmentRelevantAdded),
-    removedRefs: sortedUnique(assessmentRelevantRemoved),
-    changedRefs,
-    unchangedCriticalRefs: unchangedCritical(critical, before, after),
+    changed: membership.addedRefs.length > 0 || membership.removedRefs.length > 0,
+    ...membership,
+    changedRefs: [],
+    unchangedCriticalRefs: sortedUnique(before.filter((ref) => afterSet.has(ref) && beforeSet.has(ref))),
   };
 }
 
@@ -156,7 +139,7 @@ export function buildSemanticTransitionPayload(
   const beforeManifest = toMap(from.semanticPayload.sourceManifest);
   const afterManifest = toMap(to.semanticPayload.sourceManifest);
   const source = sourceDelta(beforeManifest, afterManifest, critical);
-  const epistemic = epistemicDelta(beforeManifest, afterManifest, critical);
+  const epistemic = epistemicDelta(from, to);
   const cognitiveMembership = refOnlyDelta(cognitiveRefs(from), cognitiveRefs(to), critical);
   const governance = refOnlyDelta(governanceRefs(from), governanceRefs(to), critical);
   const cognitiveChanged = from.snapshotHash !== to.snapshotHash;
@@ -174,7 +157,8 @@ export function buildSemanticTransitionPayload(
       changed: cognitiveChanged,
       changedRefs: sortedUnique([
         ...source.changedRefs,
-        ...epistemic.changedRefs,
+        ...epistemic.addedRefs,
+        ...epistemic.removedRefs,
       ]),
     },
     governanceDelta: governance,

--- a/src/core/cognitive-spine/transitions/buildTransition.ts
+++ b/src/core/cognitive-spine/transitions/buildTransition.ts
@@ -1,0 +1,200 @@
+import type { CognitiveSpineSnapshot } from '../contracts/snapshot';
+import {
+  COGNITIVE_SPINE_TRANSITION_SCHEMA_VERSION,
+  type CognitiveSpineDeltaSummary,
+  type CognitiveSpineSemanticTransitionPayload,
+  type CognitiveSpineTransition,
+  type CognitiveSpineTransitionInput,
+} from '../contracts/transition';
+import { semanticSnapshotHash } from '../projector/cognitiveStateProjector';
+import {
+  canonicalSerialize,
+  canonicalSha256,
+  normalizeTimestamp,
+  sortedUnique,
+} from '../serialization/canonicalSerialize';
+
+type ManifestEntry = CognitiveSpineSnapshot['semanticPayload']['sourceManifest'][number];
+
+function requireNonEmpty(value: string, label: string): string {
+  if (!value || value.trim() !== value) {
+    throw new Error(`COGNITIVE_SPINE_INVALID_${label}:${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+function assertSnapshotIntegrity(snapshot: CognitiveSpineSnapshot) {
+  const calculated = semanticSnapshotHash(snapshot.semanticPayload);
+  if (calculated !== snapshot.snapshotHash) {
+    throw new Error(`COGNITIVE_SPINE_SNAPSHOT_HASH_MISMATCH:${snapshot.snapshotId}`);
+  }
+}
+
+function toMap(entries: ManifestEntry[]): Map<string, ManifestEntry> {
+  return new Map(entries.map((entry) => [entry.ref, entry]));
+}
+
+function setDelta(before: string[], after: string[]): Pick<CognitiveSpineDeltaSummary, 'addedRefs' | 'removedRefs'> {
+  const beforeSet = new Set(before);
+  const afterSet = new Set(after);
+  return {
+    addedRefs: sortedUnique(after.filter((ref) => !beforeSet.has(ref))),
+    removedRefs: sortedUnique(before.filter((ref) => !afterSet.has(ref))),
+  };
+}
+
+function unchangedCritical(
+  requested: string[],
+  before: Map<string, ManifestEntry>,
+  after: Map<string, ManifestEntry>,
+): string[] {
+  return sortedUnique(requested.filter((ref) => {
+    const left = before.get(ref);
+    const right = after.get(ref);
+    return Boolean(left && right && canonicalSerialize(left) === canonicalSerialize(right));
+  }));
+}
+
+function sourceDelta(
+  before: Map<string, ManifestEntry>,
+  after: Map<string, ManifestEntry>,
+  critical: string[],
+): CognitiveSpineDeltaSummary {
+  const beforeRefs = [...before.keys()];
+  const afterRefs = [...after.keys()];
+  const membership = setDelta(beforeRefs, afterRefs);
+  const changedRefs = sortedUnique(beforeRefs.filter((ref) => {
+    const left = before.get(ref);
+    const right = after.get(ref);
+    return Boolean(left && right && left.sourceHash !== right.sourceHash);
+  }));
+  return {
+    changed: membership.addedRefs.length > 0 || membership.removedRefs.length > 0 || changedRefs.length > 0,
+    ...membership,
+    changedRefs,
+    unchangedCriticalRefs: unchangedCritical(critical, before, after),
+  };
+}
+
+function epistemicSignature(entry: ManifestEntry) {
+  return {
+    epistemicAssessmentRef: entry.epistemicAssessmentRef,
+    epistemicClass: entry.epistemicClass,
+    ancestryRoots: entry.ancestryRoots,
+    invalidated: entry.invalidated,
+    debtType: entry.debtType,
+  };
+}
+
+function epistemicDelta(
+  before: Map<string, ManifestEntry>,
+  after: Map<string, ManifestEntry>,
+  critical: string[],
+): CognitiveSpineDeltaSummary {
+  const sharedRefs = [...before.keys()].filter((ref) => after.has(ref));
+  const changedRefs = sortedUnique(sharedRefs.filter((ref) => {
+    const left = before.get(ref);
+    const right = after.get(ref);
+    return Boolean(left && right && canonicalSerialize(epistemicSignature(left)) !== canonicalSerialize(epistemicSignature(right)));
+  }));
+  const membership = setDelta([...before.keys()], [...after.keys()]);
+  const assessmentRelevantAdded = membership.addedRefs.filter((ref) => Boolean(after.get(ref)?.epistemicAssessmentRef));
+  const assessmentRelevantRemoved = membership.removedRefs.filter((ref) => Boolean(before.get(ref)?.epistemicAssessmentRef));
+
+  return {
+    changed: changedRefs.length > 0 || assessmentRelevantAdded.length > 0 || assessmentRelevantRemoved.length > 0,
+    addedRefs: sortedUnique(assessmentRelevantAdded),
+    removedRefs: sortedUnique(assessmentRelevantRemoved),
+    changedRefs,
+    unchangedCriticalRefs: unchangedCritical(critical, before, after),
+  };
+}
+
+function governanceRefs(snapshot: CognitiveSpineSnapshot): string[] {
+  return sortedUnique([
+    ...snapshot.semanticPayload.decisionRefs,
+    ...snapshot.semanticPayload.freezeRefs,
+  ]);
+}
+
+function cognitiveRefs(snapshot: CognitiveSpineSnapshot): string[] {
+  const state = snapshot.semanticPayload;
+  return sortedUnique([
+    ...state.eventRefs,
+    ...state.evidenceRefs,
+    ...state.hypothesisRefs,
+    ...state.memoryRefs,
+    ...state.decisionRefs,
+    ...state.contradictionRefs,
+    ...state.freezeRefs,
+    ...state.questionRefs,
+    ...state.personCtRefs,
+  ]);
+}
+
+function refOnlyDelta(before: string[], after: string[], critical: string[]): CognitiveSpineDeltaSummary {
+  const membership = setDelta(before, after);
+  const beforeSet = new Set(before);
+  const afterSet = new Set(after);
+  return {
+    changed: membership.addedRefs.length > 0 || membership.removedRefs.length > 0,
+    ...membership,
+    changedRefs: [],
+    unchangedCriticalRefs: sortedUnique(critical.filter((ref) => beforeSet.has(ref) && afterSet.has(ref))),
+  };
+}
+
+export function buildSemanticTransitionPayload(
+  from: CognitiveSpineSnapshot,
+  to: CognitiveSpineSnapshot,
+  input: Pick<CognitiveSpineTransitionInput, 'transitionInputs' | 'admittedEpistemicRefs' | 'unchangedCriticalRefs'>,
+): CognitiveSpineSemanticTransitionPayload {
+  assertSnapshotIntegrity(from);
+  assertSnapshotIntegrity(to);
+
+  const critical = sortedUnique(input.unchangedCriticalRefs ?? []);
+  const beforeManifest = toMap(from.semanticPayload.sourceManifest);
+  const afterManifest = toMap(to.semanticPayload.sourceManifest);
+  const source = sourceDelta(beforeManifest, afterManifest, critical);
+  const epistemic = epistemicDelta(beforeManifest, afterManifest, critical);
+  const cognitiveMembership = refOnlyDelta(cognitiveRefs(from), cognitiveRefs(to), critical);
+  const governance = refOnlyDelta(governanceRefs(from), governanceRefs(to), critical);
+  const cognitiveChanged = from.snapshotHash !== to.snapshotHash;
+
+  return {
+    schemaVersion: COGNITIVE_SPINE_TRANSITION_SCHEMA_VERSION,
+    fromSnapshotHash: from.snapshotHash,
+    toSnapshotHash: to.snapshotHash,
+    transitionInputs: sortedUnique(input.transitionInputs),
+    admittedEpistemicRefs: sortedUnique(input.admittedEpistemicRefs),
+    sourceDelta: source,
+    epistemicDelta: epistemic,
+    cognitiveStateDelta: {
+      ...cognitiveMembership,
+      changed: cognitiveChanged,
+      changedRefs: sortedUnique([
+        ...source.changedRefs,
+        ...epistemic.changedRefs,
+      ]),
+    },
+    governanceDelta: governance,
+    projectorVersion: to.semanticPayload.projectorVersion,
+    policyVersion: to.semanticPayload.policyVersion,
+    snapshotSchemaVersion: to.semanticPayload.schemaVersion,
+  };
+}
+
+export function buildCognitiveSpineTransition(
+  from: CognitiveSpineSnapshot,
+  to: CognitiveSpineSnapshot,
+  input: CognitiveSpineTransitionInput,
+): CognitiveSpineTransition {
+  const semanticPayload = buildSemanticTransitionPayload(from, to, input);
+  return {
+    transitionId: requireNonEmpty(input.transitionId, 'TRANSITION_ID'),
+    createdAt: normalizeTimestamp(input.createdAt),
+    semanticPayload,
+    transitionHash: canonicalSha256(semanticPayload),
+    ...(input.runtimeMetadata ? { runtimeMetadata: input.runtimeMetadata } : {}),
+  };
+}


### PR DESCRIPTION
## Scope

Implements the pre-runtime Cognitive Spine infrastructure defined by the merged architectural freeze in PR #221. This PR targets `main` and does **not** connect Cognitive Runtime consumption yet.

## Adds

- Snapshot contract aligned to `SFI-CT-SNAPSHOT-CONTRACT-1.0`.
- Full semantic payload: source manifest/hashes, epistemic-state refs, lineage root, operating-mode ref, temporal state, verification debt and deterministic derived state.
- Canonical semantic serialization and SHA-256 hashing.
- Offset-aware timestamp normalization.
- Deterministic cutoff, visibility, ancestry resolution and source-ref deduplication.
- Guard: evidence cannot enter the projector without prior epistemic assessment.
- Artifact identity separated from semantic snapshot identity.
- Local/offline reconstruction CLI.
- CPRT-A deterministic fixture with frozen contract-complete hash `8c10f1f8b70833b2e4584a53684248e213e955bcff46003255eefdfd49be66fb`.
- Explicit state-transition contract and deterministic transition hashing; no `causedBy` field.
- Separate SOURCE / EPISTEMIC / COGNITIVE STATE / GOVERNANCE delta summaries.
- PERSON_CT → institution gate requiring prior institutional admission, canonical record and epistemic assessment.
- Explicit `CT AVAILABLE != CT CONSUMED` trace including profile version, consumption reason and blinded-observation prohibition.
- GitHub Actions verification independent of Vercel.

## Epistemic boundary

The projector does not create evidence, epistemic classes, independence, verification, admissibility or truth. It receives canonical records and pre-existing epistemic assessments, then performs deterministic selection/materialization only.

## Deployment boundary

The semantic core is Node/local-first and contains no Next.js/Vercel dependency. Vercel remains an optional adapter/surface, not part of semantic identity or reconstruction.

## Gate

`STATE INFRASTRUCTURE READY`: PASS.

Both `SFI Cognitive Spine` and `SFI Verify` pass on the current head. No Cognitive Runtime consumption is introduced in this PR; selective runtime integration follows separately.