### PR TITLE
Contrast WorldSpect observations against prior Cognitive Spine state

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -17,6 +17,9 @@ on:
       - 'src/app/api/root/method-lab/decision-transfer/blind/route.ts'
       - 'src/lib/method-lab/**'
       - 'src/app/api/root/method-lab/simulate/route.ts'
+      - 'src/lib/worldspect/**'
+      - 'src/app/api/worldspect/**'
+      - 'src/app/api/cron/worldspect/route.ts'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
@@ -44,6 +47,9 @@ on:
       - 'src/app/api/root/method-lab/decision-transfer/blind/route.ts'
       - 'src/lib/method-lab/**'
       - 'src/app/api/root/method-lab/simulate/route.ts'
+      - 'src/lib/worldspect/**'
+      - 'src/app/api/worldspect/**'
+      - 'src/app/api/cron/worldspect/route.ts'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
@@ -96,3 +102,5 @@ jobs:
         run: node --import tsx scripts/cognitive-spine/qa-decision-transfer-isolation.ts
       - name: Method Lab protocol-allowlisted Cognitive Spine context
         run: node --import tsx scripts/cognitive-spine/qa-method-lab-context.ts
+      - name: WorldSpect post-observation Cognitive Spine contrast
+        run: node --import tsx scripts/cognitive-spine/qa-worldspect-post-observation.ts

--- a/scripts/cognitive-spine/qa-worldspect-post-observation.ts
+++ b/scripts/cognitive-spine/qa-worldspect-post-observation.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(path.join(root, relative), 'utf8');
+
+const adapters = read('src/lib/worldspect/runAdapters.ts');
+const contrast = read('src/lib/worldspect/cognitiveSpineContrast.ts');
+const snapshotStore = read('src/lib/worldspect/snapshotStore.ts');
+const ingestRoute = read('src/app/api/worldspect/ingest/route.ts');
+
+assert.ok(adapters.includes('recordWorldSpectPostObservationCognitiveSpineContrast'), 'worldspect_ct_contrast_recorder_missing');
+const canonicalPersistPosition = adapters.indexOf('const persistence = await upsertWorldSpectSnapshot');
+const contrastPosition = adapters.indexOf('cognitiveSpineContrast = await recordWorldSpectPostObservationCognitiveSpineContrast');
+assert.ok(canonicalPersistPosition >= 0, 'worldspect_canonical_persist_missing');
+assert.ok(contrastPosition > canonicalPersistPosition, 'worldspect_ct_contrast_occurs_before_canonical_persistence');
+
+const startPosition = adapters.indexOf('const observationStartedAt = new Date().toISOString()');
+const firstAdapterObservationPosition = adapters.indexOf('adapter.observe()');
+assert.ok(startPosition >= 0, 'worldspect_observation_start_cutoff_missing');
+assert.ok(firstAdapterObservationPosition > startPosition, 'worldspect_prior_cutoff_not_captured_before_adapter_observation');
+assert.ok(adapters.includes('priorCognitiveStateCutoff: observationStartedAt'), 'worldspect_prior_cutoff_not_bound_to_observation_start');
+assert.ok(adapters.includes('ok: persistence.ok'), 'worldspect_observation_success_depends_on_ct_contrast');
+assert.ok(adapters.includes('worldspect_post_observation_ct_contrast_unavailable'), 'worldspect_ct_contrast_failure_not_degraded_to_warning');
+
+assert.ok(contrast.includes('WORLDSPECT_CONTEXT_PROFILE'), 'worldspect_projection_profile_missing');
+assert.ok(contrast.includes('consume: true'), 'worldspect_post_observation_context_not_explicitly_consumed');
+assert.ok(contrast.includes("epistemicClass: 'DERIVED'"), 'worldspect_contrast_not_derived');
+assert.ok(contrast.includes('external observation has already been'), 'worldspect_post_observation_order_not_documented');
+assert.ok(contrast.includes('association is not validation or causality'), 'worldspect_noncausal_boundary_missing');
+assert.ok(contrast.includes('priorStateCutoff'), 'worldspect_prior_state_cutoff_missing');
+
+// Cognitive Spine materialization must never enter the canonical external
+// WorldSpect snapshot or its semantic hash. The CT comparison is a separate
+// derived artifact persisted only after the observation exists.
+assert.equal(/cognitiveSpine|cognitive_spine/i.test(snapshotStore), false, 'worldspect_canonical_snapshot_contaminated_by_ct');
+assert.ok(snapshotStore.includes('function hashSnapshot(input: WorldSpectSnapshotInput)'), 'worldspect_canonical_hash_missing');
+
+const manualRouteStart = ingestRoute.indexOf('const observationStartedAt = new Date().toISOString()');
+const manualPersist = ingestRoute.indexOf('persistWorldSpectObservations(observations');
+assert.ok(manualRouteStart >= 0 && manualPersist > manualRouteStart, 'manual_worldspect_cutoff_not_captured_before_persistence');
+assert.ok(ingestRoute.includes('priorCognitiveStateCutoff: observationStartedAt'), 'manual_worldspect_prior_cutoff_not_forwarded');
+
+console.log(JSON.stringify({
+  ok: true,
+  profile: 'WORLDSPECT_CONTEXT_V1',
+  observationBeforeCtContrast: true,
+  canonicalWorldSpectHashContainsCt: false,
+  contrastEpistemicClass: 'DERIVED',
+  ctContrastFailureBlocksObservation: false,
+  priorInstitutionalCutoffCapturedBeforeObservation: true,
+}, null, 2));

