### PR TITLE
Expose non-claiming Library Cognitive Spine impact inspection

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -22,6 +22,10 @@ on:
       - 'src/app/api/cron/worldspect/route.ts'
       - 'src/lib/atlas/**'
       - 'src/app/api/atlas/**'
+      - 'src/lib/sfi/library/**'
+      - 'src/app/library/**'
+      - 'src/app/api/sfi/library/**'
+      - 'src/app/api/root/library/**'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
@@ -54,6 +58,10 @@ on:
       - 'src/app/api/cron/worldspect/route.ts'
       - 'src/lib/atlas/**'
       - 'src/app/api/atlas/**'
+      - 'src/lib/sfi/library/**'
+      - 'src/app/library/**'
+      - 'src/app/api/sfi/library/**'
+      - 'src/app/api/root/library/**'
       - 'src/lib/field/cognitiveSpineProposalLink.ts'
       - 'src/lib/field/fieldCognitiveSpineBoundary.ts'
       - 'src/lib/field/interventionExecution.ts'
@@ -110,3 +118,5 @@ jobs:
         run: node --import tsx scripts/cognitive-spine/qa-worldspect-post-observation.ts
       - name: Atlas read-only Cognitive Spine temporal context
         run: node --import tsx scripts/cognitive-spine/qa-atlas-temporal-context.ts
+      - name: Library non-claiming Cognitive Spine impact context
+        run: node --import tsx scripts/cognitive-spine/qa-library-impact-context.ts

--- a/scripts/cognitive-spine/qa-library-impact-context.ts
+++ b/scripts/cognitive-spine/qa-library-impact-context.ts
@@ -9,9 +9,18 @@ const publicPage = read('src/app/library/page.tsx');
 const inspector = read('src/lib/sfi/library/cognitiveSpineImpactContext.ts');
 const route = read('src/app/api/root/library/cognitive-spine/route.ts');
 
-// Public Library remains static and private-state free.
+// Public Library remains static and private-state free. Literal explanatory
+// text may mention Supabase; the gate detects actual private-state imports or
+// materializer/client usage rather than prose.
 assert.ok(publicPage.includes("export const dynamic = 'force-static'"), 'library_public_surface_not_static');
-assert.equal(/Supabase|cognitiveSpine|CognitiveSpine|materializeInstitutional/i.test(publicPage), false, 'library_public_surface_reads_private_cognitive_state');
+for (const forbiddenPrivateRead of [
+  "@/runtime/supabase",
+  'createServiceSupabaseClient',
+  'materializeInstitutionalCognitiveSpineProfile',
+  'cognitiveSpineImpactContext',
+]) {
+  assert.equal(publicPage.includes(forbiddenPrivateRead), false, `library_public_surface_reads_private_state:${forbiddenPrivateRead}`);
+}
 
 assert.ok(inspector.includes('LIBRARY_IMPACT_CONTEXT_PROFILE'), 'library_projection_profile_missing');
 assert.ok(inspector.includes('consume: false'), 'library_ordinary_read_must_not_consume_ct');

