### PR TITLE
Route Studio Cognitive Twin reads through sealed Cognitive Spine context

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -4,10 +4,13 @@ on:
   pull_request:
     paths:
       - 'src/core/cognitive-spine/**'
+      - 'src/core/cognitive-twin/studioContext.ts'
       - 'src/core/agents/metaOrchestrator.ts'
       - 'src/infrastructure/ai/agentLlmClient.ts'
       - 'src/lib/institution/cognitiveSpine*.ts'
       - 'src/lib/institution/institutionalCycle.ts'
+      - 'src/lib/studio/cognitive/**'
+      - 'src/app/api/studio/session/reconstruct/route.ts'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/interventionExecution.ts'
       - 'src/lib/field/governedReturn.ts'
@@ -21,10 +24,13 @@ on:
       - main
     paths:
       - 'src/core/cognitive-spine/**'
+      - 'src/core/cognitive-twin/studioContext.ts'
       - 'src/core/agents/metaOrchestrator.ts'
       - 'src/infrastructure/ai/agentLlmClient.ts'
       - 'src/lib/institution/cognitiveSpine*.ts'
       - 'src/lib/institution/institutionalCycle.ts'
+      - 'src/lib/studio/cognitive/**'
+      - 'src/app/api/studio/session/reconstruct/route.ts'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/interventionExecution.ts'
       - 'src/lib/field/governedReturn.ts'
@@ -64,3 +70,5 @@ jobs:
         run: node --import tsx --test src/core/cognitive-spine/cprt/sourcePlaneMapping.test.ts
       - name: Platform-neutral profile materialization
         run: node --import tsx --test src/core/cognitive-spine/cprt/profileMaterialization.test.ts
+      - name: Studio sealed Cognitive Spine context boundary
+        run: node --import tsx scripts/cognitive-spine/qa-studio-sealed-context.ts

