### PR TITLE
Expose read-only Cognitive Spine temporal context in Atlas

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -20,6 +20,8 @@ on:
       - 'src/lib/worldspect/**'
       - 'src/app/api/worldspect/**'
       - 'src/app/api/cron/worldspect/route.ts'
+      - 'src/lib/atlas/**'
+      - 'src/app/api/atlas/**'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
@@ -50,6 +52,8 @@ on:
       - 'src/lib/worldspect/**'
       - 'src/app/api/worldspect/**'
       - 'src/app/api/cron/worldspect/route.ts'
+      - 'src/lib/atlas/**'
+      - 'src/app/api/atlas/**'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
@@ -104,3 +108,5 @@ jobs:
         run: node --import tsx scripts/cognitive-spine/qa-method-lab-context.ts
       - name: WorldSpect post-observation Cognitive Spine contrast
         run: node --import tsx scripts/cognitive-spine/qa-worldspect-post-observation.ts
+      - name: Atlas read-only Cognitive Spine temporal context
+        run: node --import tsx scripts/cognitive-spine/qa-atlas-temporal-context.ts

--- a/scripts/cognitive-spine/qa-atlas-temporal-context.ts
+++ b/scripts/cognitive-spine/qa-atlas-temporal-context.ts
@@ -14,6 +14,18 @@ assert.ok(adapter.includes('read-only Atlas temporal and lineage inspection'), '
 assert.ok(adapter.includes('Relationship does not upgrade epistemic class'), 'atlas_epistemic_boundary_missing');
 assert.ok(adapter.includes('temporal association is not causality'), 'atlas_noncausal_boundary_missing');
 assert.equal(adapter.includes(".from('"), false, 'atlas_temporal_adapter_must_not_write_or_read_ad_hoc_stores');
+assert.ok(adapter.includes('internalRefsExposed: false'), 'atlas_internal_ref_exposure_boundary_missing');
+for (const forbiddenOutput of [
+  'sourceManifest: state.sourceManifest',
+  'eventRefs: state.eventRefs',
+  'evidenceRefs: state.evidenceRefs',
+  'hypothesisRefs: state.hypothesisRefs',
+  'memoryRefs: state.memoryRefs',
+  'decisionRefs: state.decisionRefs',
+]) {
+  assert.equal(adapter.includes(forbiddenOutput), false, `atlas_internal_ref_exposed:${forbiddenOutput}`);
+}
+assert.ok(adapter.includes('sourceCounts:'), 'atlas_safe_aggregate_counts_missing');
 
 const cutoffPosition = runtime.indexOf('const atlasStartedAt = new Date().toISOString()');
 const publisherPosition = runtime.indexOf('buildPublisherDraftRuntime()');
@@ -35,6 +47,7 @@ console.log(JSON.stringify({
   readOnly: true,
   atlasRequiresCtToOperate: false,
   contextChangesPublisherMaterial: false,
+  internalInstitutionalRefsExposed: false,
   canonicalWritePerformed: false,
   relationshipUpgradesEpistemicClass: false,
   associationImpliesCausality: false,

--- a/scripts/cognitive-spine/qa-atlas-temporal-context.ts
+++ b/scripts/cognitive-spine/qa-atlas-temporal-context.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(path.join(root, relative), 'utf8');
+
+const adapter = read('src/lib/atlas/cognitiveSpineTemporalContext.ts');
+const runtime = read('src/lib/atlas/atlasMemoryRuntime.ts');
+
+assert.ok(adapter.includes('ATLAS_TEMPORAL_CONTEXT_PROFILE'), 'atlas_projection_profile_missing');
+assert.ok(adapter.includes('consume: true'), 'atlas_temporal_context_not_explicitly_consumed');
+assert.ok(adapter.includes('read-only Atlas temporal and lineage inspection'), 'atlas_consumption_reason_missing');
+assert.ok(adapter.includes('Relationship does not upgrade epistemic class'), 'atlas_epistemic_boundary_missing');
+assert.ok(adapter.includes('temporal association is not causality'), 'atlas_noncausal_boundary_missing');
+assert.equal(adapter.includes(".from('"), false, 'atlas_temporal_adapter_must_not_write_or_read_ad_hoc_stores');
+
+const cutoffPosition = runtime.indexOf('const atlasStartedAt = new Date().toISOString()');
+const publisherPosition = runtime.indexOf('buildPublisherDraftRuntime()');
+const spinePosition = runtime.indexOf('materializeAtlasCognitiveSpineTemporalContext({');
+assert.ok(cutoffPosition >= 0, 'atlas_context_cutoff_missing');
+assert.ok(publisherPosition > cutoffPosition && spinePosition > cutoffPosition, 'atlas_cutoff_not_frozen_before_material_and_context_reads');
+assert.ok(runtime.includes('sourceCutoff: atlasStartedAt'), 'atlas_snapshot_not_bound_to_runtime_start');
+assert.ok(runtime.includes('cognitive_spine: cognitiveSpine'), 'atlas_temporal_context_not_exposed');
+assert.ok(runtime.includes('context_changes_publisher_material: false'), 'atlas_context_influence_boundary_missing');
+assert.ok(runtime.includes('atlas_requires_ct_to_operate: false'), 'atlas_became_ct_middleware');
+assert.ok(runtime.includes('canonical_write_performed: false'), 'atlas_read_causes_canonical_write');
+assert.ok(runtime.includes('atlas_cognitive_spine_unavailable:'), 'atlas_ct_unavailability_not_preserved_as_gap');
+assert.ok(runtime.includes('Missing context is preserved as a provenance gap'), 'atlas_missing_context_narrative_fill_boundary_missing');
+assert.equal(runtime.includes('recordCognitiveTwinExperience'), false, 'atlas_read_promotes_context_to_experience');
+
+console.log(JSON.stringify({
+  ok: true,
+  profile: 'ATLAS_TEMPORAL_CONTEXT_V1',
+  readOnly: true,
+  atlasRequiresCtToOperate: false,
+  contextChangesPublisherMaterial: false,
+  canonicalWritePerformed: false,
+  relationshipUpgradesEpistemicClass: false,
+  associationImpliesCausality: false,
+}, null, 2));

--- a/src/lib/atlas/atlasMemoryRuntime.ts
+++ b/src/lib/atlas/atlasMemoryRuntime.ts
@@ -14,13 +14,19 @@ function asString(value: unknown, fallback = 'n/a'): string {
 export async function buildAtlasMemoryRuntime(): Promise<AtlasMemoryRuntimeResult> {
   const atlasStartedAt = new Date().toISOString();
   const atlasExecutionId = `atlas-memory:${crypto.randomUUID()}`;
-  const [publisher, cognitiveSpine] = await Promise.all([
+  const [publisher, cognitiveSpineResult] = await Promise.all([
     buildPublisherDraftRuntime(),
     materializeAtlasCognitiveSpineTemporalContext({
       executionId: atlasExecutionId,
       sourceCutoff: atlasStartedAt,
       createdAt: atlasStartedAt,
-    }),
+    })
+      .then((context) => ({ ok: true as const, context, warning: null }))
+      .catch((error) => ({
+        ok: false as const,
+        context: null,
+        warning: `atlas_cognitive_spine_unavailable:${error instanceof Error ? error.message : String(error)}`,
+      })),
   ]);
 
   const draft = asRecord(publisher);
@@ -29,6 +35,15 @@ export async function buildAtlasMemoryRuntime(): Promise<AtlasMemoryRuntimeResul
   const contrast = asRecord(proposal.contrast);
 
   const entry_id = `atlas-${Date.now()}`;
+  const cognitiveSpine = cognitiveSpineResult.ok
+    ? cognitiveSpineResult.context
+    : {
+        contractVersion: 'SFI-ATLAS-CT-TEMPORAL-CONTEXT-1.0',
+        available: false,
+        consumed: false,
+        warning: cognitiveSpineResult.warning,
+        rule: 'Atlas remains operational when Cognitive Spine temporal context is unavailable. Missing context is preserved as a provenance gap, not reconstructed narratively.',
+      };
 
   return {
     ok: true,
@@ -53,6 +68,7 @@ export async function buildAtlasMemoryRuntime(): Promise<AtlasMemoryRuntimeResul
     atlas_cognitive_boundary: {
       context_is_read_only: true,
       context_changes_publisher_material: false,
+      atlas_requires_ct_to_operate: false,
       relationship_upgrades_epistemic_class: false,
       association_implies_causality: false,
       canonical_write_performed: false,

--- a/src/lib/atlas/atlasMemoryRuntime.ts
+++ b/src/lib/atlas/atlasMemoryRuntime.ts
@@ -1,3 +1,4 @@
+import { materializeAtlasCognitiveSpineTemporalContext } from '@/lib/atlas/cognitiveSpineTemporalContext';
 import { buildPublisherDraftRuntime } from '@/lib/publisher/publisherRuntime';
 
 export type AtlasMemoryRuntimeResult = { [key: string]: any };
@@ -11,7 +12,16 @@ function asString(value: unknown, fallback = 'n/a'): string {
 }
 
 export async function buildAtlasMemoryRuntime(): Promise<AtlasMemoryRuntimeResult> {
-  const publisher = await buildPublisherDraftRuntime();
+  const atlasStartedAt = new Date().toISOString();
+  const atlasExecutionId = `atlas-memory:${crypto.randomUUID()}`;
+  const [publisher, cognitiveSpine] = await Promise.all([
+    buildPublisherDraftRuntime(),
+    materializeAtlasCognitiveSpineTemporalContext({
+      executionId: atlasExecutionId,
+      sourceCutoff: atlasStartedAt,
+      createdAt: atlasStartedAt,
+    }),
+  ]);
 
   const draft = asRecord(publisher);
   const material = asRecord(draft.material);
@@ -39,6 +49,14 @@ export async function buildAtlasMemoryRuntime(): Promise<AtlasMemoryRuntimeResul
       asString(contrast.vector_id, ''),
     ].filter(Boolean),
     approval_required: Boolean(material.approval_required ?? draft.approval_required),
+    cognitive_spine: cognitiveSpine,
+    atlas_cognitive_boundary: {
+      context_is_read_only: true,
+      context_changes_publisher_material: false,
+      relationship_upgrades_epistemic_class: false,
+      association_implies_causality: false,
+      canonical_write_performed: false,
+    },
     publisher,
   };
 }

--- a/src/lib/atlas/cognitiveSpineTemporalContext.ts
+++ b/src/lib/atlas/cognitiveSpineTemporalContext.ts
@@ -1,0 +1,53 @@
+import 'server-only';
+
+import { ATLAS_TEMPORAL_CONTEXT_PROFILE } from '@/core/cognitive-spine/profiles/registry';
+import { materializeInstitutionalCognitiveSpineProfile } from '@/lib/institution/cognitiveSpineProfileMaterializer';
+
+export const ATLAS_COGNITIVE_SPINE_CONTEXT_CONTRACT = 'SFI-ATLAS-CT-TEMPORAL-CONTEXT-1.0' as const;
+
+/**
+ * Atlas is a read-side temporal/relational consumer. It may inspect a sealed
+ * institutional Cognitive Spine state, but it may not mutate canonical state,
+ * upgrade epistemic class, or infer causality from relationship/sequence.
+ */
+export async function materializeAtlasCognitiveSpineTemporalContext(input: {
+  executionId: string;
+  sourceCutoff: string;
+  createdAt: string;
+}) {
+  const materialized = await materializeInstitutionalCognitiveSpineProfile({
+    sourceCutoff: input.sourceCutoff,
+    executionId: input.executionId,
+    createdAt: input.createdAt,
+    profileId: ATLAS_TEMPORAL_CONTEXT_PROFILE.profileId,
+    consume: true,
+    consumptionReason: 'read-only Atlas temporal and lineage inspection',
+  });
+  const state = materialized.snapshot.semanticPayload;
+
+  return {
+    contractVersion: ATLAS_COGNITIVE_SPINE_CONTEXT_CONTRACT,
+    snapshotId: materialized.snapshot.snapshotId,
+    snapshotHash: materialized.snapshot.snapshotHash,
+    sourceCutoff: state.sourceCutoff,
+    projectionProfile: materialized.profile.profileId,
+    profileVersion: materialized.profile.version,
+    consumed: materialized.trace.ctSnapshotConsumed,
+    consumptionTrace: materialized.trace,
+    temporalState: state.temporalState,
+    lineageRoot: state.lineageRoot,
+    sourceManifest: state.sourceManifest,
+    eventRefs: state.eventRefs,
+    evidenceRefs: state.evidenceRefs,
+    hypothesisRefs: state.hypothesisRefs,
+    memoryRefs: state.memoryRefs,
+    decisionRefs: state.decisionRefs,
+    contradictionRefs: state.contradictionRefs,
+    freezeRefs: state.freezeRefs,
+    questionRefs: state.questionRefs,
+    verificationDebt: state.verificationDebt,
+    derivedState: state.derivedState,
+    warnings: materialized.warnings,
+    rule: 'Atlas reads temporal state and lineage. Relationship does not upgrade epistemic class, and temporal association is not causality. Atlas does not write canonical Cognitive Spine state by reading it.',
+  };
+}

--- a/src/lib/atlas/cognitiveSpineTemporalContext.ts
+++ b/src/lib/atlas/cognitiveSpineTemporalContext.ts
@@ -9,6 +9,10 @@ export const ATLAS_COGNITIVE_SPINE_CONTEXT_CONTRACT = 'SFI-ATLAS-CT-TEMPORAL-CON
  * Atlas is a read-side temporal/relational consumer. It may inspect a sealed
  * institutional Cognitive Spine state, but it may not mutate canonical state,
  * upgrade epistemic class, or infer causality from relationship/sequence.
+ *
+ * The current Atlas memory API is not a ROOT-private surface, so this adapter
+ * deliberately exposes only semantic identity and aggregate temporal state.
+ * Canonical source refs, memory refs and decision refs remain internal.
  */
 export async function materializeAtlasCognitiveSpineTemporalContext(input: {
   executionId: string;
@@ -36,18 +40,20 @@ export async function materializeAtlasCognitiveSpineTemporalContext(input: {
     consumptionTrace: materialized.trace,
     temporalState: state.temporalState,
     lineageRoot: state.lineageRoot,
-    sourceManifest: state.sourceManifest,
-    eventRefs: state.eventRefs,
-    evidenceRefs: state.evidenceRefs,
-    hypothesisRefs: state.hypothesisRefs,
-    memoryRefs: state.memoryRefs,
-    decisionRefs: state.decisionRefs,
-    contradictionRefs: state.contradictionRefs,
-    freezeRefs: state.freezeRefs,
-    questionRefs: state.questionRefs,
     verificationDebt: state.verificationDebt,
-    derivedState: state.derivedState,
+    sourceCounts: {
+      total: state.derivedState.sourceCount,
+      events: state.eventRefs.length,
+      evidence: state.evidenceRefs.length,
+      hypotheses: state.hypothesisRefs.length,
+      memory: state.memoryRefs.length,
+      decisions: state.decisionRefs.length,
+      contradictions: state.contradictionRefs.length,
+      freezes: state.freezeRefs.length,
+      questions: state.questionRefs.length,
+    },
     warnings: materialized.warnings,
-    rule: 'Atlas reads temporal state and lineage. Relationship does not upgrade epistemic class, and temporal association is not causality. Atlas does not write canonical Cognitive Spine state by reading it.',
+    internalRefsExposed: false as const,
+    rule: 'Atlas reads aggregate temporal state and lineage identity. Relationship does not upgrade epistemic class, temporal association is not causality, and internal institutional refs are not exposed by this non-ROOT surface.',
   };
 }


### PR DESCRIPTION
## Scope

Connects Atlas to the Cognitive Spine as a read-only temporal/lineage consumer without making CT a required middleware or changing Publisher material generation.

## Changes

- Adds `SFI-ATLAS-CT-TEMPORAL-CONTEXT-1.0` using frozen `ATLAS_TEMPORAL_CONTEXT_V1`.
- Atlas seals one institutional snapshot at runtime start and exposes only public-safe temporal identity: snapshot ID/hash, cutoff, lineage root, temporal state, verification debt and aggregate source counts.
- Canonical source refs, memory refs and decision refs remain internal and are not exposed through the non-ROOT Atlas memory API.
- Cognitive Spine context is returned alongside the existing Atlas generated material; it is not passed into Publisher material generation.
- Atlas performs no canonical Cognitive Spine write merely by reading temporal context.
- If Cognitive Spine materialization fails, Atlas remains operational and reports an explicit unavailable/unconsumed provenance gap instead of reconstructing context narratively.
- Adds CI gate enforcing read-only behavior, non-causality, no epistemic promotion, non-middleware operation and non-ROOT ref sanitization.

## Epistemic boundary

Atlas relationships and temporal adjacency do not upgrade epistemic class and do not imply causality. Atlas exposes aggregate lineage identity; it does not create truth or evidence by relationship.

## Availability boundary

Cognitive Spine is vertebral but not mandatory middleware. Atlas can operate without CT context; unavailable context is recorded as a gap.

## Security boundary

The current Atlas memory API is not ROOT-private. Therefore internal institutional refs are not surfaced by this integration.

## Deployment boundary

Temporal materialization uses the shared Node/local/worker-compatible core. The Atlas API route remains a thin surface; no Vercel semantic dependency is introduced.

## Validation target

Must pass accumulated Cognitive Spine gates, Atlas read-only/sanitization gate, typecheck and repository build before merge.