### PR TITLE
Bind Method Lab to protocol-allowlisted Cognitive Spine snapshots

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -15,6 +15,8 @@ on:
       - 'src/app/api/root/cognitive-twin/deliberate/route.ts'
       - 'src/lib/lab/decisionTransferCognitiveSpineBoundary.ts'
       - 'src/app/api/root/method-lab/decision-transfer/blind/route.ts'
+      - 'src/lib/method-lab/**'
+      - 'src/app/api/root/method-lab/simulate/route.ts'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
@@ -40,6 +42,8 @@ on:
       - 'src/app/api/root/cognitive-twin/deliberate/route.ts'
       - 'src/lib/lab/decisionTransferCognitiveSpineBoundary.ts'
       - 'src/app/api/root/method-lab/decision-transfer/blind/route.ts'
+      - 'src/lib/method-lab/**'
+      - 'src/app/api/root/method-lab/simulate/route.ts'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
@@ -80,6 +84,8 @@ jobs:
         run: node --import tsx --test src/core/cognitive-spine/cprt/sourcePlaneMapping.test.ts
       - name: Platform-neutral profile materialization
         run: node --import tsx --test src/core/cognitive-spine/cprt/profileMaterialization.test.ts
+      - name: Exact projection ref allowlists
+        run: node --import tsx --test src/core/cognitive-spine/cprt/profileAllowlist.test.ts
       - name: Studio sealed Cognitive Spine context boundary
         run: node --import tsx scripts/cognitive-spine/qa-studio-sealed-context.ts
       - name: Field blinded Cognitive Spine T0 boundary
@@ -88,3 +94,5 @@ jobs:
         run: node --import tsx scripts/cognitive-spine/qa-root-sealed-context.ts
       - name: Decision Transfer isolation from operational SFI-CT
         run: node --import tsx scripts/cognitive-spine/qa-decision-transfer-isolation.ts
+      - name: Method Lab protocol-allowlisted Cognitive Spine context
+        run: node --import tsx scripts/cognitive-spine/qa-method-lab-context.ts

--- a/scripts/cognitive-spine/qa-method-lab-context.ts
+++ b/scripts/cognitive-spine/qa-method-lab-context.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(path.join(root, relative), 'utf8');
+
+const adapter = read('src/lib/method-lab/cognitiveSpineContext.ts');
+const run = read('src/lib/method-lab/simulationRun.ts');
+const route = read('src/app/api/root/method-lab/simulate/route.ts');
+
+assert.ok(adapter.includes('LAB_EXPERIMENT_CONTEXT_PROFILE'), 'method_lab_projection_profile_missing');
+assert.ok(adapter.includes('const consume = contextRefs.length > 0'), 'method_lab_consumption_not_allowlist_bound');
+assert.ok(adapter.includes('allowedRefs: contextRefs'), 'method_lab_allowlist_not_applied');
+assert.ok(adapter.includes('requireAllAllowedRefs: true'), 'method_lab_missing_refs_do_not_fail_closed');
+assert.ok(adapter.includes('buildBoundedTwinContextFromCognitiveSpine'), 'method_lab_bounded_twin_context_missing');
+
+assert.ok(run.includes('cognitiveSpineContextRefs?: string[]'), 'method_lab_context_refs_input_missing');
+assert.ok(run.includes('materializeMethodLabCognitiveSpineContext'), 'method_lab_spine_not_materialized');
+assert.ok(run.includes('...(consumedCognitiveSpineContext ? { cognitiveSpineContext: consumedCognitiveSpineContext } : {})'), 'unconsumed_spine_leaks_into_execution_metadata');
+assert.ok(run.includes("evidence: [...evidence]"), 'method_lab_persisted_evidence_boundary_missing');
+assert.equal(run.includes('evidence.push(cognitiveSpine'), false, 'method_lab_spine_context_promoted_to_evidence');
+assert.ok(run.includes("consumedCognitiveSpine: cognitiveSpine.consumed ?"), 'method_lab_result_hash_does_not_distinguish_consumed_context');
+assert.ok(run.includes('snapshot: cognitiveSpine.snapshot'), 'method_lab_exact_snapshot_not_persisted');
+assert.ok(run.includes('consumptionTrace: cognitiveSpine.consumptionTrace'), 'method_lab_consumption_trace_not_persisted');
+assert.ok(run.includes("epistemicClass: 'SIMULATED'"), 'method_lab_epistemic_class_changed');
+
+assert.ok(route.includes('cognitiveSpineContextRefs'), 'method_lab_route_context_allowlist_missing');
+assert.ok(route.includes('cognitiveSpineSnapshotHash'), 'method_lab_root_audit_snapshot_hash_missing');
+assert.ok(route.includes('cognitiveSpineConsumed'), 'method_lab_root_audit_consumption_missing');
+
+console.log(JSON.stringify({
+  ok: true,
+  profile: 'LAB_EXPERIMENT_CONTEXT_V1',
+  allowlistRequiredForConsumption: true,
+  missingAllowedRefFailsClosed: true,
+  noAllowlistMeansUnconsumed: true,
+  contextPromotedToEvidence: false,
+  simulationEpistemicClass: 'SIMULATED',
+  exactSnapshotPersisted: true,
+}, null, 2));

