### PR TITLE
Generalize Cognitive Spine materialization by projection profile

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -62,3 +62,5 @@ jobs:
         run: node --import tsx --test src/core/cognitive-spine/cprt/projectionProfiles.test.ts
       - name: Append-only institutional source-plane mappings
         run: node --import tsx --test src/core/cognitive-spine/cprt/sourcePlaneMapping.test.ts
+      - name: Platform-neutral profile materialization
+        run: node --import tsx --test src/core/cognitive-spine/cprt/profileMaterialization.test.ts

--- a/src/core/cognitive-spine/cprt/profileMaterialization.test.ts
+++ b/src/core/cognitive-spine/cprt/profileMaterialization.test.ts
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { CognitiveSpineSourceRecord } from '../contracts/snapshot';
+import { materializeCognitiveSpineProfileSnapshot } from '../profiles/materializeProfile';
+
+function fixtureRecords(): CognitiveSpineSourceRecord[] {
+  return [
+    {
+      ref: 'root_evidence_entries:E-001',
+      kind: 'EVIDENCE',
+      recordedAt: '2026-08-16T08:00:00.000Z',
+      sourceHash: 'a'.repeat(64),
+      epistemicAssessmentRef: 'EA-001',
+      epistemicClass: 'OBSERVED',
+      ancestryRoots: ['OBS-001'],
+      visibilityProfiles: ['*'],
+    },
+    {
+      ref: 'sfi_amv_memory:M-001',
+      kind: 'MEMORY',
+      recordedAt: '2026-08-16T08:01:00.000Z',
+      sourceHash: 'b'.repeat(64),
+      visibilityProfiles: ['*'],
+      debtType: 'VERIFICATION',
+    },
+    {
+      ref: 'sfi_hypotheses:H-001',
+      kind: 'HYPOTHESIS',
+      recordedAt: '2026-08-16T08:02:00.000Z',
+      sourceHash: 'c'.repeat(64),
+      visibilityProfiles: ['*'],
+      debtType: 'VERIFICATION',
+    },
+    {
+      ref: 'person_ct:CT-A01:REP-001',
+      kind: 'PERSON_CT',
+      recordedAt: '2026-08-16T08:03:00.000Z',
+      sourceHash: 'd'.repeat(64),
+      visibilityProfiles: ['*'],
+    },
+  ];
+}
+
+test('Runtime profile seals institutional refs and excludes direct PERSON_CT inheritance', () => {
+  const result = materializeCognitiveSpineProfileSnapshot({
+    records: fixtureRecords(),
+    sourceCutoff: '2026-08-16T08:10:00.000Z',
+    executionId: 'RUN-001',
+    createdAt: '2026-08-16T08:10:01.000Z',
+    profileId: 'RUNTIME_GENERAL_CONTEXT_V1',
+    consume: true,
+  });
+
+  assert.equal(result.trace.ctSnapshotConsumed, true);
+  assert.equal(result.trace.projectionProfile, 'RUNTIME_GENERAL_CONTEXT_V1');
+  assert.deepEqual(result.snapshot.semanticPayload.evidenceRefs, ['root_evidence_entries:E-001']);
+  assert.deepEqual(result.snapshot.semanticPayload.memoryRefs, ['sfi_amv_memory:M-001']);
+  assert.deepEqual(result.snapshot.semanticPayload.hypothesisRefs, ['sfi_hypotheses:H-001']);
+  assert.deepEqual(result.snapshot.semanticPayload.personCtRefs, []);
+  assert.equal(result.snapshot.semanticPayload.verificationDebt.absolute, 2);
+});
+
+test('blinded Field profile can record CT availability but exposes and consumes no refs', () => {
+  const result = materializeCognitiveSpineProfileSnapshot({
+    records: fixtureRecords(),
+    sourceCutoff: '2026-08-16T08:10:00.000Z',
+    executionId: 'FIELD-BLIND-001',
+    createdAt: '2026-08-16T08:10:01.000Z',
+    profileId: 'FIELD_BLINDED_OBSERVATION_V1',
+    consume: false,
+  });
+
+  assert.equal(result.profile.blindedByDefault, true);
+  assert.equal(result.trace.ctSnapshotConsumed, false);
+  assert.equal(result.trace.blindedObservation, true);
+  assert.ok(result.trace.ctSnapshotAvailable);
+  assert.equal(result.visibleRecordCount, 0);
+  assert.equal(result.snapshot.semanticPayload.sourceManifest.length, 0);
+  assert.equal(result.snapshot.semanticPayload.derivedState.sourceCount, 0);
+});
+
+test('blinded profiles reject attempted CT consumption', () => {
+  assert.throws(() => materializeCognitiveSpineProfileSnapshot({
+    records: fixtureRecords(),
+    sourceCutoff: '2026-08-16T08:10:00.000Z',
+    executionId: 'LAB-BLIND-001',
+    createdAt: '2026-08-16T08:10:01.000Z',
+    profileId: 'LAB_BLINDED_V1',
+    consume: true,
+  }), /COGNITIVE_SPINE_BLINDED_PROFILE_CANNOT_CONSUME/);
+});
+
+test('same source set in different insertion order yields the same profile snapshot semantic hash', () => {
+  const records = fixtureRecords();
+  const common = {
+    sourceCutoff: '2026-08-16T08:10:00.000Z',
+    createdAt: '2026-08-16T08:10:01.000Z',
+    profileId: 'ROOT_GOVERNANCE_CONTEXT_V1' as const,
+    consume: true,
+  };
+  const left = materializeCognitiveSpineProfileSnapshot({ ...common, records, executionId: 'ROOT-001' });
+  const right = materializeCognitiveSpineProfileSnapshot({ ...common, records: [...records].reverse(), executionId: 'ROOT-002' });
+
+  assert.equal(left.snapshot.snapshotHash, right.snapshot.snapshotHash);
+  assert.deepEqual(left.snapshot.semanticPayload, right.snapshot.semanticPayload);
+});
+
+test('profile identity is semantic even when visible source refs coincide', () => {
+  const records = fixtureRecords();
+  const runtime = materializeCognitiveSpineProfileSnapshot({
+    records,
+    sourceCutoff: '2026-08-16T08:10:00.000Z',
+    executionId: 'RUN-001',
+    createdAt: '2026-08-16T08:10:01.000Z',
+    profileId: 'RUNTIME_GENERAL_CONTEXT_V1',
+    consume: true,
+  });
+  const root = materializeCognitiveSpineProfileSnapshot({
+    records,
+    sourceCutoff: '2026-08-16T08:10:00.000Z',
+    executionId: 'ROOT-001',
+    createdAt: '2026-08-16T08:10:01.000Z',
+    profileId: 'ROOT_GOVERNANCE_CONTEXT_V1',
+    consume: true,
+  });
+
+  assert.notEqual(runtime.snapshot.snapshotHash, root.snapshot.snapshotHash);
+  assert.equal(runtime.snapshot.semanticPayload.projectionProfile, 'RUNTIME_GENERAL_CONTEXT_V1');
+  assert.equal(root.snapshot.semanticPayload.projectionProfile, 'ROOT_GOVERNANCE_CONTEXT_V1');
+});