--- a/src/app/api/cron/worldspect/route.ts
+++ b/src/app/api/cron/worldspect/route.ts
@@ -85,7 +85,12 @@ export async function GET(request: NextRequest) {
     degraded_sources: result.degraded_sources,
     writesPerformed: result.persistence.ok,
     persistence: result.persistence,
-    warnings: auth.warnings,
+    cognitiveSpineContrast: result.cognitiveSpineContrast,
+    cognitiveSpineContrastWarning: result.cognitiveSpineContrastWarning,
+    warnings: [
+      ...auth.warnings,
+      ...(result.cognitiveSpineContrastWarning ? [result.cognitiveSpineContrastWarning] : []),
+    ],
   })
 }
 

--- a/src/app/api/worldspect/ingest/route.ts
+++ b/src/app/api/worldspect/ingest/route.ts
@@ -35,6 +35,7 @@ function manualCulturalObservation(body: Record<string, unknown>): SourceObserva
 }
 
 export async function POST(request: Request) {
+  const observationStartedAt = new Date().toISOString()
   const body = record(await request.json().catch(() => ({})))
   const observations = manualCulturalObservation(body)
   const includePublicAdapters = body.includePublicAdapters !== false
@@ -48,12 +49,16 @@ export async function POST(request: Request) {
       sourceHealth: result.sourceHealth,
       persistence: result.persistence,
       degraded_sources: result.degraded_sources,
+      cognitiveSpineContrast: result.cognitiveSpineContrast,
+      cognitiveSpineContrastWarning: result.cognitiveSpineContrastWarning,
     })
   }
 
   const result = await persistWorldSpectObservations(observations, 'manual', {
     manual_ingest: true,
     includePublicAdapters,
+  }, {
+    priorCognitiveStateCutoff: observationStartedAt,
   })
 
   return NextResponse.json({
@@ -63,5 +68,7 @@ export async function POST(request: Request) {
     sourceHealth: result.sourceHealth,
     persistence: result.persistence,
     degraded_sources: result.degraded_sources,
+    cognitiveSpineContrast: result.cognitiveSpineContrast,
+    cognitiveSpineContrastWarning: result.cognitiveSpineContrastWarning,
   })
 }

