### PR TITLE
Route ROOT deliberation through sealed Cognitive Spine context

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -11,6 +11,8 @@ on:
       - 'src/lib/institution/institutionalCycle.ts'
       - 'src/lib/studio/cognitive/**'
       - 'src/app/api/studio/session/reconstruct/route.ts'
+      - 'src/lib/root/cognitiveSpineRootContext.ts'
+      - 'src/app/api/root/cognitive-twin/deliberate/route.ts'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
@@ -32,6 +34,8 @@ on:
       - 'src/lib/institution/institutionalCycle.ts'
       - 'src/lib/studio/cognitive/**'
       - 'src/app/api/studio/session/reconstruct/route.ts'
+      - 'src/lib/root/cognitiveSpineRootContext.ts'
+      - 'src/app/api/root/cognitive-twin/deliberate/route.ts'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
@@ -76,3 +80,5 @@ jobs:
         run: node --import tsx scripts/cognitive-spine/qa-studio-sealed-context.ts
       - name: Field blinded Cognitive Spine T0 boundary
         run: node --import tsx scripts/cognitive-spine/qa-field-blinded-t0.ts
+      - name: ROOT sealed Cognitive Spine governance boundary
+        run: node --import tsx scripts/cognitive-spine/qa-root-sealed-context.ts

--- a/scripts/cognitive-spine/qa-root-sealed-context.ts
+++ b/scripts/cognitive-spine/qa-root-sealed-context.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(path.join(root, relative), 'utf8');
+
+const adapter = read('src/lib/root/cognitiveSpineRootContext.ts');
+const route = read('src/app/api/root/cognitive-twin/deliberate/route.ts');
+
+assert.ok(adapter.includes('ROOT_GOVERNANCE_CONTEXT_PROFILE'), 'root_projection_profile_missing');
+assert.ok(adapter.includes('materializeInstitutionalCognitiveSpineProfile'), 'root_generic_materializer_missing');
+assert.ok(adapter.includes('buildBoundedTwinContextFromCognitiveSpine'), 'root_bounded_context_missing');
+assert.ok(adapter.includes('consume: true'), 'root_ct_consumption_not_explicit');
+
+for (const forbidden of [
+  "from('sfi_cognitive_twin_memory')",
+  "from('sfi_cognitive_twin_decisions')",
+]) {
+  assert.equal(route.includes(forbidden), false, `root_live_twin_read_reintroduced:${forbidden}`);
+}
+
+assert.ok(route.includes('materializeRootCognitiveSpineContext'), 'root_deliberation_not_using_spine');
+assert.ok(route.includes('snapshot: cognitiveSpine.snapshot'), 'root_run_exact_snapshot_not_persisted');
+assert.ok(route.includes('consumptionTrace: cognitiveSpine.trace'), 'root_run_consumption_trace_not_persisted');
+assert.ok(route.includes('cognitiveSpineSnapshotHash: cognitiveSpine.snapshot.snapshotHash'), 'root_audit_snapshot_hash_missing');
+assert.ok(route.includes('ROOT governance authority does not upgrade evidence, independence, epistemic class or truth.'), 'root_truth_authority_boundary_missing');
+assert.ok(route.includes('The consumed Cognitive Spine state is sealed at the declared cutoff'), 'root_midrun_refresh_boundary_missing');
+
+console.log(JSON.stringify({
+  ok: true,
+  profile: 'ROOT_GOVERNANCE_CONTEXT_V1',
+  liveTwinTableRead: false,
+  exactSnapshotPersisted: true,
+  consumptionTracePersisted: true,
+  auditCarriesSnapshotHash: true,
+  governanceAuthorityOverTruth: false,
+}, null, 2));

--- a/src/app/api/root/cognitive-twin/deliberate/route.ts
+++ b/src/app/api/root/cognitive-twin/deliberate/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { runLlmTask } from '@/lib/ai/providerRouter';
 import { createCognitiveTwinEnvelope, evaluateCognitiveTwinAuthority } from '@/core/cognitive-twin/contract';
 import { syncSfiInstitutionalStateToCognitiveTwin } from '@/core/cognitive-twin/institutionalIntegration';
