### PR TITLE
Keep Decision Transfer isolated from live institutional Cognitive Spine

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -13,6 +13,8 @@ on:
       - 'src/app/api/studio/session/reconstruct/route.ts'
       - 'src/lib/root/cognitiveSpineRootContext.ts'
       - 'src/app/api/root/cognitive-twin/deliberate/route.ts'
+      - 'src/lib/lab/decisionTransferCognitiveSpineBoundary.ts'
+      - 'src/app/api/root/method-lab/decision-transfer/blind/route.ts'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
@@ -36,6 +38,8 @@ on:
       - 'src/app/api/studio/session/reconstruct/route.ts'
       - 'src/lib/root/cognitiveSpineRootContext.ts'
       - 'src/app/api/root/cognitive-twin/deliberate/route.ts'
+      - 'src/lib/lab/decisionTransferCognitiveSpineBoundary.ts'
+      - 'src/app/api/root/method-lab/decision-transfer/blind/route.ts'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
@@ -82,3 +86,5 @@ jobs:
         run: node --import tsx scripts/cognitive-spine/qa-field-blinded-t0.ts
       - name: ROOT sealed Cognitive Spine governance boundary
         run: node --import tsx scripts/cognitive-spine/qa-root-sealed-context.ts
+      - name: Decision Transfer isolation from operational SFI-CT
+        run: node --import tsx scripts/cognitive-spine/qa-decision-transfer-isolation.ts

--- a/scripts/cognitive-spine/qa-decision-transfer-isolation.ts
+++ b/scripts/cognitive-spine/qa-decision-transfer-isolation.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(path.join(root, relative), 'utf8');
+
+const boundary = read('src/lib/lab/decisionTransferCognitiveSpineBoundary.ts');
+const route = read('src/app/api/root/method-lab/decision-transfer/blind/route.ts');
+const experimentalContext = read('src/core/cognitive-twin/reentry/decisionTransferContext.ts');
+
+assert.ok(boundary.includes('LAB_BLINDED_PROFILE'), 'decision_transfer_operational_profile_not_blinded');
+assert.ok(boundary.includes('consume: false'), 'decision_transfer_operational_sfi_ct_must_not_be_consumed');
+assert.ok(boundary.includes('operationalSfiCtConsumed: false'), 'decision_transfer_unconsumed_declaration_missing');
+assert.ok(boundary.includes('runStartCutoff'), 'decision_transfer_operational_cutoff_missing');
+
+const executionPosition = route.indexOf('const result = await executeBlindDecisionReconstruction(input)');
+const operationalObservationPosition = route.indexOf('operationalCognitiveSpine = await materializeDecisionTransferOperationalSpineBoundary');
+assert.ok(executionPosition >= 0, 'decision_transfer_execution_call_missing');
+assert.ok(operationalObservationPosition > executionPosition, 'operational_sfi_ct_observed_before_experimental_execution');
+
+assert.ok(route.includes('materializeDecisionTransferContext(parseMaterializedBlindDecisionRequest(raw))'), 'frozen_experimental_context_materialization_missing');
+assert.ok(route.includes('bindDecisionTransferContextReceipt'), 'frozen_experimental_context_receipt_not_bound');
+assert.ok(route.includes('verifyDecisionTransferContextReceiptBound'), 'frozen_experimental_context_receipt_not_verified');
+assert.ok(route.includes('operationalSfiCtConsumed: false'), 'audit_does_not_declare_operational_ct_unconsumed');
+
+// Existing Decision Transfer materialization remains the treatment-context
+// implementation. The institutional Cognitive Spine boundary must not replace
+// or bypass it.
+assert.ok(experimentalContext.includes('materializeDecisionTransferContext'), 'decision_transfer_context_engine_missing');
+assert.ok(experimentalContext.includes('cutoffAt'), 'decision_transfer_frozen_cutoff_missing');
+
+console.log(JSON.stringify({
+  ok: true,
+  operationalProfile: 'LAB_BLINDED_V1',
+  operationalSfiCtConsumed: false,
+  operationalObservationOccursAfterPrediction: true,
+  experimentalContextRemainsSeparate: true,
+  experimentDependsOnOperationalSfiCt: false,
+}, null, 2));

