### PR TITLE
Implement frozen Cognitive Spine projection profile registry

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -58,3 +58,5 @@ jobs:
         run: node --import tsx --test src/core/cognitive-spine/cprt/cprtB.runtime.test.ts
       - name: CPRT-B full path provenance fixtures
         run: node --import tsx --test src/core/cognitive-spine/cprt/cprtB.full.test.ts
+      - name: Frozen projection profile registry
+        run: node --import tsx --test src/core/cognitive-spine/cprt/projectionProfiles.test.ts

--- a/src/core/cognitive-spine/contracts/projectionProfile.ts
+++ b/src/core/cognitive-spine/contracts/projectionProfile.ts
@@ -1,0 +1,54 @@
+import type { CognitiveSpineRefKind } from './snapshot';
+
+export const COGNITIVE_SPINE_PROJECTION_PROFILE_CONTRACT_VERSION = 'SFI-CT-PROJECTION-PROFILE-1.0' as const;
+
+export type CognitiveProjectionSurface =
+  | 'ROOT'
+  | 'FIELD'
+  | 'STUDIO'
+  | 'LAB'
+  | 'WORLDSPECT'
+  | 'ATLAS'
+  | 'LIBRARY'
+  | 'COGNITIVE_RUNTIME';
+
+/**
+ * Semantic visibility configuration over an already-sealed Cognitive Spine
+ * snapshot. A projection profile does not create evidence, alter epistemic
+ * class, mutate the snapshot, or grant authority to its consumer.
+ */
+export type CognitiveProjectionProfile = {
+  contractVersion: typeof COGNITIVE_SPINE_PROJECTION_PROFILE_CONTRACT_VERSION;
+  profileId: string;
+  version: string;
+  surface: CognitiveProjectionSurface;
+  allowedRefKinds: readonly CognitiveSpineRefKind[];
+  deniedRefKinds: readonly CognitiveSpineRefKind[];
+  fieldVisibilityRules: Readonly<Record<string, unknown>>;
+  blindedByDefault: boolean;
+  purpose: string;
+};
+
+export function profileAllowsKind(
+  profile: CognitiveProjectionProfile,
+  kind: CognitiveSpineRefKind,
+): boolean {
+  return profile.allowedRefKinds.includes(kind) && !profile.deniedRefKinds.includes(kind);
+}
+
+export function assertProjectionProfileContract(profile: CognitiveProjectionProfile): CognitiveProjectionProfile {
+  if (!profile.profileId.trim()) throw new Error('COGNITIVE_SPINE_PROFILE_ID_REQUIRED');
+  if (!profile.version.trim()) throw new Error('COGNITIVE_SPINE_PROFILE_VERSION_REQUIRED');
+  if (!profile.purpose.trim()) throw new Error('COGNITIVE_SPINE_PROFILE_PURPOSE_REQUIRED');
+
+  const overlap = profile.allowedRefKinds.filter((kind) => profile.deniedRefKinds.includes(kind));
+  if (overlap.length) {
+    throw new Error(`COGNITIVE_SPINE_PROFILE_ALLOW_DENY_OVERLAP:${profile.profileId}:${overlap.join(',')}`);
+  }
+
+  if (profile.blindedByDefault && profile.allowedRefKinds.length > 0) {
+    throw new Error(`COGNITIVE_SPINE_BLINDED_PROFILE_EXPOSES_REFS:${profile.profileId}`);
+  }
+
+  return profile;
+}

