### PR TITLE
Expand Cognitive Spine with append-only institutional sources

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -60,3 +60,5 @@ jobs:
         run: node --import tsx --test src/core/cognitive-spine/cprt/cprtB.full.test.ts
       - name: Frozen projection profile registry
         run: node --import tsx --test src/core/cognitive-spine/cprt/projectionProfiles.test.ts
+      - name: Append-only institutional source-plane mappings
+        run: node --import tsx --test src/core/cognitive-spine/cprt/sourcePlaneMapping.test.ts

--- a/src/core/cognitive-spine/cprt/sourcePlaneMapping.test.ts
+++ b/src/core/cognitive-spine/cprt/sourcePlaneMapping.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  governanceEventToCognitiveSpineSource,
+  labHypothesisToCognitiveSpineSource,
+} from '../sourcePlane/institutionalSourceMapping';
+
+test('append-only Lab hypothesis enters as HYPOTHESIS and verification debt, never evidence', () => {
+  const record = labHypothesisToCognitiveSpineSource({
+    hypothesis: {
+      id: 'H-LAB-001',
+      analysis_id: 'A-001',
+      title: 'Cross-domain persistence hypothesis',
+      status: 'persistent_signal',
+      confidence: 0.71,
+      payload: { statement: 'Pattern may persist across contexts.' },
+      created_at: '2026-08-16T08:00:00.000Z',
+    },
+    analysis: {
+      id: 'A-001',
+      mode: 'detect_signals',
+      source: 'method_lab',
+      data_mode: 'real_input',
+    },
+  });
+
+  assert.ok(record);
+  assert.equal(record.kind, 'HYPOTHESIS');
+  assert.equal(record.ref, 'sfi_hypotheses:H-LAB-001');
+  assert.equal(record.debtType, 'VERIFICATION');
+  assert.equal(record.epistemicClass, undefined);
+  assert.deepEqual(record.ancestryRoots, ['sfi_lab_analyses:A-001']);
+  assert.deepEqual(record.visibilityProfiles, ['*']);
+});
+
+test('ROOT governance transitions are reconstructed from immutable epistemic events', () => {
+  const base = {
+    event_id: 'EV-GOV-001',
+    epistemic_class: 'derived',
+    occurred_at: '2026-08-16T08:05:00.000Z',
+    hash_self: 'a'.repeat(64),
+    schema_version: 'EPISTEMIC-EVENT-1.0',
+    lineage: ['PROPOSAL-001'],
+    payload: { proposal_id: 'PROPOSAL-001' },
+  };
+
+  const approved = governanceEventToCognitiveSpineSource({ ...base, event_name: 'acp.proposal.design_approved' });
+  const rejected = governanceEventToCognitiveSpineSource({ ...base, event_id: 'EV-GOV-002', hash_self: 'b'.repeat(64), event_name: 'acp.proposal.rejected' });
+  const frozen = governanceEventToCognitiveSpineSource({ ...base, event_id: 'EV-GOV-003', hash_self: 'c'.repeat(64), event_name: 'acp.proposal.frozen' });
+  const waiting = governanceEventToCognitiveSpineSource({ ...base, event_id: 'EV-GOV-004', hash_self: 'd'.repeat(64), event_name: 'acp.proposal.waiting_evidence' });
+
+  assert.equal(approved?.kind, 'DECISION');
+  assert.equal(rejected?.kind, 'DECISION');
+  assert.equal(frozen?.kind, 'FREEZE');
+  assert.equal(waiting?.kind, 'QUESTION');
+  assert.equal(waiting?.debtType, 'VERIFICATION');
+  assert.equal(approved?.epistemicClass, 'DERIVED');
+  assert.equal(approved?.sourceHash, 'a'.repeat(64));
+  assert.deepEqual(approved?.ancestryRoots, ['PROPOSAL-001']);
+});
+
+test('unrelated epistemic events do not enter governance projection by pattern guessing', () => {
+  const record = governanceEventToCognitiveSpineSource({
+    event_id: 'EV-OTHER',
+    event_name: 'root.state.read',
+    epistemic_class: 'observed',
+    occurred_at: '2026-08-16T08:10:00.000Z',
+    hash_self: 'e'.repeat(64),
+    schema_version: 'EPISTEMIC-EVENT-1.0',
+    lineage: [],
+  });
+  assert.equal(record, null);
+});
+
+test('missing append-only identity fields fail closed instead of fabricating a source record', () => {
+  assert.equal(labHypothesisToCognitiveSpineSource({
+    hypothesis: { id: 'H-001', analysis_id: 'A-001' },
+    analysis: { id: 'A-001' },
+  }), null);
+
+  assert.equal(governanceEventToCognitiveSpineSource({
+    event_id: 'EV-001',
+    event_name: 'acp.proposal.frozen',
+    occurred_at: '2026-08-16T08:10:00.000Z',
+  }), null);
+});

