### PR TITLE
Integrate institutional Runtime with sealed Cognitive Spine context

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - 'src/core/cognitive-spine/**'
+      - 'src/core/agents/metaOrchestrator.ts'
+      - 'src/infrastructure/ai/agentLlmClient.ts'
+      - 'src/lib/institution/cognitiveSpineRuntime*.ts'
+      - 'src/lib/institution/institutionalCycle.ts'
       - 'scripts/cognitive-spine/**'
       - 'docs/architecture/cognitive-spine/**'
       - '.github/workflows/sfi-cognitive-spine.yml'
@@ -12,6 +16,10 @@ on:
       - main
     paths:
       - 'src/core/cognitive-spine/**'
+      - 'src/core/agents/metaOrchestrator.ts'
+      - 'src/infrastructure/ai/agentLlmClient.ts'
+      - 'src/lib/institution/cognitiveSpineRuntime*.ts'
+      - 'src/lib/institution/institutionalCycle.ts'
       - 'scripts/cognitive-spine/**'
       - 'docs/architecture/cognitive-spine/**'
       - '.github/workflows/sfi-cognitive-spine.yml'
@@ -20,7 +28,7 @@ permissions:
   contents: read
 
 jobs:
-  pre-runtime:
+  cognitive-spine:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -36,3 +44,5 @@ jobs:
         run: node --import tsx --test src/core/cognitive-spine/cprt/cprtA.test.ts
       - name: Pre-runtime boundaries and transition semantics
         run: node --import tsx --test src/core/cognitive-spine/cprt/preRuntime.test.ts
+      - name: CPRT-B Runtime scope reconstruction and CT ablation
+        run: node --import tsx --test src/core/cognitive-spine/cprt/cprtB.runtime.test.ts

--- a/src/core/agents/metaOrchestrator.ts
+++ b/src/core/agents/metaOrchestrator.ts
@@ -1,478 +1,197 @@
-﻿import type {
+import type {
   KernelContext,
   KernelEvidence,
   AgentResult,
   AgentDefinition,
-  MemoryWriteDefinition
-} from "@/core/contracts";
+  MemoryWriteDefinition,
+} from '@/core/contracts';
 
-import { SfiAgent } from "./base";
-
+import { SfiAgent } from './base';
 
 export interface CognitiveTaskPlan {
-
   taskId: string;
-
   requiredAgents: string[];
-
   executionOrder: string[];
-
   missingInputs: string[];
-
   readiness: number;
-
 }
 
-
-/**
- * Canonical Cognitive Runtime Agent IDs
- */
 const AGENT_IDS = {
-
-  evidence_hunter:
-    "evidence_hunter",
-
-  phenotype_resolver:
-    "phenotype_resolver",
-
-  context_builder:
-    "context_builder",
-
-  cross_impact:
-    "cross_impact",
-
-  risk_agent:
-    "risk_agent",
-
-  social_field_simulator:
-    "social_field_simulator",
-
-  economic_field_simulator:
-    "economic_field_simulator",
-
-  cultural_simulator:
-    "cultural_simulator",
-
-  psychological_simulator:
-    "psychological_simulator",
-
-  policy_simulator:
-    "policy_simulator",
-
-  reality_calibration:
-    "reality_calibration"
-
+  evidence_hunter: 'evidence_hunter',
+  phenotype_resolver: 'phenotype_resolver',
+  context_builder: 'context_builder',
+  cross_impact: 'cross_impact',
+  risk_agent: 'risk_agent',
+  social_field_simulator: 'social_field_simulator',
+  economic_field_simulator: 'economic_field_simulator',
+  cultural_simulator: 'cultural_simulator',
+  psychological_simulator: 'psychological_simulator',
+  policy_simulator: 'policy_simulator',
+  reality_calibration: 'reality_calibration',
 } as const;
 
-
-
 const META_MEMORY_WRITES: MemoryWriteDefinition[] = [
-
   {
-    entityType:
-      "COGNITIVE_PLAN",
-
-    operation:
-      "CREATE"
-  }
-
+    entityType: 'COGNITIVE_PLAN',
+    operation: 'CREATE',
+  },
 ];
 
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
 