--- a/src/app/api/root/method-lab/decision-transfer/blind/route.ts
+++ b/src/app/api/root/method-lab/decision-transfer/blind/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { ZodError } from 'zod';
 import { auditRootAction, requireRootActor } from '@/lib/root/server';
+import { materializeDecisionTransferOperationalSpineBoundary } from '@/lib/lab/decisionTransferCognitiveSpineBoundary';
 import {
   executeBlindDecisionReconstruction,
   parseBlindDecisionRunInput,
@@ -26,15 +27,32 @@ export async function POST(request: Request) {
   if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
 
   try {
+    const runStartedAt = new Date().toISOString();
     const raw = await request.json();
     const materialized = isCanonicalMaterializationRequest(raw)
       ? await materializeDecisionTransferContext(parseMaterializedBlindDecisionRequest(raw))
       : null;
     const input = materialized?.blindInput ?? parseBlindDecisionRunInput(raw);
+
+    // The experimental execution happens before observing the operational
+    // institutional Cognitive Spine boundary. This guarantees the live SFI-CT
+    // cannot influence model input, provider selection, or experiment success.
     const result = await executeBlindDecisionReconstruction(input);
     if (materialized) {
       await bindDecisionTransferContextReceipt(result.runId, materialized.receipt);
       await verifyDecisionTransferContextReceiptBound(result.runId, materialized.receipt.receiptHash);
+    }
+
+    let operationalCognitiveSpine: Awaited<ReturnType<typeof materializeDecisionTransferOperationalSpineBoundary>> | null = null;
+    let operationalCognitiveSpineWarning: string | null = null;
+    try {
+      operationalCognitiveSpine = await materializeDecisionTransferOperationalSpineBoundary({
+        executionId: result.runId,
+        runStartCutoff: runStartedAt,
+        recordedAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      operationalCognitiveSpineWarning = `operational_sfi_ct_boundary_unavailable:${error instanceof Error ? error.message : String(error)}`;
     }
 
     const audit = await auditRootAction({
@@ -57,6 +75,21 @@ export async function POST(request: Request) {
         contextMaterializationReceiptHash: materialized?.receipt.receiptHash ?? null,
         contextMaterializationVerified: Boolean(materialized),
         cutoffAt: materialized?.receipt.cutoffAt ?? null,
+        operationalCognitiveSpine: operationalCognitiveSpine ? {
+          available: operationalCognitiveSpine.operationalSfiCtAvailable,
+          consumed: operationalCognitiveSpine.operationalSfiCtConsumed,
+          profile: operationalCognitiveSpine.profile,
+          profileVersion: operationalCognitiveSpine.profileVersion,
+          sourceCutoff: operationalCognitiveSpine.sourceCutoff,
+          snapshotId: operationalCognitiveSpine.snapshotId,
+          snapshotHash: operationalCognitiveSpine.snapshotHash,
+          visibleRecordCount: operationalCognitiveSpine.visibleRecordCount,
+        } : {
+          available: false,
+          consumed: false,
+          profile: 'LAB_BLINDED_V1',
+          warning: operationalCognitiveSpineWarning,
+        },
       },
       request,
     });
@@ -64,6 +97,14 @@ export async function POST(request: Request) {
     return NextResponse.json({
       ...result,
       contextMaterialization: materialized?.receipt ?? null,
+      operationalCognitiveSpineBoundary: operationalCognitiveSpine ?? {
+        contractVersion: 'SFI-DT-OPERATIONAL-SPINE-BOUNDARY-1.0',
+        operationalSfiCtAvailable: false,
+        operationalSfiCtConsumed: false,
+        profile: 'LAB_BLINDED_V1',
+        warning: operationalCognitiveSpineWarning,
+        rule: 'Decision Transfer execution is not blocked by operational SFI-CT availability because operational SFI-CT is not an experimental input.',
+      },
       audit,
     }, { headers: { 'Cache-Control': 'no-store' } });
   } catch (error) {

--- a/src/lib/lab/decisionTransferCognitiveSpineBoundary.ts
+++ b/src/lib/lab/decisionTransferCognitiveSpineBoundary.ts
@@ -1,0 +1,44 @@
+import 'server-only';
+
+import { LAB_BLINDED_PROFILE } from '@/core/cognitive-spine/profiles/registry';
+import { materializeInstitutionalCognitiveSpineProfile } from '@/lib/institution/cognitiveSpineProfileMaterializer';
+
+/**
+ * Decision Transfer isolation boundary.
+ *
+ * The operational institutional Cognitive Spine may exist while an experiment
+ * runs, but it is never consumed by a Decision Transfer arm. The experimental
+ * context remains the separately frozen Decision Transfer context.
+ *
+ * This materialization can be performed after the model run using the exact
+ * run-start cutoff, so observation of operational SFI-CT availability cannot
+ * alter model inputs or experiment latency/availability requirements.
+ */
+export async function materializeDecisionTransferOperationalSpineBoundary(input: {
+  executionId: string;
+  runStartCutoff: string;
+  recordedAt: string;
+}) {
+  const materialized = await materializeInstitutionalCognitiveSpineProfile({
+    sourceCutoff: input.runStartCutoff,
+    executionId: input.executionId,
+    createdAt: input.recordedAt,
+    profileId: LAB_BLINDED_PROFILE.profileId,
+    consume: false,
+  });
+
+  return {
+    contractVersion: 'SFI-DT-OPERATIONAL-SPINE-BOUNDARY-1.0' as const,
+    operationalSfiCtAvailable: true as const,
+    operationalSfiCtConsumed: false as const,
+    profile: materialized.profile.profileId,
+    profileVersion: materialized.profile.version,
+    sourceCutoff: materialized.snapshot.semanticPayload.sourceCutoff,
+    snapshotId: materialized.snapshot.snapshotId,
+    snapshotHash: materialized.snapshot.snapshotHash,
+    visibleRecordCount: materialized.visibleRecordCount,
+    sourcePlane: materialized.sourcePlane.summary,
+    warnings: materialized.warnings,
+    rule: 'Operational SFI-CT is recorded as available but unconsumed. Decision Transfer arms use only their separately frozen experimental context.',
+  };
+}


### PR DESCRIPTION
## Scope

Replaces superseded PR #230 with a clean branch from the current `main` after Studio, Field T0 and ROOT Cognitive Spine convergence.

## Changes

- Adds `SFI-DT-OPERATIONAL-SPINE-BOUNDARY-1.0` using frozen `LAB_BLINDED_V1`.
- Operational SFI-CT is recorded as available/unconsumed for Decision Transfer.
- Experimental prediction executes before operational Spine observation.
- After prediction, the system reconstructs the operational institutional snapshot at the exact run-start cutoff for audit only.
- Existing frozen Decision Transfer treatment context, receipt binding and target commitment remain unchanged.
- Failure to observe the operational Spine cannot fail the experiment because it is not an experimental input.
- Preserves accumulated Studio, Field and ROOT Cognitive Spine gates and adds the Decision Transfer isolation gate.

## Experimental boundary

`operational SFI-CT != experimental CT treatment context`

Even `CT_FULL` uses only its separately frozen Decision Transfer context. The live institutional Cognitive Spine is not an extra treatment layer and does not enter model input or provider selection.

## Epistemic boundary

Operational SFI-CT availability is provenance metadata, not corroboration, validation or independent evidence.

## Deployment boundary

The boundary uses the shared Node/local/worker-compatible Cognitive Spine core. The Next.js route is a thin experiment surface; Vercel is not experimental or semantic infrastructure.

## Validation target

Must pass accumulated Cognitive Spine gates and repository verification on top of current `main` before merge.