--- a/src/core/cognitive-spine/sourcePlane/institutionalSourceMapping.ts
+++ b/src/core/cognitive-spine/sourcePlane/institutionalSourceMapping.ts
@@ -1,0 +1,120 @@
+import type {
+  AssessedEpistemicClass,
+  CognitiveSpineSourceRecord,
+} from '../contracts/snapshot';
+import { canonicalSha256, normalizeTimestamp, sortedUnique } from '../serialization/canonicalSerialize';
+
+type Row = Record<string, unknown>;
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
+}
+
+function assessedClass(value: unknown): AssessedEpistemicClass | null {
+  const normalized = text(value)?.toLowerCase() ?? null;
+  if (normalized === 'observed') return 'OBSERVED';
+  if (normalized === 'declared') return 'DECLARED';
+  if (normalized === 'derived') return 'DERIVED';
+  if (normalized === 'inferred') return 'INFERRED';
+  if (normalized === 'simulated') return 'SIMULATED';
+  if (normalized === 'projected') return 'PROJECTED';
+  if (normalized === 'verified_contrast') return 'VERIFIED_CONTRAST';
+  if (normalized === 'invalidated') return 'INVALIDATED';
+  return null;
+}
+
+/**
+ * SFI Lab hypotheses are append-only hypothesis records. Their kind is
+ * explicit in the source schema; this adapter does not upgrade them to
+ * evidence or assign a new epistemic class. Every open hypothesis contributes
+ * verification debt until a separate epistemic/governance process resolves it.
+ */
+export function labHypothesisToCognitiveSpineSource(input: {
+  hypothesis: Row;
+  analysis: Row;
+}): CognitiveSpineSourceRecord | null {
+  const id = text(input.hypothesis.id);
+  const analysisId = text(input.hypothesis.analysis_id) ?? text(input.analysis.id);
+  const createdAt = text(input.hypothesis.created_at);
+  if (!id || !analysisId || !createdAt) return null;
+
+  return {
+    ref: `sfi_hypotheses:${id}`,
+    kind: 'HYPOTHESIS',
+    recordedAt: normalizeTimestamp(createdAt),
+    sourceHash: canonicalSha256({
+      store: 'sfi_hypotheses',
+      id,
+      analysisId,
+      title: text(input.hypothesis.title),
+      status: text(input.hypothesis.status),
+      confidence: typeof input.hypothesis.confidence === 'number' ? input.hypothesis.confidence : Number(input.hypothesis.confidence ?? 0),
+      payload: input.hypothesis.payload ?? null,
+      analysis: {
+        mode: text(input.analysis.mode),
+        source: text(input.analysis.source),
+        dataMode: text(input.analysis.data_mode),
+      },
+      createdAt: normalizeTimestamp(createdAt),
+    }),
+    sourceVersion: 'SFI-LAB-HYPOTHESIS-1.0',
+    ancestryRoots: [`sfi_lab_analyses:${analysisId}`],
+    visibilityProfiles: ['*'],
+    debtType: 'VERIFICATION',
+  };
+}
+
+const GOVERNANCE_KIND_BY_EVENT: Record<string, CognitiveSpineSourceRecord['kind']> = {
+  'acp.proposal.design_approved': 'DECISION',
+  'acp.proposal.rejected': 'DECISION',
+  'acp.proposal.frozen': 'FREEZE',
+  'acp.proposal.waiting_evidence': 'QUESTION',
+};
+
+/**
+ * Governance state is reconstructed from immutable epistemic events rather
+ * than the mutable current row in action_proposals. This preserves historical
+ * cutoffs and prevents retroactive rewriting of earlier snapshots.
+ */
+export function governanceEventToCognitiveSpineSource(event: Row): CognitiveSpineSourceRecord | null {
+  const eventName = text(event.event_name);
+  const eventId = text(event.event_id);
+  const occurredAt = text(event.occurred_at);
+  const hashSelf = text(event.hash_self);
+  const kind = eventName ? GOVERNANCE_KIND_BY_EVENT[eventName] : undefined;
+  if (!eventName || !eventId || !occurredAt || !hashSelf || !kind) return null;
+
+  const epistemicClass = assessedClass(event.epistemic_class);
+  const lineage = sortedUnique(strings(event.lineage));
+
+  return {
+    ref: `epistemic_events:${eventId}`,
+    kind,
+    recordedAt: normalizeTimestamp(occurredAt),
+    sourceHash: hashSelf,
+    sourceVersion: text(event.schema_version) ?? undefined,
+    ...(epistemicClass ? {
+      epistemicAssessmentRef: eventId,
+      epistemicClass,
+    } : {}),
+    ancestryRoots: lineage,
+    visibilityProfiles: ['*'],
+    ...(kind === 'QUESTION' ? { debtType: 'VERIFICATION' as const } : {}),
+  };
+}
+
+export function isCognitiveSpineGovernanceEventName(value: string): boolean {
+  return Object.prototype.hasOwnProperty.call(GOVERNANCE_KIND_BY_EVENT, value);
+}
+
+export function governancePayloadForAudit(event: Row): Row {
+  return record(event.payload);
+}

