### PR TITLE
Keep Field T0 blinded while tracing Cognitive Spine availability

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -12,6 +12,7 @@ on:
       - 'src/lib/studio/cognitive/**'
       - 'src/app/api/studio/session/reconstruct/route.ts'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
+      - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
       - 'src/lib/field/governedReturn.ts'
       - 'src/app/api/root/cognitive-spine/**'
@@ -32,6 +33,7 @@ on:
       - 'src/lib/studio/cognitive/**'
       - 'src/app/api/studio/session/reconstruct/route.ts'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
+      - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
       - 'src/lib/field/governedReturn.ts'
       - 'src/app/api/root/cognitive-spine/**'
@@ -72,3 +74,5 @@ jobs:
         run: node --import tsx --test src/core/cognitive-spine/cprt/profileMaterialization.test.ts
       - name: Studio sealed Cognitive Spine context boundary
         run: node --import tsx scripts/cognitive-spine/qa-studio-sealed-context.ts
+      - name: Field blinded Cognitive Spine T0 boundary
+        run: node --import tsx scripts/cognitive-spine/qa-field-blinded-t0.ts

--- a/scripts/cognitive-spine/qa-field-blinded-t0.ts
+++ b/scripts/cognitive-spine/qa-field-blinded-t0.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(path.join(root, relative), 'utf8');
+
+const boundary = read('src/lib/field/fieldCognitiveSpineBoundary.ts');
+const governed = read('src/lib/field/governedReturn.ts');
+
+assert.ok(boundary.includes('FIELD_BLINDED_OBSERVATION_PROFILE'), 'field_t0_profile_not_blinded');
+assert.ok(boundary.includes('consume: false'), 'field_t0_must_not_consume_ct');
+assert.ok(boundary.includes('sourceCutoff'), 'field_t0_cutoff_missing');
+
+const baselinePosition = governed.indexOf('const result = await createFieldCycle(ownerId, input)');
+const spinePosition = governed.indexOf('cognitiveSpineT0 = await materializeFieldBlindedCognitiveSpineT0');
+assert.ok(baselinePosition >= 0, 'field_baseline_cycle_call_missing');
+assert.ok(spinePosition > baselinePosition, 'field_ct_materialized_before_blinded_baseline_capture');
+
+assert.ok(governed.includes('cognitiveSpineT0: cognitiveSpineT0 ??'), 'field_t0_not_persisted_in_case_metadata');
+assert.ok(governed.includes('operationalSfiCtConsumed: false'), 'field_t0_degraded_path_does_not_preserve_nonconsumption');
+assert.ok(governed.includes('cognitiveSpineT0: metadata.cognitiveSpineT0 ?? null'), 'field_return_does_not_preserve_t0_provenance');
+assert.ok(governed.includes('FIELD_COGNITIVE_SPINE_T0_UNAVAILABLE'), 'field_t0_unavailability_not_explicit');
+
+console.log(JSON.stringify({
+  ok: true,
+  profile: 'FIELD_BLINDED_OBSERVATION_V1',
+  baselineCapturedBeforeCtObservation: true,
+  ctConsumedAtT0: false,
+  ctFailureBlocksField: false,
+  t0PreservedThroughReturn: true,
+}, null, 2));