--- a/src/app/api/root/method-lab/simulate/route.ts
+++ b/src/app/api/root/method-lab/simulate/route.ts
@@ -22,9 +22,18 @@ export async function POST(request: Request) {
   const parameters = body.parameters && typeof body.parameters === 'object' && !Array.isArray(body.parameters)
     ? body.parameters as Record<string, unknown>
     : {};
+  const cognitiveSpineContextRefs = Array.isArray(body.cognitiveSpineContextRefs)
+    ? [...new Set(body.cognitiveSpineContextRefs.filter((value): value is string => typeof value === 'string' && value.trim().length > 0))]
+    : [];
 
   try {
-    const result = await runMethodLabSimulation({ protocolId, evidenceIds, actorId: gate.ctx.user.id, parameters });
+    const result = await runMethodLabSimulation({
+      protocolId,
+      evidenceIds,
+      actorId: gate.ctx.user.id,
+      parameters,
+      cognitiveSpineContextRefs,
+    });
     const audit = await auditRootAction({
       actorId: gate.ctx.user.id,
       action: 'method_lab.simulation.executed',
@@ -36,6 +45,11 @@ export async function POST(request: Request) {
         evidenceIds,
         epistemicClass: result.run.epistemicClass,
         validationLevel: result.run.validationLevel,
+        cognitiveSpineSnapshotId: result.cognitiveSpine.snapshotId,
+        cognitiveSpineSnapshotHash: result.cognitiveSpine.snapshotHash,
+        cognitiveSpineProfile: result.cognitiveSpine.profile,
+        cognitiveSpineConsumed: result.cognitiveSpine.consumed,
+        cognitiveSpineContextRefs: result.cognitiveSpine.requestedContextRefs,
       },
       request,
     });
@@ -43,7 +57,13 @@ export async function POST(request: Request) {
     return NextResponse.json({ ...result, audit });
   } catch (error) {
     const details = error instanceof Error ? error.message : String(error);
-    const status = details.includes('EVIDENCE') ? 400 : details.includes('CONTAMINATED') ? 500 : 503;
+    const status = details.startsWith('COGNITIVE_SPINE_ALLOWED_REF_UNAVAILABLE')
+      ? 400
+      : details.includes('EVIDENCE')
+        ? 400
+        : details.includes('CONTAMINATED')
+          ? 500
+          : 503;
     return NextResponse.json({ ok: false, error: 'method_lab_simulation_failed', details }, { status });
   }
 }

--- a/src/core/cognitive-spine/cprt/profileAllowlist.test.ts
+++ b/src/core/cognitive-spine/cprt/profileAllowlist.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { CognitiveSpineSourceRecord } from '../contracts/snapshot';
+import { materializeCognitiveSpineProfileSnapshot } from '../profiles/materializeProfile';
+
+const records: CognitiveSpineSourceRecord[] = [
+  {
+    ref: 'root_evidence_entries:E-001',
+    kind: 'EVIDENCE',
+    recordedAt: '2026-08-16T08:00:00.000Z',
+    sourceHash: 'a'.repeat(64),
+    epistemicAssessmentRef: 'EA-001',
+    epistemicClass: 'OBSERVED',
+    ancestryRoots: ['OBS-001'],
+    visibilityProfiles: ['*'],
+  },
+  {
+    ref: 'sfi_amv_memory:M-001',
+    kind: 'MEMORY',
+    recordedAt: '2026-08-16T08:01:00.000Z',
+    sourceHash: 'b'.repeat(64),
+    visibilityProfiles: ['*'],
+  },
+  {
+    ref: 'sfi_cognitive_twin_decisions:D-001',
+    kind: 'DECISION',
+    recordedAt: '2026-08-16T08:02:00.000Z',
+    sourceHash: 'c'.repeat(64),
+    visibilityProfiles: ['*'],
+  },
+];
+
+test('exact allowlist selects only requested refs under the profile', () => {
+  const result = materializeCognitiveSpineProfileSnapshot({
+    records,
+    sourceCutoff: '2026-08-16T08:10:00.000Z',
+    executionId: 'LAB-ALLOW-001',
+    createdAt: '2026-08-16T08:10:01.000Z',
+    profileId: 'LAB_EXPERIMENT_CONTEXT_V1',
+    consume: true,
+    allowedRefs: ['sfi_amv_memory:M-001', 'root_evidence_entries:E-001'],
+    requireAllAllowedRefs: true,
+  });
+
+  assert.deepEqual(result.requestedAllowedRefs, [
+    'root_evidence_entries:E-001',
+    'sfi_amv_memory:M-001',
+  ]);
+  assert.deepEqual(result.missingAllowedRefs, []);
+  assert.equal(result.visibleRecordCount, 2);
+  assert.deepEqual(result.snapshot.semanticPayload.evidenceRefs, ['root_evidence_entries:E-001']);
+  assert.deepEqual(result.snapshot.semanticPayload.memoryRefs, ['sfi_amv_memory:M-001']);
+  assert.deepEqual(result.snapshot.semanticPayload.decisionRefs, []);
+});
+
+test('same explicit allowlist is insertion-order independent', () => {
+  const common = {
+    sourceCutoff: '2026-08-16T08:10:00.000Z',
+    createdAt: '2026-08-16T08:10:01.000Z',
+    profileId: 'LAB_EXPERIMENT_CONTEXT_V1' as const,
+    consume: true,
+    requireAllAllowedRefs: true,
+  };
+  const left = materializeCognitiveSpineProfileSnapshot({
+    ...common,
+    records,
+    executionId: 'LAB-ALLOW-LEFT',
+    allowedRefs: ['sfi_amv_memory:M-001', 'root_evidence_entries:E-001'],
+  });
+  const right = materializeCognitiveSpineProfileSnapshot({
+    ...common,
+    records: [...records].reverse(),
+    executionId: 'LAB-ALLOW-RIGHT',
+    allowedRefs: ['root_evidence_entries:E-001', 'sfi_amv_memory:M-001'],
+  });
+
+  assert.equal(left.snapshot.snapshotHash, right.snapshot.snapshotHash);
+  assert.deepEqual(left.snapshot.semanticPayload, right.snapshot.semanticPayload);
+});
+
+test('required allowlist fails closed when a ref is missing or profile-denied', () => {
+  assert.throws(() => materializeCognitiveSpineProfileSnapshot({
+    records,
+    sourceCutoff: '2026-08-16T08:10:00.000Z',
+    executionId: 'LAB-ALLOW-MISSING',
+    createdAt: '2026-08-16T08:10:01.000Z',
+    profileId: 'LAB_EXPERIMENT_CONTEXT_V1',
+    consume: true,
+    allowedRefs: ['sfi_amv_memory:M-404'],
+    requireAllAllowedRefs: true,
+  }), /COGNITIVE_SPINE_ALLOWED_REF_UNAVAILABLE:sfi_amv_memory:M-404/);
+});
+
+test('PERSON_CT cannot enter institutional Lab context through an allowlist', () => {
+  const withPerson: CognitiveSpineSourceRecord[] = [
+    ...records,
+    {
+      ref: 'person_ct:CT-A01:REP-001',
+      kind: 'PERSON_CT',
+      recordedAt: '2026-08-16T08:03:00.000Z',
+      sourceHash: 'd'.repeat(64),
+      visibilityProfiles: ['*'],
+    },
+  ];
+
+  assert.throws(() => materializeCognitiveSpineProfileSnapshot({
+    records: withPerson,
+    sourceCutoff: '2026-08-16T08:10:00.000Z',
+    executionId: 'LAB-ALLOW-PERSON',
+    createdAt: '2026-08-16T08:10:01.000Z',
+    profileId: 'LAB_EXPERIMENT_CONTEXT_V1',
+    consume: true,
+    allowedRefs: ['person_ct:CT-A01:REP-001'],
+    requireAllAllowedRefs: true,
+  }), /COGNITIVE_SPINE_ALLOWED_REF_UNAVAILABLE:person_ct:CT-A01:REP-001/);
+});

--- a/src/core/cognitive-spine/profiles/materializeProfile.ts
+++ b/src/core/cognitive-spine/profiles/materializeProfile.ts
@@ -9,7 +9,7 @@ import {
   sealCognitiveSnapshot,
   semanticSnapshotHash,
 } from '../projector/cognitiveStateProjector';
-import { normalizeTimestamp } from '../serialization/canonicalSerialize';
+import { normalizeTimestamp, sortedUnique } from '../serialization/canonicalSerialize';
 import { buildCognitiveContextConsumptionTrace } from '../trace/consumptionTrace';
 
 export const COGNITIVE_SPINE_PROJECTOR_VERSION = 'SFI-CT-PROJECTOR-1.0' as const;
@@ -23,14 +23,30 @@ export type MaterializeCognitiveSpineProfileSnapshotInput = {
   profileId: CognitiveSpineProjectionProfileId;
   consume: boolean;
   consumptionReason?: string;
+  /**
+   * Optional exact source-ref allowlist applied after profile kind visibility.
+   * This is a deterministic selection constraint, not an epistemic judgment.
+   */
+  allowedRefs?: readonly string[];
+  /**
+   * When true, every requested allowed ref must exist and be visible under the
+   * profile at the declared cutoff. Missing refs fail closed rather than being
+   * silently substituted or dropped.
+   */
+  requireAllAllowedRefs?: boolean;
 };
 
 export function selectCognitiveSpineRecordsForProfile(
   records: CognitiveSpineSourceRecord[],
   profileId: CognitiveSpineProjectionProfileId,
+  allowedRefs?: readonly string[],
 ): CognitiveSpineSourceRecord[] {
   const profile = getCognitiveProjectionProfile(profileId);
-  return records.filter((record) => profileAllowsKind(profile, record.kind));
+  const allowlist = allowedRefs ? new Set(sortedUnique([...allowedRefs])) : null;
+  return records.filter((record) =>
+    profileAllowsKind(profile, record.kind)
+    && (!allowlist || allowlist.has(record.ref))
+  );
 }
 
 /**
@@ -47,7 +63,16 @@ export function materializeCognitiveSpineProfileSnapshot(
 
   const sourceCutoff = normalizeTimestamp(input.sourceCutoff);
   const createdAt = normalizeTimestamp(input.createdAt);
-  const records = selectCognitiveSpineRecordsForProfile(input.records, input.profileId);
+  const requestedAllowedRefs = input.allowedRefs ? sortedUnique([...input.allowedRefs]) : null;
+  const records = selectCognitiveSpineRecordsForProfile(input.records, input.profileId, requestedAllowedRefs ?? undefined);
+  const selectedRefs = new Set(records.map((record) => record.ref));
+  const missingAllowedRefs = requestedAllowedRefs
+    ? requestedAllowedRefs.filter((ref) => !selectedRefs.has(ref))
+    : [];
+
+  if (input.requireAllAllowedRefs && missingAllowedRefs.length > 0) {
+    throw new Error(`COGNITIVE_SPINE_ALLOWED_REF_UNAVAILABLE:${missingAllowedRefs.join(',')}`);
+  }
 
   const semanticPayload = projectCognitiveState({
     sourceCutoff,
@@ -87,5 +112,7 @@ export function materializeCognitiveSpineProfileSnapshot(
     snapshot,
     trace,
     visibleRecordCount: records.length,
+    requestedAllowedRefs,
+    missingAllowedRefs,
   };
 }

--- a/src/lib/institution/cognitiveSpineProfileMaterializer.ts
+++ b/src/lib/institution/cognitiveSpineProfileMaterializer.ts
@@ -11,6 +11,8 @@ export type MaterializeInstitutionalCognitiveSpineProfileInput = {
   profileId: CognitiveSpineProjectionProfileId;
   consume: boolean;
   consumptionReason?: string;
+  allowedRefs?: readonly string[];
+  requireAllAllowedRefs?: boolean;
 };
 
 /**
@@ -30,6 +32,8 @@ export async function materializeInstitutionalCognitiveSpineProfile(
     profileId: input.profileId,
     consume: input.consume,
     consumptionReason: input.consumptionReason,
+    allowedRefs: input.allowedRefs,
+    requireAllAllowedRefs: input.requireAllAllowedRefs,
   });
 
   return {

--- a/src/lib/method-lab/cognitiveSpineContext.ts
+++ b/src/lib/method-lab/cognitiveSpineContext.ts
@@ -1,0 +1,62 @@
+import 'server-only';
+
+import { LAB_EXPERIMENT_CONTEXT_PROFILE } from '@/core/cognitive-spine/profiles/registry';
+import { sortedUnique } from '@/core/cognitive-spine/serialization/canonicalSerialize';
+import { materializeInstitutionalCognitiveSpineProfile } from '@/lib/institution/cognitiveSpineProfileMaterializer';
+import { buildBoundedTwinContextFromCognitiveSpine } from '@/lib/institution/cognitiveSpineTwinContextAdapter';
+
+export const METHOD_LAB_COGNITIVE_SPINE_CONTEXT_CONTRACT = 'SFI-METHOD-LAB-CT-CONTEXT-1.0' as const;
+
+/**
+ * Materializes the institutional Cognitive Spine available at experiment start.
+ *
+ * No explicit allowlist => state may be recorded as AVAILABLE but is NOT
+ * consumed by the experiment. An explicit allowlist => only those exact refs
+ * may enter the sealed experimental context and every ref must resolve at the
+ * declared cutoff. Missing/hidden refs fail closed.
+ */
+export async function materializeMethodLabCognitiveSpineContext(input: {
+  labRunId: string;
+  sourceCutoff: string;
+  createdAt: string;
+  contextRefs?: readonly string[];
+}) {
+  const contextRefs = sortedUnique([...(input.contextRefs ?? [])]);
+  const consume = contextRefs.length > 0;
+  const materialized = await materializeInstitutionalCognitiveSpineProfile({
+    sourceCutoff: input.sourceCutoff,
+    executionId: input.labRunId,
+    createdAt: input.createdAt,
+    profileId: LAB_EXPERIMENT_CONTEXT_PROFILE.profileId,
+    consume,
+    consumptionReason: consume ? 'protocol-allowlisted Method Lab experimental context' : undefined,
+    ...(consume ? {
+      allowedRefs: contextRefs,
+      requireAllAllowedRefs: true,
+    } : {}),
+  });
+
+  const twinContext = consume
+    ? buildBoundedTwinContextFromCognitiveSpine({
+        snapshot: materialized.snapshot,
+        sourcePlane: materialized.sourcePlane,
+      })
+    : null;
+
+  return {
+    contractVersion: METHOD_LAB_COGNITIVE_SPINE_CONTEXT_CONTRACT,
+    requestedContextRefs: contextRefs,
+    consumed: materialized.trace.ctSnapshotConsumed,
+    profile: materialized.profile.profileId,
+    profileVersion: materialized.profile.version,
+    snapshot: materialized.snapshot,
+    consumptionTrace: materialized.trace,
+    visibleRefs: materialized.snapshot.semanticPayload.sourceManifest.map((item) => item.ref),
+    twinContext,
+    sourcePlane: materialized.sourcePlane.summary,
+    warnings: materialized.warnings,
+    rule: consume
+      ? 'Only protocol-allowlisted Cognitive Spine refs are available to this Method Lab execution. Context remains distinct from evidence and simulation output remains SIMULATED.'
+      : 'Operational Cognitive Spine state is available for provenance only and is not consumed because no protocol context allowlist was supplied.',
+  };
+}

--- a/src/lib/method-lab/simulationRun.ts
+++ b/src/lib/method-lab/simulationRun.ts
@@ -7,6 +7,7 @@ import type { KernelContext, KernelEvidence } from '@/lib/sfi/cognitive-runtime/
 import { METHOD_LAB_CONTRACT_VERSION, assertMethodLabRunEnvelope, type MethodLabProtocolId, type MethodLabRunEnvelope } from './contracts';
 import { methodLabProtocol } from './registry';
 import { specializedModel } from './specializedModels';
+import { materializeMethodLabCognitiveSpineContext } from './cognitiveSpineContext';
 import { recordCognitiveTwinExperience } from '@/core/cognitive-twin/experience';
 
 const SIMULATION_PROTOCOL_AGENTS: Partial<Record<MethodLabProtocolId, string[]>> = {
@@ -82,6 +83,7 @@ export async function runMethodLabSimulation(input: {
   evidenceIds: string[];
   actorId: string;
   parameters?: Record<string, unknown>;
+  cognitiveSpineContextRefs?: string[];
 }) {
   const definition = methodLabProtocol(input.protocolId);
   if (!definition) throw new Error('METHOD_LAB_PROTOCOL_NOT_REGISTERED');
@@ -94,10 +96,29 @@ export async function runMethodLabSimulation(input: {
     throw new Error('METHOD_LAB_SPECIALIZED_MODEL_CONTRACT_MISMATCH');
   }
 
-  const evidence = await loadPersistedEvidence(input.evidenceIds);
-  const initialEvidenceIds = evidence.map((item) => item.id);
   const startedAt = new Date().toISOString();
   const labRunId = crypto.randomUUID();
+  const evidence = await loadPersistedEvidence(input.evidenceIds);
+  const initialEvidenceIds = evidence.map((item) => item.id);
+  const cognitiveSpine = await materializeMethodLabCognitiveSpineContext({
+    labRunId,
+    sourceCutoff: startedAt,
+    createdAt: new Date().toISOString(),
+    contextRefs: input.cognitiveSpineContextRefs,
+  });
+
+  const consumedCognitiveSpineContext = cognitiveSpine.consumed ? {
+    contractVersion: cognitiveSpine.contractVersion,
+    snapshotId: cognitiveSpine.snapshot.snapshotId,
+    snapshotHash: cognitiveSpine.snapshot.snapshotHash,
+    sourceCutoff: cognitiveSpine.snapshot.semanticPayload.sourceCutoff,
+    projectionProfile: cognitiveSpine.profile,
+    profileVersion: cognitiveSpine.profileVersion,
+    visibleRefs: cognitiveSpine.visibleRefs,
+    twinContext: cognitiveSpine.twinContext,
+    rule: 'Cognitive Spine context is protocol-bounded context. It is not appended to Method Lab evidence and cannot upgrade simulation epistemic class.',
+  } : null;
+
   let context: KernelContext = {
     cycleId: labRunId,
     logbookId: `LAB_${input.protocolId}:${labRunId}`,
@@ -123,7 +144,8 @@ export async function runMethodLabSimulation(input: {
       },
       requestedBy: input.actorId,
       parameters: input.parameters ?? {},
-      epistemicRule: 'LAB simulation may read persisted evidence but may not append simulated output to observed evidence or canonical state.',
+      ...(consumedCognitiveSpineContext ? { cognitiveSpineContext: consumedCognitiveSpineContext } : {}),
+      epistemicRule: 'LAB simulation may read persisted evidence and explicitly allowlisted Cognitive Spine context, but contextual state may not be appended to observed evidence or canonical state by inheritance.',
     },
   };
 
@@ -140,7 +162,18 @@ export async function runMethodLabSimulation(input: {
   }
 
   const finishedAt = new Date().toISOString();
-  const resultHash = hash({ protocolId: input.protocolId, specializedModelId: modelContract.id, evidenceRefs: initialEvidenceIds, parameters: input.parameters ?? {}, simulations: context.simulations, metadata: context.metadata });
+  const resultHash = hash({
+    protocolId: input.protocolId,
+    specializedModelId: modelContract.id,
+    evidenceRefs: initialEvidenceIds,
+    parameters: input.parameters ?? {},
+    consumedCognitiveSpine: cognitiveSpine.consumed ? {
+      snapshotHash: cognitiveSpine.snapshot.snapshotHash,
+      visibleRefs: cognitiveSpine.visibleRefs,
+    } : null,
+    simulations: context.simulations,
+    metadata: context.metadata,
+  });
   const envelope: MethodLabRunEnvelope = assertMethodLabRunEnvelope({
     contractVersion: METHOD_LAB_CONTRACT_VERSION,
     labRunId,
@@ -149,9 +182,12 @@ export async function runMethodLabSimulation(input: {
     epistemicClass: 'SIMULATED',
     validationLevel: 'SIMULATION',
     datasetHash: hash(initialEvidenceIds),
-    parametersHash: hash(input.parameters ?? {}),
+    parametersHash: hash({
+      parameters: input.parameters ?? {},
+      cognitiveSpineContextRefs: cognitiveSpine.requestedContextRefs,
+    }),
     seed: null,
-    codeCommit: process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.GITHUB_SHA ?? null,
+    codeCommit: process.env.GITHUB_SHA ?? process.env.VERCEL_GIT_COMMIT_SHA ?? null,
     provider: 'deterministic:sfi-cognitive-runtime',
     model: modelContract.id,
     startedAt,
@@ -161,6 +197,7 @@ export async function runMethodLabSimulation(input: {
     limitations: [
       'Simulation output is not observed evidence.',
       'Current field simulators are bounded deterministic signal estimators; their indices are not independently calibrated causal measurements.',
+      'Cognitive Spine context, when consumed, is protocol-allowlisted context and is not evidence by inheritance.',
       'A later observed return is required before any stronger validation claim.',
     ],
     promotionAllowed: false,
@@ -181,6 +218,19 @@ export async function runMethodLabSimulation(input: {
       agentResults,
       simulations: context.simulations,
       metadata: context.metadata,
+      cognitiveSpine: {
+        contractVersion: cognitiveSpine.contractVersion,
+        requestedContextRefs: cognitiveSpine.requestedContextRefs,
+        consumed: cognitiveSpine.consumed,
+        profile: cognitiveSpine.profile,
+        profileVersion: cognitiveSpine.profileVersion,
+        snapshot: cognitiveSpine.snapshot,
+        consumptionTrace: cognitiveSpine.consumptionTrace,
+        visibleRefs: cognitiveSpine.visibleRefs,
+        sourcePlane: cognitiveSpine.sourcePlane,
+        warnings: cognitiveSpine.warnings,
+        rule: cognitiveSpine.rule,
+      },
     },
   }).select('id').single();
   if (persisted.error || !persisted.data?.id) throw new Error(`METHOD_LAB_RUN_PERSIST_FAILED:${persisted.error?.message ?? 'unknown'}`);
@@ -199,6 +249,9 @@ export async function runMethodLabSimulation(input: {
       resultHash,
       validationLevel:'SIMULATION',
       simulationCount:context.simulations.length,
+      cognitiveSpineSnapshotHash:cognitiveSpine.snapshot.snapshotHash,
+      cognitiveSpineConsumed:cognitiveSpine.consumed,
+      cognitiveSpineContextRefs:cognitiveSpine.requestedContextRefs,
       limitations:envelope.limitations,
       rule:'Method Lab simulation is available to the Cognitive Twin for comparison and planning but remains SIMULATED until contrasted with observed returns.',
     },
@@ -212,7 +265,18 @@ export async function runMethodLabSimulation(input: {
     run: envelope,
     agentResults,
     simulations: context.simulations,
+    cognitiveSpine: {
+      snapshotId: cognitiveSpine.snapshot.snapshotId,
+      snapshotHash: cognitiveSpine.snapshot.snapshotHash,
+      sourceCutoff: cognitiveSpine.snapshot.semanticPayload.sourceCutoff,
+      profile: cognitiveSpine.profile,
+      profileVersion: cognitiveSpine.profileVersion,
+      requestedContextRefs: cognitiveSpine.requestedContextRefs,
+      visibleRefs: cognitiveSpine.visibleRefs,
+      consumed: cognitiveSpine.consumed,
+      consumptionTrace: cognitiveSpine.consumptionTrace,
+    },
     cognitiveTwinExperience,
-    claimBoundary: 'This run is SIMULATED. It is not observed evidence, canonical validation, approval or external execution.',
+    claimBoundary: 'This run is SIMULATED. Cognitive Spine context is bounded by explicit protocol allowlist when consumed; neither context nor simulation output is observed evidence, canonical validation, approval or external execution.',
   };
 }


### PR DESCRIPTION
## Scope

Connects general Method Lab simulations to the Cognitive Spine without granting experiments access to live or unbounded institutional context.

## Changes

- Adds exact source-ref allowlists to the platform-neutral Cognitive Spine profile materializer.
- Optional allowlists are applied after profile visibility; required allowlists fail closed if any ref is missing or profile-denied.
- Adds `SFI-METHOD-LAB-CT-CONTEXT-1.0` over frozen `LAB_EXPERIMENT_CONTEXT_V1`.
- No context allowlist => operational CT state may be recorded as AVAILABLE but is NOT CONSUMED.
- Explicit context allowlist => only those exact refs are sealed and exposed; every requested ref must resolve at the run-start cutoff.
- Direct `PERSON_CT` inheritance remains impossible through the institutional Lab profile.
- Method Lab simulation accepts optional `cognitiveSpineContextRefs` and persists exact snapshot + consumption trace in existing `sfi_lab_analyses.raw_analysis`.
- Cognitive Spine context is placed only in execution metadata when consumed; it is never appended to `KernelEvidence`.
- Unconsumed operational CT state does not enter simulation execution metadata or result-hash inputs.
- Result remains `SIMULATED`; CT context cannot upgrade epistemic class or validation level.
- ROOT Method Lab route accepts/audits the explicit context allowlist and snapshot hash.
- Adds deterministic allowlist tests and Method Lab boundary QA to accumulated Cognitive Spine CI.

## Epistemic boundary

Protocol context != evidence. A context ref may affect a simulation only when explicitly allowlisted; it does not become observed evidence, independent corroboration, or validation by being present.

## Reproducibility boundary

The exact allowlist is preserved in run configuration. Missing/hidden refs fail closed instead of silently changing experimental context. The snapshot remains cutoff/version/profile/hash bound.

## Deployment boundary

Allowlist filtering, projection, hashing and sealing remain pure Node/local compatible. Supabase reads are server/worker adapters; Vercel remains an optional route surface.

## Validation target

Must pass accumulated Cognitive Spine gates, exact allowlist tests, Method Lab context QA, typecheck and repository build before merge.