### PR TITLE
Close Cognitive Spine governance and Field provenance path

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -6,8 +6,13 @@ on:
       - 'src/core/cognitive-spine/**'
       - 'src/core/agents/metaOrchestrator.ts'
       - 'src/infrastructure/ai/agentLlmClient.ts'
-      - 'src/lib/institution/cognitiveSpineRuntime*.ts'
+      - 'src/lib/institution/cognitiveSpine*.ts'
       - 'src/lib/institution/institutionalCycle.ts'
+      - 'src/lib/field/cognitiveSpineProposalLink.ts'
+      - 'src/lib/field/interventionExecution.ts'
+      - 'src/lib/field/governedReturn.ts'
+      - 'src/app/api/root/cognitive-spine/**'
+      - 'src/app/api/field/cases/**'
       - 'scripts/cognitive-spine/**'
       - 'docs/architecture/cognitive-spine/**'
       - '.github/workflows/sfi-cognitive-spine.yml'
@@ -18,8 +23,13 @@ on:
       - 'src/core/cognitive-spine/**'
       - 'src/core/agents/metaOrchestrator.ts'
       - 'src/infrastructure/ai/agentLlmClient.ts'
-      - 'src/lib/institution/cognitiveSpineRuntime*.ts'
+      - 'src/lib/institution/cognitiveSpine*.ts'
       - 'src/lib/institution/institutionalCycle.ts'
+      - 'src/lib/field/cognitiveSpineProposalLink.ts'
+      - 'src/lib/field/interventionExecution.ts'
+      - 'src/lib/field/governedReturn.ts'
+      - 'src/app/api/root/cognitive-spine/**'
+      - 'src/app/api/field/cases/**'
       - 'scripts/cognitive-spine/**'
       - 'docs/architecture/cognitive-spine/**'
       - '.github/workflows/sfi-cognitive-spine.yml'
@@ -46,3 +56,5 @@ jobs:
         run: node --import tsx --test src/core/cognitive-spine/cprt/preRuntime.test.ts
       - name: CPRT-B Runtime scope reconstruction and CT ablation
         run: node --import tsx --test src/core/cognitive-spine/cprt/cprtB.runtime.test.ts
+      - name: CPRT-B full path provenance fixtures
+        run: node --import tsx --test src/core/cognitive-spine/cprt/cprtB.full.test.ts

--- a/scripts/cognitive-spine/reconstruct-decision.ts
+++ b/scripts/cognitive-spine/reconstruct-decision.ts
@@ -1,0 +1,16 @@
+import { reconstructCognitiveSpineDecisionPath } from '../../src/lib/institution/cognitiveSpineProvenanceReconstruction';
+
+const runId = process.argv[2]?.trim();
+if (!runId) {
+  console.error('Usage: node --import tsx scripts/cognitive-spine/reconstruct-decision.ts <institutional-run-id>');
+  process.exit(2);
+}
+
+try {
+  const reconstruction = await reconstructCognitiveSpineDecisionPath(runId);
+  console.log(JSON.stringify(reconstruction, null, 2));
+  if (reconstruction.assessment.status === 'FAIL') process.exitCode = 1;
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/src/app/api/field/cases/[id]/execute/route.ts
+++ b/src/app/api/field/cases/[id]/execute/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { acknowledgeFieldInterventionExecution } from '@/lib/field/interventionExecution';
+import { AccessDeniedError, requireAuthenticatedUser } from '@/lib/system/access/server';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
+type RouteContext = { params: Promise<{ id: string }> | { id: string } };
+
+type Row = Record<string, unknown>;
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function text(value: unknown, max = 6000): string {
+  return typeof value === 'string' ? value.trim().slice(0, max) : '';
+}
+function requiredNumber01(value: unknown, field: string): number {
+  if (value === null || typeof value === 'undefined' || value === '') throw new Error(`${field}_REQUIRED`);
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' && value.trim() ? Number(value) : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) throw new Error(`${field}_INVALID`);
+  return parsed;
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const { id } = await Promise.resolve(context.params);
+    const caseId = decodeURIComponent(id).trim();
+    if (!caseId) return NextResponse.json({ ok: false, error: 'missing_case_id' }, { status: 400 });
+    const body = record(await request.json().catch(() => null));
+    const result = await acknowledgeFieldInterventionExecution({
+      ownerId: user.id,
+      caseId,
+      executionNote: text(body.executionNote),
+      executionSource: text(body.executionSource, 180) || 'participant_execution_declaration',
+      reliability: requiredNumber01(body.reliability, 'FIELD_INTERVENTION_EXECUTION_RELIABILITY'),
+      executedAt: text(body.executedAt, 80) || null,
+    });
+    return NextResponse.json({ ok: true, result }, { status: result.created ? 201 : 200 });
+  } catch (error) {
+    if (error instanceof AccessDeniedError) {
+      return NextResponse.json({ ok: false, error: error.code, details: error.message }, { status: error.status });
+    }
+    const details = error instanceof Error ? error.message : String(error);
+    const status = details.includes('_REQUIRED') || details.includes('_INVALID') || details.includes('_NOT_READY') || details.includes('_ACK_REQUIRED') || details.includes('_CONTRACT_NOT_ENABLED')
+      ? 400
+      : details.includes('NOT_FOUND')
+        ? 404
+        : details.includes('ALREADY_CLAIMED')
+          ? 409
+          : 500;
+    return NextResponse.json({ ok: false, error: 'FIELD_INTERVENTION_EXECUTION_ACK_FAILED', details }, { status });
+  }
+}

--- a/src/app/api/field/cases/route.ts
+++ b/src/app/api/field/cases/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { listFieldCycles, type FieldVerificationWindow } from '@/lib/field/operationalCycle';
 import { createGovernedFieldCycle } from '@/lib/field/governedReturn';
+import { createGovernedFieldCycleFromCognitiveSpineProposal } from '@/lib/field/cognitiveSpineProposalLink';
 import type { StudioFieldHandoff } from '@/lib/studio/fieldHandoff';
 import { AccessDeniedError, requireAuthenticatedUser } from '@/lib/system/access/server';
 
@@ -36,7 +37,7 @@ function failure(error: unknown) {
     return NextResponse.json({ ok: false, error: error.code, details: error.message }, { status: error.status });
   }
   const details = error instanceof Error ? error.message : String(error);
-  const status = details.includes('_REQUIRED') || details.includes('_INVALID') || details.includes('_NOT_OPEN') || details.includes('_NOT_READY') || details.includes('HANDOFF')
+  const status = details.includes('_REQUIRED') || details.includes('_INVALID') || details.includes('_NOT_OPEN') || details.includes('_NOT_READY') || details.includes('HANDOFF') || details.includes('_NOT_LINKABLE')
     ? 400
     : details.includes('NOT_FOUND')
       ? 404
@@ -58,6 +59,9 @@ function withReturnAvailability(value: unknown) {
       persisted_status: persistedStatus,
       status: persistedStatus === 'WAITING_RETURN' && !returnAvailable ? 'SEALED_WINDOW_ACTIVE' : persistedStatus,
       return_available: returnAvailable,
+      intervention_execution_required: text(metadata.interventionExecutionContract, 120) === 'SFI-FIELD-EXECUTION-ACK-1.0'
+        && !record(metadata.interventionExecutionAcknowledgement).evidenceId,
+      cognitive_spine_proposal_id: text(record(metadata.cognitiveSpineProposalLink).proposalId, 120) || null,
     };
   });
 }