--- a/src/lib/institution/cognitiveSpineAdditionalSources.ts
+++ b/src/lib/institution/cognitiveSpineAdditionalSources.ts
@@ -1,0 +1,151 @@
+import 'server-only';
+
+import type { CognitiveSpineSourceRecord } from '@/core/cognitive-spine/contracts/snapshot';
+import {
+  governanceEventToCognitiveSpineSource,
+  labHypothesisToCognitiveSpineSource,
+} from '@/core/cognitive-spine/sourcePlane/institutionalSourceMapping';
+import { normalizeTimestamp, sortedUnique } from '@/core/cognitive-spine/serialization/canonicalSerialize';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+const MAX_LAB_HYPOTHESES = 96;
+const MAX_GOVERNANCE_EVENTS = 128;
+
+const GOVERNANCE_EVENT_NAMES = [
+  'acp.proposal.design_approved',
+  'acp.proposal.rejected',
+  'acp.proposal.frozen',
+  'acp.proposal.waiting_evidence',
+] as const;
+
+type Row = Record<string, unknown>;
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+function rows(value: unknown): Row[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is Row => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+    : [];
+}
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+export type AdditionalCognitiveSpineSourceSummary = {
+  labHypotheses: number;
+  governanceDecisions: number;
+  governanceFreezes: number;
+  governanceQuestions: number;
+};
+
+/**
+ * Reads only source families whose historical identity can be reconstructed at
+ * the requested cutoff without consulting mutable present-day state.
+ *
+ * Deliberately excluded here:
+ * - action_proposals current rows (mutable lifecycle state)
+ * - sfi_predictive_runs current rows (mutable status/calibration state)
+ * - graph_nodes / graph_edges (rebuildable projections)
+ *
+ * Those sources require event/history semantics before they can participate in
+ * historical Cognitive Spine snapshots.
+ */
+export async function readAdditionalInstitutionalCognitiveSpineSources(sourceCutoff: string): Promise<{
+  records: CognitiveSpineSourceRecord[];
+  warnings: string[];
+  summary: AdditionalCognitiveSpineSourceSummary;
+}> {
+  const cutoff = normalizeTimestamp(sourceCutoff);
+  const db = createServiceSupabaseClient();
+  const warnings: string[] = [];
+
+  const [hypothesisResult, governanceResult] = await Promise.all([
+    db.from('sfi_hypotheses')
+      .select('id,analysis_id,title,status,confidence,payload,created_at')
+      .lte('created_at', cutoff)
+      .order('created_at', { ascending: false })
+      .limit(MAX_LAB_HYPOTHESES),
+    db.from('epistemic_events')
+      .select('event_id,event_name,epistemic_class,schema_version,payload,lineage,occurred_at,hash_self')
+      .in('event_name', [...GOVERNANCE_EVENT_NAMES])
+      .lte('occurred_at', cutoff)
+      .order('occurred_at', { ascending: false })
+      .limit(MAX_GOVERNANCE_EVENTS),
+  ]);
+
+  if (hypothesisResult.error) {
+    warnings.push(`cognitive_spine_lab_hypotheses_unavailable:${hypothesisResult.error.message}`);
+  }
+  if (governanceResult.error) {
+    warnings.push(`cognitive_spine_governance_events_unavailable:${governanceResult.error.message}`);
+  }
+
+  const hypothesisRows = rows(hypothesisResult.data);
+  const analysisIds = sortedUnique(hypothesisRows
+    .map((row) => text(row.analysis_id))
+    .filter((value): value is string => Boolean(value)));
+
+  const analysisResult = analysisIds.length
+    ? await db.from('sfi_lab_analyses')
+        .select('id,mode,source,data_mode,created_at')
+        .in('id', analysisIds)
+        .lte('created_at', cutoff)
+    : { data: [], error: null };
+
+  if (analysisResult.error) {
+    warnings.push(`cognitive_spine_lab_analyses_unavailable:${analysisResult.error.message}`);
+  }
+
+  const analysisById = new Map(rows(analysisResult.data)
+    .map((row) => [text(row.id), row] as const)
+    .filter((entry): entry is [string, Row] => Boolean(entry[0])));
+
+  const records: CognitiveSpineSourceRecord[] = [];
+  let labHypotheses = 0;
+  for (const hypothesis of hypothesisRows) {
+    const analysisId = text(hypothesis.analysis_id);
+    if (!analysisId) {
+      warnings.push(`cognitive_spine_lab_hypothesis_analysis_ref_missing:${text(hypothesis.id) ?? 'unknown'}`);
+      continue;
+    }
+    const analysis = analysisById.get(analysisId);
+    if (!analysis) {
+      warnings.push(`cognitive_spine_lab_hypothesis_analysis_missing:${text(hypothesis.id) ?? 'unknown'}:${analysisId}`);
+      continue;
+    }
+    const mapped = labHypothesisToCognitiveSpineSource({ hypothesis, analysis });
+    if (!mapped) {
+      warnings.push(`cognitive_spine_lab_hypothesis_mapping_failed:${text(hypothesis.id) ?? 'unknown'}`);
+      continue;
+    }
+    records.push(mapped);
+    labHypotheses += 1;
+  }
+
+  let governanceDecisions = 0;
+  let governanceFreezes = 0;
+  let governanceQuestions = 0;
+  for (const event of rows(governanceResult.data)) {
+    const mapped = governanceEventToCognitiveSpineSource(event);
+    if (!mapped) {
+      warnings.push(`cognitive_spine_governance_event_mapping_failed:${text(event.event_id) ?? 'unknown'}`);
+      continue;
+    }
+    records.push(mapped);
+    if (mapped.kind === 'DECISION') governanceDecisions += 1;
+    if (mapped.kind === 'FREEZE') governanceFreezes += 1;
+    if (mapped.kind === 'QUESTION') governanceQuestions += 1;
+  }
+
+  return {
+    records,
+    warnings: sortedUnique(warnings),
+    summary: {
+      labHypotheses,
+      governanceDecisions,
+      governanceFreezes,
+      governanceQuestions,
+    },
+  };
+}