--- a/src/core/cognitive-spine/cprt/projectionProfiles.test.ts
+++ b/src/core/cognitive-spine/cprt/projectionProfiles.test.ts
@@ -5,6 +5,7 @@ import {
   COGNITIVE_SPINE_PROJECTION_PROFILE_CONTRACT_VERSION,
   assertProjectionProfileContract,
   profileAllowsKind,
+  type CognitiveProjectionProfile,
 } from '../contracts/projectionProfile';
 import {
   ALL_COGNITIVE_SPINE_REF_KINDS,
@@ -37,30 +38,33 @@ test('projection registry contains exactly the frozen baseline profiles', () => 
 
 test('every projection profile is versioned, purposeful and contract-valid', () => {
   for (const profile of COGNITIVE_SPINE_PROJECTION_PROFILES) {
-    assert.equal(profile.contractVersion, COGNITIVE_SPINE_PROJECTION_PROFILE_CONTRACT_VERSION);
-    assert.ok(profile.version.length > 0);
-    assert.ok(profile.purpose.length > 0);
-    assert.equal(assertProjectionProfileContract(profile), profile);
+    const contractProfile: CognitiveProjectionProfile = profile;
+    assert.equal(contractProfile.contractVersion, COGNITIVE_SPINE_PROJECTION_PROFILE_CONTRACT_VERSION);
+    assert.ok(contractProfile.version.length > 0);
+    assert.ok(contractProfile.purpose.length > 0);
+    assert.equal(assertProjectionProfileContract(contractProfile), contractProfile);
 
-    const overlap = profile.allowedRefKinds.filter((kind) => profile.deniedRefKinds.includes(kind));
-    assert.deepEqual(overlap, [], `${profile.profileId} must not both allow and deny the same ref kind`);
+    const overlap = contractProfile.allowedRefKinds.filter((kind) => contractProfile.deniedRefKinds.includes(kind));
+    assert.deepEqual(overlap, [], `${contractProfile.profileId} must not both allow and deny the same ref kind`);
   }
 });
 
 test('institutional projection profiles never inherit PERSON_CT directly', () => {
   for (const profile of COGNITIVE_SPINE_PROJECTION_PROFILES) {
-    assert.equal(profileAllowsKind(profile, 'PERSON_CT'), false, profile.profileId);
-    assert.ok(profile.deniedRefKinds.includes('PERSON_CT'), `${profile.profileId} must deny direct PERSON_CT`);
+    const contractProfile: CognitiveProjectionProfile = profile;
+    assert.equal(profileAllowsKind(contractProfile, 'PERSON_CT'), false, contractProfile.profileId);
+    assert.ok(contractProfile.deniedRefKinds.includes('PERSON_CT'), `${contractProfile.profileId} must deny direct PERSON_CT`);
   }
 });
 
 test('blinded Field and Lab profiles expose no Cognitive Spine ref kinds', () => {
   for (const profile of [FIELD_BLINDED_OBSERVATION_PROFILE, LAB_BLINDED_PROFILE]) {
-    assert.equal(profile.blindedByDefault, true);
-    assert.deepEqual(profile.allowedRefKinds, []);
-    assert.deepEqual([...profile.deniedRefKinds].sort(), [...ALL_COGNITIVE_SPINE_REF_KINDS].sort());
+    const contractProfile: CognitiveProjectionProfile = profile;
+    assert.equal(contractProfile.blindedByDefault, true);
+    assert.deepEqual(contractProfile.allowedRefKinds, []);
+    assert.deepEqual([...contractProfile.deniedRefKinds].sort(), [...ALL_COGNITIVE_SPINE_REF_KINDS].sort());
     for (const kind of ALL_COGNITIVE_SPINE_REF_KINDS) {
-      assert.equal(profileAllowsKind(profile, kind), false);
+      assert.equal(profileAllowsKind(contractProfile, kind), false);
     }
   }
 });

--- a/src/core/cognitive-spine/cprt/projectionProfiles.test.ts
+++ b/src/core/cognitive-spine/cprt/projectionProfiles.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  COGNITIVE_SPINE_PROJECTION_PROFILE_CONTRACT_VERSION,
+  assertProjectionProfileContract,
+  profileAllowsKind,
+} from '../contracts/projectionProfile';
+import {
+  ALL_COGNITIVE_SPINE_REF_KINDS,
+  COGNITIVE_SPINE_PROJECTION_PROFILES,
+  FIELD_BLINDED_OBSERVATION_PROFILE,
+  LAB_BLINDED_PROFILE,
+  LAB_EXPERIMENT_CONTEXT_PROFILE,
+  getCognitiveProjectionProfile,
+} from '../profiles/registry';
+import { RUNTIME_GENERAL_CONTEXT_PROFILE } from '../profiles/runtimeGeneral';
+
+const EXPECTED_PROFILE_IDS = [
+  'ROOT_GOVERNANCE_CONTEXT_V1',
+  'FIELD_CASE_CONTEXT_V1',
+  'FIELD_BLINDED_OBSERVATION_V1',
+  'STUDIO_OBJECT_CONTEXT_V1',
+  'LAB_EXPERIMENT_CONTEXT_V1',
+  'LAB_BLINDED_V1',
+  'WORLDSPECT_CONTEXT_V1',
+  'ATLAS_TEMPORAL_CONTEXT_V1',
+  'LIBRARY_IMPACT_CONTEXT_V1',
+  'RUNTIME_GENERAL_CONTEXT_V1',
+].sort();
+
+test('projection registry contains exactly the frozen baseline profiles', () => {
+  const actual = COGNITIVE_SPINE_PROJECTION_PROFILES.map((profile) => profile.profileId).sort();
+  assert.deepEqual(actual, EXPECTED_PROFILE_IDS);
+  assert.equal(new Set(actual).size, actual.length);
+});
+
+test('every projection profile is versioned, purposeful and contract-valid', () => {
+  for (const profile of COGNITIVE_SPINE_PROJECTION_PROFILES) {
+    assert.equal(profile.contractVersion, COGNITIVE_SPINE_PROJECTION_PROFILE_CONTRACT_VERSION);
+    assert.ok(profile.version.length > 0);
+    assert.ok(profile.purpose.length > 0);
+    assert.equal(assertProjectionProfileContract(profile), profile);
+
+    const overlap = profile.allowedRefKinds.filter((kind) => profile.deniedRefKinds.includes(kind));
+    assert.deepEqual(overlap, [], `${profile.profileId} must not both allow and deny the same ref kind`);
+  }
+});
+
+test('institutional projection profiles never inherit PERSON_CT directly', () => {
+  for (const profile of COGNITIVE_SPINE_PROJECTION_PROFILES) {
+    assert.equal(profileAllowsKind(profile, 'PERSON_CT'), false, profile.profileId);
+    assert.ok(profile.deniedRefKinds.includes('PERSON_CT'), `${profile.profileId} must deny direct PERSON_CT`);
+  }
+});
+
+test('blinded Field and Lab profiles expose no Cognitive Spine ref kinds', () => {
+  for (const profile of [FIELD_BLINDED_OBSERVATION_PROFILE, LAB_BLINDED_PROFILE]) {
+    assert.equal(profile.blindedByDefault, true);
+    assert.deepEqual(profile.allowedRefKinds, []);
+    assert.deepEqual([...profile.deniedRefKinds].sort(), [...ALL_COGNITIVE_SPINE_REF_KINDS].sort());
+    for (const kind of ALL_COGNITIVE_SPINE_REF_KINDS) {
+      assert.equal(profileAllowsKind(profile, kind), false);
+    }
+  }
+});
+
+test('Lab experiment profile requires protocol-bound frozen context', () => {
+  assert.equal(LAB_EXPERIMENT_CONTEXT_PROFILE.blindedByDefault, false);
+  assert.equal(LAB_EXPERIMENT_CONTEXT_PROFILE.fieldVisibilityRules.protocolAllowlistRequired, true);
+  assert.equal(LAB_EXPERIMENT_CONTEXT_PROFILE.fieldVisibilityRules.exactSnapshotHashRequired, true);
+  assert.equal(LAB_EXPERIMENT_CONTEXT_PROFILE.fieldVisibilityRules.liveCtAdvancementDuringFrozenRun, 'DENIED');
+});
+
+test('Runtime general profile in registry is the existing runtime contract', () => {
+  const fromRegistry = getCognitiveProjectionProfile('RUNTIME_GENERAL_CONTEXT_V1');
+  assert.equal(fromRegistry, RUNTIME_GENERAL_CONTEXT_PROFILE);
+  assert.equal(fromRegistry.surface, 'COGNITIVE_RUNTIME');
+  assert.equal(fromRegistry.blindedByDefault, false);
+  assert.equal(profileAllowsKind(fromRegistry, 'MEMORY'), true);
+  assert.equal(profileAllowsKind(fromRegistry, 'DECISION'), true);
+  assert.equal(profileAllowsKind(fromRegistry, 'PERSON_CT'), false);
+});
+
+test('blinded profiles cannot be constructed with visible ref kinds', () => {
+  assert.throws(() => assertProjectionProfileContract({
+    contractVersion: COGNITIVE_SPINE_PROJECTION_PROFILE_CONTRACT_VERSION,
+    profileId: 'INVALID_BLINDED_PROFILE',
+    version: '1.0',
+    surface: 'FIELD',
+    allowedRefKinds: ['EVIDENCE'],
+    deniedRefKinds: ['PERSON_CT'],
+    fieldVisibilityRules: {},
+    blindedByDefault: true,
+    purpose: 'negative fixture',
+  }), /COGNITIVE_SPINE_BLINDED_PROFILE_EXPOSES_REFS/);
+});

--- a/src/core/cognitive-spine/profiles/registry.ts
+++ b/src/core/cognitive-spine/profiles/registry.ts
@@ -1,0 +1,195 @@
+import type { CognitiveSpineRefKind } from '../contracts/snapshot';
+import {
+  COGNITIVE_SPINE_PROJECTION_PROFILE_CONTRACT_VERSION,
+  assertProjectionProfileContract,
+  type CognitiveProjectionProfile,
+} from '../contracts/projectionProfile';
+import { RUNTIME_GENERAL_CONTEXT_PROFILE } from './runtimeGeneral';
+
+export const ALL_COGNITIVE_SPINE_REF_KINDS = [
+  'EVENT',
+  'EVIDENCE',
+  'HYPOTHESIS',
+  'MEMORY',
+  'DECISION',
+  'CONTRADICTION',
+  'FREEZE',
+  'QUESTION',
+  'PERSON_CT',
+] as const satisfies readonly CognitiveSpineRefKind[];
+
+export const INSTITUTIONAL_NON_PERSON_REF_KINDS = [
+  'EVENT',
+  'EVIDENCE',
+  'HYPOTHESIS',
+  'MEMORY',
+  'DECISION',
+  'CONTRADICTION',
+  'FREEZE',
+  'QUESTION',
+] as const satisfies readonly CognitiveSpineRefKind[];
+
+function institutionalProfile(input: Omit<CognitiveProjectionProfile,
+  'contractVersion' | 'allowedRefKinds' | 'deniedRefKinds'> & {
+    allowedRefKinds?: readonly CognitiveSpineRefKind[];
+    deniedRefKinds?: readonly CognitiveSpineRefKind[];
+  }): CognitiveProjectionProfile {
+  return assertProjectionProfileContract({
+    contractVersion: COGNITIVE_SPINE_PROJECTION_PROFILE_CONTRACT_VERSION,
+    allowedRefKinds: input.allowedRefKinds ?? INSTITUTIONAL_NON_PERSON_REF_KINDS,
+    deniedRefKinds: input.deniedRefKinds ?? ['PERSON_CT'],
+    ...input,
+  });
+}
+
+export const ROOT_GOVERNANCE_CONTEXT_PROFILE = institutionalProfile({
+  profileId: 'ROOT_GOVERNANCE_CONTEXT_V1',
+  version: '1.0',
+  surface: 'ROOT',
+  fieldVisibilityRules: {
+    governanceAuthorityDoesNotUpgradeEpistemicClass: true,
+    decisionsRemainGovernanceRecords: true,
+    provenanceAndUncertaintyRemainVisible: true,
+  },
+  blindedByDefault: false,
+  purpose: 'Provide governed institutional context for ROOT deliberation without granting ROOT authority over truth or epistemic class.',
+});
+
+export const FIELD_CASE_CONTEXT_PROFILE = institutionalProfile({
+  profileId: 'FIELD_CASE_CONTEXT_V1',
+  version: '1.0',
+  surface: 'FIELD',
+  fieldVisibilityRules: {
+    caseRelevanceRequired: true,
+    priorContextIsNotObservation: true,
+    blindedAlternativeMustRemainAvailable: true,
+  },
+  blindedByDefault: false,
+  purpose: 'Expose only case-relevant prior institutional context when prior knowledge is operationally justified.',
+});
+
+export const FIELD_BLINDED_OBSERVATION_PROFILE = institutionalProfile({
+  profileId: 'FIELD_BLINDED_OBSERVATION_V1',
+  version: '1.0',
+  surface: 'FIELD',
+  allowedRefKinds: [],
+  deniedRefKinds: ALL_COGNITIVE_SPINE_REF_KINDS,
+  fieldVisibilityRules: {
+    snapshotMayBeAvailableForProvenance: true,
+    contextExposure: 'DENIED',
+    expectationContaminationGuard: true,
+  },
+  blindedByDefault: true,
+  purpose: 'Prevent prior Cognitive Spine context from influencing Field capture where expectation contamination is a methodological risk.',
+});
+
+export const STUDIO_OBJECT_CONTEXT_PROFILE = institutionalProfile({
+  profileId: 'STUDIO_OBJECT_CONTEXT_V1',
+  version: '1.0',
+  surface: 'STUDIO',
+  fieldVisibilityRules: {
+    objectRelevanceRequired: true,
+    versionHistoryVisible: true,
+    decisionsRemainContextNotTruth: true,
+  },
+  blindedByDefault: false,
+  purpose: 'Expose object-specific temporal history, decisions, approved relevant memory and provenance without granting Studio institutional epistemic authority.',
+});
+
+export const LAB_EXPERIMENT_CONTEXT_PROFILE = institutionalProfile({
+  profileId: 'LAB_EXPERIMENT_CONTEXT_V1',
+  version: '1.0',
+  surface: 'LAB',
+  fieldVisibilityRules: {
+    protocolAllowlistRequired: true,
+    exactSnapshotHashRequired: true,
+    sourceCutoffRequired: true,
+    projectorPolicySchemaProfileVersionsRequired: true,
+    liveCtAdvancementDuringFrozenRun: 'DENIED',
+  },
+  blindedByDefault: false,
+  purpose: 'Expose only context explicitly permitted by an experimental protocol and bind frozen runs to an exact sealed Cognitive Spine state.',
+});
+
+export const LAB_BLINDED_PROFILE = institutionalProfile({
+  profileId: 'LAB_BLINDED_V1',
+  version: '1.0',
+  surface: 'LAB',
+  allowedRefKinds: [],
+  deniedRefKinds: ALL_COGNITIVE_SPINE_REF_KINDS,
+  fieldVisibilityRules: {
+    snapshotMayBeAvailableForProvenance: true,
+    contextExposure: 'DENIED',
+    protocolBlindnessRequired: true,
+  },
+  blindedByDefault: true,
+  purpose: 'Execute an experimental arm without Cognitive Spine context while preserving that an operational CT state existed but was not consumed.',
+});
+
+export const WORLDSPECT_CONTEXT_PROFILE = institutionalProfile({
+  profileId: 'WORLDSPECT_CONTEXT_V1',
+  version: '1.0',
+  surface: 'WORLDSPECT',
+  fieldVisibilityRules: {
+    externalObservationMustRemainIndependent: true,
+    priorExpectationIsNotObservation: true,
+    priorContextMayOnlyBeUsedForPostObservationContrast: true,
+  },
+  blindedByDefault: false,
+  purpose: 'Compare external observations and signals with prior institutional state without converting expectation into observation or evidence.',
+});
+
+export const ATLAS_TEMPORAL_CONTEXT_PROFILE = institutionalProfile({
+  profileId: 'ATLAS_TEMPORAL_CONTEXT_V1',
+  version: '1.0',
+  surface: 'ATLAS',
+  fieldVisibilityRules: {
+    lineageReadOnly: true,
+    relationshipDoesNotUpgradeEpistemicClass: true,
+    associationIsNotCausality: true,
+  },
+  blindedByDefault: false,
+  purpose: 'Expose lineage, temporal transitions and graph relationships required to inspect trajectories without epistemic promotion.',
+});
+
+export const LIBRARY_IMPACT_CONTEXT_PROFILE = institutionalProfile({
+  profileId: 'LIBRARY_IMPACT_CONTEXT_V1',
+  version: '1.0',
+  surface: 'LIBRARY',
+  fieldVisibilityRules: {
+    artifactAssociationIsNotCausality: true,
+    preservedArtifactDoesNotBecomeEvidenceByStorage: true,
+    lineageReadOnly: true,
+  },
+  blindedByDefault: false,
+  purpose: 'Expose associations between formalized artifacts and later cognitive-state transitions while preserving provenance and non-causal semantics.',
+});
+
+export const COGNITIVE_SPINE_PROJECTION_PROFILES = [
+  ROOT_GOVERNANCE_CONTEXT_PROFILE,
+  FIELD_CASE_CONTEXT_PROFILE,
+  FIELD_BLINDED_OBSERVATION_PROFILE,
+  STUDIO_OBJECT_CONTEXT_PROFILE,
+  LAB_EXPERIMENT_CONTEXT_PROFILE,
+  LAB_BLINDED_PROFILE,
+  WORLDSPECT_CONTEXT_PROFILE,
+  ATLAS_TEMPORAL_CONTEXT_PROFILE,
+  LIBRARY_IMPACT_CONTEXT_PROFILE,
+  RUNTIME_GENERAL_CONTEXT_PROFILE,
+] as const satisfies readonly CognitiveProjectionProfile[];
+
+export type CognitiveSpineProjectionProfileId = typeof COGNITIVE_SPINE_PROJECTION_PROFILES[number]['profileId'];
+
+const PROFILE_BY_ID = new Map<string, CognitiveProjectionProfile>(
+  COGNITIVE_SPINE_PROJECTION_PROFILES.map((profile) => [profile.profileId, profile]),
+);
+
+export function getCognitiveProjectionProfile(profileId: string): CognitiveProjectionProfile {
+  const profile = PROFILE_BY_ID.get(profileId);
+  if (!profile) throw new Error(`COGNITIVE_SPINE_PROJECTION_PROFILE_UNKNOWN:${profileId}`);
+  return profile;
+}
+
+export function isCognitiveProjectionProfileId(value: string): value is CognitiveSpineProjectionProfileId {
+  return PROFILE_BY_ID.has(value);
+}

--- a/src/core/cognitive-spine/profiles/runtimeGeneral.ts
+++ b/src/core/cognitive-spine/profiles/runtimeGeneral.ts
@@ -1,6 +1,12 @@
 import type { CognitiveSpineRefKind } from '../contracts/snapshot';
+import {
+  COGNITIVE_SPINE_PROJECTION_PROFILE_CONTRACT_VERSION,
+  type CognitiveProjectionProfile,
+  profileAllowsKind,
+} from '../contracts/projectionProfile';
 
 export const RUNTIME_GENERAL_CONTEXT_PROFILE = {
+  contractVersion: COGNITIVE_SPINE_PROJECTION_PROFILE_CONTRACT_VERSION,
   profileId: 'RUNTIME_GENERAL_CONTEXT_V1',
   version: '1.0',
   surface: 'COGNITIVE_RUNTIME',
@@ -13,8 +19,8 @@ export const RUNTIME_GENERAL_CONTEXT_PROFILE = {
     'CONTRADICTION',
     'FREEZE',
     'QUESTION',
-  ] as CognitiveSpineRefKind[],
-  deniedRefKinds: ['PERSON_CT'] as CognitiveSpineRefKind[],
+  ],
+  deniedRefKinds: ['PERSON_CT'],
   fieldVisibilityRules: {
     personCtInheritance: 'DENIED',
     memoryStatusMustRemainVisible: true,
@@ -24,12 +30,8 @@ export const RUNTIME_GENERAL_CONTEXT_PROFILE = {
   },
   blindedByDefault: false,
   purpose: 'Provide one bounded sealed institutional cognitive-state cut to the Cognitive Runtime without promoting memory or governance records into evidence.',
-} as const;
+} as const satisfies CognitiveProjectionProfile;
 
 export function runtimeGeneralAllowsKind(kind: CognitiveSpineRefKind): boolean {
-  return RUNTIME_GENERAL_CONTEXT_PROFILE.allowedRefKinds.includes(
-    kind as (typeof RUNTIME_GENERAL_CONTEXT_PROFILE.allowedRefKinds)[number],
-  ) && !RUNTIME_GENERAL_CONTEXT_PROFILE.deniedRefKinds.includes(
-    kind as (typeof RUNTIME_GENERAL_CONTEXT_PROFILE.deniedRefKinds)[number],
-  );
+  return profileAllowsKind(RUNTIME_GENERAL_CONTEXT_PROFILE, kind);
 }