--- a/src/core/cognitive-spine/profiles/materializeProfile.ts
+++ b/src/core/cognitive-spine/profiles/materializeProfile.ts
@@ -1,0 +1,91 @@
+import type { CognitiveSpineSourceRecord } from '../contracts/snapshot';
+import {
+  getCognitiveProjectionProfile,
+  type CognitiveSpineProjectionProfileId,
+} from './registry';
+import { profileAllowsKind } from '../contracts/projectionProfile';
+import {
+  projectCognitiveState,
+  sealCognitiveSnapshot,
+  semanticSnapshotHash,
+} from '../projector/cognitiveStateProjector';
+import { normalizeTimestamp } from '../serialization/canonicalSerialize';
+import { buildCognitiveContextConsumptionTrace } from '../trace/consumptionTrace';
+
+export const COGNITIVE_SPINE_PROJECTOR_VERSION = 'SFI-CT-PROJECTOR-1.0' as const;
+export const COGNITIVE_SPINE_POLICY_VERSION = 'SFI-CT-INVARIANTS-1.0' as const;
+
+export type MaterializeCognitiveSpineProfileSnapshotInput = {
+  records: CognitiveSpineSourceRecord[];
+  sourceCutoff: string;
+  executionId: string;
+  createdAt: string;
+  profileId: CognitiveSpineProjectionProfileId;
+  consume: boolean;
+  consumptionReason?: string;
+};
+
+export function selectCognitiveSpineRecordsForProfile(
+  records: CognitiveSpineSourceRecord[],
+  profileId: CognitiveSpineProjectionProfileId,
+): CognitiveSpineSourceRecord[] {
+  const profile = getCognitiveProjectionProfile(profileId);
+  return records.filter((record) => profileAllowsKind(profile, record.kind));
+}
+
+/**
+ * Platform-neutral profile materialization over an already reconstructed
+ * canonical source plane. No database, Next.js or Vercel dependency.
+ */
+export function materializeCognitiveSpineProfileSnapshot(
+  input: MaterializeCognitiveSpineProfileSnapshotInput,
+) {
+  const profile = getCognitiveProjectionProfile(input.profileId);
+  if (profile.blindedByDefault && input.consume) {
+    throw new Error(`COGNITIVE_SPINE_BLINDED_PROFILE_CANNOT_CONSUME:${profile.profileId}`);
+  }
+
+  const sourceCutoff = normalizeTimestamp(input.sourceCutoff);
+  const createdAt = normalizeTimestamp(input.createdAt);
+  const records = selectCognitiveSpineRecordsForProfile(input.records, input.profileId);
+
+  const semanticPayload = projectCognitiveState({
+    sourceCutoff,
+    projectorVersion: COGNITIVE_SPINE_PROJECTOR_VERSION,
+    policyVersion: COGNITIVE_SPINE_POLICY_VERSION,
+    projectionProfile: profile.profileId,
+    records,
+  });
+  const snapshotHash = semanticSnapshotHash(semanticPayload);
+  const snapshot = sealCognitiveSnapshot(semanticPayload, {
+    snapshotId: `CT-${snapshotHash.slice(0, 16)}`,
+    createdAt,
+    runtimeMetadata: {
+      runner: 'cognitive-spine-profile-materializer',
+      surface: profile.surface,
+    },
+  });
+
+  const trace = buildCognitiveContextConsumptionTrace({
+    executionId: input.executionId,
+    ctSnapshotAvailable: snapshot.snapshotId,
+    ctSnapshotHashAvailable: snapshot.snapshotHash,
+    ctSnapshotConsumed: input.consume,
+    ...(input.consume ? {
+      consumedSnapshotId: snapshot.snapshotId,
+      consumedSnapshotHash: snapshot.snapshotHash,
+      projectionProfile: profile.profileId,
+      profileVersion: profile.version,
+      consumptionReason: input.consumptionReason ?? `bounded ${profile.surface.toLowerCase()} Cognitive Spine context`,
+    } : {}),
+    blindedObservation: profile.blindedByDefault,
+    recordedAt: createdAt,
+  });
+
+  return {
+    profile,
+    snapshot,
+    trace,
+    visibleRecordCount: records.length,
+  };
+}