--- a/scripts/cognitive-spine/qa-library-impact-context.ts
+++ b/scripts/cognitive-spine/qa-library-impact-context.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(path.join(root, relative), 'utf8');
+
+const publicPage = read('src/app/library/page.tsx');
+const inspector = read('src/lib/sfi/library/cognitiveSpineImpactContext.ts');
+const route = read('src/app/api/root/library/cognitive-spine/route.ts');
+
+// Public Library remains static and private-state free.
+assert.ok(publicPage.includes("export const dynamic = 'force-static'"), 'library_public_surface_not_static');
+assert.equal(/Supabase|cognitiveSpine|CognitiveSpine|materializeInstitutional/i.test(publicPage), false, 'library_public_surface_reads_private_cognitive_state');
+
+assert.ok(inspector.includes('LIBRARY_IMPACT_CONTEXT_PROFILE'), 'library_projection_profile_missing');
+assert.ok(inspector.includes('consume: false'), 'library_ordinary_read_must_not_consume_ct');
+assert.ok(inspector.includes("status: 'UNDEMONSTRATED'"), 'library_impact_overclaimed');
+assert.ok(inspector.includes('impactLinks: []'), 'library_impact_links_fabricated');
+assert.ok(inspector.includes("artifactContentHashRegistryAvailable: false"), 'library_artifact_identity_gap_not_declared');
+assert.ok(inspector.includes('No canonical artifact-to-Cognitive-Spine-transition relationship is currently registered'), 'library_missing_impact_provenance_not_declared');
+assert.ok(inspector.includes('storageCreatesEvidence: false'), 'library_storage_evidence_boundary_missing');
+assert.ok(inspector.includes('artifactAssociationImpliesCausality: false'), 'library_noncausal_boundary_missing');
+assert.ok(inspector.includes('unavailableCtBlocksLibrary: false'), 'library_became_ct_middleware');
+assert.ok(inspector.includes('ctContextConsumedByLibraryRead: false'), 'library_read_consumes_ct');
+assert.equal(inspector.includes('recordCognitiveTwinExperience'), false, 'library_inspection_promotes_state');
+assert.equal(inspector.includes(".insert("), false, 'library_impact_inspection_writes_state');
+assert.equal(inspector.includes(".update("), false, 'library_impact_inspection_mutates_state');
+
+assert.ok(route.includes("requireRootViewer('root.library.cognitive-spine.read')"), 'library_impact_inspection_not_root_gated');
+assert.ok(route.includes('Cache-Control'), 'library_root_inspection_cache_boundary_missing');
+
+console.log(JSON.stringify({
+  ok: true,
+  profile: 'LIBRARY_IMPACT_CONTEXT_V1',
+  publicLibraryStatic: true,
+  publicLibraryReadsPrivateCt: false,
+  ordinaryLibraryReadConsumesCt: false,
+  impactStatus: 'UNDEMONSTRATED',
+  fabricatedImpactLinks: false,
+  artifactContentHashIdentityReady: false,
+  storageCreatesEvidence: false,
+  associationImpliesCausality: false,
+}, null, 2));

--- a/src/app/api/root/library/cognitive-spine/route.ts
+++ b/src/app/api/root/library/cognitive-spine/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { inspectLibraryCognitiveSpineImpact } from '@/lib/sfi/library/cognitiveSpineImpactContext';
+import { requireRootViewer } from '@/lib/root/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const gate = await requireRootViewer('root.library.cognitive-spine.read');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  const inspection = await inspectLibraryCognitiveSpineImpact();
+  return NextResponse.json({
+    ok: true,
+    inspection,
+  }, {
+    headers: { 'Cache-Control': 'no-store' },
+  });
+}