@@ -76,7 +80,7 @@ export async function POST(request: Request) {
   try {
     const { user } = await requireAuthenticatedUser();
     const body = record(await request.json().catch(() => null));
-    const result = await createGovernedFieldCycle(user.id, {
+    const cycleInput = {
       title: text(body.title, 180),
       domain: text(body.domain, 80) || 'other',
       stuckSystem: text(body.stuckSystem),
@@ -93,7 +97,15 @@ export async function POST(request: Request) {
       rivalHypothesis: text(body.rivalHypothesis) || undefined,
       stoppingCondition: text(body.stoppingCondition) || undefined,
       studioHandoff: studioHandoff(body.studioHandoff),
-    });
+    };
+    const sourceActionProposalId = text(body.sourceActionProposalId, 120);
+    const result = sourceActionProposalId
+      ? await createGovernedFieldCycleFromCognitiveSpineProposal({
+          ownerId: user.id,
+          proposalId: sourceActionProposalId,
+          cycle: cycleInput,
+        })
+      : await createGovernedFieldCycle(user.id, cycleInput);
     return NextResponse.json({ ok: true, result }, { status: 201 });
   } catch (error) {
     return failure(error);

--- a/src/app/api/field/cases/route.ts
+++ b/src/app/api/field/cases/route.ts
@@ -37,11 +37,13 @@ function failure(error: unknown) {
     return NextResponse.json({ ok: false, error: error.code, details: error.message }, { status: error.status });
   }
   const details = error instanceof Error ? error.message : String(error);
-  const status = details.includes('_REQUIRED') || details.includes('_INVALID') || details.includes('_NOT_OPEN') || details.includes('_NOT_READY') || details.includes('HANDOFF') || details.includes('_NOT_LINKABLE')
-    ? 400
-    : details.includes('NOT_FOUND')
-      ? 404
-      : 500;
+  const status = details.includes('_ACTOR_MISMATCH')
+    ? 403
+    : details.includes('_REQUIRED') || details.includes('_INVALID') || details.includes('_NOT_OPEN') || details.includes('_NOT_READY') || details.includes('HANDOFF') || details.includes('_NOT_LINKABLE')
+      ? 400
+      : details.includes('NOT_FOUND')
+        ? 404
+        : 500;
   return NextResponse.json({ ok: false, error: 'FIELD_CYCLE_FAILED', details }, { status });
 }
 

--- a/src/app/api/root/cognitive-spine/runs/[id]/propose/route.ts
+++ b/src/app/api/root/cognitive-spine/runs/[id]/propose/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { proposeFromCognitiveSpineRun } from '@/lib/institution/cognitiveSpineProposal';
+import { requireGovernedActor } from '@/lib/operational/common';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
+type RouteContext = { params: Promise<{ id: string }> | { id: string } };
+
+type Row = Record<string, unknown>;
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function text(value: unknown, max = 4000): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim().slice(0, max) : null;
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  const gate = await requireGovernedActor('cognitive_spine.run.propose');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+  if (!gate.ctx.isRoot) return NextResponse.json({ ok: false, error: 'root_required' }, { status: 403 });
+
+  try {
+    const { id } = await Promise.resolve(context.params);
+    const runId = decodeURIComponent(id).trim();
+    if (!runId) return NextResponse.json({ ok: false, error: 'missing_run_id' }, { status: 400 });
+    const body = record(await request.json().catch(() => ({})));
+    const result = await proposeFromCognitiveSpineRun({
+      runId,
+      actorId: gate.ctx.user.id,
+      title: text(body.title, 300),
+      objective: text(body.objective, 4000),
+      note: text(body.note, 4000),
+    });
+    return NextResponse.json(result, { status: result.created ? 201 : 200 });
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    const status = details.includes('NOT_FOUND') ? 404 : details.includes('NOT_PROMOTABLE') || details.includes('NOT_CONSUMED') ? 409 : 400;
+    return NextResponse.json({ ok: false, error: 'COGNITIVE_SPINE_PROPOSAL_FAILED', details }, { status });
+  }
+}

--- a/src/core/cognitive-spine/contracts/decisionProvenance.ts
+++ b/src/core/cognitive-spine/contracts/decisionProvenance.ts
@@ -1,3 +1,5 @@
+import type { CognitiveSpineTransition } from './transition';
+
 export const COGNITIVE_SPINE_DECISION_PROVENANCE_VERSION = 'SFI-CT-DECISION-PROVENANCE-1.0' as const;
 
 export type CognitiveSpineDecisionProvenance = {
@@ -15,6 +17,15 @@ export type CognitiveSpineDecisionProvenance = {
     profileVersion: string | null;
     sourceCutoff: string;
   };
+
+  /**
+   * Explicit Δ from the immediately preceding institutional snapshot into the
+   * state consumed by this execution. It closes the previous state's T12 when
+   * a later run materializes this entry transition.
+   */
+  entryTransitionRef: string | null;
+  entryTransitionHash: string | null;
+  entryTransition: CognitiveSpineTransition | null;
 
   stateRefs: {
     observations: string[];
@@ -39,6 +50,7 @@ export type CognitiveSpineDecisionProvenance = {
   rootActionRef: string | null;
   interventionRef: string | null;
   returnRef: string | null;
+  /** Post-execution transition into a later state; expected to be discovered in a later run. */
   transitionRef: string | null;
 
   provenanceGaps: string[];

--- a/src/core/cognitive-spine/cprt/cprtB.full.test.ts
+++ b/src/core/cognitive-spine/cprt/cprtB.full.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { assessCprtBPath, type CprtBPathInput } from './cprtBPath';
+
+function completePath(): CprtBPathInput {
+  return {
+    run: {
+      runId: 'RUN-001',
+      snapshotId: 'CT-v143',
+      snapshotHash: 'a'.repeat(64),
+      snapshotHashValid: true,
+      snapshotConsumed: true,
+    },
+    proposal: {
+      proposalId: 'PROPOSAL-001',
+      sourceRunId: 'RUN-001',
+      sourceSnapshotHash: 'a'.repeat(64),
+      proposalEventId: 'EV-PROPOSAL-001',
+    },
+    governance: {
+      disposition: 'DESIGN_APPROVED',
+      rootActionRef: 'EV-ROOT-001',
+    },
+    field: {
+      caseId: 'FIELD-001',
+      linkedProposalId: 'PROPOSAL-001',
+      interventionRef: 'INT-001',
+      executionAcknowledgementRef: 'FIELD-EVID-EXEC-001',
+      executionEpistemicClass: 'DECLARED',
+      returnRef: 'RETURN-001',
+      outcomeRef: 'OUTCOME-001',
+      returnObserved: true,
+    },
+    resultingState: {
+      memoryRef: 'sfi_amv_memory:MEM-RETURN-001',
+      transitionRef: 'CT-TR-001',
+      transitionHash: 'b'.repeat(64),
+      transitionHashValid: true,
+      transitionAdmitsMemory: true,
+    },
+  };
+}
+
+test('CPRT-B full path passes only with complete provenance through resulting state', () => {
+  const result = assessCprtBPath(completePath());
+  assert.equal(result.status, 'PASS');
+  assert.deepEqual(result.gaps, []);
+  assert.equal(result.assertions.interventionProvenance, true);
+  assert.equal(result.assertions.returnProvenance, true);
+  assert.equal(result.assertions.resultingStateTransition, true);
+});
+
+test('CPRT-B does not infer intervention execution from a later return', () => {
+  const path = completePath();
+  if (!path.field) throw new Error('fixture field missing');
+  path.field.executionAcknowledgementRef = null;
+
+  const result = assessCprtBPath(path);
+  assert.equal(result.status, 'PARTIAL');
+  assert.ok(result.gaps.includes('explicit_intervention_execution_provenance_missing'));
+  assert.equal(result.assertions.returnProvenance, true);
+});
+
+test('CPRT-B rejects proposal lineage that points at another snapshot', () => {
+  const path = completePath();
+  if (!path.proposal) throw new Error('fixture proposal missing');
+  path.proposal.sourceSnapshotHash = 'c'.repeat(64);
+
+  const result = assessCprtBPath(path);
+  assert.equal(result.status, 'PARTIAL');
+  assert.ok(result.gaps.includes('proposal_lineage_missing_or_invalid'));
+});
+
+test('CPRT-B treats rejected governance as a non-intervention path, not a fabricated execution gap', () => {
+  const path = completePath();
+  path.governance = {
+    disposition: 'REJECTED',
+    rootActionRef: 'EV-ROOT-REJECT-001',
+  };
+  path.field = null;
+
+  const result = assessCprtBPath(path);
+  assert.equal(result.status, 'PASS');
+  assert.equal(result.assertions.interventionProvenance, 'NOT_APPLICABLE');
+  assert.equal(result.assertions.returnProvenance, 'NOT_APPLICABLE');
+});
+
+test('CPRT-B fails hard when the source snapshot semantic hash is invalid', () => {
+  const path = completePath();
+  path.run.snapshotHashValid = false;
+
+  const result = assessCprtBPath(path);
+  assert.equal(result.status, 'FAIL');
+  assert.ok(result.gaps.includes('snapshot_hash_invalid'));
+});

--- a/src/core/cognitive-spine/cprt/cprtBPath.ts
+++ b/src/core/cognitive-spine/cprt/cprtBPath.ts
@@ -1,0 +1,140 @@
+export const CPRT_B_PATH_VERSION = 'SFI-CT-CPRT-B-PATH-1.0' as const;
+
+export type CprtBGovernanceDisposition =
+  | 'DESIGN_APPROVED'
+  | 'REJECTED'
+  | 'FROZEN'
+  | 'WAITING_EVIDENCE'
+  | 'MISSING';
+
+export type CprtBPathInput = {
+  run: {
+    runId: string;
+    snapshotId: string;
+    snapshotHash: string;
+    snapshotHashValid: boolean;
+    snapshotConsumed: boolean;
+  };
+  proposal: {
+    proposalId: string;
+    sourceRunId: string;
+    sourceSnapshotHash: string;
+    proposalEventId: string | null;
+  } | null;
+  governance: {
+    disposition: CprtBGovernanceDisposition;
+    rootActionRef: string | null;
+  };
+  field: {
+    caseId: string;
+    linkedProposalId: string;
+    interventionRef: string | null;
+    executionAcknowledgementRef: string | null;
+    executionEpistemicClass: string | null;
+    returnRef: string | null;
+    outcomeRef: string | null;
+    returnObserved: boolean;
+  } | null;
+  resultingState: {
+    memoryRef: string | null;
+    transitionRef: string | null;
+    transitionHash: string | null;
+    transitionHashValid: boolean;
+    transitionAdmitsMemory: boolean;
+  } | null;
+};
+
+export type CprtBPathAssessment = {
+  contractVersion: typeof CPRT_B_PATH_VERSION;
+  status: 'PASS' | 'PARTIAL' | 'FAIL';
+  assertions: {
+    snapshotIntegrity: boolean;
+    snapshotConsumed: boolean;
+    proposalLineage: boolean;
+    rootGovernance: boolean;
+    interventionProvenance: boolean | 'NOT_APPLICABLE';
+    returnProvenance: boolean | 'NOT_APPLICABLE';
+    resultingStateTransition: boolean;
+  };
+  gaps: string[];
+};
+
+export function assessCprtBPath(input: CprtBPathInput): CprtBPathAssessment {
+  const gaps: string[] = [];
+  const snapshotIntegrity = input.run.snapshotHashValid;
+  const snapshotConsumed = input.run.snapshotConsumed;
+  if (!snapshotIntegrity) gaps.push('snapshot_hash_invalid');
+  if (!snapshotConsumed) gaps.push('snapshot_not_consumed');
+
+  const proposalLineage = Boolean(
+    input.proposal
+      && input.proposal.sourceRunId === input.run.runId
+      && input.proposal.sourceSnapshotHash === input.run.snapshotHash,
+  );
+  if (!proposalLineage) gaps.push('proposal_lineage_missing_or_invalid');
+
+  const rootGovernance = input.governance.disposition !== 'MISSING'
+    && Boolean(input.governance.rootActionRef);
+  if (!rootGovernance) gaps.push('root_governance_missing');
+
+  const noInterventionExpected = input.governance.disposition === 'REJECTED'
+    || input.governance.disposition === 'FROZEN';
+
+  let interventionProvenance: boolean | 'NOT_APPLICABLE';
+  let returnProvenance: boolean | 'NOT_APPLICABLE';
+
+  if (noInterventionExpected) {
+    interventionProvenance = 'NOT_APPLICABLE';
+    returnProvenance = 'NOT_APPLICABLE';
+  } else {
+    interventionProvenance = Boolean(
+      input.field
+        && input.proposal
+        && input.field.linkedProposalId === input.proposal.proposalId
+        && input.field.interventionRef
+        && input.field.executionAcknowledgementRef
+        && input.field.executionEpistemicClass === 'DECLARED',
+    );
+    if (!interventionProvenance) gaps.push('explicit_intervention_execution_provenance_missing');
+
+    returnProvenance = Boolean(
+      input.field
+        && input.field.returnObserved
+        && input.field.returnRef
+        && input.field.outcomeRef,
+    );
+    if (!returnProvenance) gaps.push('observed_return_provenance_missing');
+  }
+
+  const resultingStateTransition = Boolean(
+    input.resultingState
+      && input.resultingState.memoryRef
+      && input.resultingState.transitionRef
+      && input.resultingState.transitionHash
+      && input.resultingState.transitionHashValid
+      && input.resultingState.transitionAdmitsMemory,
+  );
+  if (!resultingStateTransition) gaps.push('resulting_state_transition_missing');
+
+  const hardFailure = !snapshotIntegrity;
+  const status = hardFailure
+    ? 'FAIL'
+    : gaps.length === 0
+      ? 'PASS'
+      : 'PARTIAL';
+
+  return {
+    contractVersion: CPRT_B_PATH_VERSION,
+    status,
+    assertions: {
+      snapshotIntegrity,
+      snapshotConsumed,
+      proposalLineage,
+      rootGovernance,
+      interventionProvenance,
+      returnProvenance,
+      resultingStateTransition,
+    },
+    gaps: [...new Set(gaps)],
+  };
+}

--- a/src/lib/field/cognitiveSpineProposalLink.ts
+++ b/src/lib/field/cognitiveSpineProposalLink.ts
@@ -1,0 +1,127 @@
+import 'server-only';
+
+import { canonicalSha256 } from '@/core/cognitive-spine/serialization/canonicalSerialize';
+import { appendOperationalEvent, recordValue, stringValue } from '@/lib/operational/common';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { createGovernedFieldCycle, type GovernedFieldCreateInput } from './governedReturn';
+
+type Row = Record<string, unknown>;
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+const LINKABLE_PROPOSAL_STATES = new Set(['design_approved', 'queued']);
+
+function spineProvenanceFromProposal(proposal: Row) {
+  const expectedDelta = record(proposal.expected_field_delta);
+  const payload = record(expectedDelta.payload);
+  const cognitiveSpine = record(payload.cognitiveSpine);
+  const proposalType = text(expectedDelta.proposalType) ?? text(record(proposal.proportionality_check).proposalType);
+  if (proposalType !== 'cognitive_spine_runtime_proposal') {
+    throw new Error('FIELD_COGNITIVE_SPINE_PROPOSAL_TYPE_INVALID');
+  }
+  const sourceRunId = text(cognitiveSpine.sourceRunId);
+  const snapshotId = text(cognitiveSpine.snapshotId);
+  const snapshotHash = text(cognitiveSpine.snapshotHash);
+  const sourceCutoff = text(cognitiveSpine.sourceCutoff);
+  if (!sourceRunId || !snapshotId || !snapshotHash || !sourceCutoff) {
+    throw new Error('FIELD_COGNITIVE_SPINE_PROPOSAL_PROVENANCE_MISSING');
+  }
+  return { sourceRunId, snapshotId, snapshotHash, sourceCutoff };
+}
+
+/**
+ * Optional bridge: a Field cycle may be opened from a ROOT-reviewed Cognitive
+ * Spine proposal. Field remains independently usable without this bridge.
+ *
+ * A design-approved/queued proposal is context, not proof and not automatic
+ * execution authority. Participant consent and the Field execution
+ * acknowledgement remain separate requirements.
+ */
+export async function createGovernedFieldCycleFromCognitiveSpineProposal(input: {
+  ownerId: string;
+  proposalId: string;
+  cycle: GovernedFieldCreateInput;
+}) {
+  const db = createServiceSupabaseClient();
+  const proposalResult = await db.from('action_proposals')
+    .select('*')
+    .eq('id', input.proposalId)
+    .maybeSingle();
+  if (proposalResult.error || !proposalResult.data) throw new Error('FIELD_COGNITIVE_SPINE_PROPOSAL_NOT_FOUND');
+  const proposal = record(proposalResult.data);
+  const state = text(proposal.status);
+  if (!state || !LINKABLE_PROPOSAL_STATES.has(state)) {
+    throw new Error(`FIELD_COGNITIVE_SPINE_PROPOSAL_NOT_LINKABLE:${state ?? 'missing'}`);
+  }
+  const spine = spineProvenanceFromProposal(proposal);
+
+  const result = await createGovernedFieldCycle(input.ownerId, input.cycle);
+  const fieldCase = record(result.case);
+  const caseId = text(fieldCase.id);
+  if (!caseId) throw new Error('FIELD_COGNITIVE_SPINE_LINK_CASE_ID_MISSING');
+  const linkedAt = new Date().toISOString();
+  const linkSemantic = {
+    contract: 'SFI-CT-FIELD-PROPOSAL-LINK-1.0',
+    proposalId: input.proposalId,
+    proposalStatusAtLink: state,
+    proposalEventId: text(proposal.event_id),
+    fieldCaseId: caseId,
+    sourceRunId: spine.sourceRunId,
+    snapshotId: spine.snapshotId,
+    snapshotHash: spine.snapshotHash,
+    sourceCutoff: spine.sourceCutoff,
+    participantConsent: true,
+    automaticExecution: false,
+  };
+  const linkHash = canonicalSha256(linkSemantic);
+
+  const event = await appendOperationalEvent({
+    eventName: 'cognitive_spine.proposal.field_case_linked',
+    actorId: input.ownerId,
+    confidence: 1,
+    payload: {
+      ...linkSemantic,
+      linkHash,
+      rule: 'The governed proposal is context for this Field case. Linking does not constitute execution, causal validation, or epistemic promotion.',
+    },
+    lineage: [input.proposalId, caseId, spine.sourceRunId, spine.snapshotHash],
+  });
+  if (!event.ok) throw new Error(`FIELD_COGNITIVE_SPINE_LINK_EVENT_FAILED:${'error' in event ? event.error : 'unknown'}`);
+
+  const metadata = record(fieldCase.metadata);
+  const link = {
+    ...linkSemantic,
+    linkEventId: event.data.id,
+    linkedAt,
+    linkHash,
+  };
+  const update = await db.from('field_cases')
+    .update({
+      metadata: {
+        ...metadata,
+        cognitiveSpineProposalLink: link,
+      },
+      updated_at: linkedAt,
+    })
+    .eq('id', caseId)
+    .eq('owner_id', input.ownerId)
+    .select('*')
+    .single();
+  if (update.error || !update.data) throw new Error(`FIELD_COGNITIVE_SPINE_LINK_PERSIST_FAILED:${update.error?.message ?? 'unknown'}`);
+
+  return {
+    ...result,
+    case: update.data,
+    cognitiveSpineProposalLink: link,
+    proposal: {
+      id: input.proposalId,
+      status: state,
+      title: stringValue(proposal.title),
+      expectedFieldDelta: recordValue(proposal.expected_field_delta),
+    },
+  };
+}

--- a/src/lib/field/cognitiveSpineProposalLink.ts
+++ b/src/lib/field/cognitiveSpineProposalLink.ts
@@ -27,15 +27,20 @@ function spineProvenanceFromProposal(proposal: Row) {
   const snapshotId = text(cognitiveSpine.snapshotId);
   const snapshotHash = text(cognitiveSpine.snapshotHash);
   const sourceCutoff = text(cognitiveSpine.sourceCutoff);
-  if (!sourceRunId || !snapshotId || !snapshotHash || !sourceCutoff) {
+  const actorId = text(expectedDelta.actorId);
+  if (!sourceRunId || !snapshotId || !snapshotHash || !sourceCutoff || !actorId) {
     throw new Error('FIELD_COGNITIVE_SPINE_PROPOSAL_PROVENANCE_MISSING');
   }
-  return { sourceRunId, snapshotId, snapshotHash, sourceCutoff };
+  return { sourceRunId, snapshotId, snapshotHash, sourceCutoff, actorId };
 }
 
 /**
  * Optional bridge: a Field cycle may be opened from a ROOT-reviewed Cognitive
  * Spine proposal. Field remains independently usable without this bridge.
+ *
+ * In this first implementation the proposal actor must also own the Field
+ * case. Cross-user delegation must use a future explicit invitation contract;
+ * possession of a proposal UUID is never delegation.
  *
  * A design-approved/queued proposal is context, not proof and not automatic
  * execution authority. Participant consent and the Field execution
@@ -58,6 +63,9 @@ export async function createGovernedFieldCycleFromCognitiveSpineProposal(input: 
     throw new Error(`FIELD_COGNITIVE_SPINE_PROPOSAL_NOT_LINKABLE:${state ?? 'missing'}`);
   }
   const spine = spineProvenanceFromProposal(proposal);
+  if (spine.actorId !== input.ownerId) {
+    throw new Error('FIELD_COGNITIVE_SPINE_PROPOSAL_ACTOR_MISMATCH');
+  }
 
   const result = await createGovernedFieldCycle(input.ownerId, input.cycle);
   const fieldCase = record(result.case);
@@ -74,6 +82,7 @@ export async function createGovernedFieldCycleFromCognitiveSpineProposal(input: 
     snapshotId: spine.snapshotId,
     snapshotHash: spine.snapshotHash,
     sourceCutoff: spine.sourceCutoff,
+    proposalActorId: spine.actorId,
     participantConsent: true,
     automaticExecution: false,
   };
@@ -121,7 +130,6 @@ export async function createGovernedFieldCycleFromCognitiveSpineProposal(input: 
       id: input.proposalId,
       status: state,
       title: stringValue(proposal.title),
-      expectedFieldDelta: recordValue(proposal.expected_field_delta),
     },
   };
 }

--- a/src/lib/field/governedReturn.ts
+++ b/src/lib/field/governedReturn.ts
@@ -7,6 +7,7 @@ import {
   type CreateFieldCycleInput,
   type ReturnFieldCycleInput,
 } from './operationalCycle';
+import { FIELD_INTERVENTION_EXECUTION_CONTRACT } from './interventionExecution';
 import { finalizeReturnContrast, canMarkLongitudinalCaseComplete } from './returnContrastContract';
 import { verifyStudioFieldHandoff, type StudioFieldHandoff } from '@/lib/studio/fieldHandoff';
 import { recordCognitiveTwinExperience } from '@/core/cognitive-twin/experience';
@@ -48,6 +49,8 @@ export async function createGovernedFieldCycle(ownerId: string, input: GovernedF
     frozenStoppingCondition,
     contrastContract: 'SFI-RETURN-CONTRAST-1.0',
     contrastFrozenAt: frozenAt,
+    interventionExecutionContract: FIELD_INTERVENTION_EXECUTION_CONTRACT,
+    interventionExecutionAcknowledgement: null,
     longitudinalComplete: false,
     studioFieldHandoff: input.studioHandoff ?? null,
     studioHandoffId: input.studioHandoff?.handoffId ?? null,
@@ -62,7 +65,57 @@ export async function createGovernedFieldCycle(ownerId: string, input: GovernedF
     frozenRivalHypothesis,
     frozenStoppingCondition,
     contrastFrozenAt: frozenAt,
+    interventionExecutionContract: FIELD_INTERVENTION_EXECUTION_CONTRACT,
     studioHandoff: input.studioHandoff ?? null,
+  };
+}
+
+async function requireExecutionAcknowledgement(db: ReturnType<typeof createServiceSupabaseClient>, ownerId: string, caseId: string, metadata: Row) {
+  if (text(metadata.interventionExecutionContract) !== FIELD_INTERVENTION_EXECUTION_CONTRACT) {
+    return {
+      legacy: true as const,
+      acknowledgement: null,
+      warnings: ['legacy_field_cycle_without_execution_ack_contract'],
+    };
+  }
+
+  const acknowledgement = record(metadata.interventionExecutionAcknowledgement);
+  const interventionId = text(acknowledgement.interventionId);
+  const evidenceId = text(acknowledgement.evidenceId);
+  const acknowledgementHash = text(acknowledgement.acknowledgementHash);
+  if (!interventionId || !evidenceId || !acknowledgementHash) {
+    throw new Error('FIELD_INTERVENTION_EXECUTION_ACK_REQUIRED');
+  }
+
+  const intervention = await db.from('field_interventions')
+    .select('id,status,completed_at,evidence_ids')
+    .eq('id', interventionId)
+    .eq('case_id', caseId)
+    .eq('owner_id', ownerId)
+    .maybeSingle();
+  if (intervention.error || !intervention.data) throw new Error('FIELD_INTERVENTION_EXECUTION_ACK_TARGET_MISSING');
+  if (text(intervention.data.status) !== 'EXECUTION_RECORDED') throw new Error('FIELD_INTERVENTION_EXECUTION_ACK_NOT_FINALIZED');
+  if (!strings(intervention.data.evidence_ids).includes(evidenceId)) throw new Error('FIELD_INTERVENTION_EXECUTION_ACK_EVIDENCE_NOT_LINKED');
+
+  const evidence = await db.from('field_case_evidence')
+    .select('id,evidence_type,payload,observed_at')
+    .eq('id', evidenceId)
+    .eq('case_id', caseId)
+    .eq('owner_id', ownerId)
+    .maybeSingle();
+  if (evidence.error || !evidence.data) throw new Error('FIELD_INTERVENTION_EXECUTION_ACK_EVIDENCE_MISSING');
+  if (text(evidence.data.evidence_type) !== 'intervention_execution_acknowledgement') {
+    throw new Error('FIELD_INTERVENTION_EXECUTION_ACK_EVIDENCE_INVALID');
+  }
+  const payload = record(evidence.data.payload);
+  if (text(payload.acknowledgementHash) !== acknowledgementHash) {
+    throw new Error('FIELD_INTERVENTION_EXECUTION_ACK_HASH_MISMATCH');
+  }
+
+  return {
+    legacy: false as const,
+    acknowledgement,
+    warnings: [] as string[],
   };
 }
 
@@ -77,6 +130,8 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
   if (!predictionSeal) throw new Error('FIELD_RETURN_PREDICTION_SEAL_REQUIRED');
   if (!rivalInterpretation) throw new Error('FIELD_RETURN_RIVAL_NOT_FROZEN_AT_T0');
   if (!stoppingCondition) throw new Error('FIELD_RETURN_STOPPING_CONDITION_NOT_FROZEN_AT_T0');
+
+  const execution = await requireExecutionAcknowledgement(db, ownerId, caseId, metadata);
 
   const handoffValue = metadata.studioFieldHandoff;
   if (handoffValue && !verifyStudioFieldHandoff(handoffValue as StudioFieldHandoff)) {
@@ -107,6 +162,8 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
       ...record(returnRow.data.payload),
       returnContrast: contrast,
       longitudinalComplete: true,
+      interventionExecutionAcknowledgement: execution.acknowledgement,
+      legacyExecutionProvenanceGap: execution.legacy,
       studioHandoffId: text(metadata.studioHandoffId) || null,
       studioHandoffHash: text(metadata.studioHandoffHash) || null,
     },
@@ -117,7 +174,12 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
   }
 
   const casePersist = await db.from('field_cases').update({
-    metadata: { ...metadata, returnContrast: contrast, longitudinalComplete: true },
+    metadata: {
+      ...metadata,
+      returnContrast: contrast,
+      longitudinalComplete: true,
+      legacyExecutionProvenanceGap: execution.legacy,
+    },
   }).eq('id', caseId).eq('owner_id', ownerId);
   if (casePersist.error) {
     await db.from('field_cases').update({ status: 'CLOSED_RETURN_CONTRAST_INCOMPLETE', updated_at: new Date().toISOString() }).eq('id', caseId).eq('owner_id', ownerId);
@@ -132,7 +194,13 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
     sourceKind:'field_outcomes',
     sourceRef:outcomeId,
     createdBy:ownerId,
-    evidenceRefs:[...strings(outcome.evidence_ids), ...(evidenceId ? [`field_case_evidence:${evidenceId}`] : [])],
+    evidenceRefs:[
+      ...strings(outcome.evidence_ids),
+      ...(evidenceId ? [`field_case_evidence:${evidenceId}`] : []),
+      ...(!execution.legacy && text(execution.acknowledgement?.evidenceId)
+        ? [`field_case_evidence:${text(execution.acknowledgement?.evidenceId)}`]
+        : []),
+    ],
     content:{
       epistemicClass:'OBSERVED_RETURN',
       caseId,
@@ -143,10 +211,12 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
       accepted:result.accepted,
       verified:result.verified,
       explanation:result.explanation,
+      interventionExecutionAcknowledgement: execution.acknowledgement,
+      legacyExecutionProvenanceGap: execution.legacy,
       returnContrast:contrast,
       studioHandoffId:text(metadata.studioHandoffId) || null,
       studioHandoffHash:text(metadata.studioHandoffHash) || null,
-      rule:'This is a completed Field return available to the Cognitive Twin as candidate institutional experience. One return does not establish general causality or mutate canon.',
+      rule:'This is a completed Field return available to the Cognitive Twin as candidate institutional experience. The execution acknowledgement remains DECLARED unless separately observed; one return does not establish general causality or mutate canon.',
     },
   });
 
@@ -154,6 +224,9 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
     ...result,
     returnContrast: contrast,
     longitudinalComplete: true as const,
+    interventionExecutionAcknowledgement: execution.acknowledgement,
+    legacyExecutionProvenanceGap: execution.legacy,
+    executionWarnings: execution.warnings,
     studioHandoffId: text(metadata.studioHandoffId) || null,
     studioHandoffHash: text(metadata.studioHandoffHash) || null,
     cognitiveTwinExperience:twinExperience,

--- a/src/lib/field/interventionExecution.ts
+++ b/src/lib/field/interventionExecution.ts
@@ -1,0 +1,230 @@
+import 'server-only';
+
+import { canonicalSha256, normalizeTimestamp, sortedUnique } from '@/core/cognitive-spine/serialization/canonicalSerialize';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+export const FIELD_INTERVENTION_EXECUTION_CONTRACT = 'SFI-FIELD-EXECUTION-ACK-1.0' as const;
+
+type Row = Record<string, unknown>;
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
+}
+function reliability(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) throw new Error('FIELD_INTERVENTION_EXECUTION_RELIABILITY_INVALID');
+  return parsed;
+}
+
+async function writeFieldAudit(input: {
+  ownerId: string;
+  caseId: string;
+  interventionId: string;
+  evidenceId: string;
+  executedAt: string;
+  acknowledgementHash: string;
+}) {
+  const db = createServiceSupabaseClient();
+  const audit = await db.from('sfi_audit_events').insert({
+    actor_id: input.ownerId,
+    action: 'field.intervention.execution_recorded',
+    target_type: 'field_intervention',
+    target_id: input.interventionId,
+    after_state: {
+      caseId: input.caseId,
+      interventionId: input.interventionId,
+      evidenceId: input.evidenceId,
+      executedAt: input.executedAt,
+      acknowledgementHash: input.acknowledgementHash,
+      epistemicClass: 'DECLARED',
+    },
+    context: {
+      surface: 'field',
+      contract: FIELD_INTERVENTION_EXECUTION_CONTRACT,
+      executionPerformedBySystem: false,
+    },
+  });
+  if (audit.error) throw new Error(`FIELD_INTERVENTION_EXECUTION_AUDIT_FAILED:${audit.error.message}`);
+}
+
+/**
+ * Records that the participant/operator declares the sealed intervention was
+ * executed. This function NEVER executes the intervention itself.
+ *
+ * The acknowledgement is a canonical Field record with epistemic class
+ * DECLARED unless a separate observation/evidence process later establishes a
+ * stronger relation. Governance cannot upgrade it by decree.
+ */
+export async function acknowledgeFieldInterventionExecution(input: {
+  ownerId: string;
+  caseId: string;
+  executionNote: string;
+  executionSource: string;
+  reliability: number;
+  executedAt?: string | null;
+}) {
+  if (input.executionNote.trim().length < 12) throw new Error('FIELD_INTERVENTION_EXECUTION_NOTE_REQUIRED');
+  if (!input.executionSource.trim()) throw new Error('FIELD_INTERVENTION_EXECUTION_SOURCE_REQUIRED');
+
+  const db = createServiceSupabaseClient();
+  const executedAt = normalizeTimestamp(input.executedAt?.trim() || new Date().toISOString());
+  if (new Date(executedAt).getTime() > Date.now() + 5 * 60 * 1000) {
+    throw new Error('FIELD_INTERVENTION_EXECUTION_IN_FUTURE');
+  }
+  const declaredReliability = reliability(input.reliability);
+
+  const [caseResult, interventionResult] = await Promise.all([
+    db.from('field_cases')
+      .select('id,status,metadata')
+      .eq('id', input.caseId)
+      .eq('owner_id', input.ownerId)
+      .maybeSingle(),
+    db.from('field_interventions')
+      .select('id,status,evidence_ids,minimum_change,started_at,created_at')
+      .eq('case_id', input.caseId)
+      .eq('owner_id', input.ownerId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  if (caseResult.error || !caseResult.data) throw new Error('FIELD_CASE_NOT_FOUND');
+  if (interventionResult.error || !interventionResult.data) throw new Error('FIELD_INTERVENTION_NOT_FOUND');
+  const fieldCase = record(caseResult.data);
+  const intervention = record(interventionResult.data);
+  const metadata = record(fieldCase.metadata);
+  if (text(metadata.interventionExecutionContract) !== FIELD_INTERVENTION_EXECUTION_CONTRACT) {
+    throw new Error('FIELD_INTERVENTION_EXECUTION_CONTRACT_NOT_ENABLED');
+  }
+  if (text(fieldCase.status) !== 'WAITING_RETURN') throw new Error('FIELD_INTERVENTION_EXECUTION_CASE_NOT_READY');
+  if (text(intervention.status) === 'EXECUTION_RECORDED') {
+    const existingAck = record(metadata.interventionExecutionAcknowledgement);
+    return {
+      ok: true as const,
+      created: false as const,
+      caseId: input.caseId,
+      interventionId: String(intervention.id),
+      acknowledgement: existingAck,
+    };
+  }
+  if (text(intervention.status) !== 'READY_FOR_EXECUTION') throw new Error('FIELD_INTERVENTION_EXECUTION_NOT_READY');
+
+  const interventionId = String(intervention.id);
+  const claim = await db.from('field_interventions')
+    .update({ status: 'EXECUTION_RECORDING' })
+    .eq('id', interventionId)
+    .eq('owner_id', input.ownerId)
+    .eq('case_id', input.caseId)
+    .eq('status', 'READY_FOR_EXECUTION')
+    .select('id')
+    .maybeSingle();
+  if (claim.error || !claim.data) throw new Error('FIELD_INTERVENTION_EXECUTION_ALREADY_CLAIMED');
+
+  try {
+    const acknowledgementSemantic = {
+      contract: FIELD_INTERVENTION_EXECUTION_CONTRACT,
+      caseId: input.caseId,
+      interventionId,
+      minimumChange: text(intervention.minimum_change),
+      executedAt,
+      executionSource: input.executionSource.trim(),
+      executionNote: input.executionNote.trim(),
+      reliability: declaredReliability,
+      epistemicClass: 'DECLARED',
+      executionPerformedBySystem: false,
+    };
+    const acknowledgementHash = canonicalSha256(acknowledgementSemantic);
+
+    const evidence = await db.from('field_case_evidence').insert({
+      case_id: input.caseId,
+      owner_id: input.ownerId,
+      evidence_type: 'intervention_execution_acknowledgement',
+      label: 'Intervention execution acknowledgement',
+      source: input.executionSource.trim(),
+      reliability: declaredReliability,
+      visibility: 'private',
+      payload: {
+        ...acknowledgementSemantic,
+        acknowledgementHash,
+        rule: 'This record states that execution was declared by the operator/participant. It does not independently verify that the world changed or that the intervention caused a later return.',
+      },
+      observed_at: executedAt,
+    }).select('*').single();
+    if (evidence.error || !evidence.data) throw new Error(`FIELD_INTERVENTION_EXECUTION_EVIDENCE_FAILED:${evidence.error?.message ?? 'unknown'}`);
+    const evidenceId = String(evidence.data.id);
+    const evidenceIds = sortedUnique([...strings(intervention.evidence_ids), evidenceId]);
+
+    const interventionUpdate = await db.from('field_interventions')
+      .update({
+        status: 'EXECUTION_RECORDED',
+        completed_at: executedAt,
+        evidence_ids: evidenceIds,
+      })
+      .eq('id', interventionId)
+      .eq('owner_id', input.ownerId)
+      .eq('case_id', input.caseId)
+      .eq('status', 'EXECUTION_RECORDING')
+      .select('*')
+      .single();
+    if (interventionUpdate.error || !interventionUpdate.data) {
+      throw new Error(`FIELD_INTERVENTION_EXECUTION_PERSIST_FAILED:${interventionUpdate.error?.message ?? 'unknown'}`);
+    }
+
+    const acknowledgement = {
+      contract: FIELD_INTERVENTION_EXECUTION_CONTRACT,
+      interventionId,
+      evidenceId,
+      executedAt,
+      source: input.executionSource.trim(),
+      reliability: declaredReliability,
+      epistemicClass: 'DECLARED',
+      acknowledgementHash,
+    };
+    const caseUpdate = await db.from('field_cases')
+      .update({
+        metadata: {
+          ...metadata,
+          interventionExecutionAcknowledgement: acknowledgement,
+        },
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', input.caseId)
+      .eq('owner_id', input.ownerId);
+    if (caseUpdate.error) throw new Error(`FIELD_INTERVENTION_EXECUTION_CASE_LINK_FAILED:${caseUpdate.error.message}`);
+
+    await writeFieldAudit({
+      ownerId: input.ownerId,
+      caseId: input.caseId,
+      interventionId,
+      evidenceId,
+      executedAt,
+      acknowledgementHash,
+    });
+
+    return {
+      ok: true as const,
+      created: true as const,
+      caseId: input.caseId,
+      interventionId,
+      evidence: evidence.data,
+      intervention: interventionUpdate.data,
+      acknowledgement,
+    };
+  } catch (error) {
+    await db.from('field_interventions')
+      .update({ status: 'READY_FOR_EXECUTION' })
+      .eq('id', interventionId)
+      .eq('owner_id', input.ownerId)
+      .eq('case_id', input.caseId)
+      .eq('status', 'EXECUTION_RECORDING');
+    throw error;
+  }
+}

--- a/src/lib/institution/cognitiveSpineProposal.ts
+++ b/src/lib/institution/cognitiveSpineProposal.ts
@@ -1,0 +1,150 @@
+import 'server-only';
+
+import type { CognitiveSpineSnapshot } from '@/core/cognitive-spine/contracts/snapshot';
+import { semanticSnapshotHash } from '@/core/cognitive-spine/projector/cognitiveStateProjector';
+import { canonicalSha256 } from '@/core/cognitive-spine/serialization/canonicalSerialize';
+import { appendOperationalEvent, createActionProposal, recordValue, stringValue } from '@/lib/operational/common';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+type Row = Record<string, unknown>;
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function extractSnapshot(run: Row): CognitiveSpineSnapshot {
+  const inputSnapshot = record(run.input_snapshot);
+  const cognitiveSpine = record(inputSnapshot.cognitiveSpine);
+  const snapshot = record(cognitiveSpine.snapshot) as unknown as CognitiveSpineSnapshot;
+  if (!snapshot.snapshotId || !snapshot.snapshotHash || !snapshot.semanticPayload) {
+    throw new Error('COGNITIVE_SPINE_RUN_SNAPSHOT_MISSING');
+  }
+  const calculated = semanticSnapshotHash(snapshot.semanticPayload);
+  if (calculated !== snapshot.snapshotHash) {
+    throw new Error('COGNITIVE_SPINE_RUN_SNAPSHOT_HASH_MISMATCH');
+  }
+  return snapshot;
+}
+
+async function existingProposalForRun(runId: string) {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('action_proposals')
+    .select('*')
+    .eq('expected_field_delta->payload->cognitiveSpine->>sourceRunId', runId)
+    .limit(1)
+    .maybeSingle();
+  if (result.error) throw new Error(`COGNITIVE_SPINE_PROPOSAL_LOOKUP_FAILED:${result.error.message}`);
+  return result.data ?? null;
+}
+
+/**
+ * Explicitly promotes one completed institutional Runtime run into the existing
+ * governed action-proposal lifecycle. Scheduled cycles do not auto-propose.
+ *
+ * The historical run is never rewritten. The new proposal points back to the
+ * run and sealed snapshot, preserving the temporal transition as a new node.
+ */
+export async function proposeFromCognitiveSpineRun(input: {
+  runId: string;
+  actorId: string;
+  title?: string | null;
+  objective?: string | null;
+  note?: string | null;
+}) {
+  const db = createServiceSupabaseClient();
+  const runResult = await db.from('sfi_cognitive_twin_runs')
+    .select('id,task_id,role,status,input_snapshot,output_envelope,evidence_refs,started_at,finished_at')
+    .eq('id', input.runId)
+    .maybeSingle();
+
+  if (runResult.error) throw new Error(`COGNITIVE_SPINE_RUN_LOOKUP_FAILED:${runResult.error.message}`);
+  if (!runResult.data) throw new Error('COGNITIVE_SPINE_RUN_NOT_FOUND');
+  const run = record(runResult.data);
+  if (text(run.role) !== 'institutional_cycle') throw new Error('COGNITIVE_SPINE_RUN_ROLE_NOT_PROMOTABLE');
+
+  const existing = await existingProposalForRun(input.runId);
+  if (existing) {
+    return { ok: true as const, created: false as const, proposal: existing, sourceRunId: input.runId };
+  }
+
+  const snapshot = extractSnapshot(run);
+  const inputSnapshot = record(run.input_snapshot);
+  const spine = record(inputSnapshot.cognitiveSpine);
+  const consumptionTrace = record(spine.consumptionTrace);
+  if (consumptionTrace.ctSnapshotConsumed !== true) {
+    throw new Error('COGNITIVE_SPINE_RUN_WAS_NOT_CONSUMED');
+  }
+
+  const objective = input.objective?.trim()
+    || 'Submit a selected Cognitive Spine Runtime result to ROOT/ACP governance without authorizing execution.';
+  const provenance = {
+    sourceRunId: String(run.id),
+    sourceTaskId: text(run.task_id),
+    runStatus: text(run.status),
+    runStartedAt: text(run.started_at),
+    runFinishedAt: text(run.finished_at),
+    snapshotId: snapshot.snapshotId,
+    snapshotHash: snapshot.snapshotHash,
+    sourceCutoff: snapshot.semanticPayload.sourceCutoff,
+    projectorVersion: snapshot.semanticPayload.projectorVersion,
+    policyVersion: snapshot.semanticPayload.policyVersion,
+    projectionProfile: snapshot.semanticPayload.projectionProfile,
+    evidenceRefs: Array.isArray(run.evidence_refs) ? run.evidence_refs : [],
+    note: input.note?.trim() || null,
+    executionAllowed: false,
+  };
+  const provenanceHash = canonicalSha256(provenance);
+
+  const event = await appendOperationalEvent({
+    eventName: 'cognitive_spine.runtime.proposal_created',
+    actorId: input.actorId,
+    confidence: 1,
+    payload: {
+      source_run_id: String(run.id),
+      snapshot_id: snapshot.snapshotId,
+      snapshot_hash: snapshot.snapshotHash,
+      provenance_hash: provenanceHash,
+      execution_allowed: false,
+      governance_required: true,
+      note: provenance.note,
+    },
+    lineage: [String(run.id), snapshot.snapshotId, snapshot.snapshotHash],
+  });
+  if (!event.ok) throw new Error(`COGNITIVE_SPINE_PROPOSAL_EVENT_FAILED:${'error' in event ? event.error : 'unknown'}`);
+
+  const proposal = await createActionProposal({
+    proposalType: 'cognitive_spine_runtime_proposal',
+    actorId: input.actorId,
+    title: input.title?.trim() || `Cognitive Spine proposal · ${snapshot.snapshotId}`,
+    objective,
+    inputVectorHash: snapshot.snapshotHash,
+    contentHash: provenanceHash,
+    status: 'proposed',
+    eventId: event.data.id,
+    payload: {
+      cognitiveSpine: provenance,
+      governanceBoundary: {
+        rootDecisionRequired: true,
+        executionAllowed: false,
+        epistemicUpgradeAllowed: false,
+      },
+      sourceRunOutputHash: canonicalSha256(recordValue(run.output_envelope)),
+    },
+  });
+  if (!proposal.ok) throw new Error(`COGNITIVE_SPINE_ACTION_PROPOSAL_FAILED:${proposal.error}:${stringValue(proposal.details) ?? 'unknown'}`);
+
+  return {
+    ok: true as const,
+    created: true as const,
+    proposal: proposal.data,
+    sourceRunId: String(run.id),
+    sourceSnapshotId: snapshot.snapshotId,
+    sourceSnapshotHash: snapshot.snapshotHash,
+    proposalEventId: event.data.id,
+    provenanceHash,
+  };
+}

--- a/src/lib/institution/cognitiveSpineProvenanceReconstruction.ts
+++ b/src/lib/institution/cognitiveSpineProvenanceReconstruction.ts
@@ -1,0 +1,413 @@
+import 'server-only';
+
+import type { CognitiveSpineSnapshot } from '@/core/cognitive-spine/contracts/snapshot';
+import type { CognitiveSpineTransition } from '@/core/cognitive-spine/contracts/transition';
+import {
+  assessCprtBPath,
+  type CprtBGovernanceDisposition,
+  type CprtBPathInput,
+} from '@/core/cognitive-spine/cprt/cprtBPath';
+import { semanticSnapshotHash } from '@/core/cognitive-spine/projector/cognitiveStateProjector';
+import { canonicalSha256 } from '@/core/cognitive-spine/serialization/canonicalSerialize';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+type Row = Record<string, unknown>;
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function rows(value: unknown): Row[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is Row => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+    : [];
+}
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
+}
+
+function snapshotFromRun(run: Row): CognitiveSpineSnapshot | null {
+  const inputSnapshot = record(run.input_snapshot);
+  const spine = record(inputSnapshot.cognitiveSpine);
+  const candidate = record(spine.snapshot) as unknown as CognitiveSpineSnapshot;
+  if (!candidate.snapshotId || !candidate.snapshotHash || !candidate.semanticPayload) return null;
+  return candidate;
+}
+
+function snapshotHashValid(snapshot: CognitiveSpineSnapshot | null) {
+  if (!snapshot) return false;
+  try {
+    return semanticSnapshotHash(snapshot.semanticPayload) === snapshot.snapshotHash;
+  } catch {
+    return false;
+  }
+}
+
+function proposalSpine(row: Row) {
+  const expected = record(row.expected_field_delta);
+  const payload = record(expected.payload);
+  return record(payload.cognitiveSpine);
+}
+
+function governanceDisposition(events: Row[]): {
+  disposition: CprtBGovernanceDisposition;
+  rootActionRef: string | null;
+  event: Row | null;
+} {
+  let selected: Row | null = null;
+  let disposition: CprtBGovernanceDisposition = 'MISSING';
+
+  for (const event of events) {
+    const name = text(event.event_name) ?? '';
+    if (name.endsWith('.design_approved')) {
+      selected = event;
+      disposition = 'DESIGN_APPROVED';
+    } else if (name.endsWith('.rejected')) {
+      selected = event;
+      disposition = 'REJECTED';
+    } else if (name.endsWith('.frozen')) {
+      selected = event;
+      disposition = 'FROZEN';
+    } else if (name.endsWith('.waiting_evidence')) {
+      selected = event;
+      disposition = 'WAITING_EVIDENCE';
+    }
+  }
+
+  return {
+    disposition,
+    rootActionRef: selected ? text(selected.event_id) : null,
+    event: selected,
+  };
+}
+
+function transitionIntegrity(transition: CognitiveSpineTransition | null) {
+  if (!transition?.transitionHash || !transition.semanticPayload) return false;
+  try {
+    return canonicalSha256(transition.semanticPayload) === transition.transitionHash;
+  } catch {
+    return false;
+  }
+}
+
+function entryTransitionFromRun(run: Row): CognitiveSpineTransition | null {
+  const inputSnapshot = record(run.input_snapshot);
+  const spine = record(inputSnapshot.cognitiveSpine);
+  const provenance = record(spine.decisionProvenance);
+  const transition = record(provenance.entryTransition) as unknown as CognitiveSpineTransition;
+  if (!transition.transitionId || !transition.transitionHash || !transition.semanticPayload) return null;
+  return transition;
+}
+
+async function findResultingTransition(input: {
+  db: ReturnType<typeof createServiceSupabaseClient>;
+  memoryRef: string;
+  memoryCreatedAt: string;
+}) {
+  const runs = await input.db.from('sfi_cognitive_twin_runs')
+    .select('id,task_id,input_snapshot,started_at')
+    .eq('role', 'institutional_cycle')
+    .gt('started_at', input.memoryCreatedAt)
+    .order('started_at', { ascending: true })
+    .limit(128);
+
+  if (runs.error) {
+    return {
+      run: null,
+      transition: null,
+      hashValid: false,
+      admitsMemory: false,
+      warning: `cprt_b_resulting_transition_lookup_failed:${runs.error.message}`,
+    };
+  }
+
+  for (const row of rows(runs.data)) {
+    const snapshot = snapshotFromRun(row);
+    if (!snapshot || !snapshotHashValid(snapshot)) continue;
+    if (!snapshot.semanticPayload.memoryRefs.includes(input.memoryRef)) continue;
+
+    const transition = entryTransitionFromRun(row);
+    const hashValid = transitionIntegrity(transition);
+    const admitsMemory = Boolean(transition && (
+      transition.semanticPayload.transitionInputs.includes(input.memoryRef)
+      || transition.semanticPayload.sourceDelta.addedRefs.includes(input.memoryRef)
+      || transition.semanticPayload.cognitiveStateDelta.addedRefs.includes(input.memoryRef)
+    ));
+
+    return {
+      run: {
+        id: text(row.id),
+        taskId: text(row.task_id),
+        startedAt: text(row.started_at),
+        snapshotId: snapshot.snapshotId,
+        snapshotHash: snapshot.snapshotHash,
+      },
+      transition,
+      hashValid,
+      admitsMemory,
+      warning: null,
+    };
+  }
+
+  return {
+    run: null,
+    transition: null,
+    hashValid: false,
+    admitsMemory: false,
+    warning: 'cprt_b_resulting_transition_not_yet_materialized',
+  };
+}
+
+/**
+ * Reconstructs a Cognitive Spine decision path from persisted canonical and
+ * governed records. Missing stages remain explicit gaps; this function never
+ * infers that an intervention occurred merely because a later return exists.
+ *
+ * This is a Node/server-worker adapter over existing stores. The assessment
+ * logic itself remains pure in `src/core/cognitive-spine/cprt/cprtBPath.ts`.
+ */
+export async function reconstructCognitiveSpineDecisionPath(runId: string) {
+  const db = createServiceSupabaseClient();
+  const warnings: string[] = [];
+
+  const runResult = await db.from('sfi_cognitive_twin_runs')
+    .select('id,task_id,role,status,input_snapshot,output_envelope,evidence_refs,started_at,finished_at')
+    .eq('id', runId)
+    .maybeSingle();
+  if (runResult.error) throw new Error(`CPRT_B_RUN_LOOKUP_FAILED:${runResult.error.message}`);
+  if (!runResult.data) throw new Error('CPRT_B_RUN_NOT_FOUND');
+
+  const run = record(runResult.data);
+  if (text(run.role) !== 'institutional_cycle') throw new Error('CPRT_B_RUN_ROLE_INVALID');
+  const snapshot = snapshotFromRun(run);
+  if (!snapshot) throw new Error('CPRT_B_RUN_SNAPSHOT_MISSING');
+  const hashValid = snapshotHashValid(snapshot);
+  const spineEnvelope = record(record(run.input_snapshot).cognitiveSpine);
+  const consumptionTrace = record(spineEnvelope.consumptionTrace);
+
+  const proposalResult = await db.from('action_proposals')
+    .select('*')
+    .eq('expected_field_delta->payload->cognitiveSpine->>sourceRunId', runId)
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+  if (proposalResult.error) warnings.push(`cprt_b_proposal_lookup_failed:${proposalResult.error.message}`);
+  const proposal = proposalResult.data ? record(proposalResult.data) : null;
+  const proposalId = proposal ? text(proposal.id) : null;
+  const proposalContext = proposal ? proposalSpine(proposal) : {};
+
+  let governanceEvents: Row[] = [];
+  if (proposalId) {
+    const governanceResult = await db.from('epistemic_events')
+      .select('event_id,event_name,epistemic_class,payload,lineage,occurred_at,hash_self')
+      .contains('lineage', [proposalId])
+      .order('occurred_at', { ascending: true })
+      .limit(64);
+    if (governanceResult.error) warnings.push(`cprt_b_governance_lookup_failed:${governanceResult.error.message}`);
+    governanceEvents = rows(governanceResult.data);
+  }
+  const governance = governanceDisposition(governanceEvents);
+
+  let selectedFieldCase: Row | null = null;
+  let fieldCandidates: Row[] = [];
+  if (proposalId) {
+    const fields = await db.from('field_cases')
+      .select('id,status,metadata,created_at,updated_at')
+      .eq('metadata->cognitiveSpineProposalLink->>proposalId', proposalId)
+      .order('created_at', { ascending: true })
+      .limit(20);
+    if (fields.error) warnings.push(`cprt_b_field_link_lookup_failed:${fields.error.message}`);
+    fieldCandidates = rows(fields.data);
+  }
+
+  let fieldDetail: {
+    caseId: string;
+    linkedProposalId: string;
+    interventionRef: string | null;
+    executionAcknowledgementRef: string | null;
+    executionEpistemicClass: string | null;
+    returnRef: string | null;
+    outcomeRef: string | null;
+    returnObserved: boolean;
+    returnEvidenceRefs: string[];
+    metadata: Row;
+  } | null = null;
+  let outcomeId: string | null = null;
+
+  for (const fieldCase of fieldCandidates) {
+    const caseId = text(fieldCase.id);
+    if (!caseId) continue;
+    const [interventionResult, returnResult, outcomeResult] = await Promise.all([
+      db.from('field_interventions')
+        .select('id,status,completed_at,evidence_ids,created_at')
+        .eq('case_id', caseId)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      db.from('field_returns')
+        .select('id,status,returned_at,evidence_ids,payload,created_at')
+        .eq('case_id', caseId)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      db.from('field_outcomes')
+        .select('id,intervention_id,evidence_ids,recorded_at,verified')
+        .eq('case_id', caseId)
+        .order('recorded_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+    ]);
+    if (interventionResult.error) warnings.push(`cprt_b_intervention_lookup_failed:${interventionResult.error.message}`);
+    if (returnResult.error) warnings.push(`cprt_b_return_lookup_failed:${returnResult.error.message}`);
+    if (outcomeResult.error) warnings.push(`cprt_b_outcome_lookup_failed:${outcomeResult.error.message}`);
+
+    const metadata = record(fieldCase.metadata);
+    const link = record(metadata.cognitiveSpineProposalLink);
+    const acknowledgement = record(metadata.interventionExecutionAcknowledgement);
+    const returnRow = returnResult.data ? record(returnResult.data) : {};
+    const outcomeRow = outcomeResult.data ? record(outcomeResult.data) : {};
+    const candidate = {
+      caseId,
+      linkedProposalId: text(link.proposalId) ?? '',
+      interventionRef: text(acknowledgement.interventionId) ?? text(interventionResult.data?.id),
+      executionAcknowledgementRef: text(acknowledgement.evidenceId),
+      executionEpistemicClass: text(acknowledgement.epistemicClass),
+      returnRef: text(returnRow.id),
+      outcomeRef: text(outcomeRow.id),
+      returnObserved: Boolean(text(returnRow.returned_at) && strings(returnRow.evidence_ids).length > 0),
+      returnEvidenceRefs: strings(returnRow.evidence_ids),
+      metadata,
+    };
+
+    if (!fieldDetail || (candidate.returnObserved && candidate.outcomeRef)) {
+      selectedFieldCase = fieldCase;
+      fieldDetail = candidate;
+      outcomeId = candidate.outcomeRef;
+    }
+    if (candidate.returnObserved && candidate.outcomeRef) break;
+  }
+
+  let returnMemory: {
+    id: string;
+    ref: string;
+    createdAt: string;
+  } | null = null;
+  let resultingState: Awaited<ReturnType<typeof findResultingTransition>> | null = null;
+
+  if (outcomeId) {
+    const memoryResult = await db.from('sfi_amv_memory')
+      .select('id,memory_delta,created_at')
+      .eq('module', 'institutionalEventPipeline')
+      .eq('memory_delta->raw->>sourceKind', 'field_outcomes')
+      .eq('memory_delta->raw->>sourceRef', outcomeId)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    if (memoryResult.error) warnings.push(`cprt_b_return_memory_lookup_failed:${memoryResult.error.message}`);
+    if (memoryResult.data?.id && memoryResult.data.created_at) {
+      returnMemory = {
+        id: String(memoryResult.data.id),
+        ref: `sfi_amv_memory:${String(memoryResult.data.id)}`,
+        createdAt: String(memoryResult.data.created_at),
+      };
+      resultingState = await findResultingTransition({
+        db,
+        memoryRef: returnMemory.ref,
+        memoryCreatedAt: returnMemory.createdAt,
+      });
+      if (resultingState.warning) warnings.push(resultingState.warning);
+    }
+  }
+
+  const assessmentInput: CprtBPathInput = {
+    run: {
+      runId,
+      snapshotId: snapshot.snapshotId,
+      snapshotHash: snapshot.snapshotHash,
+      snapshotHashValid: hashValid,
+      snapshotConsumed: consumptionTrace.ctSnapshotConsumed === true,
+    },
+    proposal: proposalId ? {
+      proposalId,
+      sourceRunId: text(proposalContext.sourceRunId) ?? '',
+      sourceSnapshotHash: text(proposalContext.snapshotHash) ?? '',
+      proposalEventId: proposal ? text(proposal.event_id) : null,
+    } : null,
+    governance: {
+      disposition: governance.disposition,
+      rootActionRef: governance.rootActionRef,
+    },
+    field: fieldDetail ? {
+      caseId: fieldDetail.caseId,
+      linkedProposalId: fieldDetail.linkedProposalId,
+      interventionRef: fieldDetail.interventionRef,
+      executionAcknowledgementRef: fieldDetail.executionAcknowledgementRef,
+      executionEpistemicClass: fieldDetail.executionEpistemicClass,
+      returnRef: fieldDetail.returnRef,
+      outcomeRef: fieldDetail.outcomeRef,
+      returnObserved: fieldDetail.returnObserved,
+    } : null,
+    resultingState: returnMemory && resultingState ? {
+      memoryRef: returnMemory.ref,
+      transitionRef: resultingState.transition?.transitionId ?? null,
+      transitionHash: resultingState.transition?.transitionHash ?? null,
+      transitionHashValid: resultingState.hashValid,
+      transitionAdmitsMemory: resultingState.admitsMemory,
+    } : null,
+  };
+
+  const assessment = assessCprtBPath(assessmentInput);
+
+  return {
+    contractVersion: 'SFI-CT-CPRT-B-RECONSTRUCTION-1.0' as const,
+    reconstructedAt: new Date().toISOString(),
+    sourceRun: {
+      id: runId,
+      taskId: text(run.task_id),
+      status: text(run.status),
+      startedAt: text(run.started_at),
+      finishedAt: text(run.finished_at),
+    },
+    snapshot: {
+      id: snapshot.snapshotId,
+      hash: snapshot.snapshotHash,
+      hashValid,
+      consumed: consumptionTrace.ctSnapshotConsumed === true,
+      sourceCutoff: snapshot.semanticPayload.sourceCutoff,
+      projectorVersion: snapshot.semanticPayload.projectorVersion,
+      policyVersion: snapshot.semanticPayload.policyVersion,
+      projectionProfile: snapshot.semanticPayload.projectionProfile,
+    },
+    proposal: proposalId ? {
+      id: proposalId,
+      status: proposal ? text(proposal.status) : null,
+      eventId: proposal ? text(proposal.event_id) : null,
+      sourceRunId: text(proposalContext.sourceRunId),
+      snapshotHash: text(proposalContext.snapshotHash),
+    } : null,
+    governance: {
+      disposition: governance.disposition,
+      rootActionRef: governance.rootActionRef,
+      event: governance.event,
+      events: governanceEvents,
+    },
+    field: fieldDetail ? {
+      ...fieldDetail,
+      candidateCount: fieldCandidates.length,
+      selectedCaseCreatedAt: selectedFieldCase ? text(selectedFieldCase.created_at) : null,
+    } : null,
+    returnMemory,
+    resultingState: resultingState ? {
+      run: resultingState.run,
+      transition: resultingState.transition,
+      transitionHashValid: resultingState.hashValid,
+      transitionAdmitsReturnMemory: resultingState.admitsMemory,
+    } : null,
+    assessment,
+    warnings: [...new Set(warnings)],
+  };
+}

--- a/src/lib/institution/cognitiveSpineProvenanceReconstruction.ts
+++ b/src/lib/institution/cognitiveSpineProvenanceReconstruction.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import type { CognitiveSpineSnapshot } from '@/core/cognitive-spine/contracts/snapshot';
 import type { CognitiveSpineTransition } from '@/core/cognitive-spine/contracts/transition';
 import {

--- a/src/lib/institution/cognitiveSpineRuntimeExecution.ts
+++ b/src/lib/institution/cognitiveSpineRuntimeExecution.ts
@@ -7,6 +7,7 @@ import {
 import type { KernelContext } from '@/lib/sfi/cognitive-runtime/kernelContext';
 import { executeSfiRuntime } from '@/lib/sfi/cognitive-runtime/runtime';
 import { materializeInstitutionalRuntimeCognitiveSpine } from './cognitiveSpineRuntimeMaterializer';
+import { buildTransitionFromPreviousInstitutionalSnapshot } from './cognitiveSpineTransitionStore';
 
 export async function executeInstitutionalRuntimeWithCognitiveSpine(input: {
   context: KernelContext;
@@ -20,6 +21,12 @@ export async function executeInstitutionalRuntimeWithCognitiveSpine(input: {
     executionId: input.context.cycleId,
     createdAt: input.createdAt,
     consume,
+  });
+
+  const entryTransitionState = await buildTransitionFromPreviousInstitutionalSnapshot({
+    currentSnapshot: materialized.snapshot,
+    sourceCutoff: input.sourceCutoff,
+    createdAt: input.createdAt,
   });
 
   input.context.metadata = {
@@ -60,6 +67,9 @@ export async function executeInstitutionalRuntimeWithCognitiveSpine(input: {
       profileVersion: spine.ctSnapshotConsumed ? spine.profileVersion : null,
       sourceCutoff: spine.sourceCutoff,
     },
+    entryTransitionRef: entryTransitionState.transition?.transitionId ?? null,
+    entryTransitionHash: entryTransitionState.transition?.transitionHash ?? null,
+    entryTransition: entryTransitionState.transition ?? null,
     stateRefs: {
       observations: [...spine.eventRefs],
       evidence: [...spine.evidenceRefs],
@@ -89,6 +99,8 @@ export async function executeInstitutionalRuntimeWithCognitiveSpine(input: {
     runtime,
     cognitiveSpine: {
       ...materialized,
+      warnings: [...new Set([...materialized.warnings, ...entryTransitionState.warnings])],
+      entryTransition: entryTransitionState,
       decisionProvenance,
     },
   };

--- a/src/lib/institution/cognitiveSpineTransitionStore.ts
+++ b/src/lib/institution/cognitiveSpineTransitionStore.ts
@@ -1,0 +1,114 @@
+import 'server-only';
+
+import type { CognitiveSpineSnapshot } from '@/core/cognitive-spine/contracts/snapshot';
+import { semanticSnapshotHash } from '@/core/cognitive-spine/projector/cognitiveStateProjector';
+import { buildCognitiveSpineTransition } from '@/core/cognitive-spine/transitions/buildTransition';
+import { sortedUnique } from '@/core/cognitive-spine/serialization/canonicalSerialize';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+type Row = Record<string, unknown>;
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function snapshotFromRun(row: Row): CognitiveSpineSnapshot | null {
+  const inputSnapshot = record(row.input_snapshot);
+  const spine = record(inputSnapshot.cognitiveSpine);
+  const candidate = record(spine.snapshot) as unknown as CognitiveSpineSnapshot;
+  if (!candidate.snapshotId || !candidate.snapshotHash || !candidate.semanticPayload) return null;
+  try {
+    return semanticSnapshotHash(candidate.semanticPayload) === candidate.snapshotHash ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+function difference(current: string[], previous: string[]) {
+  const previousSet = new Set(previous);
+  return sortedUnique(current.filter((value) => !previousSet.has(value)));
+}
+
+/**
+ * Builds the explicit Δ record from the immediately preceding persisted
+ * institutional snapshot to the current one. The transition is later stored
+ * inside the current run input_snapshot; no new table is required.
+ */
+export async function buildTransitionFromPreviousInstitutionalSnapshot(input: {
+  currentSnapshot: CognitiveSpineSnapshot;
+  sourceCutoff: string;
+  createdAt: string;
+}) {
+  const db = createServiceSupabaseClient();
+  const previousResult = await db.from('sfi_cognitive_twin_runs')
+    .select('id,task_id,input_snapshot,started_at')
+    .eq('role', 'institutional_cycle')
+    .lt('started_at', input.sourceCutoff)
+    .order('started_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (previousResult.error) {
+    return {
+      transition: null,
+      previousRunId: null,
+      warnings: [`cognitive_spine_previous_snapshot_lookup_failed:${previousResult.error.message}`],
+    };
+  }
+  if (!previousResult.data) {
+    return {
+      transition: null,
+      previousRunId: null,
+      warnings: ['cognitive_spine_genesis_no_previous_snapshot'],
+    };
+  }
+
+  const previousRow = record(previousResult.data);
+  const previousSnapshot = snapshotFromRun(previousRow);
+  if (!previousSnapshot) {
+    return {
+      transition: null,
+      previousRunId: text(previousRow.id),
+      warnings: ['cognitive_spine_previous_snapshot_invalid_or_legacy'],
+    };
+  }
+
+  const currentManifestRefs = input.currentSnapshot.semanticPayload.sourceManifest.map((item) => item.ref);
+  const previousManifestRefs = previousSnapshot.semanticPayload.sourceManifest.map((item) => item.ref);
+  const transitionInputs = difference(currentManifestRefs, previousManifestRefs);
+  const admittedEpistemicRefs = difference(
+    input.currentSnapshot.semanticPayload.epistemicStateRefs,
+    previousSnapshot.semanticPayload.epistemicStateRefs,
+  );
+  const currentCritical = new Set([
+    ...input.currentSnapshot.semanticPayload.decisionRefs,
+    ...input.currentSnapshot.semanticPayload.freezeRefs,
+  ]);
+  const unchangedCriticalRefs = sortedUnique([
+    ...previousSnapshot.semanticPayload.decisionRefs,
+    ...previousSnapshot.semanticPayload.freezeRefs,
+  ].filter((ref) => currentCritical.has(ref)));
+
+  const transition = buildCognitiveSpineTransition(previousSnapshot, input.currentSnapshot, {
+    transitionId: `CT-TR-${previousSnapshot.snapshotHash.slice(0, 12)}-${input.currentSnapshot.snapshotHash.slice(0, 12)}`,
+    createdAt: input.createdAt,
+    transitionInputs,
+    admittedEpistemicRefs,
+    unchangedCriticalRefs,
+    runtimeMetadata: {
+      previousRunId: text(previousRow.id),
+      previousTaskId: text(previousRow.task_id),
+      materializedBy: 'institutional_cycle',
+    },
+  });
+
+  return {
+    transition,
+    previousRunId: text(previousRow.id),
+    previousSnapshotId: previousSnapshot.snapshotId,
+    previousSnapshotHash: previousSnapshot.snapshotHash,
+    warnings: [] as string[],
+  };
+}


### PR DESCRIPTION
## Scope

Closes the next CPRT-B provenance segment after the merged Runtime Spine integration.

This PR does **not** make Vercel the Cognitive Spine runtime. Core assessment and reconstruction remain Node/worker/CLI compatible; Next routes are thin adapters only where needed.

## Changes

- Promotes a selected institutional Cognitive Spine run into the existing `action_proposals` lifecycle without rewriting the historical run.
- Preserves `runId`, `snapshotId`, `snapshotHash`, cutoff and provenance hash in the governed proposal.
- Allows an optional ROOT-reviewed Cognitive Spine proposal to seed a Field case while preserving participant consent and independent Field governance.
- Restricts direct proposal→Field linking to the proposal actor; proposal UUID possession is not delegation.
- Adds explicit Field intervention execution acknowledgement (`SFI-FIELD-EXECUTION-ACK-1.0`). The system records that an operator/participant declares execution; it does not claim the system executed the intervention or that execution caused the return.
- New governed Field cycles require that acknowledgement before accepting a return. Legacy cycles remain reconstructable with an explicit provenance gap instead of retroactive execution claims.
- Materializes an explicit entry transition from the immediately preceding valid institutional snapshot into each new Runtime snapshot.
- Separates immediate snapshot transition from a later **resulting transition** that actually admits a Field-return-derived memory into a later snapshot.
- Adds a pure CPRT-B path evaluator and full-path fixtures.
- Adds a Node/worker/CLI-first CPRT-B reconstructor that starts from an institutional `runId` and resolves proposal, ROOT event, Field link, execution acknowledgement, observed return, return-derived canonical memory and resulting state transition.
- Extends Cognitive Spine CI coverage across governance/Field integration files.

## Epistemic boundaries

- A later return never proves that an intervention occurred; execution must have its own explicit record.
- Execution acknowledgement is `DECLARED` unless independently assessed elsewhere.
- Proposal approval does not authorize execution by itself.
- Transition inputs are not described as causal factors.
- Missing stages remain `PROVENANCE GAP`; the reconstructor does not narratively fill them.
- `entry transition` and `resulting transition` are distinct because intervening institutional snapshots may exist between decision and return.

## Deployment boundary

- Pure contracts, path assessment, hashing and transition logic remain platform-neutral.
- CPRT-B reconstruction can run from Node/worker/CLI using the service client.
- Vercel routes remain optional adapters/surfaces, not semantic infrastructure.

## Gates

- SFI Cognitive Spine: PASS
- CPRT-A: PASS
- CPRT-B Runtime scope: PASS
- CPRT-B full-path fixtures: PASS
- SFI CT Institutional Integration: PASS
- SFI Final Closure Verify: PASS
- SFI Verify / production build: PASS
- Studio audio gates: PASS

## Claim boundary

The proposal → ROOT → Field execution acknowledgement → return → resulting-state path is now reconstructable **when those records actually exist**. Legacy or incomplete paths remain explicit gaps. This PR does not claim that every SFI surface consumes the Cognitive Spine.