--- a/src/lib/institution/cognitiveSpineInstitutionalSourcePlane.ts
+++ b/src/lib/institution/cognitiveSpineInstitutionalSourcePlane.ts
@@ -1,0 +1,363 @@
+import 'server-only';
+
+import type {
+  AssessedEpistemicClass,
+  CognitiveDebtType,
+  CognitiveSpineSourceRecord,
+} from '@/core/cognitive-spine/contracts/snapshot';
+import { canonicalSha256, normalizeTimestamp, sortedUnique } from '@/core/cognitive-spine/serialization/canonicalSerialize';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { readAdditionalInstitutionalCognitiveSpineSources } from './cognitiveSpineAdditionalSources';
+
+const CANONICAL_MEMORY_MODULE = 'institutionalEventPipeline';
+const MEMORY_PAGE_SIZE = 128;
+const MAX_MEMORY_ROWS = 48;
+const MAX_DECISION_ROWS = 24;
+const MAX_EVIDENCE_ROWS = 64;
+const CONSUMABLE_MEMORY_STATUSES = new Set(['CANDIDATE', 'VERIFIED', 'CANONICAL']);
+
+type Row = Record<string, unknown>;
+
+export type InstitutionalCognitiveSpineMemory = {
+  id: string;
+  key: string;
+  type: string;
+  status: string;
+  content: unknown;
+  evidenceRefs: string[];
+  version: string;
+  createdAt: string;
+};
+
+export type InstitutionalCognitiveSpineDecision = {
+  id: string;
+  situation: string;
+  correctState: string | null;
+  generalRule: string;
+  requiredEvidence: string[];
+  evidenceRefs: string[];
+  approvedAt: string;
+};
+
+export type InstitutionalCognitiveSpineSourcePlane = {
+  sourceCutoff: string;
+  records: CognitiveSpineSourceRecord[];
+  memory: InstitutionalCognitiveSpineMemory[];
+  decisions: InstitutionalCognitiveSpineDecision[];
+  warnings: string[];
+  summary: {
+    rootEvidence: number;
+    canonicalMemory: number;
+    approvedTwinDecisions: number;
+    labHypotheses: number;
+    governanceDecisions: number;
+    governanceFreezes: number;
+    governanceQuestions: number;
+  };
+};
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
+}
+
+function memoryStatus(content: Row) {
+  const lifecycle = text(content.lifecycleStatus);
+  if (lifecycle === 'REJECTED' || lifecycle === 'OBSOLETE' || lifecycle === 'FOUNDER_RESERVED') return lifecycle;
+  if (lifecycle === 'INSTITUTIONALIZED') return 'CANONICAL';
+  if (lifecycle === 'REPRODUCIBLE') return 'VERIFIED';
+
+  const declared = text(content.memoryStatus) ?? text(content.status);
+  if (declared && ['CANDIDATE', 'VERIFIED', 'CANONICAL', 'REJECTED', 'OBSOLETE', 'FOUNDER_RESERVED'].includes(declared)) {
+    return declared;
+  }
+  return 'CANDIDATE';
+}
+
+function assessedClass(value: unknown): AssessedEpistemicClass | null {
+  const normalized = text(value)?.toLowerCase() ?? null;
+  if (normalized === 'observed') return 'OBSERVED';
+  if (normalized === 'declared') return 'DECLARED';
+  if (normalized === 'derived') return 'DERIVED';
+  if (normalized === 'inferred') return 'INFERRED';
+  if (normalized === 'simulated') return 'SIMULATED';
+  if (normalized === 'projected') return 'PROJECTED';
+  if (normalized === 'verified_contrast') return 'VERIFIED_CONTRAST';
+  return null;
+}
+
+async function readCanonicalMemoryAtCutoff(sourceCutoff: string): Promise<{
+  rows: InstitutionalCognitiveSpineMemory[];
+  warnings: string[];
+}> {
+  const db = createServiceSupabaseClient();
+  const latestByKey = new Map<string, InstitutionalCognitiveSpineMemory>();
+  const seenKeys = new Set<string>();
+  const warnings: string[] = [];
+  let offset = 0;
+
+  while (latestByKey.size < MAX_MEMORY_ROWS) {
+    const page = await db.from('sfi_amv_memory')
+      .select('id,module,memory_delta,created_at')
+      .eq('module', CANONICAL_MEMORY_MODULE)
+      .not('memory_delta->raw->>memoryKey', 'is', null)
+      .lte('created_at', sourceCutoff)
+      .order('created_at', { ascending: false })
+      .range(offset, offset + MEMORY_PAGE_SIZE - 1);
+
+    if (page.error) {
+      warnings.push(`cognitive_spine_memory_unavailable:${page.error.message}`);
+      break;
+    }
+
+    const pageRows = page.data ?? [];
+    for (const item of pageRows) {
+      const row = record(item);
+      const delta = record(row.memory_delta);
+      const raw = record(delta.raw);
+      const key = text(raw.memoryKey);
+      const type = text(raw.memoryType);
+      const id = text(row.id);
+      const createdAt = text(row.created_at);
+      if (!key || !type || !id || !createdAt || seenKeys.has(key)) continue;
+
+      seenKeys.add(key);
+      const content = record(raw.content);
+      const status = memoryStatus(content);
+      if (!CONSUMABLE_MEMORY_STATUSES.has(status)) continue;
+
+      latestByKey.set(key, {
+        id,
+        key,
+        type,
+        status,
+        content: raw.content ?? null,
+        evidenceRefs: sortedUnique(strings(raw.evidenceRefs)),
+        version: text(content.cognitiveTwinExperienceContract) ?? 'SFI-CT-EXPERIENCE-2.0',
+        createdAt: normalizeTimestamp(createdAt),
+      });
+      if (latestByKey.size >= MAX_MEMORY_ROWS) break;
+    }
+
+    if (pageRows.length < MEMORY_PAGE_SIZE) break;
+    offset += MEMORY_PAGE_SIZE;
+  }
+
+  return { rows: [...latestByKey.values()], warnings };
+}
+
+async function readApprovedDecisionsAtCutoff(sourceCutoff: string): Promise<{
+  rows: InstitutionalCognitiveSpineDecision[];
+  warnings: string[];
+}> {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_cognitive_twin_decisions')
+    .select('decision_id,situation,correct_state,general_rule,required_evidence,evidence_refs,approved_at,status')
+    .eq('status', 'APPROVED')
+    .lte('approved_at', sourceCutoff)
+    .order('approved_at', { ascending: false })
+    .limit(MAX_DECISION_ROWS);
+
+  if (result.error) {
+    return { rows: [], warnings: [`cognitive_spine_decisions_unavailable:${result.error.message}`] };
+  }
+
+  const rowsOut: InstitutionalCognitiveSpineDecision[] = [];
+  for (const item of result.data ?? []) {
+    const row = record(item);
+    const id = text(row.decision_id);
+    const approvedAt = text(row.approved_at);
+    if (!id || !approvedAt) continue;
+    rowsOut.push({
+      id,
+      situation: text(row.situation) ?? '',
+      correctState: text(row.correct_state),
+      generalRule: text(row.general_rule) ?? '',
+      requiredEvidence: sortedUnique(strings(row.required_evidence)),
+      evidenceRefs: sortedUnique(strings(row.evidence_refs)),
+      approvedAt: normalizeTimestamp(approvedAt),
+    });
+  }
+
+  return { rows: rowsOut, warnings: [] };
+}
+
+async function readAssessedEvidenceAtCutoff(sourceCutoff: string): Promise<{
+  records: CognitiveSpineSourceRecord[];
+  warnings: string[];
+}> {
+  const db = createServiceSupabaseClient();
+  const evidenceResult = await db.from('root_evidence_entries')
+    .select('id,title,content,evidence_type,payload,epistemic_event_id,created_at')
+    .lte('created_at', sourceCutoff)
+    .order('created_at', { ascending: false })
+    .limit(MAX_EVIDENCE_ROWS);
+
+  if (evidenceResult.error) {
+    return { records: [], warnings: [`cognitive_spine_root_evidence_unavailable:${evidenceResult.error.message}`] };
+  }
+
+  const evidenceRows = (evidenceResult.data ?? []).map(record);
+  const eventIds = sortedUnique(evidenceRows
+    .map((row) => text(row.epistemic_event_id))
+    .filter((value): value is string => Boolean(value)));
+  const eventResult = eventIds.length
+    ? await db.from('epistemic_events')
+        .select('event_id,epistemic_class,occurred_at,hash_self,lineage,schema_version')
+        .in('event_id', eventIds)
+    : { data: [], error: null };
+
+  const warnings: string[] = [];
+  if (eventResult.error) warnings.push(`cognitive_spine_epistemic_events_unavailable:${eventResult.error.message}`);
+  const events = new Map((eventResult.data ?? []).map((item) => {
+    const row = record(item);
+    return [text(row.event_id) ?? '', row] as const;
+  }).filter(([id]) => Boolean(id)));
+
+  const recordsOut: CognitiveSpineSourceRecord[] = [];
+  for (const row of evidenceRows) {
+    const id = text(row.id);
+    const eventId = text(row.epistemic_event_id);
+    const createdAt = text(row.created_at);
+    if (!id || !eventId || !createdAt) continue;
+    const event = events.get(eventId);
+    if (!event) {
+      warnings.push(`cognitive_spine_evidence_assessment_missing:${id}`);
+      continue;
+    }
+    const epistemicClass = assessedClass(event.epistemic_class);
+    if (!epistemicClass) {
+      warnings.push(`cognitive_spine_evidence_class_not_admissible:${id}:${text(event.epistemic_class) ?? 'missing'}`);
+      continue;
+    }
+
+    const occurredAt = text(event.occurred_at) ?? createdAt;
+    const lineage = sortedUnique(strings(event.lineage));
+    const debtType: CognitiveDebtType | undefined = lineage.length === 0 ? 'PROVENANCE' : undefined;
+    const sourceHash = canonicalSha256({
+      store: 'root_evidence_entries',
+      id,
+      title: text(row.title),
+      content: text(row.content),
+      evidenceType: text(row.evidence_type),
+      payload: row.payload ?? null,
+      createdAt: normalizeTimestamp(createdAt),
+      epistemicEvent: {
+        eventId,
+        class: epistemicClass,
+        hashSelf: text(event.hash_self),
+        occurredAt: normalizeTimestamp(occurredAt),
+      },
+    });
+
+    recordsOut.push({
+      ref: `root_evidence_entries:${id}`,
+      kind: 'EVIDENCE',
+      recordedAt: normalizeTimestamp(occurredAt),
+      sourceHash,
+      sourceVersion: text(event.schema_version) ?? undefined,
+      epistemicAssessmentRef: eventId,
+      epistemicClass,
+      ancestryRoots: lineage,
+      visibilityProfiles: ['*'],
+      debtType,
+    });
+  }
+
+  return { records: recordsOut, warnings };
+}
+
+function memorySourceRecord(memory: InstitutionalCognitiveSpineMemory): CognitiveSpineSourceRecord {
+  return {
+    ref: `sfi_amv_memory:${memory.id}`,
+    kind: 'MEMORY',
+    recordedAt: memory.createdAt,
+    sourceHash: canonicalSha256({
+      store: 'sfi_amv_memory',
+      id: memory.id,
+      key: memory.key,
+      type: memory.type,
+      status: memory.status,
+      content: memory.content,
+      evidenceRefs: memory.evidenceRefs,
+      version: memory.version,
+      createdAt: memory.createdAt,
+    }),
+    sourceVersion: memory.version,
+    visibilityProfiles: ['*'],
+    ...(memory.status === 'CANDIDATE' ? { debtType: 'VERIFICATION' as const } : {}),
+  };
+}
+
+function decisionSourceRecord(decision: InstitutionalCognitiveSpineDecision): CognitiveSpineSourceRecord {
+  return {
+    ref: `sfi_cognitive_twin_decisions:${decision.id}`,
+    kind: 'DECISION',
+    recordedAt: decision.approvedAt,
+    sourceHash: canonicalSha256({
+      store: 'sfi_cognitive_twin_decisions',
+      decisionId: decision.id,
+      situation: decision.situation,
+      correctState: decision.correctState,
+      generalRule: decision.generalRule,
+      requiredEvidence: decision.requiredEvidence,
+      evidenceRefs: decision.evidenceRefs,
+      approvedAt: decision.approvedAt,
+      status: 'APPROVED',
+    }),
+    visibilityProfiles: ['*'],
+  };
+}
+
+/**
+ * Canonical read-side source plane for institutional Cognitive Spine
+ * materialization. This function does not choose a projection profile and does
+ * not decide consumption. It only reconstructs admissible source records at a
+ * cutoff from canonical/append-only stores.
+ */
+export async function readInstitutionalCognitiveSpineSourcePlane(
+  sourceCutoff: string,
+): Promise<InstitutionalCognitiveSpineSourcePlane> {
+  const cutoff = normalizeTimestamp(sourceCutoff);
+  const [evidence, memory, decisions, additionalSources] = await Promise.all([
+    readAssessedEvidenceAtCutoff(cutoff),
+    readCanonicalMemoryAtCutoff(cutoff),
+    readApprovedDecisionsAtCutoff(cutoff),
+    readAdditionalInstitutionalCognitiveSpineSources(cutoff),
+  ]);
+
+  const records = [
+    ...evidence.records,
+    ...memory.rows.map(memorySourceRecord),
+    ...decisions.rows.map(decisionSourceRecord),
+    ...additionalSources.records,
+  ];
+
+  return {
+    sourceCutoff: cutoff,
+    records,
+    memory: memory.rows,
+    decisions: decisions.rows,
+    warnings: sortedUnique([
+      ...evidence.warnings,
+      ...memory.warnings,
+      ...decisions.warnings,
+      ...additionalSources.warnings,
+    ]),
+    summary: {
+      rootEvidence: evidence.records.length,
+      canonicalMemory: memory.rows.length,
+      approvedTwinDecisions: decisions.rows.length,
+      ...additionalSources.summary,
+    },
+  };
+}

