### PR TITLE
Make Cognitive Spine state persistently observable in ROOT

### DIFF
--- a/.github/workflows/sfi-cognitive-spine.yml
+++ b/.github/workflows/sfi-cognitive-spine.yml
@@ -12,6 +12,9 @@ on:
       - 'src/lib/studio/cognitive/**'
       - 'src/app/api/studio/session/reconstruct/route.ts'
       - 'src/lib/root/cognitiveSpineRootContext.ts'
+      - 'src/lib/root/cognitiveSpineStatus.ts'
+      - 'src/components/root/cognitive-spine/**'
+      - 'src/app/root/layout.tsx'
       - 'src/app/api/root/cognitive-twin/deliberate/route.ts'
       - 'src/lib/lab/decisionTransferCognitiveSpineBoundary.ts'
       - 'src/app/api/root/method-lab/decision-transfer/blind/route.ts'
@@ -48,6 +51,9 @@ on:
       - 'src/lib/studio/cognitive/**'
       - 'src/app/api/studio/session/reconstruct/route.ts'
       - 'src/lib/root/cognitiveSpineRootContext.ts'
+      - 'src/lib/root/cognitiveSpineStatus.ts'
+      - 'src/components/root/cognitive-spine/**'
+      - 'src/app/root/layout.tsx'
       - 'src/app/api/root/cognitive-twin/deliberate/route.ts'
       - 'src/lib/lab/decisionTransferCognitiveSpineBoundary.ts'
       - 'src/app/api/root/method-lab/decision-transfer/blind/route.ts'
@@ -122,3 +128,5 @@ jobs:
         run: node --import tsx scripts/cognitive-spine/qa-library-impact-context.ts
       - name: Final transversal Cognitive Spine technical integration
         run: node --import tsx scripts/cognitive-spine/qa-cognitive-spine-integrated.ts
+      - name: ROOT Cognitive Spine status observability boundary
+        run: node --import tsx scripts/cognitive-spine/qa-root-cognitive-spine-observability.ts

--- a/scripts/cognitive-spine/qa-root-cognitive-spine-observability.ts
+++ b/scripts/cognitive-spine/qa-root-cognitive-spine-observability.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(path.join(root, relative), 'utf8');
+
+const reader = read('src/lib/root/cognitiveSpineStatus.ts');
+const route = read('src/app/api/root/cognitive-spine/status/route.ts');
+const bar = read('src/components/root/cognitive-spine/CognitiveSpineStatusBar.tsx');
+const layout = read('src/app/root/layout.tsx');
+
+assert.ok(reader.includes('ROOT_GOVERNANCE_CONTEXT_PROFILE'), 'root_ct_status_profile_missing');
+assert.ok(reader.includes('consume: false'), 'root_ct_status_must_not_consume_context');
+assert.ok(reader.includes('internalRefsExposed: false'), 'root_ct_status_internal_ref_boundary_missing');
+assert.ok(reader.includes('sources: state.derivedState.sourceCount'), 'root_ct_status_source_count_missing');
+assert.ok(reader.includes('evidence: state.evidenceRefs.length'), 'root_ct_status_evidence_count_missing');
+assert.ok(reader.includes('verificationDebt: state.verificationDebt.absolute'), 'root_ct_status_verification_debt_missing');
+assert.equal(reader.includes('evidenceRefs: state.evidenceRefs'), false, 'root_ct_status_exposes_evidence_refs');
+assert.equal(reader.includes('memoryRefs: state.memoryRefs'), false, 'root_ct_status_exposes_memory_refs');
+assert.equal(reader.includes('decisionRefs: state.decisionRefs'), false, 'root_ct_status_exposes_decision_refs');
+assert.equal(reader.includes(".insert("), false, 'root_ct_status_writes_state');
+assert.equal(reader.includes(".update("), false, 'root_ct_status_mutates_state');
+assert.ok(reader.includes('available: false as const'), 'root_ct_status_unavailability_fallback_missing');
+
+assert.ok(route.includes("requireRootViewer('root.cognitive-spine.status')"), 'root_ct_status_endpoint_not_root_gated');
+assert.ok(route.includes("'Cache-Control': 'no-store'"), 'root_ct_status_endpoint_cache_boundary_missing');
+
+assert.ok(bar.includes("fetch('/api/root/cognitive-spine/status'"), 'root_ct_status_bar_endpoint_missing');
+assert.ok(bar.includes('CT STATE'), 'root_ct_status_bar_label_missing');
+assert.ok(bar.includes('CT AVAILABLE ≠ CT CONSUMED'), 'root_ct_status_bar_consumption_boundary_missing');
+assert.ok(bar.includes('ROOT remains operational'), 'root_ct_status_bar_nonmiddleware_fallback_missing');
+assert.equal(bar.includes('setInterval'), false, 'root_ct_status_bar_unbounded_polling_introduced');
+
+assert.ok(layout.includes('<CognitiveSpineStatusBar />'), 'root_layout_missing_persistent_ct_status');
+assert.ok(layout.indexOf('<CognitiveSpineStatusBar />') > layout.indexOf("<RoleGate allowedRoles={['root']}>"), 'root_ct_status_rendered_outside_role_gate');
+
+console.log(JSON.stringify({
+  ok: true,
+  statusContract: 'SFI-ROOT-CT-STATUS-1.0',
+  rootOnly: true,
+  consumesCt: false,
+  canonicalWrite: false,
+  internalRefsExposed: false,
+  automaticPolling: false,
+  rootDependsOnCtAvailability: false,
+  persistentRootStatusBar: true,
+}, null, 2));