--- a/src/lib/sfi/library/cognitiveSpineImpactContext.ts
+++ b/src/lib/sfi/library/cognitiveSpineImpactContext.ts
@@ -1,0 +1,107 @@
+import 'server-only';
+
+import { LIBRARY_IMPACT_CONTEXT_PROFILE } from '@/core/cognitive-spine/profiles/registry';
+import { materializeInstitutionalCognitiveSpineProfile } from '@/lib/institution/cognitiveSpineProfileMaterializer';
+import { getSfiLibraryManifest } from './manifest';
+
+export const LIBRARY_COGNITIVE_SPINE_IMPACT_CONTRACT = 'SFI-LIBRARY-CT-IMPACT-CONTEXT-1.0' as const;
+
+/**
+ * Library impact is an inspection problem, not a default cognition input.
+ *
+ * The static Library preserves/formalizes artifacts. Until an explicit
+ * canonical record links an artifact identity to a Cognitive Spine state
+ * transition, artifact -> state-change impact remains UNDEMONSTRATED.
+ */
+export async function inspectLibraryCognitiveSpineImpact() {
+  const inspectedAt = new Date().toISOString();
+  const manifest = getSfiLibraryManifest();
+
+  const materialized = await materializeInstitutionalCognitiveSpineProfile({
+    sourceCutoff: inspectedAt,
+    executionId: `library-impact:${crypto.randomUUID()}`,
+    createdAt: inspectedAt,
+    profileId: LIBRARY_IMPACT_CONTEXT_PROFILE.profileId,
+    consume: false,
+  }).then((value) => ({ ok: true as const, value, warning: null }))
+    .catch((error) => ({
+      ok: false as const,
+      value: null,
+      warning: `library_cognitive_spine_unavailable:${error instanceof Error ? error.message : String(error)}`,
+    }));
+
+  const cognitiveSpine = materialized.ok
+    ? {
+        available: true as const,
+        consumed: false as const,
+        snapshotId: materialized.value.snapshot.snapshotId,
+        snapshotHash: materialized.value.snapshot.snapshotHash,
+        sourceCutoff: materialized.value.snapshot.semanticPayload.sourceCutoff,
+        projectionProfile: materialized.value.profile.profileId,
+        profileVersion: materialized.value.profile.version,
+        lineageRoot: materialized.value.snapshot.semanticPayload.lineageRoot,
+        sourceCount: materialized.value.snapshot.semanticPayload.derivedState.sourceCount,
+        verificationDebt: materialized.value.snapshot.semanticPayload.verificationDebt,
+        consumptionTrace: materialized.value.trace,
+        warning: null,
+      }
+    : {
+        available: false as const,
+        consumed: false as const,
+        snapshotId: null,
+        snapshotHash: null,
+        sourceCutoff: inspectedAt,
+        projectionProfile: LIBRARY_IMPACT_CONTEXT_PROFILE.profileId,
+        profileVersion: LIBRARY_IMPACT_CONTEXT_PROFILE.version,
+        lineageRoot: null,
+        sourceCount: null,
+        verificationDebt: null,
+        consumptionTrace: null,
+        warning: materialized.warning,
+      };
+
+  return {
+    contractVersion: LIBRARY_COGNITIVE_SPINE_IMPACT_CONTRACT,
+    inspectedAt,
+    library: {
+      packageName: manifest.packageName,
+      packageVersion: manifest.version,
+      artifacts: manifest.documents.map((document) => ({
+        id: document.id,
+        title: document.title,
+        kind: document.kind,
+        status: document.status,
+        publicPath: document.publicPath,
+      })),
+      publicSurfaceRemainsStatic: true as const,
+      publicSurfaceReadsPrivateCognitiveState: false as const,
+    },
+    cognitiveSpine,
+    impactAssessment: {
+      status: 'UNDEMONSTRATED' as const,
+      impactLinks: [] as Array<{
+        artifactId: string;
+        artifactHash: string;
+        transitionId: string;
+        epistemicAssessmentRef: string;
+      }>,
+      artifactIdentityStatus: 'PARTIAL_ID_AND_PACKAGE_VERSION_ONLY' as const,
+      artifactContentHashRegistryAvailable: false as const,
+      reason: 'No canonical artifact-to-Cognitive-Spine-transition relationship is currently registered, and Library artifact content hashes are not yet part of the static manifest identity contract.',
+      requiredForDemonstratedAssociation: [
+        'stable artifact identity including content hash and version',
+        'canonical event recording the artifact use/admission',
+        'explicit transition reference',
+        'epistemic assessment of the artifact-to-transition relationship',
+        'lineage proving the association is not inherited from the resulting snapshot itself',
+      ],
+    },
+    invariants: {
+      storageCreatesEvidence: false as const,
+      artifactAssociationImpliesCausality: false as const,
+      unavailableCtBlocksLibrary: false as const,
+      ctContextConsumedByLibraryRead: false as const,
+    },
+    rule: 'Library preservation does not create evidence. Artifact association is not causality. Cognitive Spine remains available for ROOT inspection but is not consumed by ordinary Library reads.',
+  };
+}


### PR DESCRIPTION
## Scope

Resolves Library's Cognitive Spine boundary without turning ordinary Library reads into CT consumption or fabricating artifact impact.

## Changes

- Adds `SFI-LIBRARY-CT-IMPACT-CONTEXT-1.0` using frozen `LIBRARY_IMPACT_CONTEXT_V1`.
- The public Library remains force-static, reads no Supabase/private Cognitive Spine state and keeps its existing editorial role.
- Adds a separate ROOT-viewer inspection endpoint for Library/Cognitive Spine impact status.
- Operational Cognitive Spine state is materialized as AVAILABLE / NOT CONSUMED for impact inspection.
- Impact status is explicitly `UNDEMONSTRATED`; `impactLinks` is empty because no canonical artifact→state-transition relationship exists today.
- Declares artifact identity debt: Library manifest currently provides artifact ID + package version but no canonical content-hash registry.
- Defines evidence required before any future impact association can be claimed: stable artifact hash/version, canonical use/admission event, explicit transition ref, epistemic assessment, and non-self-validating lineage.
- CT unavailability does not block Library.
- Adds CI gate preserving public-static behavior, no private CT reads, no writes/promotion, no fake impact/causality.

## Epistemic boundary

Library storage does not create evidence. Artifact association does not imply causality. Preserving a document does not prove that it changed institutional cognitive state.

## Surface boundary

Ordinary/public Library reads do not consume CT. Only a ROOT-private inspection may view aggregate Cognitive Spine availability/identity, and even that does not create impact links.

## Deployment boundary

The static public Library remains deployment-independent. The optional ROOT inspection uses the shared Node/server-worker materializer; Vercel is not semantic infrastructure.

## Validation target

Must pass accumulated Cognitive Spine gates, Library impact boundary gate, typecheck and repository build before merge.