+function numeric(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+}
+
+function arrayLength(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
 
 export class MetaOrchestratorAgent extends SfiAgent {
-
-
   definition: AgentDefinition = {
-
-
-    id:
-      "AGENT_META_ORCHESTRATOR",
-
-
-    name:
-      "Meta Orchestrator",
-
-
-    type:
-      "ORCHESTRATION",
-
-
-    capabilities: [
-
-      "CAPABILITY_META_ORCHESTRATION"
-
-    ],
-
-
+    id: 'AGENT_META_ORCHESTRATOR',
+    name: 'Meta Orchestrator',
+    type: 'ORCHESTRATION',
+    capabilities: ['CAPABILITY_META_ORCHESTRATION'],
     readsMemory: [],
-
-
-    writesMemory:
-
-      META_MEMORY_WRITES,
-
-
-    emits: [
-
-      "SFI_COGNITIVE_PLAN_CREATED"
-
-    ],
-
-
-    humanApprovalRequired:
-
-      false,
-
-
-    confidenceModel:
-
-      "signal_coverage",
-
-
-    status:
-
-      "ACTIVE"
-
+    writesMemory: META_MEMORY_WRITES,
+    emits: ['SFI_COGNITIVE_PLAN_CREATED'],
+    humanApprovalRequired: false,
+    confidenceModel: 'signal_coverage',
+    status: 'ACTIVE',
   };
 
-
-
-  async execute(
-    context: KernelContext
-  ): Promise<AgentResult> {
-
-
-
+  async execute(context: KernelContext): Promise<AgentResult> {
     const requiredAgents: string[] = [];
-
     const missingInputs: string[] = [];
+    const addAgent = (agentId: string) => {
+      if (!requiredAgents.includes(agentId)) requiredAgents.push(agentId);
+    };
+    const addMissing = (input: string) => {
+      if (!missingInputs.includes(input)) missingInputs.push(input);
+    };
 
-
-
-    const hasEvidence =
-      context.evidence.length > 0;
-
-
-
-    const hasHypothesis =
-      context.hypotheses.length > 0;
-
-
+    const hasEvidence = context.evidence.length > 0;
+    const hasHypothesis = context.hypotheses.length > 0;
 
     if (!hasEvidence) {
-
-      requiredAgents.push(
-        AGENT_IDS.evidence_hunter
-      );
-
-
-      missingInputs.push(
-        "evidence"
-      );
-
+      addAgent(AGENT_IDS.evidence_hunter);
+      addMissing('evidence');
     }
 
+    if (!hasHypothesis) addAgent(AGENT_IDS.phenotype_resolver);
 
+    const cognitiveSpine = record(context.metadata?.cognitiveSpine);
+    const spineConsumed = cognitiveSpine.ctSnapshotConsumed === true;
+    const verificationDebt = record(cognitiveSpine.verificationDebt);
+    const verificationDebtAbsolute = spineConsumed ? numeric(verificationDebt.absolute) : 0;
 
-    if (!hasHypothesis) {
-
-      requiredAgents.push(
-        AGENT_IDS.phenotype_resolver
-      );
-
+    // CT state may request more verification, but it never substitutes for
+    // evidence. A consumed snapshot with verification debt therefore expands
+    // the plan toward evidence collection instead of upgrading confidence.
+    if (verificationDebtAbsolute > 0) {
+      addAgent(AGENT_IDS.evidence_hunter);
+      addMissing('cognitive_spine_verification_debt');
     }
 
+    addAgent(AGENT_IDS.context_builder);
+    addAgent(AGENT_IDS.cross_impact);
+    addAgent(AGENT_IDS.risk_agent);
 
-
-    requiredAgents.push(
-
-      AGENT_IDS.context_builder,
-
-      AGENT_IDS.cross_impact,
-
-      AGENT_IDS.risk_agent
-
-    );
-
-
-
-    if (
-      context.simulations.length === 0
-    ) {
-
-      requiredAgents.push(
-
-        AGENT_IDS.social_field_simulator,
-
-        AGENT_IDS.economic_field_simulator,
-
-        AGENT_IDS.cultural_simulator,
-
-        AGENT_IDS.psychological_simulator,
-
-        AGENT_IDS.policy_simulator
-
-      );
-
+    if (context.simulations.length === 0) {
+      addAgent(AGENT_IDS.social_field_simulator);
+      addAgent(AGENT_IDS.economic_field_simulator);
+      addAgent(AGENT_IDS.cultural_simulator);
+      addAgent(AGENT_IDS.psychological_simulator);
+      addAgent(AGENT_IDS.policy_simulator);
     }
 
+    addAgent(AGENT_IDS.reality_calibration);
 
-
-    requiredAgents.push(
-
-      AGENT_IDS.reality_calibration
-
-    );
-
-
-
-    const executionOrder = [
-
-      "meta_orchestrator",
-
-      ...requiredAgents
-
-    ];
-
-
-
+    const executionOrder = ['meta_orchestrator', ...requiredAgents];
     const plan: CognitiveTaskPlan = {
-
-
-      taskId:
-
-        context.taskId ??
-        crypto.randomUUID(),
-
-
+      taskId: context.taskId ?? crypto.randomUUID(),
       requiredAgents,
-
-
       executionOrder,
-
-
       missingInputs,
-
-
-      readiness:
-
-        0
-
+      readiness: 0,
     };
-
-
 
     const evidence: KernelEvidence = {
-
-
-      id:
-
-        crypto.randomUUID(),
-
-
-      source:
-
-        "MetaOrchestratorAgent",
-
-
-      confidence:
-
-        0,
-
-
-      payload:
-
-        plan
-
+      id: crypto.randomUUID(),
+      source: 'MetaOrchestratorAgent',
+      confidence: 0,
+      payload: plan,
     };
 
+    context.evidence.push(evidence);
 
-
-    context.evidence.push(
-
-      evidence
-
-    );
-
-
+    const cognitiveContextSignals = spineConsumed
+      ? Math.min(
+          arrayLength(cognitiveSpine.memoryRefs)
+          + arrayLength(cognitiveSpine.decisionRefs)
+          + arrayLength(cognitiveSpine.contradictionRefs)
+          + arrayLength(cognitiveSpine.questionRefs),
+          4,
+        )
+      : 0;
 
     const availableSignals =
-
-      context.evidence.length +
-
-      context.hypotheses.length +
-
-      context.simulations.length;
-
-
-
-    const readiness =
-
-      Math.min(
-
-        availableSignals / 10,
-
-        1
-
-      );
-
-
+      context.evidence.length
+      + context.hypotheses.length
+      + context.simulations.length
+      + cognitiveContextSignals;
+    const readiness = Math.min(availableSignals / 10, 1);
 
     plan.readiness = readiness;
-
-
     evidence.confidence = readiness;
 
-
-
     const taskGraph = {
-
-
-      nodes:
-
-        executionOrder,
-
-
-      edges:
-
-        executionOrder
-
-          .map(
-
-            (agent,index)=>({
-
-              from:
-
-                executionOrder[index - 1],
-
-              to:
-
-                agent
-
-            })
-
-          )
-
-          .filter(
-
-            edge =>
-              Boolean(edge.from)
-
-          )
-
+      nodes: executionOrder,
+      edges: executionOrder
+        .map((agent, index) => ({
+          from: executionOrder[index - 1],
+          to: agent,
+        }))
+        .filter((edge) => Boolean(edge.from)),
     };
-
-
 
     context.metadata = {
-
-
       ...context.metadata,
-
-
-      cognitivePlan:
-
-        plan,
-
-
+      cognitivePlan: plan,
       taskGraph,
-
-
       metaOrchestrator: {
-
-
-        executed:
-
-          true,
-
-
+        executed: true,
         readiness,
-
-
-        plannedAgents:
-
-          executionOrder.length,
-
-
-        taskGraphNodes:
-
-          taskGraph.nodes.length,
-
-
-        taskGraphEdges:
-
-          taskGraph.edges.length,
-
-
-        executedAt:
-
-          new Date().toISOString()
-
-      }
-
+        plannedAgents: executionOrder.length,
+        taskGraphNodes: taskGraph.nodes.length,
+        taskGraphEdges: taskGraph.edges.length,
+        cognitiveSpineConsumed: spineConsumed,
+        cognitiveSpineContextSignals: cognitiveContextSignals,
+        cognitiveSpineVerificationDebt: verificationDebtAbsolute,
+        executedAt: new Date().toISOString(),
+      },
     };
-
-
 
     return {
-
-
-      trace:
-
-        context.trace,
-
-
-      agentId:
-
-        this.definition.id,
-
-
-      status:
-
-        readiness > 0 ? "SUCCESS" : "PARTIAL",
-
-
+      trace: context.trace,
+      agentId: this.definition.id,
+      status: readiness > 0 ? 'SUCCESS' : 'PARTIAL',
       output: {
-
-
         plan,
-
-
-        taskGraph
-
+        taskGraph,
       },
-
-
       observations: [],
-
-
-      evidence: [
-
-        evidence
-
-      ],
-
-
+      evidence: [evidence],
       events: [],
-
-
-      memoryWrites:
-
-        META_MEMORY_WRITES,
-
-
-      confidence:
-
-        readiness,
-
-
-      executionTime:
-
-        0
-
+      memoryWrites: META_MEMORY_WRITES,
+      confidence: readiness,
+      executionTime: 0,
     };
-
   }
-
 }

--- a/src/core/cognitive-spine/contracts/decisionProvenance.ts
+++ b/src/core/cognitive-spine/contracts/decisionProvenance.ts
@@ -1,0 +1,45 @@
+export const COGNITIVE_SPINE_DECISION_PROVENANCE_VERSION = 'SFI-CT-DECISION-PROVENANCE-1.0' as const;
+
+export type CognitiveSpineDecisionProvenance = {
+  contractVersion: typeof COGNITIVE_SPINE_DECISION_PROVENANCE_VERSION;
+  executionId: string;
+  recordedAt: string;
+
+  snapshot: {
+    availableId: string;
+    availableHash: string;
+    consumed: boolean;
+    consumedId: string | null;
+    consumedHash: string | null;
+    projectionProfile: string | null;
+    profileVersion: string | null;
+    sourceCutoff: string;
+  };
+
+  stateRefs: {
+    observations: string[];
+    evidence: string[];
+    memory: string[];
+    hypotheses: string[];
+    constraints: string[];
+    contradictions: string[];
+    epistemicState: string[];
+  };
+
+  execution: {
+    operations: string[];
+    alternatives: string[];
+    rejectedConditions: string[];
+    model: string | null;
+    provider: string | null;
+    promptHash: string | null;
+  };
+
+  proposalRef: string | null;
+  rootActionRef: string | null;
+  interventionRef: string | null;
+  returnRef: string | null;
+  transitionRef: string | null;
+
+  provenanceGaps: string[];
+};

--- a/src/core/cognitive-spine/cprt/cprtB.runtime.test.ts
+++ b/src/core/cognitive-spine/cprt/cprtB.runtime.test.ts
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { MetaOrchestratorAgent } from '../../agents/metaOrchestrator';
+import type { KernelContext } from '../../contracts';
+import { COGNITIVE_TWIN_CONTRACT_VERSION } from '../../cognitive-twin/contract';
+import { materializeCognitiveSnapshot } from '../projector/cognitiveStateProjector';
+import { buildRuntimeCognitiveSpineProjection } from '../runtime/kernelProjection';
+import { buildCognitiveContextConsumptionTrace } from '../trace/consumptionTrace';
+import { cprtAProjectionInputA } from './fixture';
+
+function runtimeSnapshot() {
+  const input = cprtAProjectionInputA();
+  input.records.push(
+    {
+      ref: 'MEM-001',
+      kind: 'MEMORY',
+      recordedAt: '2026-08-16T07:10:00.000Z',
+      sourceHash: '1'.repeat(64),
+      visibilityProfiles: ['RUNTIME_GENERAL_CONTEXT_V1'],
+      debtType: 'VERIFICATION',
+    },
+    {
+      ref: 'DEC-001',
+      kind: 'DECISION',
+      recordedAt: '2026-08-16T07:11:00.000Z',
+      sourceHash: '2'.repeat(64),
+      visibilityProfiles: ['RUNTIME_GENERAL_CONTEXT_V1'],
+    },
+  );
+  input.projectionProfile = 'RUNTIME_GENERAL_CONTEXT_V1';
+  return materializeCognitiveSnapshot(input, {
+    snapshotId: 'CT-RUNTIME-FIXTURE',
+    createdAt: '2026-08-16T07:30:00.000Z',
+  });
+}
+
+function twinContext() {
+  return {
+    contractVersion: COGNITIVE_TWIN_CONTRACT_VERSION,
+    memory: [{
+      key: 'MEM-001',
+      type: 'RULE_CANDIDATE',
+      status: 'CANDIDATE',
+      content: { rule: 'request more evidence under uncertainty' },
+      evidenceRefs: ['EVID-001'],
+      version: 'fixture-v1',
+    }],
+    decisions: [{
+      id: 'DEC-001',
+      situation: 'verification debt present',
+      correctState: 'REQUEST_EVIDENCE',
+      generalRule: 'Do not promote uncertainty by repetition.',
+      requiredEvidence: ['independent observation'],
+      evidenceRefs: ['EVID-001'],
+    }],
+    warnings: [],
+  };
+}
+
+function baseKernelContext(metadata: Record<string, unknown> = {}): KernelContext {
+  return {
+    trace: {
+      logbookId: 'CPRT-B-RUNTIME',
+      correlationId: 'CPRT-B-RUNTIME-001',
+      initiatedBy: 'CPRT-B',
+      createdAt: '2026-08-16T07:30:00.000Z',
+    },
+    input: { fixture: true },
+    taskId: 'CPRT-B-RUNTIME-TASK',
+    currentEvent: 'CPRT_B_RUNTIME_FIXTURE',
+    evidence: [{
+      id: 'EVID-OBSERVED-001',
+      source: 'fixture:observed',
+      confidence: 1,
+      payload: { observed: true },
+    }],
+    hypotheses: [{
+      id: 'H-FIXTURE-001',
+      statement: 'A bounded prior context may alter verification planning.',
+      confidence: 0.5,
+    }],
+    contradictions: [],
+    simulations: [],
+    risks: [],
+    opportunities: [],
+    predictions: [],
+    metadata,
+  };
+}
+
+test('CPRT-B Runtime: one sealed snapshot reconstructs available and consumed state', () => {
+  const snapshot = runtimeSnapshot();
+  const trace = buildCognitiveContextConsumptionTrace({
+    executionId: 'CPRT-B-RUNTIME-001',
+    ctSnapshotAvailable: snapshot.snapshotId,
+    ctSnapshotHashAvailable: snapshot.snapshotHash,
+    ctSnapshotConsumed: true,
+    consumedSnapshotId: snapshot.snapshotId,
+    consumedSnapshotHash: snapshot.snapshotHash,
+    projectionProfile: snapshot.semanticPayload.projectionProfile,
+    profileVersion: '1.0',
+    consumptionReason: 'CPRT-B runtime fixture',
+    recordedAt: '2026-08-16T07:30:00.000Z',
+  });
+  const projection = buildRuntimeCognitiveSpineProjection({
+    snapshot,
+    trace,
+    cognitiveTwinContext: twinContext(),
+  });
+
+  assert.equal(projection.snapshotId, 'CT-RUNTIME-FIXTURE');
+  assert.equal(projection.ctSnapshotConsumed, true);
+  assert.deepEqual(projection.memoryRefs, ['MEM-001']);
+  assert.deepEqual(projection.decisionRefs, ['DEC-001']);
+  assert.equal(projection.verificationDebt.absolute, 2);
+  assert.equal(projection.cognitiveTwinContext?.memory.length, 1);
+  assert.equal(projection.cognitiveTwinContext?.decisions.length, 1);
+});
+
+test('CPRT-B Runtime: available but not consumed snapshot exposes no Twin content', () => {
+  const snapshot = runtimeSnapshot();
+  const trace = buildCognitiveContextConsumptionTrace({
+    executionId: 'CPRT-B-RUNTIME-ABLATION',
+    ctSnapshotAvailable: snapshot.snapshotId,
+    ctSnapshotHashAvailable: snapshot.snapshotHash,
+    ctSnapshotConsumed: false,
+    recordedAt: '2026-08-16T07:30:00.000Z',
+  });
+  const projection = buildRuntimeCognitiveSpineProjection({
+    snapshot,
+    trace,
+    cognitiveTwinContext: twinContext(),
+  });
+
+  assert.equal(projection.ctSnapshotAvailable, true);
+  assert.equal(projection.ctSnapshotConsumed, false);
+  assert.equal(projection.cognitiveTwinContext, null);
+});
+
+test('CPRT-B Runtime: CT verification debt changes planning without becoming evidence', async () => {
+  const snapshot = runtimeSnapshot();
+  const trace = buildCognitiveContextConsumptionTrace({
+    executionId: 'CPRT-B-RUNTIME-PLAN',
+    ctSnapshotAvailable: snapshot.snapshotId,
+    ctSnapshotHashAvailable: snapshot.snapshotHash,
+    ctSnapshotConsumed: true,
+    consumedSnapshotId: snapshot.snapshotId,
+    consumedSnapshotHash: snapshot.snapshotHash,
+    projectionProfile: snapshot.semanticPayload.projectionProfile,
+    profileVersion: '1.0',
+    consumptionReason: 'CPRT-B planning ablation fixture',
+    recordedAt: '2026-08-16T07:30:00.000Z',
+  });
+  const projection = buildRuntimeCognitiveSpineProjection({
+    snapshot,
+    trace,
+    cognitiveTwinContext: twinContext(),
+  });
+
+  const withCt = baseKernelContext({ cognitiveSpine: projection });
+  const withoutCt = baseKernelContext({});
+  const agent = new MetaOrchestratorAgent();
+
+  const withCtResult = await agent.execute(withCt);
+  const withoutCtResult = await agent.execute(withoutCt);
+  const withPlan = withCtResult.output as { plan: { requiredAgents: string[]; missingInputs: string[] } };
+  const withoutPlan = withoutCtResult.output as { plan: { requiredAgents: string[]; missingInputs: string[] } };
+
+  assert.ok(withPlan.plan.requiredAgents.includes('evidence_hunter'));
+  assert.ok(withPlan.plan.missingInputs.includes('cognitive_spine_verification_debt'));
+  assert.equal(withoutPlan.plan.requiredAgents.includes('evidence_hunter'), false);
+  assert.equal(withoutPlan.plan.missingInputs.includes('cognitive_spine_verification_debt'), false);
+
+  const ctEvidenceSources = withCt.evidence
+    .map((item) => item.source)
+    .filter((source) => /cognitive.?spine|cognitive.?twin|MEM-001|DEC-001/i.test(source));
+  assert.deepEqual(ctEvidenceSources, []);
+});
+
+test('CPRT-B Runtime: scope remains incomplete beyond execution and preserves gaps', () => {
+  const requiredGaps = [
+    'proposal_not_produced_by_institutional_cycle',
+    'root_action_not_part_of_institutional_cycle',
+    'intervention_not_part_of_institutional_cycle',
+    'observed_return_not_part_of_institutional_cycle',
+    'next_state_transition_not_materialized_in_same_cycle',
+  ];
+
+  assert.equal(requiredGaps.length, 5);
+  // This fixture deliberately does not declare the global CPRT-B gate passed.
+  // The next implementation stage must eliminate these gaps with preserved
+  // proposal → ROOT → intervention → return → transition provenance.
+});

--- a/src/core/cognitive-spine/profiles/runtimeGeneral.ts
+++ b/src/core/cognitive-spine/profiles/runtimeGeneral.ts
@@ -1,0 +1,35 @@
+import type { CognitiveSpineRefKind } from '../contracts/snapshot';
+
+export const RUNTIME_GENERAL_CONTEXT_PROFILE = {
+  profileId: 'RUNTIME_GENERAL_CONTEXT_V1',
+  version: '1.0',
+  surface: 'COGNITIVE_RUNTIME',
+  allowedRefKinds: [
+    'EVENT',
+    'EVIDENCE',
+    'HYPOTHESIS',
+    'MEMORY',
+    'DECISION',
+    'CONTRADICTION',
+    'FREEZE',
+    'QUESTION',
+  ] as CognitiveSpineRefKind[],
+  deniedRefKinds: ['PERSON_CT'] as CognitiveSpineRefKind[],
+  fieldVisibilityRules: {
+    personCtInheritance: 'DENIED',
+    memoryStatusMustRemainVisible: true,
+    decisionsAreGovernanceContextNotEvidence: true,
+    snapshotMustBeSealedBeforeExecution: true,
+    midRunLiveTwinReads: 'DENIED',
+  },
+  blindedByDefault: false,
+  purpose: 'Provide one bounded sealed institutional cognitive-state cut to the Cognitive Runtime without promoting memory or governance records into evidence.',
+} as const;
+
+export function runtimeGeneralAllowsKind(kind: CognitiveSpineRefKind): boolean {
+  return RUNTIME_GENERAL_CONTEXT_PROFILE.allowedRefKinds.includes(
+    kind as (typeof RUNTIME_GENERAL_CONTEXT_PROFILE.allowedRefKinds)[number],
+  ) && !RUNTIME_GENERAL_CONTEXT_PROFILE.deniedRefKinds.includes(
+    kind as (typeof RUNTIME_GENERAL_CONTEXT_PROFILE.deniedRefKinds)[number],
+  );
+}

--- a/src/core/cognitive-spine/runtime/kernelProjection.ts
+++ b/src/core/cognitive-spine/runtime/kernelProjection.ts
@@ -1,0 +1,84 @@
+import type { StudioTwinContext } from '@/core/cognitive-twin/studioContext';
+import type { CognitiveContextConsumptionTrace } from '../contracts/consumptionTrace';
+import type { CognitiveSpineSnapshot } from '../contracts/snapshot';
+
+export type RuntimeCognitiveSpineProjection = {
+  snapshotId: string;
+  snapshotHash: string;
+  sourceCutoff: string;
+  projectorVersion: string;
+  policyVersion: string;
+  projectionProfile: string;
+  profileVersion: string | null;
+  ctSnapshotAvailable: boolean;
+  ctSnapshotConsumed: boolean;
+  consumptionReason: string | null;
+
+  eventRefs: string[];
+  evidenceRefs: string[];
+  hypothesisRefs: string[];
+  memoryRefs: string[];
+  decisionRefs: string[];
+  contradictionRefs: string[];
+  freezeRefs: string[];
+  questionRefs: string[];
+  epistemicStateRefs: string[];
+
+  lineageRoot: string;
+  verificationDebt: CognitiveSpineSnapshot['semanticPayload']['verificationDebt'];
+  derivedState: CognitiveSpineSnapshot['semanticPayload']['derivedState'];
+
+  /**
+   * Frozen content resolved during the same materialization as snapshot refs.
+   * Memory and decisions remain context, never KernelEvidence by inheritance.
+   */
+  cognitiveTwinContext: StudioTwinContext | null;
+};
+
+export function buildRuntimeCognitiveSpineProjection(input: {
+  snapshot: CognitiveSpineSnapshot;
+  trace: CognitiveContextConsumptionTrace;
+  cognitiveTwinContext: StudioTwinContext;
+}): RuntimeCognitiveSpineProjection {
+  const { snapshot, trace } = input;
+
+  if (trace.ctSnapshotAvailable !== snapshot.snapshotId || trace.ctSnapshotHashAvailable !== snapshot.snapshotHash) {
+    throw new Error('COGNITIVE_SPINE_RUNTIME_AVAILABLE_SNAPSHOT_MISMATCH');
+  }
+
+  if (trace.ctSnapshotConsumed) {
+    if (trace.consumedSnapshotId !== snapshot.snapshotId || trace.consumedSnapshotHash !== snapshot.snapshotHash) {
+      throw new Error('COGNITIVE_SPINE_RUNTIME_CONSUMED_SNAPSHOT_MISMATCH');
+    }
+    if (trace.projectionProfile !== snapshot.semanticPayload.projectionProfile) {
+      throw new Error('COGNITIVE_SPINE_RUNTIME_PROFILE_MISMATCH');
+    }
+  }
+
+  const state = snapshot.semanticPayload;
+  return {
+    snapshotId: snapshot.snapshotId,
+    snapshotHash: snapshot.snapshotHash,
+    sourceCutoff: state.sourceCutoff,
+    projectorVersion: state.projectorVersion,
+    policyVersion: state.policyVersion,
+    projectionProfile: state.projectionProfile,
+    profileVersion: trace.profileVersion,
+    ctSnapshotAvailable: true,
+    ctSnapshotConsumed: trace.ctSnapshotConsumed,
+    consumptionReason: trace.consumptionReason,
+    eventRefs: [...state.eventRefs],
+    evidenceRefs: [...state.evidenceRefs],
+    hypothesisRefs: [...state.hypothesisRefs],
+    memoryRefs: [...state.memoryRefs],
+    decisionRefs: [...state.decisionRefs],
+    contradictionRefs: [...state.contradictionRefs],
+    freezeRefs: [...state.freezeRefs],
+    questionRefs: [...state.questionRefs],
+    epistemicStateRefs: [...state.epistemicStateRefs],
+    lineageRoot: state.lineageRoot,
+    verificationDebt: state.verificationDebt,
+    derivedState: state.derivedState,
+    cognitiveTwinContext: trace.ctSnapshotConsumed ? input.cognitiveTwinContext : null,
+  };
+}

--- a/src/infrastructure/ai/agentLlmClient.ts
+++ b/src/infrastructure/ai/agentLlmClient.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { runLlmTask, type LlmProviderId } from '@/lib/ai/providerRouter';
+import { COGNITIVE_TWIN_CONTRACT_VERSION } from '@/core/cognitive-twin/contract';
 import type { StudioTwinContext } from '@/core/cognitive-twin/studioContext';
 import { readStudioTwinContext } from '@/core/cognitive-twin/studioContext';
 import { SFI_CONVERGED_COGNITIVE_AGENT_REGISTRY } from '@/lib/sfi/cognitive-runtime/convergedRegistry';
@@ -96,6 +97,35 @@ function providerPreference(value: unknown): LlmProviderId | undefined {
   return typeof value === 'string' && allowed.includes(value as LlmProviderId) ? value as LlmProviderId : undefined;
 }
 
+async function resolveTwinContextForExecution(context: KernelContext): Promise<StudioTwinContext> {
+  const spine = record(context.metadata?.cognitiveSpine);
+  const explicitConsumption = typeof spine.ctSnapshotConsumed === 'boolean';
+  const twinFromContext = context.metadata?.cognitiveTwinContext;
+  const injectedTwin = twinFromContext && typeof twinFromContext === 'object' && !Array.isArray(twinFromContext)
+    ? twinFromContext as StudioTwinContext
+    : null;
+
+  if (explicitConsumption) {
+    if (spine.ctSnapshotConsumed === false) {
+      return {
+        contractVersion: COGNITIVE_TWIN_CONTRACT_VERSION,
+        memory: [],
+        decisions: [],
+        warnings: ['cognitive_spine_snapshot_available_but_not_consumed'],
+      };
+    }
+    if (!injectedTwin) {
+      throw new Error('COGNITIVE_SPINE_SEALED_TWIN_CONTEXT_REQUIRED');
+    }
+    return injectedTwin;
+  }
+
+  // Backward-compatible path for executions not yet wired to the Cognitive
+  // Spine. Once a run declares availability/consumption explicitly, live Twin
+  // reads are prohibited for the duration of that run.
+  return injectedTwin ?? await readStudioTwinContext();
+}
+
 export async function augmentAgentWithLlm(agentId: string, context: KernelContext): Promise<KernelContext> {
   if (context.metadata?.llmAugmentation !== true) return context;
   if (agentId === 'meta_orchestrator') return context;
@@ -103,10 +133,7 @@ export async function augmentAgentWithLlm(agentId: string, context: KernelContex
   const contract = SFI_CONVERGED_COGNITIVE_AGENT_REGISTRY.find((item) => item.id === agentId);
   if (!contract) return context;
 
-  const twinFromContext = context.metadata?.cognitiveTwinContext;
-  const twin = twinFromContext && typeof twinFromContext === 'object'
-    ? twinFromContext as StudioTwinContext
-    : await readStudioTwinContext();
+  const twin = await resolveTwinContextForExecution(context);
   const requestedProvider = providerPreference(context.metadata?.preferredLlmProvider) ?? 'groq';
   const studio = record(context.metadata?.studio);
   const existingInsights = record(context.metadata?.agentInsights);
@@ -117,6 +144,7 @@ export async function augmentAgentWithLlm(agentId: string, context: KernelContex
     `Layer: ${contract.layer}. Domain: ${contract.domain}. Authority: ${contract.authorityLevel}.`,
     'The Cognitive Twin contract is binding: evidence before inference; simulation is not observation; missing evidence remains missing; presentation is not state; never invent measurements, history, lineage, causal relations, attractor attainment, or completed actions.',
     'CANDIDATE Cognitive Twin memory is evidence-bound prior learning only. It is not VERIFIED or CANONICAL fact, must retain its status, and must never be promoted by the model. VERIFIED and CANONICAL memory remain distinct governed states.',
+    'Cognitive Spine memory and approved decisions are contextual state, not independent observed evidence. Repetition and derivation do not create evidence or independence.',
     'Treat deterministic metrics and persisted evidence as observations. Treat your interpretation as INFERENCE only.',
     'Do not issue irreversible actions. Do not claim that an object is ready for production unless explicit persisted checks support it.',
     'Return ONLY valid JSON using this schema: {"summary":string|null,"observations":string[],"hypotheses":string[],"contradictions":string[],"missingEvidence":string[],"recommendations":string[],"confidence":number}.',
@@ -135,11 +163,12 @@ export async function augmentAgentWithLlm(agentId: string, context: KernelContex
     predictions: context.predictions.slice(-6).map(item=>compactUnknown(item)),
     risks: context.risks.slice(-6).map(item=>compactUnknown(item)),
     opportunities: context.opportunities.slice(-6).map(item=>compactUnknown(item)),
+    cognitiveSpine: compactUnknown(context.metadata?.cognitiveSpine),
     cognitiveTwin: compactTwin(twin),
     previousAgentInsights: Object.fromEntries(Object.entries(existingInsights).slice(-4).map(([key,value])=>[key,compactUnknown(value)])),
     contextBoundary: {
       maxPromptCharacters: MAX_PROMPT_CHARS,
-      selectionRule: 'latest bounded evidence + bounded Twin memory + current deterministic state; omitted material remains available in persistent stores and is not treated as absent evidence',
+      selectionRule: 'one sealed Cognitive Spine cut when explicitly integrated; bounded memory remains context, never independent evidence; agents must not enrich the same run from live Twin state',
     },
   };
   const prompt = boundedPrompt(promptPayload);

--- a/src/lib/institution/cognitiveSpineRuntimeExecution.ts
+++ b/src/lib/institution/cognitiveSpineRuntimeExecution.ts
@@ -1,0 +1,95 @@
+import 'server-only';
+
+import {
+  COGNITIVE_SPINE_DECISION_PROVENANCE_VERSION,
+  type CognitiveSpineDecisionProvenance,
+} from '@/core/cognitive-spine/contracts/decisionProvenance';
+import type { KernelContext } from '@/lib/sfi/cognitive-runtime/kernelContext';
+import { executeSfiRuntime } from '@/lib/sfi/cognitive-runtime/runtime';
+import { materializeInstitutionalRuntimeCognitiveSpine } from './cognitiveSpineRuntimeMaterializer';
+
+export async function executeInstitutionalRuntimeWithCognitiveSpine(input: {
+  context: KernelContext;
+  sourceCutoff: string;
+  createdAt: string;
+  consume?: boolean;
+}) {
+  const consume = input.consume ?? true;
+  const materialized = await materializeInstitutionalRuntimeCognitiveSpine({
+    sourceCutoff: input.sourceCutoff,
+    executionId: input.context.cycleId,
+    createdAt: input.createdAt,
+    consume,
+  });
+
+  input.context.metadata = {
+    ...input.context.metadata,
+    cognitiveSpine: materialized.runtimeProjection,
+    // Existing LLM augmentation already supports an injected Twin context. By
+    // injecting the frozen materialization here, every agent in this run sees
+    // the same cut and has no reason to query live Twin state mid-run.
+    cognitiveTwinContext: materialized.runtimeProjection.cognitiveTwinContext,
+  };
+
+  const runtime = await executeSfiRuntime(input.context);
+  const spine = materialized.runtimeProjection;
+  const llmRuntime = runtime.context.metadata?.llmRuntime;
+  const llm = llmRuntime && typeof llmRuntime === 'object' && !Array.isArray(llmRuntime)
+    ? llmRuntime as Record<string, unknown>
+    : {};
+
+  const provenanceGaps = [
+    'proposal_not_produced_by_institutional_cycle',
+    'root_action_not_part_of_institutional_cycle',
+    'intervention_not_part_of_institutional_cycle',
+    'observed_return_not_part_of_institutional_cycle',
+    'next_state_transition_not_materialized_in_same_cycle',
+  ];
+
+  const decisionProvenance: CognitiveSpineDecisionProvenance = {
+    contractVersion: COGNITIVE_SPINE_DECISION_PROVENANCE_VERSION,
+    executionId: input.context.cycleId,
+    recordedAt: new Date().toISOString(),
+    snapshot: {
+      availableId: spine.snapshotId,
+      availableHash: spine.snapshotHash,
+      consumed: spine.ctSnapshotConsumed,
+      consumedId: spine.ctSnapshotConsumed ? spine.snapshotId : null,
+      consumedHash: spine.ctSnapshotConsumed ? spine.snapshotHash : null,
+      projectionProfile: spine.ctSnapshotConsumed ? spine.projectionProfile : null,
+      profileVersion: spine.ctSnapshotConsumed ? spine.profileVersion : null,
+      sourceCutoff: spine.sourceCutoff,
+    },
+    stateRefs: {
+      observations: [...spine.eventRefs],
+      evidence: [...spine.evidenceRefs],
+      memory: [...spine.memoryRefs],
+      hypotheses: [...spine.hypothesisRefs],
+      constraints: [...spine.decisionRefs, ...spine.freezeRefs],
+      contradictions: [...spine.contradictionRefs],
+      epistemicState: [...spine.epistemicStateRefs],
+    },
+    execution: {
+      operations: [...runtime.executedAgents],
+      alternatives: [],
+      rejectedConditions: [],
+      model: typeof llm.lastModel === 'string' ? llm.lastModel : null,
+      provider: typeof llm.lastProvider === 'string' ? llm.lastProvider : null,
+      promptHash: null,
+    },
+    proposalRef: null,
+    rootActionRef: null,
+    interventionRef: null,
+    returnRef: null,
+    transitionRef: null,
+    provenanceGaps,
+  };
+
+  return {
+    runtime,
+    cognitiveSpine: {
+      ...materialized,
+      decisionProvenance,
+    },
+  };
+}

--- a/src/lib/institution/cognitiveSpineRuntimeMaterializer.ts
+++ b/src/lib/institution/cognitiveSpineRuntimeMaterializer.ts
@@ -1,0 +1,371 @@
+import 'server-only';
+
+import { COGNITIVE_TWIN_CONTRACT_VERSION } from '@/core/cognitive-twin/contract';
+import type { StudioTwinContext } from '@/core/cognitive-twin/studioContext';
+import type {
+  AssessedEpistemicClass,
+  CognitiveDebtType,
+  CognitiveSpineSourceRecord,
+} from '@/core/cognitive-spine/contracts/snapshot';
+import { RUNTIME_GENERAL_CONTEXT_PROFILE, runtimeGeneralAllowsKind } from '@/core/cognitive-spine/profiles/runtimeGeneral';
+import {
+  projectCognitiveState,
+  sealCognitiveSnapshot,
+  semanticSnapshotHash,
+} from '@/core/cognitive-spine/projector/cognitiveStateProjector';
+import { buildRuntimeCognitiveSpineProjection } from '@/core/cognitive-spine/runtime/kernelProjection';
+import { canonicalSha256, normalizeTimestamp, sortedUnique } from '@/core/cognitive-spine/serialization/canonicalSerialize';
+import { buildCognitiveContextConsumptionTrace } from '@/core/cognitive-spine/trace/consumptionTrace';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+const PROJECTOR_VERSION = 'SFI-CT-PROJECTOR-1.0';
+const POLICY_VERSION = 'SFI-CT-INVARIANTS-1.0';
+const CANONICAL_MEMORY_MODULE = 'institutionalEventPipeline';
+const MEMORY_PAGE_SIZE = 128;
+const MAX_MEMORY_ROWS = 48;
+const MAX_DECISION_ROWS = 24;
+const MAX_EVIDENCE_ROWS = 64;
+const CONSUMABLE_MEMORY_STATUSES = new Set(['CANDIDATE', 'VERIFIED', 'CANONICAL']);
+
+type Row = Record<string, unknown>;
+
+type MaterializedMemory = StudioTwinContext['memory'][number] & {
+  id: string;
+  createdAt: string;
+};
+
+type MaterializedDecision = StudioTwinContext['decisions'][number] & {
+  approvedAt: string;
+};
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
+}
+
+function memoryStatus(content: Row) {
+  const lifecycle = text(content.lifecycleStatus);
+  if (lifecycle === 'REJECTED' || lifecycle === 'OBSOLETE' || lifecycle === 'FOUNDER_RESERVED') return lifecycle;
+  if (lifecycle === 'INSTITUTIONALIZED') return 'CANONICAL';
+  if (lifecycle === 'REPRODUCIBLE') return 'VERIFIED';
+
+  const declared = text(content.memoryStatus) ?? text(content.status);
+  if (declared && ['CANDIDATE', 'VERIFIED', 'CANONICAL', 'REJECTED', 'OBSOLETE', 'FOUNDER_RESERVED'].includes(declared)) {
+    return declared;
+  }
+  return 'CANDIDATE';
+}
+
+function assessedClass(value: unknown): AssessedEpistemicClass | null {
+  const normalized = text(value)?.toLowerCase() ?? null;
+  if (normalized === 'observed') return 'OBSERVED';
+  if (normalized === 'declared') return 'DECLARED';
+  if (normalized === 'derived') return 'DERIVED';
+  if (normalized === 'inferred') return 'INFERRED';
+  if (normalized === 'simulated') return 'SIMULATED';
+  if (normalized === 'projected') return 'PROJECTED';
+  if (normalized === 'verified_contrast') return 'VERIFIED_CONTRAST';
+  return null;
+}
+
+async function readCanonicalMemoryAtCutoff(sourceCutoff: string): Promise<{
+  rows: MaterializedMemory[];
+  warnings: string[];
+}> {
+  const db = createServiceSupabaseClient();
+  const latestByKey = new Map<string, MaterializedMemory>();
+  const seenKeys = new Set<string>();
+  const warnings: string[] = [];
+  let offset = 0;
+
+  while (latestByKey.size < MAX_MEMORY_ROWS) {
+    const page = await db.from('sfi_amv_memory')
+      .select('id,module,memory_delta,created_at')
+      .eq('module', CANONICAL_MEMORY_MODULE)
+      .not('memory_delta->raw->>memoryKey', 'is', null)
+      .lte('created_at', sourceCutoff)
+      .order('created_at', { ascending: false })
+      .range(offset, offset + MEMORY_PAGE_SIZE - 1);
+
+    if (page.error) {
+      warnings.push(`cognitive_spine_memory_unavailable:${page.error.message}`);
+      break;
+    }
+
+    const pageRows = page.data ?? [];
+    for (const item of pageRows) {
+      const row = record(item);
+      const delta = record(row.memory_delta);
+      const raw = record(delta.raw);
+      const key = text(raw.memoryKey);
+      const type = text(raw.memoryType);
+      const id = text(row.id);
+      const createdAt = text(row.created_at);
+      if (!key || !type || !id || !createdAt || seenKeys.has(key)) continue;
+
+      seenKeys.add(key);
+      const content = record(raw.content);
+      const status = memoryStatus(content);
+      if (!CONSUMABLE_MEMORY_STATUSES.has(status)) continue;
+
+      latestByKey.set(key, {
+        id,
+        key,
+        type,
+        status,
+        content: raw.content ?? null,
+        evidenceRefs: sortedUnique(strings(raw.evidenceRefs)),
+        version: text(content.cognitiveTwinExperienceContract) ?? 'SFI-CT-EXPERIENCE-2.0',
+        createdAt: normalizeTimestamp(createdAt),
+      });
+      if (latestByKey.size >= MAX_MEMORY_ROWS) break;
+    }
+
+    if (pageRows.length < MEMORY_PAGE_SIZE) break;
+    offset += MEMORY_PAGE_SIZE;
+  }
+
+  return { rows: [...latestByKey.values()], warnings };
+}
+
+async function readApprovedDecisionsAtCutoff(sourceCutoff: string): Promise<{
+  rows: MaterializedDecision[];
+  warnings: string[];
+}> {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_cognitive_twin_decisions')
+    .select('decision_id,situation,correct_state,general_rule,required_evidence,evidence_refs,approved_at,status')
+    .eq('status', 'APPROVED')
+    .lte('approved_at', sourceCutoff)
+    .order('approved_at', { ascending: false })
+    .limit(MAX_DECISION_ROWS);
+
+  if (result.error) {
+    return { rows: [], warnings: [`cognitive_spine_decisions_unavailable:${result.error.message}`] };
+  }
+
+  const rowsOut: MaterializedDecision[] = [];
+  for (const item of result.data ?? []) {
+    const row = record(item);
+    const id = text(row.decision_id);
+    const approvedAt = text(row.approved_at);
+    if (!id || !approvedAt) continue;
+    rowsOut.push({
+      id,
+      situation: text(row.situation) ?? '',
+      correctState: text(row.correct_state),
+      generalRule: text(row.general_rule) ?? '',
+      requiredEvidence: sortedUnique(strings(row.required_evidence)),
+      evidenceRefs: sortedUnique(strings(row.evidence_refs)),
+      approvedAt: normalizeTimestamp(approvedAt),
+    });
+  }
+
+  return { rows: rowsOut, warnings: [] };
+}
+
+async function readAssessedEvidenceAtCutoff(sourceCutoff: string): Promise<{
+  records: CognitiveSpineSourceRecord[];
+  warnings: string[];
+}> {
+  const db = createServiceSupabaseClient();
+  const evidenceResult = await db.from('root_evidence_entries')
+    .select('id,title,content,evidence_type,payload,epistemic_event_id,created_at')
+    .lte('created_at', sourceCutoff)
+    .order('created_at', { ascending: false })
+    .limit(MAX_EVIDENCE_ROWS);
+
+  if (evidenceResult.error) {
+    return { records: [], warnings: [`cognitive_spine_root_evidence_unavailable:${evidenceResult.error.message}`] };
+  }
+
+  const evidenceRows = (evidenceResult.data ?? []).map(record);
+  const eventIds = sortedUnique(evidenceRows
+    .map((row) => text(row.epistemic_event_id))
+    .filter((value): value is string => Boolean(value)));
+  const eventResult = eventIds.length
+    ? await db.from('epistemic_events')
+        .select('event_id,epistemic_class,occurred_at,hash_self,lineage,schema_version')
+        .in('event_id', eventIds)
+    : { data: [], error: null };
+
+  const warnings: string[] = [];
+  if (eventResult.error) warnings.push(`cognitive_spine_epistemic_events_unavailable:${eventResult.error.message}`);
+  const events = new Map((eventResult.data ?? []).map((item) => {
+    const row = record(item);
+    return [text(row.event_id) ?? '', row] as const;
+  }).filter(([id]) => Boolean(id)));
+
+  const recordsOut: CognitiveSpineSourceRecord[] = [];
+  for (const row of evidenceRows) {
+    const id = text(row.id);
+    const eventId = text(row.epistemic_event_id);
+    const createdAt = text(row.created_at);
+    if (!id || !eventId || !createdAt) continue;
+    const event = events.get(eventId);
+    if (!event) {
+      warnings.push(`cognitive_spine_evidence_assessment_missing:${id}`);
+      continue;
+    }
+    const epistemicClass = assessedClass(event.epistemic_class);
+    if (!epistemicClass) {
+      warnings.push(`cognitive_spine_evidence_class_not_admissible:${id}:${text(event.epistemic_class) ?? 'missing'}`);
+      continue;
+    }
+
+    const occurredAt = text(event.occurred_at) ?? createdAt;
+    const lineage = sortedUnique(strings(event.lineage));
+    const debtType: CognitiveDebtType | undefined = lineage.length === 0 ? 'PROVENANCE' : undefined;
+    const sourceHash = canonicalSha256({
+      store: 'root_evidence_entries',
+      id,
+      title: text(row.title),
+      content: text(row.content),
+      evidenceType: text(row.evidence_type),
+      payload: row.payload ?? null,
+      createdAt: normalizeTimestamp(createdAt),
+      epistemicEvent: {
+        eventId,
+        class: epistemicClass,
+        hashSelf: text(event.hash_self),
+        occurredAt: normalizeTimestamp(occurredAt),
+      },
+    });
+
+    recordsOut.push({
+      ref: `root_evidence_entries:${id}`,
+      kind: 'EVIDENCE',
+      recordedAt: normalizeTimestamp(occurredAt),
+      sourceHash,
+      sourceVersion: text(event.schema_version) ?? undefined,
+      epistemicAssessmentRef: eventId,
+      epistemicClass,
+      ancestryRoots: lineage,
+      visibilityProfiles: [RUNTIME_GENERAL_CONTEXT_PROFILE.profileId],
+      debtType,
+    });
+  }
+
+  return { records: recordsOut, warnings };
+}
+
+function memorySourceRecord(memory: MaterializedMemory): CognitiveSpineSourceRecord {
+  return {
+    ref: `sfi_amv_memory:${memory.id}`,
+    kind: 'MEMORY',
+    recordedAt: memory.createdAt,
+    sourceHash: canonicalSha256({
+      store: 'sfi_amv_memory',
+      id: memory.id,
+      key: memory.key,
+      type: memory.type,
+      status: memory.status,
+      content: memory.content,
+      evidenceRefs: memory.evidenceRefs,
+      version: memory.version,
+      createdAt: memory.createdAt,
+    }),
+    sourceVersion: memory.version,
+    visibilityProfiles: [RUNTIME_GENERAL_CONTEXT_PROFILE.profileId],
+    ...(memory.status === 'CANDIDATE' ? { debtType: 'VERIFICATION' as const } : {}),
+  };
+}
+
+function decisionSourceRecord(decision: MaterializedDecision): CognitiveSpineSourceRecord {
+  return {
+    ref: `sfi_cognitive_twin_decisions:${decision.id}`,
+    kind: 'DECISION',
+    recordedAt: decision.approvedAt,
+    sourceHash: canonicalSha256({
+      store: 'sfi_cognitive_twin_decisions',
+      decisionId: decision.id,
+      situation: decision.situation,
+      correctState: decision.correctState,
+      generalRule: decision.generalRule,
+      requiredEvidence: decision.requiredEvidence,
+      evidenceRefs: decision.evidenceRefs,
+      approvedAt: decision.approvedAt,
+      status: 'APPROVED',
+    }),
+    visibilityProfiles: [RUNTIME_GENERAL_CONTEXT_PROFILE.profileId],
+  };
+}
+
+export async function materializeInstitutionalRuntimeCognitiveSpine(input: {
+  sourceCutoff: string;
+  executionId: string;
+  createdAt: string;
+  consume: boolean;
+}) {
+  const sourceCutoff = normalizeTimestamp(input.sourceCutoff);
+  const [evidence, memory, decisions] = await Promise.all([
+    readAssessedEvidenceAtCutoff(sourceCutoff),
+    readCanonicalMemoryAtCutoff(sourceCutoff),
+    readApprovedDecisionsAtCutoff(sourceCutoff),
+  ]);
+
+  const cognitiveTwinContext: StudioTwinContext = {
+    contractVersion: COGNITIVE_TWIN_CONTRACT_VERSION,
+    memory: memory.rows.map(({ id: _id, createdAt: _createdAt, ...item }) => item),
+    decisions: decisions.rows.map(({ approvedAt: _approvedAt, ...item }) => item),
+    warnings: sortedUnique([...evidence.warnings, ...memory.warnings, ...decisions.warnings]),
+  };
+
+  const records = [
+    ...evidence.records,
+    ...memory.rows.map(memorySourceRecord),
+    ...decisions.rows.map(decisionSourceRecord),
+  ].filter((item) => runtimeGeneralAllowsKind(item.kind));
+
+  const semanticPayload = projectCognitiveState({
+    sourceCutoff,
+    projectorVersion: PROJECTOR_VERSION,
+    policyVersion: POLICY_VERSION,
+    projectionProfile: RUNTIME_GENERAL_CONTEXT_PROFILE.profileId,
+    records,
+  });
+  const snapshotHash = semanticSnapshotHash(semanticPayload);
+  const snapshot = sealCognitiveSnapshot(semanticPayload, {
+    snapshotId: `CT-${snapshotHash.slice(0, 16)}`,
+    createdAt: normalizeTimestamp(input.createdAt),
+    runtimeMetadata: { runner: 'institutional-runtime-materializer' },
+  });
+
+  const trace = buildCognitiveContextConsumptionTrace({
+    executionId: input.executionId,
+    ctSnapshotAvailable: snapshot.snapshotId,
+    ctSnapshotHashAvailable: snapshot.snapshotHash,
+    ctSnapshotConsumed: input.consume,
+    ...(input.consume ? {
+      consumedSnapshotId: snapshot.snapshotId,
+      consumedSnapshotHash: snapshot.snapshotHash,
+      projectionProfile: RUNTIME_GENERAL_CONTEXT_PROFILE.profileId,
+      profileVersion: RUNTIME_GENERAL_CONTEXT_PROFILE.version,
+      consumptionReason: 'bounded shared institutional runtime context',
+    } : {}),
+    recordedAt: normalizeTimestamp(input.createdAt),
+  });
+
+  const runtimeProjection = buildRuntimeCognitiveSpineProjection({
+    snapshot,
+    trace,
+    cognitiveTwinContext,
+  });
+
+  return {
+    snapshot,
+    trace,
+    runtimeProjection,
+    cognitiveTwinContext,
+    warnings: cognitiveTwinContext.warnings,
+  };
+}

--- a/src/lib/institution/institutionalCycle.ts
+++ b/src/lib/institution/institutionalCycle.ts
@@ -1,13 +1,13 @@
 import 'server-only';
 
 import { createServiceSupabaseClient } from '@/runtime/supabase/server';
-import { executeSfiRuntime } from '@/lib/sfi/cognitive-runtime/runtime';
 import type { KernelContext, KernelEvidence } from '@/lib/sfi/cognitive-runtime/kernelContext';
 import { createCognitiveTwinEnvelope } from '@/core/cognitive-twin/contract';
 import { syncRecentInstitutionalEvidenceToCognitiveTwin } from '@/core/cognitive-twin/evidenceIngestion';
 import { reconcileAutomaticPpoi } from '@/lib/mihm/automaticPpoiReconciliation';
 import { readInstitutionalAttractor, refreshInstitutionalAttractorTrajectory, SFI_INSTITUTIONAL_ATTRACTOR_KEY } from './institutionalAttractor';
 import { refreshPhenomenonTrajectoriesAndPpoi } from './phenomenonTrajectory';
+import { executeInstitutionalRuntimeWithCognitiveSpine } from './cognitiveSpineRuntimeExecution';
 
 type Row = Record<string, unknown>;
 
@@ -155,12 +155,28 @@ export async function runInstitutionalCycle(trigger = 'scheduled') {
     },
   };
 
-  const result = await executeSfiRuntime(context);
+  // The source cutoff is the cycle start, intentionally before current-cycle
+  // sync writes. This prevents a cycle from feeding its own newly materialized
+  // memory back into the state it claims to have started with.
+  const runtimeExecution = await executeInstitutionalRuntimeWithCognitiveSpine({
+    context,
+    sourceCutoff: startedAt,
+    createdAt: startedAt,
+    consume: true,
+  });
+  const result = runtimeExecution.runtime;
+  const cognitiveSpine = runtimeExecution.cognitiveSpine;
   const completedAt = new Date().toISOString();
   const memoryWarnings = cognitiveTwinSyncWarnings(memorySync);
   const phenomenonWarnings = 'warnings' in phenomenonRefresh && Array.isArray(phenomenonRefresh.warnings) ? phenomenonRefresh.warnings : [];
   const ppoiWarnings = automaticPpoi.warnings;
-  const criticalSubstepsOk = memorySync.ok && phenomenonRefresh.ok && automaticPpoi.ok && attractorRefresh.ok && cycleEvidence.warnings.length === 0;
+  const spineWarnings = cognitiveSpine.warnings;
+  const criticalSubstepsOk = memorySync.ok
+    && phenomenonRefresh.ok
+    && automaticPpoi.ok
+    && attractorRefresh.ok
+    && cycleEvidence.warnings.length === 0
+    && spineWarnings.length === 0;
   const runStatus = !result.completed ? 'ESCALATED' : criticalSubstepsOk ? 'CLOSED' : 'EVIDENCE_PENDING';
 
   const envelope = createCognitiveTwinEnvelope({
@@ -176,6 +192,19 @@ export async function runInstitutionalCycle(trigger = 'scheduled') {
       risks: result.context.risks.length,
       opportunities: result.context.opportunities.length,
       closureState: runStatus,
+      cognitiveSpine: {
+        snapshotId: cognitiveSpine.snapshot.snapshotId,
+        snapshotHash: cognitiveSpine.snapshot.snapshotHash,
+        sourceCutoff: cognitiveSpine.snapshot.semanticPayload.sourceCutoff,
+        projectionProfile: cognitiveSpine.trace.projectionProfile,
+        profileVersion: cognitiveSpine.trace.profileVersion,
+        consumed: cognitiveSpine.trace.ctSnapshotConsumed,
+        sourceCount: cognitiveSpine.snapshot.semanticPayload.derivedState.sourceCount,
+        memoryRefs: cognitiveSpine.snapshot.semanticPayload.memoryRefs.length,
+        decisionRefs: cognitiveSpine.snapshot.semanticPayload.decisionRefs.length,
+        verificationDebt: cognitiveSpine.snapshot.semanticPayload.verificationDebt.absolute,
+        provenanceGaps: cognitiveSpine.decisionProvenance.provenanceGaps,
+      },
       attractor: {
         key: SFI_INSTITUTIONAL_ATTRACTOR_KEY,
         evidenceCoverage: attractorRefresh.evidenceCoverage,
@@ -204,20 +233,25 @@ export async function runInstitutionalCycle(trigger = 'scheduled') {
     limitations: [
       'Attractor direction is founder-declared; attainment is evidence-dependent.',
       'Agent execution does not constitute external execution or independent validation.',
+      'Cognitive Spine memory and approved decisions are contextual state and are not promoted into observed evidence by consumption.',
+      'The consumed Cognitive Spine snapshot is sealed at the cycle-start cutoff; agents may not enrich the same run from live Twin state.',
       'Automatic PPOI registration is workflow state only; it does not constitute evidence, approval, intervention or outcome.',
       'Evidence coverage measures whether a dimension is evidenced or contradicted; it is not an attainment percentage.',
       ...cycleEvidence.warnings,
       ...memoryWarnings,
       ...phenomenonWarnings,
       ...ppoiWarnings,
+      ...spineWarnings,
+      ...cognitiveSpine.decisionProvenance.provenanceGaps.map((gap) => `cprt_b_gap:${gap}`),
     ],
     contradictions: [
       ...result.context.contradictions.map((item) => item.id),
       ...attractorRefresh.contradictedDimensions.map((dimension) => `attractor:${dimension}`),
     ],
-    missingEvidence: [...new Set([...attractorRefresh.missingDimensions, ...cycleEvidence.warnings])],
+    missingEvidence: [...new Set([...attractorRefresh.missingDimensions, ...cycleEvidence.warnings, ...spineWarnings])],
     actionsExecuted: [
       ...result.executedAgents.map((agent) => `cognitive:${agent}`),
+      `cognitive_spine:consumed:${cognitiveSpine.snapshot.snapshotId}`,
       `ppoi:auto_created:${automaticPpoi.created}`,
       `ppoi:auto_linked:${automaticPpoi.linked}`,
     ],
@@ -232,13 +266,19 @@ export async function runInstitutionalCycle(trigger = 'scheduled') {
     model: null,
     role: 'institutional_cycle',
     status: runStatus,
-    objective: 'Contrast persisted institutional evidence and phenomena against the declared SFI attractor, reconcile eligible PPOI containers automatically, then execute the governed cognitive topology.',
+    objective: 'Contrast persisted institutional evidence and phenomena against the declared SFI attractor, reconcile eligible PPOI containers automatically, then execute the governed cognitive topology through one sealed Cognitive Spine context.',
     input_snapshot: {
       trigger,
       cycleId,
       logbookId,
       evidenceRefs: cycleEvidence.refs,
       attractorKey: SFI_INSTITUTIONAL_ATTRACTOR_KEY,
+      cognitiveSpine: {
+        snapshot: cognitiveSpine.snapshot,
+        consumptionTrace: cognitiveSpine.trace,
+        decisionProvenance: cognitiveSpine.decisionProvenance,
+        consumedContext: cognitiveSpine.runtimeProjection.cognitiveTwinContext,
+      },
     },
     output_envelope: envelope,
     evidence_refs: cycleEvidence.refs,
@@ -254,6 +294,7 @@ export async function runInstitutionalCycle(trigger = 'scheduled') {
     ...phenomenonWarnings,
     ...ppoiWarnings,
     ...attractorRefresh.warnings,
+    ...spineWarnings,
     ...(runInsert.error ? [`cognitive_twin_run:${runInsert.error.message}`] : []),
   ];
 
@@ -271,6 +312,14 @@ export async function runInstitutionalCycle(trigger = 'scheduled') {
     executedAgents: result.executedAgents,
     agentCount: result.executedAgents.length,
     cognitiveTwinMemory: memorySync,
+    cognitiveSpine: {
+      snapshotId: cognitiveSpine.snapshot.snapshotId,
+      snapshotHash: cognitiveSpine.snapshot.snapshotHash,
+      consumed: cognitiveSpine.trace.ctSnapshotConsumed,
+      projectionProfile: cognitiveSpine.trace.projectionProfile,
+      profileVersion: cognitiveSpine.trace.profileVersion,
+      decisionProvenance: cognitiveSpine.decisionProvenance,
+    },
     attractor: attractorRefresh,
     phenomenaPpoi: phenomenonRefresh,
     automaticPpoi,


### PR DESCRIPTION
## Scope

Integrates the general institutional Cognitive Runtime with one sealed Cognitive Spine snapshot after CPRT-A passed and PR #222 merged.

## Changes

- Adds `RUNTIME_GENERAL_CONTEXT_V1`; `PERSON_CT` is denied by default.
- Materializes one cycle-start snapshot from already-assessed ROOT evidence, canonical institutional CT memory and approved CT decisions.
- Preserves memory/decisions as contextual state; they are never appended to `KernelEvidence` by inheritance.
- Uses cycle start as source cutoff so current-cycle sync writes cannot feed back into the same starting state.
- Injects the same sealed Twin context for the complete Runtime execution.
- Prevents LLM agents from independently reading live Twin state once Cognitive Spine availability/consumption is explicit.
- Meta Orchestrator may react to verification debt by requesting evidence collection; CT context cannot satisfy missing evidence.
- Persists snapshot, consumption trace, bounded consumed context and decision-provenance trace in the existing institutional-cycle run record; no new table.
- Adds CPRT-B Runtime-scope tests including `WITH CT` vs `WITHOUT CT` ablation and evidence-contamination checks.
- Extends Cognitive Spine QA to watch Runtime integration files, not only the pure core.

## Deployment boundary

No Vercel dependency is introduced into Cognitive Spine semantics. Pure contracts/projector/hash/profiles/CPRT remain Node/local-first; the institutional materializer is a server/worker adapter over canonical stores.

## Gates

- CPRT-A: PASS.
- CPRT-B Runtime scope: PASS.
- `SFI Cognitive Spine` workflow: PASS.
- `SFI Verify`: PASS.

## Claim boundary

`RUNTIME SPINE INTEGRATED`: PASS.

Full `SFI COGNITIVE SPINE INTEGRATED`: NOT YET CLAIMED. Remaining provenance gaps are proposal → ROOT action → explicit intervention execution → observed return → next-state transition.