--- a/src/lib/worldspect/cognitiveSpineContrast.ts
+++ b/src/lib/worldspect/cognitiveSpineContrast.ts
@@ -1,0 +1,118 @@
+import 'server-only';
+
+import { COGNITIVE_TWIN_CONTRACT_VERSION } from '@/core/cognitive-twin/contract';
+import { WORLDSPECT_CONTEXT_PROFILE } from '@/core/cognitive-spine/profiles/registry';
+import { canonicalSha256 } from '@/core/cognitive-spine/serialization/canonicalSerialize';
+import { materializeInstitutionalCognitiveSpineProfile } from '@/lib/institution/cognitiveSpineProfileMaterializer';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+export const WORLDSPECT_COGNITIVE_SPINE_CONTRAST_CONTRACT = 'SFI-WORLDSPECT-CT-CONTRAST-1.0' as const;
+
+export async function recordWorldSpectPostObservationCognitiveSpineContrast(input: {
+  worldspectSnapshotId: string;
+  worldspectSnapshotHash: string;
+  observedAt: string;
+  priorStateCutoff: string;
+  sourceState: 'observed' | 'degraded';
+  confidence: number;
+  wsi: number | null;
+  nti: number | null;
+  degradedSources: string[];
+}) {
+  const recordedAt = new Date().toISOString();
+  const executionId = `worldspect:post-observation:${input.worldspectSnapshotId}`;
+
+  // This happens only after the external observation has already been
+  // persisted. The cutoff points to the state available before observation
+  // began, so prior institutional expectations cannot become observation.
+  const cognitiveSpine = await materializeInstitutionalCognitiveSpineProfile({
+    sourceCutoff: input.priorStateCutoff,
+    executionId,
+    createdAt: recordedAt,
+    profileId: WORLDSPECT_CONTEXT_PROFILE.profileId,
+    consume: true,
+    consumptionReason: 'post-observation contrast against prior institutional state',
+  });
+
+  const prior = cognitiveSpine.snapshot.semanticPayload;
+  const contrastPayload = {
+    contractVersion: WORLDSPECT_COGNITIVE_SPINE_CONTRAST_CONTRACT,
+    epistemicClass: 'DERIVED' as const,
+    externalObservation: {
+      ref: `worldspect_snapshots:${input.worldspectSnapshotId}`,
+      snapshotHash: input.worldspectSnapshotHash,
+      observedAt: input.observedAt,
+      sourceState: input.sourceState,
+      confidence: input.confidence,
+      wsi: input.wsi,
+      nti: input.nti,
+      degradedSources: [...input.degradedSources].sort(),
+    },
+    priorCognitiveState: {
+      snapshotId: cognitiveSpine.snapshot.snapshotId,
+      snapshotHash: cognitiveSpine.snapshot.snapshotHash,
+      sourceCutoff: prior.sourceCutoff,
+      projectionProfile: cognitiveSpine.profile.profileId,
+      profileVersion: cognitiveSpine.profile.version,
+      sourceCount: prior.derivedState.sourceCount,
+      evidenceRefs: prior.evidenceRefs,
+      hypothesisRefs: prior.hypothesisRefs,
+      contradictionRefs: prior.contradictionRefs,
+      questionRefs: prior.questionRefs,
+      verificationDebt: prior.verificationDebt,
+      lineageRoot: prior.lineageRoot,
+    },
+    rule: 'WorldSpect observation is independent of Cognitive Spine context. This artifact pairs an already-persisted external observation with the prior institutional state for post-observation comparison only; association is not validation or causality.',
+  };
+  const contrastHash = canonicalSha256(contrastPayload);
+
+  const db = createServiceSupabaseClient();
+  const persisted = await db.from('sfi_cognitive_twin_runs').insert({
+    task_id: `${executionId}:${contrastHash.slice(0, 16)}`,
+    contract_version: COGNITIVE_TWIN_CONTRACT_VERSION,
+    provider: null,
+    model: 'deterministic:worldspect-post-observation-contrast',
+    role: 'worldspect_post_observation_contrast',
+    status: 'READY',
+    objective: `Pair WorldSpect observation ${input.worldspectSnapshotId} with the institutional Cognitive Spine state available before observation began.`,
+    input_snapshot: {
+      worldspectSnapshotId: input.worldspectSnapshotId,
+      worldspectSnapshotHash: input.worldspectSnapshotHash,
+      observedAt: input.observedAt,
+      priorStateCutoff: input.priorStateCutoff,
+      cognitiveSpine: {
+        snapshot: cognitiveSpine.snapshot,
+        consumptionTrace: cognitiveSpine.trace,
+      },
+    },
+    output_envelope: {
+      ...contrastPayload,
+      contrastHash,
+    },
+    evidence_refs: [`worldspect_snapshots:${input.worldspectSnapshotId}`],
+    limitations: [
+      'The Cognitive Spine state was not available to WorldSpect adapters during observation.',
+      'The contrast is DERIVED and does not upgrade the external observation, prior hypotheses, or their independence.',
+      'A matching prior expectation and later observation does not by itself establish causality or validation.',
+    ],
+    started_at: recordedAt,
+    finished_at: recordedAt,
+  }).select('id').single();
+  if (persisted.error || !persisted.data?.id) {
+    throw new Error(`WORLDSPECT_CT_CONTRAST_PERSIST_FAILED:${persisted.error?.message ?? 'unknown'}`);
+  }
+
+  return {
+    ok: true as const,
+    runId: String(persisted.data.id),
+    contrastHash,
+    cognitiveSpineSnapshotId: cognitiveSpine.snapshot.snapshotId,
+    cognitiveSpineSnapshotHash: cognitiveSpine.snapshot.snapshotHash,
+    sourceCutoff: prior.sourceCutoff,
+    projectionProfile: cognitiveSpine.profile.profileId,
+    profileVersion: cognitiveSpine.profile.version,
+    consumed: cognitiveSpine.trace.ctSnapshotConsumed,
+    epistemicClass: 'DERIVED' as const,
+    rule: contrastPayload.rule,
+  };
+}