--- a/src/lib/institution/cognitiveSpineProfileMaterializer.ts
+++ b/src/lib/institution/cognitiveSpineProfileMaterializer.ts
@@ -1,0 +1,107 @@
+import 'server-only';
+
+import type { CognitiveSpineSourceRecord } from '@/core/cognitive-spine/contracts/snapshot';
+import {
+  getCognitiveProjectionProfile,
+  type CognitiveSpineProjectionProfileId,
+} from '@/core/cognitive-spine/profiles/registry';
+import { profileAllowsKind } from '@/core/cognitive-spine/contracts/projectionProfile';
+import {
+  projectCognitiveState,
+  sealCognitiveSnapshot,
+  semanticSnapshotHash,
+} from '@/core/cognitive-spine/projector/cognitiveStateProjector';
+import { normalizeTimestamp } from '@/core/cognitive-spine/serialization/canonicalSerialize';
+import { buildCognitiveContextConsumptionTrace } from '@/core/cognitive-spine/trace/consumptionTrace';
+import {
+  readInstitutionalCognitiveSpineSourcePlane,
+  type InstitutionalCognitiveSpineSourcePlane,
+} from './cognitiveSpineInstitutionalSourcePlane';
+
+const PROJECTOR_VERSION = 'SFI-CT-PROJECTOR-1.0';
+const POLICY_VERSION = 'SFI-CT-INVARIANTS-1.0';
+
+function visibleRecordsForProfile(
+  sourcePlane: InstitutionalCognitiveSpineSourcePlane,
+  profileId: CognitiveSpineProjectionProfileId,
+): CognitiveSpineSourceRecord[] {
+  const profile = getCognitiveProjectionProfile(profileId);
+  return sourcePlane.records.filter((record) => profileAllowsKind(profile, record.kind));
+}
+
+export type MaterializeInstitutionalCognitiveSpineProfileInput = {
+  sourceCutoff: string;
+  executionId: string;
+  createdAt: string;
+  profileId: CognitiveSpineProjectionProfileId;
+  consume: boolean;
+  consumptionReason?: string;
+};
+
+/**
+ * Generic institutional Cognitive Spine snapshot materializer.
+ *
+ * Responsibilities:
+ * - read one canonical source plane at an exact temporal cutoff;
+ * - apply a frozen visibility profile by ref kind;
+ * - deterministically materialize and seal the profile snapshot;
+ * - record CT AVAILABLE / CT CONSUMED explicitly.
+ *
+ * It does not build surface-specific prompts or execution context. Surface
+ * adapters consume the sealed result after this boundary.
+ */
+export async function materializeInstitutionalCognitiveSpineProfile(
+  input: MaterializeInstitutionalCognitiveSpineProfileInput,
+) {
+  const profile = getCognitiveProjectionProfile(input.profileId);
+  if (profile.blindedByDefault && input.consume) {
+    throw new Error(`COGNITIVE_SPINE_BLINDED_PROFILE_CANNOT_CONSUME:${profile.profileId}`);
+  }
+
+  const sourceCutoff = normalizeTimestamp(input.sourceCutoff);
+  const createdAt = normalizeTimestamp(input.createdAt);
+  const sourcePlane = await readInstitutionalCognitiveSpineSourcePlane(sourceCutoff);
+  const records = visibleRecordsForProfile(sourcePlane, input.profileId);
+
+  const semanticPayload = projectCognitiveState({
+    sourceCutoff,
+    projectorVersion: PROJECTOR_VERSION,
+    policyVersion: POLICY_VERSION,
+    projectionProfile: profile.profileId,
+    records,
+  });
+  const snapshotHash = semanticSnapshotHash(semanticPayload);
+  const snapshot = sealCognitiveSnapshot(semanticPayload, {
+    snapshotId: `CT-${snapshotHash.slice(0, 16)}`,
+    createdAt,
+    runtimeMetadata: {
+      runner: 'institutional-cognitive-spine-profile-materializer',
+      surface: profile.surface,
+    },
+  });
+
+  const trace = buildCognitiveContextConsumptionTrace({
+    executionId: input.executionId,
+    ctSnapshotAvailable: snapshot.snapshotId,
+    ctSnapshotHashAvailable: snapshot.snapshotHash,
+    ctSnapshotConsumed: input.consume,
+    ...(input.consume ? {
+      consumedSnapshotId: snapshot.snapshotId,
+      consumedSnapshotHash: snapshot.snapshotHash,
+      projectionProfile: profile.profileId,
+      profileVersion: profile.version,
+      consumptionReason: input.consumptionReason ?? `bounded ${profile.surface.toLowerCase()} Cognitive Spine context`,
+    } : {}),
+    blindedObservation: profile.blindedByDefault,
+    recordedAt: createdAt,
+  });
+
+  return {
+    profile,
+    snapshot,
+    trace,
+    sourcePlane,
+    visibleRecordCount: records.length,
+    warnings: sourcePlane.warnings,
+  };
+}

--- a/src/lib/institution/cognitiveSpineProfileMaterializer.ts
+++ b/src/lib/institution/cognitiveSpineProfileMaterializer.ts
@@ -1,33 +1,8 @@
 import 'server-only';
 