--- a/src/app/api/root/cognitive-spine/status/route.ts
+++ b/src/app/api/root/cognitive-spine/status/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { readRootCognitiveSpineStatus } from '@/lib/root/cognitiveSpineStatus';
+import { requireRootViewer } from '@/lib/root/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const gate = await requireRootViewer('root.cognitive-spine.status');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
+  const status = await readRootCognitiveSpineStatus();
+  return NextResponse.json({ ok: true, status }, {
+    headers: { 'Cache-Control': 'no-store' },
+  });
+}

--- a/src/app/root/layout.tsx
+++ b/src/app/root/layout.tsx
@@ -1,4 +1,5 @@
 import { RoleGate } from '@/components/auth/RoleGate';
+import { CognitiveSpineStatusBar } from '@/components/root/cognitive-spine/CognitiveSpineStatusBar';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -8,6 +9,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <RoleGate allowedRoles={['root']}>
+      <CognitiveSpineStatusBar />
       {children}
     </RoleGate>
   );

--- a/src/components/root/cognitive-spine/CognitiveSpineStatusBar.tsx
+++ b/src/components/root/cognitive-spine/CognitiveSpineStatusBar.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type Status = {
+  available: boolean;
+  consumed: false;
+  inspectedAt: string;
+  snapshot: null | {
+    id: string;
+    hash: string;
+    sourceCutoff: string;
+    projectionProfile: string;
+    profileVersion: string;
+  };
+  state: null | {
+    sources: number;
+    evidence: number;
+    hypotheses: number;
+    contradictions: number;
+    questions: number;
+    freezes: number;
+    memory: number;
+    decisions: number;
+    verificationDebt: number;
+  };
+  surfaces: Array<{ surface: string; posture: string }>;
+  warnings: string[];
+};
+
+export function CognitiveSpineStatusBar() {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/root/cognitive-spine/status', {
+        cache: 'no-store',
+        credentials: 'include',
+      });
+      const body = await response.json().catch(() => null) as { ok?: boolean; status?: Status } | null;
+      if (!response.ok || !body?.ok || !body.status) throw new Error('CT_STATE_UNAVAILABLE');
+      setStatus(body.status);
+    } catch {
+      setStatus(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  const available = Boolean(status?.available && status.snapshot && status.state);
+  const shortHash = status?.snapshot?.hash ? status.snapshot.hash.slice(0, 8) : '--------';
+  const surfaceCount = status?.surfaces?.length ?? 0;
+
+  return (
+    <aside
+      aria-label="Cognitive Spine status"
+      style={{
+        position: 'fixed', top: 10, right: 12, zIndex: 90,
+        minWidth: 300, maxWidth: 'min(560px, calc(100vw - 24px))',
+        border: '1px solid rgba(191,160,78,.34)', background: 'rgba(8,8,7,.96)',
+        color: '#d5c28a', boxShadow: '0 10px 30px rgba(0,0,0,.28)',
+        font: '10px ui-monospace,SFMono-Regular,Menlo,monospace', letterSpacing: '.045em',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '8px 10px', borderBottom: '1px solid rgba(191,160,78,.16)' }}>
+        <span aria-hidden="true" style={{ width: 7, height: 7, borderRadius: 999, background: available ? '#c6ad69' : '#5e5a50', display: 'inline-block' }} />
+        <strong style={{ fontSize: 10, letterSpacing: '.12em' }}>CT STATE</strong>
+        <span style={{ opacity: .72 }}>{loading ? 'READING' : available ? status?.snapshot?.id : 'UNAVAILABLE'}</span>
+        <span style={{ marginLeft: 'auto', opacity: .58 }}>#{shortHash}</span>
+        <button
+          type="button"
+          onClick={() => void refresh()}
+          disabled={loading}
+          aria-label="Refresh Cognitive Spine status"
+          style={{ border: 0, background: 'transparent', color: '#c6ad69', cursor: loading ? 'default' : 'pointer', font: 'inherit', padding: 0 }}
+        >
+          ↻
+        </button>
+      </div>
+      {available ? (
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5,minmax(0,1fr))', gap: 1, padding: '7px 10px 8px' }}>
+          <Metric label="SOURCES" value={status!.state!.sources} />
+          <Metric label="EVIDENCE" value={status!.state!.evidence} />
+          <Metric label="HYP" value={status!.state!.hypotheses} />
+          <Metric label="CONTRA" value={status!.state!.contradictions} />
+          <Metric label="V-DEBT" value={status!.state!.verificationDebt} />
+          <Metric label="QUEST" value={status!.state!.questions} />
+          <Metric label="FREEZE" value={status!.state!.freezes} />
+          <Metric label="MEM" value={status!.state!.memory} />
+          <Metric label="DEC" value={status!.state!.decisions} />
+          <Metric label="SURFACES" value={surfaceCount} />
+        </div>
+      ) : (
+        <div style={{ padding: '8px 10px', opacity: .66 }}>
+          ROOT remains operational. Cognitive Spine status is currently unavailable and is not reconstructed narratively.
+        </div>
+      )}
+      <div style={{ padding: '0 10px 7px', opacity: .48, fontSize: 8 }}>
+        STATUS VIEW · CT AVAILABLE ≠ CT CONSUMED · NO CANONICAL WRITE
+      </div>
+    </aside>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return <div style={{ minWidth: 0 }}><div style={{ opacity: .46, fontSize: 7 }}>{label}</div><div style={{ fontSize: 11 }}>{value}</div></div>;
+}

--- a/src/lib/root/cognitiveSpineStatus.ts
+++ b/src/lib/root/cognitiveSpineStatus.ts
@@ -1,0 +1,86 @@
+import 'server-only';
+
+import { ROOT_GOVERNANCE_CONTEXT_PROFILE } from '@/core/cognitive-spine/profiles/registry';
+import {
+  COGNITIVE_SPINE_INTEGRATION_STATUS_CONTRACT,
+  COGNITIVE_SPINE_SURFACE_INTEGRATIONS,
+  COGNITIVE_SPINE_TECHNICAL_CLAIM_BOUNDARY,
+} from '@/core/cognitive-spine/surfaceIntegrationRegistry';
+import { materializeInstitutionalCognitiveSpineProfile } from '@/lib/institution/cognitiveSpineProfileMaterializer';
+
+export const ROOT_COGNITIVE_SPINE_STATUS_CONTRACT = 'SFI-ROOT-CT-STATUS-1.0' as const;
+
+export async function readRootCognitiveSpineStatus() {
+  const inspectedAt = new Date().toISOString();
+  try {
+    const materialized = await materializeInstitutionalCognitiveSpineProfile({
+      sourceCutoff: inspectedAt,
+      executionId: `root-ct-status:${crypto.randomUUID()}`,
+      createdAt: inspectedAt,
+      profileId: ROOT_GOVERNANCE_CONTEXT_PROFILE.profileId,
+      consume: false,
+    });
+    const state = materialized.snapshot.semanticPayload;
+
+    return {
+      contractVersion: ROOT_COGNITIVE_SPINE_STATUS_CONTRACT,
+      integrationContractVersion: COGNITIVE_SPINE_INTEGRATION_STATUS_CONTRACT,
+      available: true as const,
+      consumed: false as const,
+      inspectedAt,
+      snapshot: {
+        id: materialized.snapshot.snapshotId,
+        hash: materialized.snapshot.snapshotHash,
+        sourceCutoff: state.sourceCutoff,
+        projectorVersion: state.projectorVersion,
+        policyVersion: state.policyVersion,
+        projectionProfile: materialized.profile.profileId,
+        profileVersion: materialized.profile.version,
+      },
+      state: {
+        sources: state.derivedState.sourceCount,
+        evidence: state.evidenceRefs.length,
+        hypotheses: state.hypothesisRefs.length,
+        contradictions: state.contradictionRefs.length,
+        questions: state.questionRefs.length,
+        freezes: state.freezeRefs.length,
+        memory: state.memoryRefs.length,
+        decisions: state.decisionRefs.length,
+        verificationDebt: state.verificationDebt.absolute,
+        normalizedVerificationDebt: state.verificationDebt.normalized,
+        temporalState: state.temporalState,
+        lineageRoot: state.lineageRoot,
+      },
+      surfaces: COGNITIVE_SPINE_SURFACE_INTEGRATIONS.map((entry) => ({
+        surface: entry.surface,
+        profileId: entry.profileId,
+        posture: entry.posture,
+        operationalCtConsumed: entry.operationalCtConsumed,
+        ctRequiredMiddleware: entry.ctRequiredMiddleware,
+      })),
+      claimBoundary: COGNITIVE_SPINE_TECHNICAL_CLAIM_BOUNDARY,
+      warnings: materialized.warnings,
+      internalRefsExposed: false as const,
+    };
+  } catch (error) {
+    return {
+      contractVersion: ROOT_COGNITIVE_SPINE_STATUS_CONTRACT,
+      integrationContractVersion: COGNITIVE_SPINE_INTEGRATION_STATUS_CONTRACT,
+      available: false as const,
+      consumed: false as const,
+      inspectedAt,
+      snapshot: null,
+      state: null,
+      surfaces: COGNITIVE_SPINE_SURFACE_INTEGRATIONS.map((entry) => ({
+        surface: entry.surface,
+        profileId: entry.profileId,
+        posture: entry.posture,
+        operationalCtConsumed: entry.operationalCtConsumed,
+        ctRequiredMiddleware: entry.ctRequiredMiddleware,
+      })),
+      claimBoundary: COGNITIVE_SPINE_TECHNICAL_CLAIM_BOUNDARY,
+      warnings: [`root_cognitive_spine_status_unavailable:${error instanceof Error ? error.message : String(error)}`],
+      internalRefsExposed: false as const,
+    };
+  }
+}

--- a/src/lib/root/cognitiveSpineStatus.ts
+++ b/src/lib/root/cognitiveSpineStatus.ts
@@ -47,7 +47,7 @@ export async function readRootCognitiveSpineStatus() {
         memory: state.memoryRefs.length,
         decisions: state.decisionRefs.length,
         verificationDebt: state.verificationDebt.absolute,
-        normalizedVerificationDebt: state.verificationDebt.normalized,
+        verificationDebtByType: state.verificationDebt.byType,
         temporalState: state.temporalState,
         lineageRoot: state.lineageRoot,
       },


### PR DESCRIPTION
## Scope

Implements the final UI/observability step after `SFI_COGNITIVE_SPINE_TECHNICAL_INTEGRATION = PASS` was merged.

This PR does not change Cognitive Spine semantics, consumption rules, authority, source stores or surface integrations. It adds a ROOT-only aggregate status view.

## Changes

- Adds `SFI-ROOT-CT-STATUS-1.0` aggregate status reader.
- Status materializes `ROOT_GOVERNANCE_CONTEXT_V1` with `consume=false`; viewing status is not cognitive consumption.
- Returns only aggregate counts/semantic identity: snapshot ID/hash, cutoff, source/evidence/hypothesis/contradiction/question/freeze/memory/decision counts, verification debt, temporal state and surface postures.
- Does not expose internal evidence/memory/decision refs.
- CT status failure does not block ROOT; unavailable state remains an explicit gap.
- Adds ROOT-gated `/api/root/cognitive-spine/status` thin endpoint with no-store semantics.
- Adds persistent `CT STATE` status bar inside the ROOT role gate.
- UI performs one initial read plus manual refresh; no automatic polling loop.
- Adds observability QA enforcing ROOT-only access, no CT consumption, no writes, no internal refs and no middleware dependency.
- Extends accumulated Cognitive Spine CI with the observability boundary gate.

## UI semantics

The bar exposes:
- snapshot identity/hash;
- sources;
- evidence;
- active hypotheses;
- contradictions;
- verification debt;
- questions/freezes;
- memory/decisions;
- integrated surface count.

It explicitly states `CT AVAILABLE ≠ CT CONSUMED` and `NO CANONICAL WRITE`.

## Deployment boundary

The semantic core remains Node/local/worker compatible and unchanged. This API/component is a ROOT UI adapter only; Vercel is not required for snapshot identity, projection, hashing or reconstruction.

## Validation target

Must pass the full accumulated Cognitive Spine workflow, observability gate, typecheck and production build before merge.