--- a/src/lib/field/fieldCognitiveSpineBoundary.ts
+++ b/src/lib/field/fieldCognitiveSpineBoundary.ts
@@ -1,0 +1,37 @@
+import 'server-only';
+
+import { FIELD_BLINDED_OBSERVATION_PROFILE } from '@/core/cognitive-spine/profiles/registry';
+import { materializeInstitutionalCognitiveSpineProfile } from '@/lib/institution/cognitiveSpineProfileMaterializer';
+
+/**
+ * Field T0 boundary.
+ *
+ * Baseline observation/cycle creation must happen before this function is
+ * called. The operational Cognitive Spine is then recorded at the baseline
+ * cutoff as AVAILABLE but explicitly NOT CONSUMED, preventing prior-state
+ * expectations from contaminating the initial observation.
+ */
+export async function materializeFieldBlindedCognitiveSpineT0(input: {
+  executionId: string;
+  sourceCutoff: string;
+  recordedAt: string;
+}) {
+  const materialized = await materializeInstitutionalCognitiveSpineProfile({
+    sourceCutoff: input.sourceCutoff,
+    executionId: input.executionId,
+    createdAt: input.recordedAt,
+    profileId: FIELD_BLINDED_OBSERVATION_PROFILE.profileId,
+    consume: false,
+  });
+
+  return {
+    contractVersion: 'SFI-FIELD-COGNITIVE-SPINE-T0-1.0' as const,
+    profile: materialized.profile.profileId,
+    profileVersion: materialized.profile.version,
+    snapshot: materialized.snapshot,
+    consumptionTrace: materialized.trace,
+    sourcePlane: materialized.sourcePlane.summary,
+    warnings: materialized.warnings,
+    rule: 'Field baseline was captured before this boundary. Cognitive Spine was available for provenance but not consumed during T0 observation.',
+  };
+}

--- a/src/lib/field/governedReturn.ts
+++ b/src/lib/field/governedReturn.ts
@@ -7,6 +7,7 @@ import {
   type CreateFieldCycleInput,
   type ReturnFieldCycleInput,
 } from './operationalCycle';
+import { materializeFieldBlindedCognitiveSpineT0 } from './fieldCognitiveSpineBoundary';
 import { FIELD_INTERVENTION_EXECUTION_CONTRACT } from './interventionExecution';
 import { finalizeReturnContrast, canMarkLongitudinalCaseComplete } from './returnContrastContract';
 import { verifyStudioFieldHandoff, type StudioFieldHandoff } from '@/lib/studio/fieldHandoff';
@@ -30,11 +31,27 @@ export async function createGovernedFieldCycle(ownerId: string, input: GovernedF
     throw new Error('FIELD_STUDIO_HANDOFF_INVALID');
   }
 
+  // Baseline capture, MOPH, hypothesis and provisional intervention are created
+  // before Cognitive Spine T0 is observed. This preserves a genuinely blinded
+  // initial Field observation rather than conditioning it on prior CT state.
   const result = await createFieldCycle(ownerId, input);
   const db = createServiceSupabaseClient();
   const fieldCase = record(result.case);
   const caseId = text(fieldCase.id);
   if (!caseId) throw new Error('FIELD_GOVERNED_CASE_ID_MISSING');