--- a/scripts/cognitive-spine/qa-studio-sealed-context.ts
+++ b/scripts/cognitive-spine/qa-studio-sealed-context.ts
@@ -22,13 +22,22 @@ for (const forbidden of [
   assert.equal(studioTwinContext.includes(forbidden), false, `studio_live_twin_read_reintroduced:${forbidden}`);
 }
 
-assert.ok(studioSpineAdapter.includes("STUDIO_OBJECT_CONTEXT_PROFILE"), 'studio_projection_profile_missing');
-assert.ok(studioSpineAdapter.includes("profileId: STUDIO_OBJECT_CONTEXT_PROFILE.profileId"), 'studio_profile_not_materialized');
+assert.ok(studioSpineAdapter.includes('STUDIO_OBJECT_CONTEXT_PROFILE'), 'studio_projection_profile_missing');
+assert.ok(studioSpineAdapter.includes('profileId: STUDIO_OBJECT_CONTEXT_PROFILE.profileId'), 'studio_profile_not_materialized');
 assert.ok(studioSpineAdapter.includes('buildBoundedTwinContextFromCognitiveSpine'), 'studio_bounded_context_adapter_missing');
 assert.ok(studioSpineAdapter.includes('consume: true'), 'studio_consumption_not_explicit');
 
-// Existing cognitive paths may keep the compatibility function during the
-// migration, but it must now resolve through the sealed boundary above.
+// Exact run provenance is transported request-locally so the persisted run
+// cannot silently rematerialize a newer CT state at write time.
+assert.ok(studioTwinContext.includes('AsyncLocalStorage<StudioCognitiveSpineRunContext>'), 'studio_request_local_spine_context_missing');
+assert.ok(studioTwinContext.includes('studioCognitiveSpineRunContext.enterWith'), 'studio_consumed_snapshot_not_bound_to_async_run');
+assert.ok(studioTwinContext.includes('studioCognitiveSpineRunContext.getStore()'), 'studio_run_persistence_not_reading_bound_snapshot');
+assert.ok(studioTwinContext.includes('snapshot: sealedSpine.snapshot'), 'studio_run_exact_snapshot_not_persisted');
+assert.ok(studioTwinContext.includes('consumptionTrace: sealedSpine.consumptionTrace'), 'studio_run_exact_consumption_trace_not_persisted');
+assert.ok(studioTwinContext.includes('cognitiveSpinePersisted: Boolean(sealedSpine)'), 'studio_run_spine_persistence_status_missing');
+
+// Existing cognitive paths keep the compatibility call in this migration,
+// but that call is now sealed and request-local as proven above.
 assert.ok(studioRuntime.includes('readStudioTwinContext'), 'studio_runtime_context_boundary_missing');
 assert.ok(reconstructionRoute.includes('readStudioTwinContext'), 'studio_reconstruction_context_boundary_missing');
 
@@ -38,6 +47,8 @@ console.log(JSON.stringify({
   liveTwinTableRead: false,
   sealedSnapshotIdentityExposed: true,
   boundedMemoryDecisionContext: true,
+  exactSnapshotPersistedWithRun: true,
+  concurrentRunIsolation: 'AsyncLocalStorage',
   runtimeCompatibilityPath: true,
   reconstructionCompatibilityPath: true,
 }, null, 2));

--- a/scripts/cognitive-spine/qa-studio-sealed-context.ts
+++ b/scripts/cognitive-spine/qa-studio-sealed-context.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(path.join(root, relative), 'utf8');
+
+const studioTwinContext = read('src/core/cognitive-twin/studioContext.ts');
+const studioSpineAdapter = read('src/lib/studio/cognitive/studioCognitiveSpineContext.ts');
+const studioRuntime = read('src/lib/studio/cognitive/studioCognitiveRuntime.ts');
+const reconstructionRoute = read('src/app/api/studio/session/reconstruct/route.ts');
+
+assert.ok(studioTwinContext.includes('materializeStudioCognitiveSpineContext'), 'studio_twin_read_not_delegated_to_spine');
+assert.ok(studioTwinContext.includes('snapshotId: materialized.snapshot.snapshotId'), 'studio_snapshot_identity_missing');
+assert.ok(studioTwinContext.includes('snapshotHash: materialized.snapshot.snapshotHash'), 'studio_snapshot_hash_missing');
+assert.ok(studioTwinContext.includes('consumed: materialized.trace.ctSnapshotConsumed'), 'studio_consumption_trace_missing');
+
+for (const forbidden of [
+  "from('sfi_cognitive_twin_memory')",
+  'readCanonicalCognitiveTwinMemory',
+]) {
+  assert.equal(studioTwinContext.includes(forbidden), false, `studio_live_twin_read_reintroduced:${forbidden}`);
+}
+
+assert.ok(studioSpineAdapter.includes("STUDIO_OBJECT_CONTEXT_PROFILE"), 'studio_projection_profile_missing');
+assert.ok(studioSpineAdapter.includes("profileId: STUDIO_OBJECT_CONTEXT_PROFILE.profileId"), 'studio_profile_not_materialized');
+assert.ok(studioSpineAdapter.includes('buildBoundedTwinContextFromCognitiveSpine'), 'studio_bounded_context_adapter_missing');
+assert.ok(studioSpineAdapter.includes('consume: true'), 'studio_consumption_not_explicit');
+
+// Existing cognitive paths may keep the compatibility function during the
+// migration, but it must now resolve through the sealed boundary above.
+assert.ok(studioRuntime.includes('readStudioTwinContext'), 'studio_runtime_context_boundary_missing');
+assert.ok(reconstructionRoute.includes('readStudioTwinContext'), 'studio_reconstruction_context_boundary_missing');
+
+console.log(JSON.stringify({
+  ok: true,
+  profile: 'STUDIO_OBJECT_CONTEXT_V1',
+  liveTwinTableRead: false,
+  sealedSnapshotIdentityExposed: true,
+  boundedMemoryDecisionContext: true,
+  runtimeCompatibilityPath: true,
+  reconstructionCompatibilityPath: true,
+}, null, 2));

--- a/src/core/cognitive-twin/studioContext.ts
+++ b/src/core/cognitive-twin/studioContext.ts
@@ -1,28 +1,11 @@
 import 'server-only';
 
 import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { materializeStudioCognitiveSpineContext } from '@/lib/studio/cognitive/studioCognitiveSpineContext';
 import { COGNITIVE_TWIN_CONTRACT_VERSION } from './contract';
-import { readCanonicalCognitiveTwinMemory } from './canonicalMemoryView';
 import { recordCognitiveTwinExperience } from './experience';
 
-const MEMORY_STATUSES = ['CANDIDATE', 'VERIFIED', 'CANONICAL'] as const;
 const STUDIO_LEARNING_VERSION = 'studio-learning-v1';
-const MAX_MEMORY_ROWS = 64;
-const MAX_DECISION_ROWS = 32;
-
-type Row = Record<string, unknown>;
-
-function record(value: unknown): Row {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
-}
-
-function text(value: unknown): string | null {
-  return typeof value === 'string' && value.trim() ? value.trim() : null;
-}
-
-function strings(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0) : [];
-}
 
 function stableStudioLearningKey(value: string) {
   return value.replace(/:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/, '');
@@ -47,71 +30,43 @@ export type StudioTwinContext = {
     evidenceRefs: string[];
   }>;
   warnings: string[];
+  cognitiveSpine?: {
+    snapshotId: string;
+    snapshotHash: string;
+    sourceCutoff: string;
+    projectionProfile: string | null;
+    profileVersion: string | null;
+    consumed: boolean;
+  };
 };
 