+import { materializeRootCognitiveSpineContext } from '@/lib/root/cognitiveSpineRootContext';
 import { auditRootAction, requireRootActor } from '@/lib/root/server';
 
 export const dynamic = 'force-dynamic';
@@ -22,38 +23,39 @@ export async function POST(request: Request) {
   if (!question) return NextResponse.json({ ok: false, error: 'question_required' }, { status: 400 });
 
   const startedAt = new Date().toISOString();
+  const taskId = `cognitive-twin:deliberate:${Date.now()}:${crypto.randomUUID()}`;
+
+  // Preserve the existing institutional intake step, then seal a single
+  // governance-context snapshot. No cognitive output from this deliberation
+  // exists yet, so the cutoff cannot contain the answer it is about to create.
   const institutionalSync = await syncSfiInstitutionalStateToCognitiveTwin();
-  const [decisions, memory] = await Promise.all([
-    gate.ctx.service
-      .from('sfi_cognitive_twin_decisions')
-      .select('id,decision_id,situation,rejected_condition,correct_state,general_rule,required_evidence,evidence_refs,status,approved_by,approved_at,created_at')
-      .eq('status', 'APPROVED')
-      .order('approved_at', { ascending: false })
-      .limit(50),
-    gate.ctx.service
-      .from('sfi_cognitive_twin_memory')
-      .select('id,memory_key,memory_type,status,content,evidence_refs,source_kind,source_ref,created_at,updated_at')
-      .in('status', ['VERIFIED', 'CANDIDATE'])
-      .order('updated_at', { ascending: false })
-      .limit(120),
-  ]);
+  const snapshotCutoff = new Date().toISOString();
+  const cognitiveSpine = await materializeRootCognitiveSpineContext({
+    executionId: taskId,
+    sourceCutoff: snapshotCutoff,
+    createdAt: snapshotCutoff,
+  });
+
+  const approvedDecisions = cognitiveSpine.twinContext.decisions;
+  const institutionalMemory = cognitiveSpine.twinContext.memory;
+  const snapshotState = cognitiveSpine.snapshot.semanticPayload;
+  const evidencePresent = snapshotState.derivedState.sourceCount > 0;
 
   const warnings = [
-    decisions.error?.message,
-    memory.error?.message,
-    ...institutionalSync.sources.filter((item)=>item.warning).map((item)=>`${item.source}:${item.warning}`),
+    ...cognitiveSpine.warnings,
+    ...institutionalSync.sources.filter((item) => item.warning).map((item) => `${item.source}:${item.warning}`),
   ].filter((item): item is string => Boolean(item));
-  const approvedDecisions = decisions.data ?? [];
-  const institutionalMemory = memory.data ?? [];
-  const evidencePresent = approvedDecisions.length > 0 || institutionalMemory.length > 0;
+
   const fallback = [
     'Cognitive Twin deliberation unavailable through an LLM provider.',
     `Question: ${question}`,
-    `Approved founder decisions available: ${approvedDecisions.length}.`,
-    `Institutional memory records available: ${institutionalMemory.length}.`,
+    `Sealed Cognitive Spine snapshot: ${cognitiveSpine.snapshot.snapshotId}.`,
+    `Snapshot sources available: ${snapshotState.derivedState.sourceCount}.`,
+    `Approved institutional decisions visible: ${approvedDecisions.length}.`,
+    `Institutional memory records visible: ${institutionalMemory.length}.`,
     `SFI organs connected: ${institutionalSync.integration.summary.connected}/${institutionalSync.integration.summary.total}.`,
     `SFI organs exercised: ${institutionalSync.integration.summary.exercised}/${institutionalSync.integration.summary.total}.`,
-    'No cognitive execution is declared. Review the underlying corpus manually.',
+    'No cognitive execution is declared. Review the sealed source refs manually.',
   ].join('\n');
 
   const llm = await runLlmTask({
@@ -61,20 +63,38 @@ export async function POST(request: Request) {
     system: [
       'You are the replaceable model execution layer of the System Friction Institute Cognitive Twin.',
       'Institutional memory, evidence, authority and the persistent subject exist outside you.',
-      'Use only the supplied institutional corpus and SFI organ integration state.',
+      'Use only the supplied sealed Cognitive Spine context and SFI organ integration state.',
+      'The Cognitive Spine snapshot is a projection of institutionally admissible state, not a source of truth.',
+      'ROOT has governance authority over actions; ROOT and the model do not have authority to upgrade epistemic class, independence or truth.',
       'Treat ROOT Evidence, Observatory, Studio, Method Lab, Field and Governance as distinct organs with distinct epistemic classes.',
       'A Field observed return is experience, not automatically general causal proof.',
-      'A Method Lab SIMULATED record remains SIMULATED.',
-      'Separate OBSERVED, DERIVED, INFERRED, PROPOSED, SIMULATED and MISSING.',
+      'A Method Lab hypothesis remains a hypothesis; a SIMULATED record remains SIMULATED.',
+      'Separate OBSERVED, DECLARED, DERIVED, INFERRED, PROPOSED, SIMULATED and MISSING.',
       'Do not claim that a proposal is approved, verified, canonical, executed or published unless supplied evidence says so.',
-      'When the corpus is insufficient, say exactly what organ/source is missing or unexercised.',
-      'Return a concise answer with: institutional reading, organ/evidence basis, contradictions, missing evidence, one proposed next action, and what remains founder-reserved.',
+      'When the corpus is insufficient, say exactly what source, organ or verification is missing.',
+      'Return a concise answer with: institutional reading, organ/evidence basis, contradictions, missing evidence, one proposed next action, and what remains ROOT-reserved.',
     ].join(' '),
     prompt: JSON.stringify({
       question,
+      cognitiveSpine: {
+        snapshotId: cognitiveSpine.snapshot.snapshotId,
+        snapshotHash: cognitiveSpine.snapshot.snapshotHash,
+        sourceCutoff: snapshotState.sourceCutoff,
+        projectionProfile: cognitiveSpine.trace.projectionProfile,
+        profileVersion: cognitiveSpine.trace.profileVersion,
+        consumed: cognitiveSpine.trace.ctSnapshotConsumed,
+        derivedState: snapshotState.derivedState,
+        evidenceRefs: snapshotState.evidenceRefs,
+        hypothesisRefs: snapshotState.hypothesisRefs,
+        contradictionRefs: snapshotState.contradictionRefs,
+        freezeRefs: snapshotState.freezeRefs,
+        questionRefs: snapshotState.questionRefs,
+        epistemicStateRefs: snapshotState.epistemicStateRefs,
+        sourcePlane: cognitiveSpine.sourcePlane,
+      },
       sfiIntegration: institutionalSync.integration,
       syncSummary: institutionalSync.sources,
-      approvedFounderDecisions: approvedDecisions,
+      approvedInstitutionalDecisions: approvedDecisions,
       institutionalMemory,
       warnings,
     }),
@@ -88,11 +108,11 @@ export async function POST(request: Request) {
     evidencePresent,
   });
   const finishedAt = new Date().toISOString();
-  const taskId = `cognitive-twin:deliberate:${Date.now()}`;
   const evidenceRefs = Array.from(new Set([
-    ...approvedDecisions.flatMap((row) => Array.isArray(row.evidence_refs) ? row.evidence_refs.filter((item): item is string => typeof item === 'string') : []),
-    ...institutionalMemory.flatMap((row) => Array.isArray(row.evidence_refs) ? row.evidence_refs.filter((item): item is string => typeof item === 'string') : []),
-  ])).slice(0, 120);
+    ...snapshotState.evidenceRefs,
+    ...approvedDecisions.flatMap((row) => row.evidenceRefs),
+    ...institutionalMemory.flatMap((row) => row.evidenceRefs),
+  ])).slice(0, 160);
 
   const envelope = createCognitiveTwinEnvelope({
     status: llm.ok ? 'PROPOSED' : 'REJECTED',
@@ -102,6 +122,19 @@ export async function POST(request: Request) {
       question,
       answer: llm.result,
       authority,
+      cognitiveSpine: {
+        snapshotId: cognitiveSpine.snapshot.snapshotId,
+        snapshotHash: cognitiveSpine.snapshot.snapshotHash,
+        sourceCutoff: snapshotState.sourceCutoff,
+        projectionProfile: cognitiveSpine.trace.projectionProfile,
+        profileVersion: cognitiveSpine.trace.profileVersion,
+        consumed: cognitiveSpine.trace.ctSnapshotConsumed,
+        sourceCount: snapshotState.derivedState.sourceCount,
+        evidenceCount: snapshotState.evidenceRefs.length,
+        hypothesisCount: snapshotState.hypothesisRefs.length,
+        contradictionCount: snapshotState.contradictionRefs.length,
+        verificationDebt: snapshotState.verificationDebt.absolute,
+      },
       corpus: {
         approvedDecisions: approvedDecisions.length,
         memoryRecords: institutionalMemory.length,
@@ -114,16 +147,21 @@ export async function POST(request: Request) {
       providerExecutionSucceeded: llm.ok,
       latencyMs: llm.latency_ms,
     },
-    limitations: [...warnings, ...llm.warnings, institutionalSync.integration.truthBoundary],
+    limitations: [
+      ...warnings,
+      ...llm.warnings,
+      institutionalSync.integration.truthBoundary,
+      'ROOT governance authority does not upgrade evidence, independence, epistemic class or truth.',
+      'The consumed Cognitive Spine state is sealed at the declared cutoff and is not refreshed during this deliberation.',
+    ],
     missingEvidence: [
-      ...(!evidencePresent ? ['approved_founder_decisions_or_institutional_memory'] : []),
-      ...institutionalSync.integration.organs.filter((item)=>!item.connected).map((item)=>`organ_disconnected:${item.organ}`),
-      ...institutionalSync.integration.organs.filter((item)=>item.connected && (item.observedRecords ?? 0) === 0).map((item)=>`organ_unexercised:${item.organ}`),
+      ...(!evidencePresent ? ['sealed_institutional_cognitive_state_empty'] : []),
+      ...institutionalSync.integration.organs.filter((item) => !item.connected).map((item) => `organ_disconnected:${item.organ}`),
+      ...institutionalSync.integration.organs.filter((item) => item.connected && (item.observedRecords ?? 0) === 0).map((item) => `organ_unexercised:${item.organ}`),
     ],
     actionsExecuted: [
       'sync_sfi_institutional_state',
-      'read_approved_decisions',
-      'read_institutional_memory',
+      `consume_cognitive_spine:${cognitiveSpine.snapshot.snapshotId}`,
       llm.ok ? 'llm_deliberation' : 'llm_deliberation_failed',
     ],
     recommendedTransition: !llm.ok ? 'BLOCKED' : evidencePresent ? 'VERIFYING' : 'EVIDENCE_PENDING',
@@ -142,8 +180,10 @@ export async function POST(request: Request) {
       objective: question,
       input_snapshot: {
         question,
-        approvedDecisionCount: approvedDecisions.length,
-        memoryCount: institutionalMemory.length,
+        cognitiveSpine: {
+          snapshot: cognitiveSpine.snapshot,
+          consumptionTrace: cognitiveSpine.trace,
+        },
         sfiIntegration: institutionalSync.integration.summary,
         requestedBy: gate.ctx.user.id,
         providerExecutionSucceeded: llm.ok,
@@ -173,6 +213,10 @@ export async function POST(request: Request) {
       providerExecutionSucceeded: llm.ok,
       authorityDecision: authority.decision,
       evidenceRefs: evidenceRefs.length,
+      cognitiveSpineSnapshotId: cognitiveSpine.snapshot.snapshotId,
+      cognitiveSpineSnapshotHash: cognitiveSpine.snapshot.snapshotHash,
+      cognitiveSpineProfile: cognitiveSpine.trace.projectionProfile,
+      cognitiveSpineConsumed: cognitiveSpine.trace.ctSnapshotConsumed,
       sfiOrgansConnected: institutionalSync.integration.summary.connected,
       sfiOrgansExercised: institutionalSync.integration.summary.exercised,
     },
@@ -184,6 +228,14 @@ export async function POST(request: Request) {
     ok: llm.ok,
     cognitiveExecution: llm.ok ? 'EXECUTED' : 'DEGRADED',
     institutionalSync,
+    cognitiveSpine: {
+      snapshotId: cognitiveSpine.snapshot.snapshotId,
+      snapshotHash: cognitiveSpine.snapshot.snapshotHash,
+      sourceCutoff: snapshotState.sourceCutoff,
+      projectionProfile: cognitiveSpine.trace.projectionProfile,
+      profileVersion: cognitiveSpine.trace.profileVersion,
+      consumed: cognitiveSpine.trace.ctSnapshotConsumed,
+    },
     run: persisted.data,
     envelope,
     audit,

--- a/src/lib/root/cognitiveSpineRootContext.ts
+++ b/src/lib/root/cognitiveSpineRootContext.ts
@@ -1,0 +1,41 @@
+import 'server-only';
+
+import { ROOT_GOVERNANCE_CONTEXT_PROFILE } from '@/core/cognitive-spine/profiles/registry';
+import { materializeInstitutionalCognitiveSpineProfile } from '@/lib/institution/cognitiveSpineProfileMaterializer';
+import { buildBoundedTwinContextFromCognitiveSpine } from '@/lib/institution/cognitiveSpineTwinContextAdapter';
+
+/**
+ * ROOT deliberation context boundary.
+ *
+ * ROOT receives one sealed institutional snapshot under the frozen governance
+ * profile. The snapshot may inform governance, but neither this adapter nor
+ * ROOT authority can upgrade evidence, create independence, or alter truth.
+ */
+export async function materializeRootCognitiveSpineContext(input: {
+  executionId: string;
+  sourceCutoff: string;
+  createdAt: string;
+}) {
+  const materialized = await materializeInstitutionalCognitiveSpineProfile({
+    sourceCutoff: input.sourceCutoff,
+    executionId: input.executionId,
+    createdAt: input.createdAt,
+    profileId: ROOT_GOVERNANCE_CONTEXT_PROFILE.profileId,
+    consume: true,
+    consumptionReason: 'bounded ROOT governance deliberation context',
+  });
+
+  const twinContext = buildBoundedTwinContextFromCognitiveSpine({
+    snapshot: materialized.snapshot,
+    sourcePlane: materialized.sourcePlane,
+  });
+
+  return {
+    profile: materialized.profile,
+    snapshot: materialized.snapshot,
+    trace: materialized.trace,
+    twinContext,
+    warnings: materialized.warnings,
+    sourcePlane: materialized.sourcePlane.summary,
+  };
+}


### PR DESCRIPTION
## Scope

Replaces superseded PR #229 with a clean branch from the current `main` after Studio and Field T0 Cognitive Spine merges.

## Changes

- Adds `materializeRootCognitiveSpineContext()` using frozen `ROOT_GOVERNANCE_CONTEXT_V1`.
- ROOT preserves the existing institutional sync/intake step, then seals one exact snapshot before deliberation.
- Removes direct live reads of `sfi_cognitive_twin_memory` and `sfi_cognitive_twin_decisions` from the ROOT deliberation route.
- Model-visible institutional memory and approved decisions are derived only from refs visible in the sealed snapshot.
- Persists exact snapshot + consumption trace in the existing Cognitive Twin run input.
- Adds snapshot ID/hash/profile/consumption state to ROOT audit.
- Preserves Studio and Field T0 Cognitive Spine gates already merged into `main` and adds the ROOT boundary gate.

## Epistemic boundary

`ROOT_GOVERNANCE_CONTEXT_V1` is governance context, not a truth oracle. ROOT authority does not upgrade evidence, independence, epistemic class or truth.

## Deployment boundary

The semantic materializer remains Node/local/worker compatible. The Next.js ROOT route is only a surface client; Vercel is not Cognitive Spine infrastructure.

## Validation target

Must pass accumulated Cognitive Spine gates, CT Institutional Integration, typecheck and SFI Verify/build on top of the current main before merge.