+
+  const baselineCutoff = text(fieldCase.created_at) || new Date().toISOString();
+  let cognitiveSpineT0: Awaited<ReturnType<typeof materializeFieldBlindedCognitiveSpineT0>> | null = null;
+  let cognitiveSpineT0Warning: string | null = null;
+  try {
+    cognitiveSpineT0 = await materializeFieldBlindedCognitiveSpineT0({
+      executionId: `field:${caseId}:t0`,
+      sourceCutoff: baselineCutoff,
+      recordedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    cognitiveSpineT0Warning = `FIELD_COGNITIVE_SPINE_T0_UNAVAILABLE:${error instanceof Error ? error.message : String(error)}`;
+  }
 
   const frozenRivalHypothesis = input.rivalHypothesis?.trim()
     || 'Null-compatible rival: any observed change may be explained by baseline drift, external field/context, measurement error, or intervention fidelity rather than the intervention itself.';
@@ -51,6 +68,15 @@ export async function createGovernedFieldCycle(ownerId: string, input: GovernedF
     contrastFrozenAt: frozenAt,
     interventionExecutionContract: FIELD_INTERVENTION_EXECUTION_CONTRACT,
     interventionExecutionAcknowledgement: null,
+    cognitiveSpineT0: cognitiveSpineT0 ?? {
+      contractVersion: 'SFI-FIELD-COGNITIVE-SPINE-T0-1.0',
+      profile: 'FIELD_BLINDED_OBSERVATION_V1',
+      operationalSfiCtAvailable: false,
+      operationalSfiCtConsumed: false,
+      sourceCutoff: baselineCutoff,
+      warning: cognitiveSpineT0Warning,
+      rule: 'Field baseline remains valid even when operational Cognitive Spine availability cannot be reconstructed, because T0 does not consume CT context.',
+    },
     longitudinalComplete: false,
     studioFieldHandoff: input.studioHandoff ?? null,
     studioHandoffId: input.studioHandoff?.handoffId ?? null,
@@ -62,10 +88,16 @@ export async function createGovernedFieldCycle(ownerId: string, input: GovernedF
   return {
     ...result,
     case: update.data,
+    warnings: [
+      ...(Array.isArray(result.warnings) ? result.warnings : []),
+      ...(cognitiveSpineT0Warning ? [cognitiveSpineT0Warning] : []),
+    ],
     frozenRivalHypothesis,
     frozenStoppingCondition,
     contrastFrozenAt: frozenAt,
     interventionExecutionContract: FIELD_INTERVENTION_EXECUTION_CONTRACT,
+    cognitiveSpineT0,
+    cognitiveSpineT0Warning,
     studioHandoff: input.studioHandoff ?? null,
   };
 }
@@ -164,6 +196,7 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
       longitudinalComplete: true,
       interventionExecutionAcknowledgement: execution.acknowledgement,
       legacyExecutionProvenanceGap: execution.legacy,
+      cognitiveSpineT0: metadata.cognitiveSpineT0 ?? null,
       studioHandoffId: text(metadata.studioHandoffId) || null,
       studioHandoffHash: text(metadata.studioHandoffHash) || null,
     },
@@ -213,6 +246,7 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
       explanation:result.explanation,
       interventionExecutionAcknowledgement: execution.acknowledgement,
       legacyExecutionProvenanceGap: execution.legacy,
+      cognitiveSpineT0: metadata.cognitiveSpineT0 ?? null,
       returnContrast:contrast,
       studioHandoffId:text(metadata.studioHandoffId) || null,
       studioHandoffHash:text(metadata.studioHandoffHash) || null,
@@ -227,6 +261,7 @@ export async function submitGovernedFieldReturn(ownerId: string, caseId: string,
     interventionExecutionAcknowledgement: execution.acknowledgement,
     legacyExecutionProvenanceGap: execution.legacy,
     executionWarnings: execution.warnings,
+    cognitiveSpineT0: metadata.cognitiveSpineT0 ?? null,
     studioHandoffId: text(metadata.studioHandoffId) || null,
     studioHandoffHash: text(metadata.studioHandoffHash) || null,
     cognitiveTwinExperience:twinExperience,


### PR DESCRIPTION
## Scope

Connects Field to the Cognitive Spine at T0 without allowing prior institutional context to contaminate baseline observation.

## Changes

- Adds `SFI-FIELD-COGNITIVE-SPINE-T0-1.0` using `FIELD_BLINDED_OBSERVATION_V1`.
- `createFieldCycle()` completes baseline capture, MOPH, provisional hypothesis and intervention **before** any Cognitive Spine materialization.
- After baseline, the system reconstructs the institutional Spine at the case creation cutoff and records it as AVAILABLE / NOT CONSUMED.
- The blinded snapshot + consumption trace + source-plane summary are persisted in `field_cases.metadata.cognitiveSpineT0`.
- If the operational Spine cannot be materialized, Field does not fail; it stores an explicit provenance warning because CT was not a required T0 input.
- Field returns carry forward the original T0 Spine provenance into return payload and candidate institutional experience.
- Adds CI order guard proving CT materialization occurs after baseline capture and remains unconsumed.

## Epistemic boundary

- prior CT state is not observation;
- Field baseline remains valid without CT;
- CT availability does not validate the baseline, hypothesis or intervention;
- `FIELD_BLINDED_OBSERVATION_V1` exposes zero CT refs at T0;
- later return provenance can reconstruct what institutional state existed when the case opened without claiming that state influenced T0.

## Deployment boundary

The blind-profile materialization uses the shared Node/worker-capable Cognitive Spine core. Field's web route remains only a client; Vercel is not required for semantic reconstruction.

## Non-goal

This PR does not yet enable `FIELD_CASE_CONTEXT_V1` consumption after T0. Case-context consumption, if useful, will be a separate explicit post-observation step rather than an implicit baseline dependency.