+/**
+ * Compatibility read boundary for existing Studio cognitive paths.
+ *
+ * This function no longer reads live Cognitive Twin memory/decision tables.
+ * It materializes one sealed `STUDIO_OBJECT_CONTEXT_V1` Cognitive Spine
+ * snapshot and returns only the bounded memory/decision values referenced by
+ * that snapshot. Callers can continue using the historical StudioTwinContext
+ * shape while the exact snapshot identity remains available for provenance.
+ */
 export async function readStudioTwinContext(): Promise<StudioTwinContext> {
-  const db = createServiceSupabaseClient();
-  const warnings: string[] = [];
-
-  const [canonicalMemory, legacyMemoryResult, decisionsResult] = await Promise.all([
-    readCanonicalCognitiveTwinMemory(MAX_MEMORY_ROWS),
-    db.from('sfi_cognitive_twin_memory')
-      .select('memory_key,memory_type,status,content,evidence_refs,version,updated_at')
-      .in('status', [...MEMORY_STATUSES])
-      .order('updated_at', { ascending: false })
-      .limit(MAX_MEMORY_ROWS),
-    db.from('sfi_cognitive_twin_decisions')
-      .select('decision_id,situation,correct_state,general_rule,required_evidence,evidence_refs,approved_at')
-      .eq('status', 'APPROVED')
-      .order('approved_at', { ascending: false })
-      .limit(MAX_DECISION_ROWS),
-  ]);
-
-  if (canonicalMemory.error) warnings.push(`twin_canonical_memory_unavailable:${canonicalMemory.error}`);
-  if (legacyMemoryResult.error) warnings.push(`twin_legacy_memory_unavailable:${legacyMemoryResult.error.message}`);
-  if (decisionsResult.error) warnings.push(`twin_decisions_unavailable:${decisionsResult.error.message}`);
-
-  const memoryByKey = new Map<string, StudioTwinContext['memory'][number]>();
-  for (const item of canonicalMemory.rows) {
-    memoryByKey.set(item.memory_key, {
-      key: item.memory_key,
-      type: item.memory_type,
-      status: item.status,
-      content: item.content,
-      evidenceRefs: item.evidence_refs,
-      version: item.version,
-    });
-  }
-  for (const item of legacyMemoryResult.data ?? []) {
-    const row = record(item);
-    const key = text(row.memory_key);
-    if (!key || memoryByKey.has(key)) continue;
-    memoryByKey.set(key, {
-      key,
-      type: text(row.memory_type) ?? 'UNKNOWN',
-      status: text(row.status) ?? 'UNKNOWN',
-      content: row.content ?? null,
-      evidenceRefs: strings(row.evidence_refs),
-      version: text(row.version) ?? 'legacy',
-    });
-    if (memoryByKey.size >= MAX_MEMORY_ROWS) break;
-  }
+  const now = new Date().toISOString();
+  const materialized = await materializeStudioCognitiveSpineContext({
+    executionId: `studio-context-${crypto.randomUUID()}`,
+    sourceCutoff: now,
+    createdAt: now,
+  });
 
   return {
-    contractVersion: COGNITIVE_TWIN_CONTRACT_VERSION,
-    memory: [...memoryByKey.values()].slice(0, MAX_MEMORY_ROWS),
-    decisions: (decisionsResult.data ?? []).map((item) => {
-      const row = record(item);
-      return {
-        id: text(row.decision_id) ?? 'unknown',
-        situation: text(row.situation) ?? '',
-        correctState: text(row.correct_state),
-        generalRule: text(row.general_rule) ?? '',
-        requiredEvidence: strings(row.required_evidence),
-        evidenceRefs: strings(row.evidence_refs),
-      };
-    }),
-    warnings,
+    ...materialized.twinContext,
+    cognitiveSpine: {
+      snapshotId: materialized.snapshot.snapshotId,
+      snapshotHash: materialized.snapshot.snapshotHash,
+      sourceCutoff: materialized.snapshot.semanticPayload.sourceCutoff,
+      projectionProfile: materialized.trace.projectionProfile,
+      profileVersion: materialized.trace.profileVersion,
+      consumed: materialized.trace.ctSnapshotConsumed,
+    },
   };
 }
 