-import type { CognitiveSpineSourceRecord } from '@/core/cognitive-spine/contracts/snapshot';
-import {
-  getCognitiveProjectionProfile,
-  type CognitiveSpineProjectionProfileId,
-} from '@/core/cognitive-spine/profiles/registry';
-import { profileAllowsKind } from '@/core/cognitive-spine/contracts/projectionProfile';
-import {
-  projectCognitiveState,
-  sealCognitiveSnapshot,
-  semanticSnapshotHash,
-} from '@/core/cognitive-spine/projector/cognitiveStateProjector';
-import { normalizeTimestamp } from '@/core/cognitive-spine/serialization/canonicalSerialize';
-import { buildCognitiveContextConsumptionTrace } from '@/core/cognitive-spine/trace/consumptionTrace';
-import {
-  readInstitutionalCognitiveSpineSourcePlane,
-  type InstitutionalCognitiveSpineSourcePlane,
-} from './cognitiveSpineInstitutionalSourcePlane';
-
-const PROJECTOR_VERSION = 'SFI-CT-PROJECTOR-1.0';
-const POLICY_VERSION = 'SFI-CT-INVARIANTS-1.0';
-
-function visibleRecordsForProfile(
-  sourcePlane: InstitutionalCognitiveSpineSourcePlane,
-  profileId: CognitiveSpineProjectionProfileId,
-): CognitiveSpineSourceRecord[] {
-  const profile = getCognitiveProjectionProfile(profileId);
-  return sourcePlane.records.filter((record) => profileAllowsKind(profile, record.kind));
-}
+import type { CognitiveSpineProjectionProfileId } from '@/core/cognitive-spine/profiles/registry';
+import { materializeCognitiveSpineProfileSnapshot } from '@/core/cognitive-spine/profiles/materializeProfile';
+import { readInstitutionalCognitiveSpineSourcePlane } from './cognitiveSpineInstitutionalSourcePlane';
 
 export type MaterializeInstitutionalCognitiveSpineProfileInput = {
   sourceCutoff: string;
@@ -39,69 +14,27 @@ export type MaterializeInstitutionalCognitiveSpineProfileInput = {
 };
 
 /**
- * Generic institutional Cognitive Spine snapshot materializer.
- *
- * Responsibilities:
- * - read one canonical source plane at an exact temporal cutoff;
- * - apply a frozen visibility profile by ref kind;
- * - deterministically materialize and seal the profile snapshot;
- * - record CT AVAILABLE / CT CONSUMED explicitly.
- *
- * It does not build surface-specific prompts or execution context. Surface
- * adapters consume the sealed result after this boundary.
+ * Node/server-worker adapter: reconstruct the canonical institutional source
+ * plane, then delegate all profile selection, deterministic snapshot sealing
+ * and CT AVAILABLE / CT CONSUMED semantics to the platform-neutral core.
  */
 export async function materializeInstitutionalCognitiveSpineProfile(
   input: MaterializeInstitutionalCognitiveSpineProfileInput,
 ) {
-  const profile = getCognitiveProjectionProfile(input.profileId);
-  if (profile.blindedByDefault && input.consume) {
-    throw new Error(`COGNITIVE_SPINE_BLINDED_PROFILE_CANNOT_CONSUME:${profile.profileId}`);
-  }
-
-  const sourceCutoff = normalizeTimestamp(input.sourceCutoff);
-  const createdAt = normalizeTimestamp(input.createdAt);
-  const sourcePlane = await readInstitutionalCognitiveSpineSourcePlane(sourceCutoff);
-  const records = visibleRecordsForProfile(sourcePlane, input.profileId);
-
-  const semanticPayload = projectCognitiveState({
-    sourceCutoff,
-    projectorVersion: PROJECTOR_VERSION,
-    policyVersion: POLICY_VERSION,
-    projectionProfile: profile.profileId,
-    records,
-  });
-  const snapshotHash = semanticSnapshotHash(semanticPayload);
-  const snapshot = sealCognitiveSnapshot(semanticPayload, {
-    snapshotId: `CT-${snapshotHash.slice(0, 16)}`,
-    createdAt,
-    runtimeMetadata: {
-      runner: 'institutional-cognitive-spine-profile-materializer',
-      surface: profile.surface,
-    },
-  });
-
-  const trace = buildCognitiveContextConsumptionTrace({
+  const sourcePlane = await readInstitutionalCognitiveSpineSourcePlane(input.sourceCutoff);
+  const materialized = materializeCognitiveSpineProfileSnapshot({
+    records: sourcePlane.records,
+    sourceCutoff: sourcePlane.sourceCutoff,
     executionId: input.executionId,
-    ctSnapshotAvailable: snapshot.snapshotId,
-    ctSnapshotHashAvailable: snapshot.snapshotHash,
-    ctSnapshotConsumed: input.consume,
-    ...(input.consume ? {
-      consumedSnapshotId: snapshot.snapshotId,
-      consumedSnapshotHash: snapshot.snapshotHash,
-      projectionProfile: profile.profileId,
-      profileVersion: profile.version,
-      consumptionReason: input.consumptionReason ?? `bounded ${profile.surface.toLowerCase()} Cognitive Spine context`,
-    } : {}),
-    blindedObservation: profile.blindedByDefault,
-    recordedAt: createdAt,
+    createdAt: input.createdAt,
+    profileId: input.profileId,
+    consume: input.consume,
+    consumptionReason: input.consumptionReason,
   });
 
   return {
-    profile,
-    snapshot,
-    trace,
+    ...materialized,
     sourcePlane,
-    visibleRecordCount: records.length,
     warnings: sourcePlane.warnings,
   };
 }

--- a/src/lib/institution/cognitiveSpineRuntimeMaterializer.ts
+++ b/src/lib/institution/cognitiveSpineRuntimeMaterializer.ts
@@ -2,386 +2,60 @@ import 'server-only';
 
 import { COGNITIVE_TWIN_CONTRACT_VERSION } from '@/core/cognitive-twin/contract';
 import type { StudioTwinContext } from '@/core/cognitive-twin/studioContext';
-import type {
-  AssessedEpistemicClass,
-  CognitiveDebtType,
-  CognitiveSpineSourceRecord,
-} from '@/core/cognitive-spine/contracts/snapshot';
-import { RUNTIME_GENERAL_CONTEXT_PROFILE, runtimeGeneralAllowsKind } from '@/core/cognitive-spine/profiles/runtimeGeneral';
-import {
-  projectCognitiveState,
-  sealCognitiveSnapshot,
-  semanticSnapshotHash,
-} from '@/core/cognitive-spine/projector/cognitiveStateProjector';
+import { RUNTIME_GENERAL_CONTEXT_PROFILE } from '@/core/cognitive-spine/profiles/runtimeGeneral';
 import { buildRuntimeCognitiveSpineProjection } from '@/core/cognitive-spine/runtime/kernelProjection';
-import { canonicalSha256, normalizeTimestamp, sortedUnique } from '@/core/cognitive-spine/serialization/canonicalSerialize';
-import { buildCognitiveContextConsumptionTrace } from '@/core/cognitive-spine/trace/consumptionTrace';
-import { createServiceSupabaseClient } from '@/runtime/supabase/server';
-import { readAdditionalInstitutionalCognitiveSpineSources } from './cognitiveSpineAdditionalSources';
+import { materializeInstitutionalCognitiveSpineProfile } from './cognitiveSpineProfileMaterializer';
 
-const PROJECTOR_VERSION = 'SFI-CT-PROJECTOR-1.0';
-const POLICY_VERSION = 'SFI-CT-INVARIANTS-1.0';
-const CANONICAL_MEMORY_MODULE = 'institutionalEventPipeline';
-const MEMORY_PAGE_SIZE = 128;
-const MAX_MEMORY_ROWS = 48;
-const MAX_DECISION_ROWS = 24;
-const MAX_EVIDENCE_ROWS = 64;
-const CONSUMABLE_MEMORY_STATUSES = new Set(['CANDIDATE', 'VERIFIED', 'CANONICAL']);
-
-type Row = Record<string, unknown>;
-
-type MaterializedMemory = StudioTwinContext['memory'][number] & {
-  id: string;
-  createdAt: string;
-};
-
-type MaterializedDecision = StudioTwinContext['decisions'][number] & {
-  approvedAt: string;
-};
-
-function record(value: unknown): Row {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
-}
-
-function text(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() ? value.trim() : null;
-}
-
-function strings(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
-    : [];
-}
-
-function memoryStatus(content: Row) {
-  const lifecycle = text(content.lifecycleStatus);
-  if (lifecycle === 'REJECTED' || lifecycle === 'OBSOLETE' || lifecycle === 'FOUNDER_RESERVED') return lifecycle;
-  if (lifecycle === 'INSTITUTIONALIZED') return 'CANONICAL';
-  if (lifecycle === 'REPRODUCIBLE') return 'VERIFIED';
-
-  const declared = text(content.memoryStatus) ?? text(content.status);
-  if (declared && ['CANDIDATE', 'VERIFIED', 'CANONICAL', 'REJECTED', 'OBSOLETE', 'FOUNDER_RESERVED'].includes(declared)) {
-    return declared;
-  }
-  return 'CANDIDATE';
-}
-
-function assessedClass(value: unknown): AssessedEpistemicClass | null {
-  const normalized = text(value)?.toLowerCase() ?? null;
-  if (normalized === 'observed') return 'OBSERVED';
-  if (normalized === 'declared') return 'DECLARED';
-  if (normalized === 'derived') return 'DERIVED';
-  if (normalized === 'inferred') return 'INFERRED';
-  if (normalized === 'simulated') return 'SIMULATED';
-  if (normalized === 'projected') return 'PROJECTED';
-  if (normalized === 'verified_contrast') return 'VERIFIED_CONTRAST';
-  return null;
-}
-
-async function readCanonicalMemoryAtCutoff(sourceCutoff: string): Promise<{
-  rows: MaterializedMemory[];
-  warnings: string[];
-}> {
-  const db = createServiceSupabaseClient();
-  const latestByKey = new Map<string, MaterializedMemory>();
-  const seenKeys = new Set<string>();
-  const warnings: string[] = [];
-  let offset = 0;
-
-  while (latestByKey.size < MAX_MEMORY_ROWS) {
-    const page = await db.from('sfi_amv_memory')
-      .select('id,module,memory_delta,created_at')
-      .eq('module', CANONICAL_MEMORY_MODULE)
-      .not('memory_delta->raw->>memoryKey', 'is', null)
-      .lte('created_at', sourceCutoff)
-      .order('created_at', { ascending: false })
-      .range(offset, offset + MEMORY_PAGE_SIZE - 1);
-
-    if (page.error) {
-      warnings.push(`cognitive_spine_memory_unavailable:${page.error.message}`);
-      break;
-    }
-
-    const pageRows = page.data ?? [];
-    for (const item of pageRows) {
-      const row = record(item);
-      const delta = record(row.memory_delta);
-      const raw = record(delta.raw);
-      const key = text(raw.memoryKey);
-      const type = text(raw.memoryType);
-      const id = text(row.id);
-      const createdAt = text(row.created_at);
-      if (!key || !type || !id || !createdAt || seenKeys.has(key)) continue;
-
-      seenKeys.add(key);
-      const content = record(raw.content);
-      const status = memoryStatus(content);
-      if (!CONSUMABLE_MEMORY_STATUSES.has(status)) continue;
-
-      latestByKey.set(key, {
-        id,
-        key,
-        type,
-        status,
-        content: raw.content ?? null,
-        evidenceRefs: sortedUnique(strings(raw.evidenceRefs)),
-        version: text(content.cognitiveTwinExperienceContract) ?? 'SFI-CT-EXPERIENCE-2.0',
-        createdAt: normalizeTimestamp(createdAt),
-      });
-      if (latestByKey.size >= MAX_MEMORY_ROWS) break;
-    }
-
-    if (pageRows.length < MEMORY_PAGE_SIZE) break;
-    offset += MEMORY_PAGE_SIZE;
-  }
-
-  return { rows: [...latestByKey.values()], warnings };
-}
-
-async function readApprovedDecisionsAtCutoff(sourceCutoff: string): Promise<{
-  rows: MaterializedDecision[];
-  warnings: string[];
-}> {
-  const db = createServiceSupabaseClient();
-  const result = await db.from('sfi_cognitive_twin_decisions')
-    .select('decision_id,situation,correct_state,general_rule,required_evidence,evidence_refs,approved_at,status')
-    .eq('status', 'APPROVED')
-    .lte('approved_at', sourceCutoff)
-    .order('approved_at', { ascending: false })
-    .limit(MAX_DECISION_ROWS);
-
-  if (result.error) {
-    return { rows: [], warnings: [`cognitive_spine_decisions_unavailable:${result.error.message}`] };
-  }
-
-  const rowsOut: MaterializedDecision[] = [];
-  for (const item of result.data ?? []) {
-    const row = record(item);
-    const id = text(row.decision_id);
-    const approvedAt = text(row.approved_at);
-    if (!id || !approvedAt) continue;
-    rowsOut.push({
-      id,
-      situation: text(row.situation) ?? '',
-      correctState: text(row.correct_state),
-      generalRule: text(row.general_rule) ?? '',
-      requiredEvidence: sortedUnique(strings(row.required_evidence)),
-      evidenceRefs: sortedUnique(strings(row.evidence_refs)),
-      approvedAt: normalizeTimestamp(approvedAt),
-    });
-  }
-
-  return { rows: rowsOut, warnings: [] };
-}
-
-async function readAssessedEvidenceAtCutoff(sourceCutoff: string): Promise<{
-  records: CognitiveSpineSourceRecord[];
-  warnings: string[];
-}> {
-  const db = createServiceSupabaseClient();
-  const evidenceResult = await db.from('root_evidence_entries')
-    .select('id,title,content,evidence_type,payload,epistemic_event_id,created_at')
-    .lte('created_at', sourceCutoff)
-    .order('created_at', { ascending: false })
-    .limit(MAX_EVIDENCE_ROWS);
-
-  if (evidenceResult.error) {
-    return { records: [], warnings: [`cognitive_spine_root_evidence_unavailable:${evidenceResult.error.message}`] };
-  }
-
-  const evidenceRows = (evidenceResult.data ?? []).map(record);
-  const eventIds = sortedUnique(evidenceRows
-    .map((row) => text(row.epistemic_event_id))
-    .filter((value): value is string => Boolean(value)));
-  const eventResult = eventIds.length
-    ? await db.from('epistemic_events')
-        .select('event_id,epistemic_class,occurred_at,hash_self,lineage,schema_version')
-        .in('event_id', eventIds)
-    : { data: [], error: null };
-
-  const warnings: string[] = [];
-  if (eventResult.error) warnings.push(`cognitive_spine_epistemic_events_unavailable:${eventResult.error.message}`);
-  const events = new Map((eventResult.data ?? []).map((item) => {
-    const row = record(item);
-    return [text(row.event_id) ?? '', row] as const;
-  }).filter(([id]) => Boolean(id)));
-
-  const recordsOut: CognitiveSpineSourceRecord[] = [];
-  for (const row of evidenceRows) {
-    const id = text(row.id);
-    const eventId = text(row.epistemic_event_id);
-    const createdAt = text(row.created_at);
-    if (!id || !eventId || !createdAt) continue;
-    const event = events.get(eventId);
-    if (!event) {
-      warnings.push(`cognitive_spine_evidence_assessment_missing:${id}`);
-      continue;
-    }
-    const epistemicClass = assessedClass(event.epistemic_class);
-    if (!epistemicClass) {
-      warnings.push(`cognitive_spine_evidence_class_not_admissible:${id}:${text(event.epistemic_class) ?? 'missing'}`);
-      continue;
-    }
-
-    const occurredAt = text(event.occurred_at) ?? createdAt;
-    const lineage = sortedUnique(strings(event.lineage));
-    const debtType: CognitiveDebtType | undefined = lineage.length === 0 ? 'PROVENANCE' : undefined;
-    const sourceHash = canonicalSha256({
-      store: 'root_evidence_entries',
-      id,
-      title: text(row.title),
-      content: text(row.content),
-      evidenceType: text(row.evidence_type),
-      payload: row.payload ?? null,
-      createdAt: normalizeTimestamp(createdAt),
-      epistemicEvent: {
-        eventId,
-        class: epistemicClass,
-        hashSelf: text(event.hash_self),
-        occurredAt: normalizeTimestamp(occurredAt),
-      },
-    });
-
-    recordsOut.push({
-      ref: `root_evidence_entries:${id}`,
-      kind: 'EVIDENCE',
-      recordedAt: normalizeTimestamp(occurredAt),
-      sourceHash,
-      sourceVersion: text(event.schema_version) ?? undefined,
-      epistemicAssessmentRef: eventId,
-      epistemicClass,
-      ancestryRoots: lineage,
-      visibilityProfiles: ['*'],
-      debtType,
-    });
-  }
-
-  return { records: recordsOut, warnings };
-}
-
-function memorySourceRecord(memory: MaterializedMemory): CognitiveSpineSourceRecord {
-  return {
-    ref: `sfi_amv_memory:${memory.id}`,
-    kind: 'MEMORY',
-    recordedAt: memory.createdAt,
-    sourceHash: canonicalSha256({
-      store: 'sfi_amv_memory',
-      id: memory.id,
-      key: memory.key,
-      type: memory.type,
-      status: memory.status,
-      content: memory.content,
-      evidenceRefs: memory.evidenceRefs,
-      version: memory.version,
-      createdAt: memory.createdAt,
-    }),
-    sourceVersion: memory.version,
-    visibilityProfiles: ['*'],
-    ...(memory.status === 'CANDIDATE' ? { debtType: 'VERIFICATION' as const } : {}),
-  };
-}
-
-function decisionSourceRecord(decision: MaterializedDecision): CognitiveSpineSourceRecord {
-  return {
-    ref: `sfi_cognitive_twin_decisions:${decision.id}`,
-    kind: 'DECISION',
-    recordedAt: decision.approvedAt,
-    sourceHash: canonicalSha256({
-      store: 'sfi_cognitive_twin_decisions',
-      decisionId: decision.id,
-      situation: decision.situation,
-      correctState: decision.correctState,
-      generalRule: decision.generalRule,
-      requiredEvidence: decision.requiredEvidence,
-      evidenceRefs: decision.evidenceRefs,
-      approvedAt: decision.approvedAt,
-      status: 'APPROVED',
-    }),
-    visibilityProfiles: ['*'],
-  };
-}
-
+/**
+ * Runtime-specific adapter over the generic institutional Cognitive Spine
+ * materializer. The shared materializer owns source reads, temporal cutoff,
+ * profile selection, semantic hashing and CT AVAILABLE / CT CONSUMED trace.
+ *
+ * This adapter only converts the already-sealed Runtime profile into the
+ * legacy bounded Twin context shape consumed by existing Runtime/LLM agents.
+ * Memory and decisions remain context; they are not appended to KernelEvidence.
+ */
 export async function materializeInstitutionalRuntimeCognitiveSpine(input: {
   sourceCutoff: string;
   executionId: string;
   createdAt: string;
   consume: boolean;
 }) {
-  const sourceCutoff = normalizeTimestamp(input.sourceCutoff);
-  const [evidence, memory, decisions, additionalSources] = await Promise.all([
-    readAssessedEvidenceAtCutoff(sourceCutoff),
-    readCanonicalMemoryAtCutoff(sourceCutoff),
-    readApprovedDecisionsAtCutoff(sourceCutoff),
-    readAdditionalInstitutionalCognitiveSpineSources(sourceCutoff),
-  ]);
+  const materialized = await materializeInstitutionalCognitiveSpineProfile({
+    sourceCutoff: input.sourceCutoff,
+    executionId: input.executionId,
+    createdAt: input.createdAt,
+    profileId: RUNTIME_GENERAL_CONTEXT_PROFILE.profileId,
+    consume: input.consume,
+    consumptionReason: 'bounded shared institutional runtime context',
+  });
 
-  const warnings = sortedUnique([
-    ...evidence.warnings,
-    ...memory.warnings,
-    ...decisions.warnings,
-    ...additionalSources.warnings,
-  ]);
+  const visibleMemoryRefs = new Set(materialized.snapshot.semanticPayload.memoryRefs);
+  const visibleDecisionRefs = new Set(materialized.snapshot.semanticPayload.decisionRefs);
 
   const cognitiveTwinContext: StudioTwinContext = {
     contractVersion: COGNITIVE_TWIN_CONTRACT_VERSION,
-    memory: memory.rows.map(({ id: _id, createdAt: _createdAt, ...item }) => item),
-    decisions: decisions.rows.map(({ approvedAt: _approvedAt, ...item }) => item),
-    warnings,
+    memory: materialized.sourcePlane.memory
+      .filter((item) => visibleMemoryRefs.has(`sfi_amv_memory:${item.id}`))
+      .map(({ id: _id, createdAt: _createdAt, ...item }) => item),
+    decisions: materialized.sourcePlane.decisions
+      .filter((item) => visibleDecisionRefs.has(`sfi_cognitive_twin_decisions:${item.id}`))
+      .map(({ approvedAt: _approvedAt, ...item }) => item),
+    warnings: materialized.warnings,
   };
 
-  const records = [
-    ...evidence.records,
-    ...memory.rows.map(memorySourceRecord),
-    ...decisions.rows.map(decisionSourceRecord),
-    ...additionalSources.records,
-  ].filter((item) => runtimeGeneralAllowsKind(item.kind));
-
-  const semanticPayload = projectCognitiveState({
-    sourceCutoff,
-    projectorVersion: PROJECTOR_VERSION,
-    policyVersion: POLICY_VERSION,
-    projectionProfile: RUNTIME_GENERAL_CONTEXT_PROFILE.profileId,
-    records,
-  });
-  const snapshotHash = semanticSnapshotHash(semanticPayload);
-  const snapshot = sealCognitiveSnapshot(semanticPayload, {
-    snapshotId: `CT-${snapshotHash.slice(0, 16)}`,
-    createdAt: normalizeTimestamp(input.createdAt),
-    runtimeMetadata: { runner: 'institutional-runtime-materializer' },
-  });
-
-  const trace = buildCognitiveContextConsumptionTrace({
-    executionId: input.executionId,
-    ctSnapshotAvailable: snapshot.snapshotId,
-    ctSnapshotHashAvailable: snapshot.snapshotHash,
-    ctSnapshotConsumed: input.consume,
-    ...(input.consume ? {
-      consumedSnapshotId: snapshot.snapshotId,
-      consumedSnapshotHash: snapshot.snapshotHash,
-      projectionProfile: RUNTIME_GENERAL_CONTEXT_PROFILE.profileId,
-      profileVersion: RUNTIME_GENERAL_CONTEXT_PROFILE.version,
-      consumptionReason: 'bounded shared institutional runtime context',
-    } : {}),
-    recordedAt: normalizeTimestamp(input.createdAt),
-  });
-
   const runtimeProjection = buildRuntimeCognitiveSpineProjection({
-    snapshot,
-    trace,
+    snapshot: materialized.snapshot,
+    trace: materialized.trace,
     cognitiveTwinContext,
   });
 
   return {
-    snapshot,
-    trace,
+    snapshot: materialized.snapshot,
+    trace: materialized.trace,
     runtimeProjection,
     cognitiveTwinContext,
-    warnings,
-    sourcePlane: {
-      rootEvidence: evidence.records.length,
-      canonicalMemory: memory.rows.length,
-      approvedTwinDecisions: decisions.rows.length,
-      ...additionalSources.summary,
-    },
+    warnings: materialized.warnings,
+    sourcePlane: materialized.sourcePlane.summary,
   };
 }

--- a/src/lib/institution/cognitiveSpineRuntimeMaterializer.ts
+++ b/src/lib/institution/cognitiveSpineRuntimeMaterializer.ts
@@ -1,10 +1,9 @@
 import 'server-only';
 
-import { COGNITIVE_TWIN_CONTRACT_VERSION } from '@/core/cognitive-twin/contract';
-import type { StudioTwinContext } from '@/core/cognitive-twin/studioContext';
 import { RUNTIME_GENERAL_CONTEXT_PROFILE } from '@/core/cognitive-spine/profiles/runtimeGeneral';
 import { buildRuntimeCognitiveSpineProjection } from '@/core/cognitive-spine/runtime/kernelProjection';
 import { materializeInstitutionalCognitiveSpineProfile } from './cognitiveSpineProfileMaterializer';
+import { buildBoundedTwinContextFromCognitiveSpine } from './cognitiveSpineTwinContextAdapter';
 
 /**
  * Runtime-specific adapter over the generic institutional Cognitive Spine
@@ -12,8 +11,8 @@ import { materializeInstitutionalCognitiveSpineProfile } from './cognitiveSpineP
  * profile selection, semantic hashing and CT AVAILABLE / CT CONSUMED trace.
  *
  * This adapter only converts the already-sealed Runtime profile into the
- * legacy bounded Twin context shape consumed by existing Runtime/LLM agents.
- * Memory and decisions remain context; they are not appended to KernelEvidence.
+ * bounded Twin context consumed by existing Runtime/LLM agents. Memory and
+ * decisions remain context; they are not appended to KernelEvidence.
  */
 export async function materializeInstitutionalRuntimeCognitiveSpine(input: {
   sourceCutoff: string;
@@ -30,19 +29,10 @@ export async function materializeInstitutionalRuntimeCognitiveSpine(input: {
     consumptionReason: 'bounded shared institutional runtime context',
   });
 
-  const visibleMemoryRefs = new Set(materialized.snapshot.semanticPayload.memoryRefs);
-  const visibleDecisionRefs = new Set(materialized.snapshot.semanticPayload.decisionRefs);
-
-  const cognitiveTwinContext: StudioTwinContext = {
-    contractVersion: COGNITIVE_TWIN_CONTRACT_VERSION,
-    memory: materialized.sourcePlane.memory
-      .filter((item) => visibleMemoryRefs.has(`sfi_amv_memory:${item.id}`))
-      .map(({ id: _id, createdAt: _createdAt, ...item }) => item),
-    decisions: materialized.sourcePlane.decisions
-      .filter((item) => visibleDecisionRefs.has(`sfi_cognitive_twin_decisions:${item.id}`))
-      .map(({ approvedAt: _approvedAt, ...item }) => item),
-    warnings: materialized.warnings,
-  };
+  const cognitiveTwinContext = buildBoundedTwinContextFromCognitiveSpine({
+    snapshot: materialized.snapshot,
+    sourcePlane: materialized.sourcePlane,
+  });
 
   const runtimeProjection = buildRuntimeCognitiveSpineProjection({
     snapshot: materialized.snapshot,

--- a/src/lib/institution/cognitiveSpineTwinContextAdapter.ts
+++ b/src/lib/institution/cognitiveSpineTwinContextAdapter.ts
@@ -1,0 +1,31 @@
+import { COGNITIVE_TWIN_CONTRACT_VERSION } from '@/core/cognitive-twin/contract';
+import type { StudioTwinContext } from '@/core/cognitive-twin/studioContext';
+import type { CognitiveSpineSnapshot } from '@/core/cognitive-spine/contracts/snapshot';
+import type { InstitutionalCognitiveSpineSourcePlane } from './cognitiveSpineInstitutionalSourcePlane';
+
+/**
+ * Converts only memory/decision values whose canonical refs are present in a
+ * sealed Cognitive Spine snapshot into the bounded legacy Twin-context shape
+ * used by existing Runtime/Studio LLM adapters.
+ *
+ * The function cannot add records that are absent from the snapshot and does
+ * not turn contextual memory/decisions into evidence.
+ */
+export function buildBoundedTwinContextFromCognitiveSpine(input: {
+  snapshot: CognitiveSpineSnapshot;
+  sourcePlane: InstitutionalCognitiveSpineSourcePlane;
+}): StudioTwinContext {
+  const visibleMemoryRefs = new Set(input.snapshot.semanticPayload.memoryRefs);
+  const visibleDecisionRefs = new Set(input.snapshot.semanticPayload.decisionRefs);
+
+  return {
+    contractVersion: COGNITIVE_TWIN_CONTRACT_VERSION,
+    memory: input.sourcePlane.memory
+      .filter((item) => visibleMemoryRefs.has(`sfi_amv_memory:${item.id}`))
+      .map(({ id: _id, createdAt: _createdAt, ...item }) => item),
+    decisions: input.sourcePlane.decisions
+      .filter((item) => visibleDecisionRefs.has(`sfi_cognitive_twin_decisions:${item.id}`))
+      .map(({ approvedAt: _approvedAt, ...item }) => item),
+    warnings: input.sourcePlane.warnings,
+  };
+}


### PR DESCRIPTION
## Scope

Refactors Cognitive Spine materialization so every future SFI surface can request a sealed snapshot from one shared canonical source plane and one platform-neutral profile engine.

This PR does **not** connect additional surfaces yet. It removes Runtime-specific source-reading ownership first.

## Changes

- Extracts one shared institutional source-plane reader for ROOT evidence, canonical institutional memory, approved Twin decisions, Method Lab hypotheses and immutable governance events.
- Adds a platform-neutral pure profile materializer:
  - profile selection;
  - ref-kind visibility;
  - deterministic projection;
  - canonical semantic hash;
  - snapshot seal;
  - explicit CT AVAILABLE / CT CONSUMED trace.
- Blinded profiles fail closed if a caller attempts to consume CT context.
- Adds Node/server-worker adapter that reads canonical stores and delegates semantic work to the pure core.
- Adds one shared `sealed snapshot → bounded Twin context` adapter; callers cannot recover memory/decision values absent from the snapshot refs.
- Converts the existing Runtime materializer into a thin client of the generic profile materializer and shared bounded-context adapter.
- Runtime still receives only memory/decision context visible in its sealed snapshot; memory/decisions are not promoted to `KernelEvidence`.
- Adds platform-neutral tests for:
  - Runtime profile excluding `PERSON_CT`;
  - blinded Field snapshot availability with zero context exposure;
  - blinded consumption prohibition;
  - insertion-order independent semantic hash;
  - projection profile identity as part of semantic identity.

## Architectural effect

Before:
`Runtime materializer = source reader + projector + profile + trace + Runtime adapter`

After:
`canonical source plane → pure profile materializer → sealed snapshot/trace → surface adapter`

Runtime becomes the first surface adapter rather than the owner of Cognitive Spine semantics.

## Deployment boundary

- Profile selection, projection, hashing, sealing and trace are pure Node-compatible core logic with no Next.js/Vercel dependency.
- Supabase reads remain in a server/worker adapter.
- Future Vercel routes will be optional thin clients, not the Cognitive Spine runtime.

## Gates

- SFI Cognitive Spine: PASS
- platform-neutral profile materialization: PASS
- frozen profile registry: PASS
- append-only source-plane mappings: PASS
- CPRT-A / CPRT-B: PASS
- Typecheck: PASS
- production build / SFI Verify: PASS
- Studio audio gates: PASS

## Non-goal

No Studio, ROOT deliberation, Lab experiment, WorldSpect, Atlas or Library consumption is enabled by this PR. Those integrations now consume the shared materializer in separate changes.