--- a/src/lib/institution/cognitiveSpineRuntimeMaterializer.ts
+++ b/src/lib/institution/cognitiveSpineRuntimeMaterializer.ts
@@ -17,6 +17,7 @@ import { buildRuntimeCognitiveSpineProjection } from '@/core/cognitive-spine/run
 import { canonicalSha256, normalizeTimestamp, sortedUnique } from '@/core/cognitive-spine/serialization/canonicalSerialize';
 import { buildCognitiveContextConsumptionTrace } from '@/core/cognitive-spine/trace/consumptionTrace';
 import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { readAdditionalInstitutionalCognitiveSpineSources } from './cognitiveSpineAdditionalSources';
 
 const PROJECTOR_VERSION = 'SFI-CT-PROJECTOR-1.0';
 const POLICY_VERSION = 'SFI-CT-INVARIANTS-1.0';
@@ -250,7 +251,7 @@ async function readAssessedEvidenceAtCutoff(sourceCutoff: string): Promise<{
       epistemicAssessmentRef: eventId,
       epistemicClass,
       ancestryRoots: lineage,
-      visibilityProfiles: [RUNTIME_GENERAL_CONTEXT_PROFILE.profileId],
+      visibilityProfiles: ['*'],
       debtType,
     });
   }
@@ -275,7 +276,7 @@ function memorySourceRecord(memory: MaterializedMemory): CognitiveSpineSourceRec
       createdAt: memory.createdAt,
     }),
     sourceVersion: memory.version,
-    visibilityProfiles: [RUNTIME_GENERAL_CONTEXT_PROFILE.profileId],
+    visibilityProfiles: ['*'],
     ...(memory.status === 'CANDIDATE' ? { debtType: 'VERIFICATION' as const } : {}),
   };
 }
@@ -296,7 +297,7 @@ function decisionSourceRecord(decision: MaterializedDecision): CognitiveSpineSou
       approvedAt: decision.approvedAt,
       status: 'APPROVED',
     }),
-    visibilityProfiles: [RUNTIME_GENERAL_CONTEXT_PROFILE.profileId],
+    visibilityProfiles: ['*'],
   };
 }
 