--- a/src/core/cognitive-twin/studioContext.ts
+++ b/src/core/cognitive-twin/studioContext.ts
@@ -1,11 +1,21 @@
 import 'server-only';
 
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { CognitiveContextConsumptionTrace } from '@/core/cognitive-spine/contracts/consumptionTrace';
+import type { CognitiveSpineSnapshot } from '@/core/cognitive-spine/contracts/snapshot';
 import { createServiceSupabaseClient } from '@/runtime/supabase/server';
 import { materializeStudioCognitiveSpineContext } from '@/lib/studio/cognitive/studioCognitiveSpineContext';
 import { COGNITIVE_TWIN_CONTRACT_VERSION } from './contract';
 import { recordCognitiveTwinExperience } from './experience';
 
 const STUDIO_LEARNING_VERSION = 'studio-learning-v1';
+
+type StudioCognitiveSpineRunContext = {
+  snapshot: CognitiveSpineSnapshot;
+  consumptionTrace: CognitiveContextConsumptionTrace;
+};
+
+const studioCognitiveSpineRunContext = new AsyncLocalStorage<StudioCognitiveSpineRunContext>();
 
 function stableStudioLearningKey(value: string) {
   return value.replace(/:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/, '');
@@ -46,8 +56,13 @@ export type StudioTwinContext = {
  * This function no longer reads live Cognitive Twin memory/decision tables.
  * It materializes one sealed `STUDIO_OBJECT_CONTEXT_V1` Cognitive Spine
  * snapshot and returns only the bounded memory/decision values referenced by
- * that snapshot. Callers can continue using the historical StudioTwinContext
- * shape while the exact snapshot identity remains available for provenance.
+ * that snapshot.
+ *
+ * The exact sealed artifact and its consumption trace are also stored in a
+ * request-local AsyncLocalStorage context. `registerStudioTwinRun()` consumes
+ * that same context later in the async execution chain, so persistence records
+ * the exact snapshot that was actually used instead of materializing a second
+ * "latest" state at write time. Concurrent requests do not share this state.
  */
 export async function readStudioTwinContext(): Promise<StudioTwinContext> {
   const now = new Date().toISOString();
@@ -55,6 +70,11 @@ export async function readStudioTwinContext(): Promise<StudioTwinContext> {
     executionId: `studio-context-${crypto.randomUUID()}`,
     sourceCutoff: now,
     createdAt: now,
+  });
+
+  studioCognitiveSpineRunContext.enterWith({
+    snapshot: materialized.snapshot,
+    consumptionTrace: materialized.trace,
   });
 
   return {
@@ -85,6 +105,17 @@ export async function registerStudioTwinRun(input: {
   finishedAt?: string | null;
 }) {
   const db = createServiceSupabaseClient();
+  const sealedSpine = studioCognitiveSpineRunContext.getStore();
+  const persistedInputSnapshot = sealedSpine
+    ? {
+        ...input.inputSnapshot,
+        cognitiveSpine: {
+          snapshot: sealedSpine.snapshot,
+          consumptionTrace: sealedSpine.consumptionTrace,
+        },
+      }
+    : input.inputSnapshot;
+
   const result = await db.from('sfi_cognitive_twin_runs').insert({
     task_id: input.taskId,
     contract_version: COGNITIVE_TWIN_CONTRACT_VERSION,
@@ -93,7 +124,7 @@ export async function registerStudioTwinRun(input: {
     role: input.role,
     status: input.status,
     objective: input.objective,
-    input_snapshot: input.inputSnapshot,
+    input_snapshot: persistedInputSnapshot,
     output_envelope: input.outputEnvelope ?? null,
     evidence_refs: [...new Set(input.evidenceRefs)],
     limitations: [...new Set(input.limitations ?? [])],
@@ -131,7 +162,14 @@ export async function registerStudioTwinRun(input: {
     }
   }
 
-  return { ok: true as const, error: null, id: String(result.data.id) };
+  return {
+    ok: true as const,
+    error: null,
+    id: String(result.data.id),
+    cognitiveSpinePersisted: Boolean(sealedSpine),
+    cognitiveSpineSnapshotId: sealedSpine?.snapshot.snapshotId ?? null,
+    cognitiveSpineSnapshotHash: sealedSpine?.snapshot.snapshotHash ?? null,
+  };
 }
 
 export async function persistStudioLearningCandidate(input: {

--- a/src/lib/studio/cognitive/studioCognitiveSpineContext.ts
+++ b/src/lib/studio/cognitive/studioCognitiveSpineContext.ts
@@ -1,0 +1,41 @@
+import 'server-only';
+
+import { STUDIO_OBJECT_CONTEXT_PROFILE } from '@/core/cognitive-spine/profiles/registry';
+import { materializeInstitutionalCognitiveSpineProfile } from '@/lib/institution/cognitiveSpineProfileMaterializer';
+import { buildBoundedTwinContextFromCognitiveSpine } from '@/lib/institution/cognitiveSpineTwinContextAdapter';
+
+/**
+ * Single Studio read boundary for institutional Cognitive Spine context.
+ *
+ * Studio receives one sealed `STUDIO_OBJECT_CONTEXT_V1` snapshot per cognitive
+ * execution. The bounded Twin context is derived only from memory/decision refs
+ * present in that snapshot. No live Twin read is permitted after this boundary.
+ */
+export async function materializeStudioCognitiveSpineContext(input: {
+  executionId: string;
+  sourceCutoff: string;
+  createdAt: string;
+}) {
+  const materialized = await materializeInstitutionalCognitiveSpineProfile({
+    sourceCutoff: input.sourceCutoff,
+    executionId: input.executionId,
+    createdAt: input.createdAt,
+    profileId: STUDIO_OBJECT_CONTEXT_PROFILE.profileId,
+    consume: true,
+    consumptionReason: 'bounded Studio object/session cognitive context',
+  });
+
+  const twinContext = buildBoundedTwinContextFromCognitiveSpine({
+    snapshot: materialized.snapshot,
+    sourcePlane: materialized.sourcePlane,
+  });
+
+  return {
+    profile: materialized.profile,
+    snapshot: materialized.snapshot,
+    trace: materialized.trace,
+    twinContext,
+    warnings: materialized.warnings,
+    sourcePlane: materialized.sourcePlane.summary,
+  };
+}


### PR DESCRIPTION
## Scope

Migrates the existing Studio Cognitive Twin read boundary onto the shared Cognitive Spine without rewriting Studio cognition or making Studio a source of truth.

## Changes

- Adds `materializeStudioCognitiveSpineContext()` using frozen `STUDIO_OBJECT_CONTEXT_V1`.
- Reuses the generic institutional profile materializer and shared `sealed snapshot → bounded Twin context` adapter.
- `readStudioTwinContext()` no longer queries live Cognitive Twin memory/decision tables or the legacy memory view.
- The compatibility read materializes one sealed Studio Cognitive Spine snapshot and returns only memory/decisions whose refs exist in that snapshot.
- Exposes snapshot ID/hash, cutoff, profile/version and consumed flag on the Studio context.
- Uses request-local `AsyncLocalStorage` to carry the exact consumed snapshot and consumption trace through the existing async Studio execution chain.
- `registerStudioTwinRun()` automatically persists that exact snapshot+trace in the existing run input; it does not rematerialize a later state at write time.
- Concurrent Studio requests do not share the request-local Spine context.
- Existing Studio runtime and session reconstruction keep their current cognitive behavior while their CT read now resolves through the sealed boundary.
- Adds CI guard against direct Studio CT table reads and against losing exact snapshot persistence.

## Epistemic boundary

- Studio context is not KernelEvidence by inheritance.
- `PERSON_CT` remains denied by `STUDIO_OBJECT_CONTEXT_V1`.
- The snapshot is a projection of institutional state, not a source of truth.
- Studio learning still returns through the existing governed Cognitive Twin experience bridge; memory policy is unchanged.

## Deployment boundary

The profile materialization core remains local/Node/worker compatible. Studio's Next.js surfaces are clients of the same server/worker-capable materializer; Vercel is not the Cognitive Spine runtime.

## Gates

- SFI Cognitive Spine: PASS
- Studio sealed-context gate: PASS
- CPRT-A / CPRT-B: PASS
- CT Institutional Integration: PASS
- Typecheck: PASS
- SFI Verify / production build: PASS
- Studio audio gates: PASS

## Result

Studio's two existing cognitive paths no longer read live Twin stores. They consume a sealed `STUDIO_OBJECT_CONTEXT_V1` projection, and Studio runs preserve the exact semantic state they used.