--- a/src/lib/worldspect/runAdapters.ts
+++ b/src/lib/worldspect/runAdapters.ts
@@ -1,6 +1,7 @@
 ﻿import type { WorldSpectSource } from '../../../packages/api-contracts/src'
 import type { SourceObservation } from './source-adapter-contract'
 import { deriveWorldSpectSourceHealth } from './contract'
+import { recordWorldSpectPostObservationCognitiveSpineContrast } from './cognitiveSpineContrast'
 import { upsertWorldSpectSnapshot } from './snapshotStore'
 import { aggregateWorldSpect } from './vector-aggregator'
 import { getWorldSpectPublicAdapters } from './adapters/publicAdapters'
@@ -40,6 +41,7 @@ export async function persistWorldSpectObservations(
   observations: SourceObservation[],
   ingestMode: WorldSpectIngestMode = 'manual',
   rawPayload: Record<string, unknown> = {},
+  options: { priorCognitiveStateCutoff?: string } = {},
 ) {
   const snapshot = aggregateWorldSpect(observations)
   const ts = new Date().toISOString()
@@ -62,6 +64,8 @@ export async function persistWorldSpectObservations(
   const confidence = clamp01(activeSources.reduce((sum, obs) => sum + obs.trust, 0) / totalSources)
   const adapterError = degraded_sources.length > 0 ? `degraded_sources:${degraded_sources.join(',')}` : null
 
+  // Canonical WorldSpect observation is persisted before any Cognitive Spine
+  // context is materialized. This preserves observation independence.
   const persistence = await upsertWorldSpectSnapshot({
     sourceState,
     evidenceLevel: 'direct',
@@ -97,6 +101,35 @@ export async function persistWorldSpectObservations(
     ingestMode,
   })
 
+  let cognitiveSpineContrast: Awaited<ReturnType<typeof recordWorldSpectPostObservationCognitiveSpineContrast>> | null = null
+  let cognitiveSpineContrastWarning: string | null = null
+  if (persistence.ok && persistence.data?.id) {
+    const observationTimes = observations
+      .map((observation) => new Date(observation.observedAt).valueOf())
+      .filter((value) => Number.isFinite(value))
+      .sort((a, b) => a - b)
+    const derivedPriorCutoff = observationTimes.length
+      ? new Date(observationTimes[0]).toISOString()
+      : ts
+    const priorStateCutoff = options.priorCognitiveStateCutoff ?? derivedPriorCutoff
+
+    try {
+      cognitiveSpineContrast = await recordWorldSpectPostObservationCognitiveSpineContrast({
+        worldspectSnapshotId: String(persistence.data.id),
+        worldspectSnapshotHash: String(persistence.data.snapshot_hash ?? ''),
+        observedAt: String(persistence.data.observed_at ?? ts),
+        priorStateCutoff,
+        sourceState,
+        confidence,
+        wsi: snapshot.wsi,
+        nti: snapshot.nti,
+        degradedSources: degraded_sources,
+      })
+    } catch (error) {
+      cognitiveSpineContrastWarning = `worldspect_post_observation_ct_contrast_unavailable:${error instanceof Error ? error.message : String(error)}`
+    }
+  }
+
   return {
     ok: persistence.ok,
     status: snapshot.status,
@@ -106,6 +139,8 @@ export async function persistWorldSpectObservations(
     degraded_sources,
     sourceHealth,
     persistence,
+    cognitiveSpineContrast,
+    cognitiveSpineContrastWarning,
   }
 }
 
@@ -138,6 +173,7 @@ function failedObservation(adapter: { sourceId: string } | undefined, index: num
 }
 
 export async function runWorldSpectAdapters(ingestMode: WorldSpectIngestMode = 'manual') {
+  const observationStartedAt = new Date().toISOString()
   const adapters = getWorldSpectPublicAdapters()
   const gdeltAdapters = adapters.filter((adapter) => adapter.sourceId.includes('_gdelt_'))
   const otherAdapters = adapters.filter((adapter) => !adapter.sourceId.includes('_gdelt_'))
@@ -163,13 +199,7 @@ export async function runWorldSpectAdapters(ingestMode: WorldSpectIngestMode = '
     adapter_count: adapters.length,
     adapter_ids: adapters.map((adapter) => adapter.sourceId),
     gdelt_mode: 'sequential_backoff',
+  }, {
+    priorCognitiveStateCutoff: observationStartedAt,
   })
 }
-
-
-
-
-
-
-
-


### PR DESCRIPTION
## Scope

Connects WorldSpect to the Cognitive Spine without allowing prior institutional state to influence external observation.

## Changes

- Captures the institutional cutoff before WorldSpect observation begins.
- Public/manual WorldSpect adapters observe and persist the canonical `worldspect_snapshots` row before any Cognitive Spine materialization.
- Adds `SFI-WORLDSPECT-CT-CONTRAST-1.0` over frozen `WORLDSPECT_CONTEXT_V1`.
- After canonical observation persistence, reconstructs the Cognitive Spine state available at the pre-observation cutoff and records a separate DERIVED post-observation contrast.
- The contrast is persisted separately as a `worldspect_post_observation_contrast` Cognitive Twin run; it is not written into the WorldSpect snapshot/raw payload/hash.
- Contrast failure degrades to an explicit warning and never changes WorldSpect observation/persistence success.
- Manual ingest and cron responses expose contrast provenance when available.
- Adds CI guard proving observation persistence precedes CT contrast, prior cutoff precedes adapter observation, canonical WorldSpect hash contains no CT fields, and association is not treated as validation/causality.

## Epistemic boundary

`WORLD OBSERVATION != PRIOR INSTITUTIONAL EXPECTATION`.

WorldSpect adapters do not see Cognitive Spine context. The later pairing is `DERIVED`; it does not upgrade the external observation, prior hypotheses, independence, or causality.

## Reproducibility boundary

The post-observation contrast references the exact WorldSpect snapshot hash and the exact prior Cognitive Spine snapshot/hash/cutoff/profile. The canonical WorldSpect snapshot remains independently reproducible.

## Deployment boundary

WorldSpect observation and Cognitive Spine materialization remain Node/server-worker compatible. Cron/Next routes are optional orchestration surfaces; Vercel is not semantic infrastructure.

## Validation target

Must pass accumulated Cognitive Spine gates, WorldSpect post-observation gate, typecheck, CT Institutional Integration and repository build before merge.