@@ -307,23 +308,32 @@ export async function materializeInstitutionalRuntimeCognitiveSpine(input: {
   consume: boolean;
 }) {
   const sourceCutoff = normalizeTimestamp(input.sourceCutoff);
-  const [evidence, memory, decisions] = await Promise.all([
+  const [evidence, memory, decisions, additionalSources] = await Promise.all([
     readAssessedEvidenceAtCutoff(sourceCutoff),
     readCanonicalMemoryAtCutoff(sourceCutoff),
     readApprovedDecisionsAtCutoff(sourceCutoff),
+    readAdditionalInstitutionalCognitiveSpineSources(sourceCutoff),
+  ]);
+
+  const warnings = sortedUnique([
+    ...evidence.warnings,
+    ...memory.warnings,
+    ...decisions.warnings,
+    ...additionalSources.warnings,
   ]);
 
   const cognitiveTwinContext: StudioTwinContext = {
     contractVersion: COGNITIVE_TWIN_CONTRACT_VERSION,
     memory: memory.rows.map(({ id: _id, createdAt: _createdAt, ...item }) => item),
     decisions: decisions.rows.map(({ approvedAt: _approvedAt, ...item }) => item),
-    warnings: sortedUnique([...evidence.warnings, ...memory.warnings, ...decisions.warnings]),
+    warnings,
   };
 
   const records = [
     ...evidence.records,
     ...memory.rows.map(memorySourceRecord),
     ...decisions.rows.map(decisionSourceRecord),
+    ...additionalSources.records,
   ].filter((item) => runtimeGeneralAllowsKind(item.kind));
 
   const semanticPayload = projectCognitiveState({
@@ -366,6 +376,12 @@ export async function materializeInstitutionalRuntimeCognitiveSpine(input: {
     trace,
     runtimeProjection,
     cognitiveTwinContext,
-    warnings: cognitiveTwinContext.warnings,
+    warnings,
+    sourcePlane: {
+      rootEvidence: evidence.records.length,
+      canonicalMemory: memory.rows.length,
+      approvedTwinDecisions: decisions.rows.length,
+      ...additionalSources.summary,
+    },
   };
 }


### PR DESCRIPTION
## Scope

Expands the sealed institutional Cognitive Spine source plane using only source families whose historical identity can be reconstructed at a cutoff without consulting mutable present-day state.

## Adds

- Pure mapping for append-only Method Lab hypotheses into `HYPOTHESIS` refs with verification debt.
- Pure mapping for immutable governance events into `DECISION`, `FREEZE`, and `QUESTION` refs.
- Server-side cutoff reader for:
  - `sfi_hypotheses` + their `sfi_lab_analyses` source context;
  - immutable `epistemic_events` for `design_approved`, `rejected`, `frozen`, and `waiting_evidence` governance transitions.
- Runtime Cognitive Spine snapshots now include these additional source refs when allowed by `RUNTIME_GENERAL_CONTEXT_V1`.
- Existing ROOT evidence, canonical memory, and approved Twin decision source records become profile-neutral (`visibilityProfiles: ['*']`) so future profile materialization can reuse the same canonical source plane.
- Source-plane counts are returned as observability metadata; they are not part of epistemic promotion.
- CI regression tests for source mapping semantics.

## Epistemic boundary

- A Method Lab hypothesis remains `HYPOTHESIS`; it is never relabeled as evidence merely because it enters the Cognitive Spine.
- An unresolved hypothesis contributes verification debt; the projector does not decide whether it is true.
- Governance history is reconstructed from immutable `epistemic_events`, not the mutable current `action_proposals` row.
- `waiting_evidence` is represented as an open `QUESTION`, not as evidence.
- These new source refs affect sealed state and debt, but are not appended to `KernelEvidence` or injected as evidence text into LLM agents by inheritance.

## Historical reconstruction boundary

Deliberately excluded for now:
- current `action_proposals` state;
- current `sfi_predictive_runs` state;
- `graph_nodes` / `graph_edges` projections.

Those surfaces are mutable or rebuildable and therefore cannot safely reconstruct a historical cognitive state without event/history semantics.

## Deployment boundary

Pure mappings are platform-neutral. Database reads live in a Node/server-worker adapter. No Vercel dependency is introduced into Cognitive Spine semantics.

## Gates

- SFI Cognitive Spine: PASS
- append-only source mapping tests: PASS
- CPRT-A / CPRT-B: PASS
- frozen profile registry: PASS
- Typecheck: PASS
- production build / SFI Verify: PASS
- Studio audio gates: PASS

## Non-goal

This PR does not connect Studio, ROOT deliberation, Lab experiments, WorldSpect, Atlas, or Library as new CT consumers. Generic profile materialization comes next.