### PR DESCRIPTION
## Scope

Materializes the already-frozen `SFI-CT-PROJECTION-PROFILES-1.0` semantics as a typed, platform-neutral registry.

This PR deliberately **does not connect additional SFI surfaces to Cognitive Spine consumption yet**. It defines and tests the profiles first so future surface adapters cannot invent visibility semantics ad hoc.

## Adds

- Typed `SFI-CT-PROJECTION-PROFILE-1.0` contract.
- Exact registry for the ten frozen baseline profiles:
  - `ROOT_GOVERNANCE_CONTEXT_V1`
  - `FIELD_CASE_CONTEXT_V1`
  - `FIELD_BLINDED_OBSERVATION_V1`
  - `STUDIO_OBJECT_CONTEXT_V1`
  - `LAB_EXPERIMENT_CONTEXT_V1`
  - `LAB_BLINDED_V1`
  - `WORLDSPECT_CONTEXT_V1`
  - `ATLAS_TEMPORAL_CONTEXT_V1`
  - `LIBRARY_IMPACT_CONTEXT_V1`
  - `RUNTIME_GENERAL_CONTEXT_V1`
- Shared helpers for profile lookup and ref-kind visibility.
- Existing Runtime profile is brought under the same typed contract without changing its runtime purpose.
- Contract gate rejects allow/deny overlap and prevents blinded profiles from exposing ref kinds.
- Institutional profiles deny direct `PERSON_CT` inheritance.
- Lab experiment profile requires protocol allowlisting, exact snapshot identity, and no silent live-CT advancement.
- CI regression test for the complete frozen profile registry.

## Epistemic boundary

A profile controls visibility over an already-sealed snapshot. It cannot create evidence, epistemic judgment, independence, authority, or mutate state.

`CT AVAILABLE != CT CONSUMED` remains unchanged.

## Deployment boundary

Profiles are pure semantic configuration with no Vercel/Next.js dependency. The same profile registry can be consumed by local CLI, worker/server, experiment runner, local model pipelines, Vercel adapters, or UI clients.

## Gates

- SFI Cognitive Spine: PASS
- Frozen projection profile registry: PASS
- CPRT-A: PASS
- CPRT-B Runtime: PASS
- CPRT-B full path fixtures: PASS
- Typecheck: PASS
- Production build: PASS
- SFI Verify: PASS
- Studio audio gates: PASS

## Non-goal

No new surface is made a mandatory CT consumer in this PR. Surface-by-surface integration follows separately and must preserve blinded modes and explicit consumption traces.