### PR TITLE
Build SFI Enterprise Assurance Domain V1

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Verify SFI Case Platform Operational V1
         run: npx tsx scripts/qa-sfi-case-platform-operational-v1.ts
 
+      - name: Verify SFI Enterprise Assurance Domain V1
+        run: npx tsx scripts/qa-sfi-enterprise-assurance-domain-v1.ts
+
       - name: Typecheck
         id: typecheck
         shell: bash

--- a/docs/architecture/sfi/SFI-ENTERPRISE-ASSURANCE-DOMAIN-1.0.md
+++ b/docs/architecture/sfi/SFI-ENTERPRISE-ASSURANCE-DOMAIN-1.0.md
@@ -1,0 +1,55 @@
+# SFI Enterprise Assurance Domain 1.0
+
+Status: `OPERATIONAL_BACKEND`
+
+The System Friction Institute (SFI) does not implement Help Desk, Warranty Assurance and Tender Assurance as three independent products. They are service profiles over one tenant-scoped longitudinal domain graph.
+
+```text
+TENDER
+  ↓
+BIDDER / SUPPLIER
+  ↓
+CONTRACT
+  ↓
+OBLIGATION
+  ↓
+ASSET / SERVICE
+  ↓
+TICKET
+  ↓
+SLA
+  ↓
+WARRANTY / WARRANTY EVENT
+  ↓
+RETURN
+  ↓
+SUPPLIER PERFORMANCE
+  ↓
+NEXT TENDER
+```
+
+## Mesa de Ayuda / Service Observability
+
+A ticket is persisted as a record and may be related to an asset, service, SLA and supplier. Ticket recurrence can be represented, but ticket count is not treated as problem count and the intake layer does not infer cause.
+
+## Contract & Warranty Assurance
+
+Warranty events remain records. A warranty event does not automatically constitute contractual breach. Contractual or legal conclusions require an epistemic assessment with determinability and evidence lineage.
+
+## Tender Assurance
+
+Requirements are frozen as source-backed records before evaluation. Requirement-by-bidder assessments are institutional analytical objects, not client assertions. PASS/FAIL requires source + page locator + evidence. Missing evidence yields `UNDETERMINED`, not an invented answer. The assessment has no winner-selection authority.
+
+## Enterprise relation graph
+
+Relations are tenant-scoped and never copied automatically into the institutional SFI graph.
+
+Client-declared relations are `RECORD` only. An inferred relation requires evidence references. Internal analytical relations may be `INFERENCE` or `EPISTEMIC_ASSESSMENT`, but never inherit truth, governance, or institutional-memory authority.
+
+## Supplier performance
+
+Supplier performance may aggregate longitudinal operational evidence, but the domain contract deliberately does not define an automatic composite score or automatic future-bidder ranking. Any weighting/ranking policy must be explicit, governed and fit to the procurement context.
+
+## Current boundary
+
+This block provides persistence contracts, normalized domain records, relation APIs, tenant graph reads and internal tender-assessment semantics. It deliberately does not define Observatory screens, charts or dashboard hierarchy.

--- a/scripts/db/sfi-operational-reset-inventory.mjs
+++ b/scripts/db/sfi-operational-reset-inventory.mjs
@@ -23,8 +23,8 @@ export const PROTECTED_TABLES = [
 
 export const OPERATIONAL_RESET_LAYERS = [
   { id:'operating-cycle-analysis', reason:'Derived cycle layers must be deleted before the cycle identity they reference.', tables:['sfi_artifact_trajectory_events','sfi_inference_traces'] },
-  { id:'case-platform-derived', reason:'Tenant-scoped commercial runtime is cleared child-first while tenant identity and membership survive as access/authority.', tables:['sfi_case_reports','sfi_case_audit_events','sfi_case_objects'] },
-  { id:'case-platform-parent', reason:'Canonical commercial case runtime is removed only after its report, audit and object children.', tables:['sfi_cases'] },
+  { id:'case-platform-derived', reason:'Tenant-scoped commercial runtime is cleared child-first while tenant identity and membership survive as access/authority.', tables:['sfi_case_reports','sfi_case_audit_events','sfi_case_relations','sfi_case_objects'] },
+  { id:'case-platform-parent', reason:'Canonical commercial case runtime is removed only after its report, audit, relation and object children.', tables:['sfi_cases'] },
   { id:'field-return', reason:'Field child records before cases; removes observed test/runtime history only after proof export.', tables:['field_outcomes','field_returns','field_interventions','field_hypotheses','field_mihm_readings','field_moph_runs','field_case_evidence'] },
   { id:'field-participant', reason:'Participant operational capture is longitudinal runtime, not identity/authority.', tables:['field_participant_actions','field_participant_sessions','field_participant_intakes','field_participant_consents','field_participant_profiles'] },
   { id:'field-cases', reason:'Parent Field cases after all child records.', tables:['field_cases'] },

--- a/scripts/qa-sfi-enterprise-assurance-domain-v1.ts
+++ b/scripts/qa-sfi-enterprise-assurance-domain-v1.ts
@@ -1,0 +1,129 @@
+import fs from 'node:fs';
+import assert from 'node:assert/strict';
+import {
+  buildSupplierPerformanceAssessment,
+  enterpriseEntityRef,
+  normalizeServiceTicketRecord,
+  normalizeTenderAssessment,
+  normalizeTenderRequirementRecord,
+  normalizeWarrantyEventRecord,
+  validateEnterpriseRelationDraft,
+} from '../src/core/case-platform';
+import { OPERATIONAL_DELETE_ORDER } from './db/sfi-operational-reset-inventory.mjs';
+
+const read = (path: string) => fs.readFileSync(path, 'utf8');
+const migration = read('supabase/migrations/20260816132000_sfi_enterprise_assurance_graph_v1.sql');
+const clientRelations = read('src/app/api/cases/[caseId]/relations/route.ts');
+const internalObjects = read('src/app/api/cases/[caseId]/internal/objects/route.ts');
+const tenderRoute = read('src/app/api/cases/[caseId]/internal/tender-assessments/route.ts');
+const intakeRoute = read('src/app/api/cases/[caseId]/enterprise/intake/route.ts');
+
+assert(migration.includes('public.sfi_case_relations'));
+assert(migration.includes('sfi_tenant_can_read'));
+assert(migration.includes('sfi_tenant_can_write'));
+assert(!migration.includes('sfi_evidence_ledger'));
+assert(!migration.includes('institutional_memory'));
+assert(!migration.includes('root_'));
+assert(OPERATIONAL_DELETE_ORDER.includes('sfi_case_relations'), 'enterprise relation runtime must be in terminal reset inventory');
+assert(clientRelations.includes("epistemicRole: 'RECORD'"), 'client relation writes must remain RECORD');
+assert(clientRelations.includes('cannot create inferred relations'));
+assert(internalObjects.includes('requireSfiMember'));
+assert(!internalObjects.includes("'GOVERNANCE_DECISION'"), 'internal generic object API must not bypass governance');
+assert(!internalObjects.includes("'INTERVENTION'"), 'internal generic object API must not bypass action gate');
+assert(tenderRoute.includes('requireSfiMember'));
+assert(tenderRoute.includes('winnerSelectionAuthority: false'));
+assert(intakeRoute.includes('does not infer cause'));
+
+const tender = enterpriseEntityRef('TENDER', 'T-001');
+const requirement = normalizeTenderRequirementRecord({
+  requirementId: 'R-001',
+  tenderRef: tender,
+  requirementText: 'Equipo con evidencia documental verificable.',
+  frozenAt: '2026-08-16T12:00:00Z',
+  sourceRefs: [{ id: 'source:tender' }],
+  pageLocator: 'p. 12',
+});
+assert.equal(requirement.object.epistemicRole, 'RECORD');
+assert.equal(requirement.relations[0]?.relationType, 'TENDER_HAS_REQUIREMENT');
+
+const ticket = normalizeServiceTicketRecord({
+  ticketId: 'TK-1',
+  openedAt: '2026-08-16T12:00:00Z',
+  status: 'OPEN',
+  assetRef: enterpriseEntityRef('ASSET', 'A-1'),
+  slaRef: enterpriseEntityRef('SLA', 'SLA-1'),
+  sourceRefs: [{ id: 'source:tickets' }],
+});
+assert.equal(ticket.object.payload.problemIdentityClaimed, false);
+assert(ticket.relations.some((item) => item.relationType === 'TICKET_AFFECTS_ASSET'));
+assert(ticket.relations.some((item) => item.relationType === 'TICKET_SUBJECT_TO_SLA'));
+
+const warranty = normalizeWarrantyEventRecord({
+  eventId: 'W-1',
+  occurredAt: '2026-08-16T12:00:00Z',
+  eventType: 'CLAIM_OPENED',
+  status: 'OPEN',
+  assetRef: enterpriseEntityRef('ASSET', 'A-1'),
+  supplierRef: enterpriseEntityRef('SUPPLIER', 'S-1'),
+});
+assert.equal(warranty.object.payload.contractualBreachDeclared, false);
+
+assert.throws(() => normalizeTenderAssessment({
+  assessmentId: 'A-bad',
+  requirementRef: enterpriseEntityRef('REQUIREMENT', 'R-001'),
+  bidderRef: enterpriseEntityRef('BIDDER', 'B-001'),
+  result: 'PASS',
+  sourceRefs: [{ id: 'source:bidder' }],
+  evidenceRefs: [],
+}), /REQUIRES_PAGE_AND_EVIDENCE/);
+
+const undetermined = normalizeTenderAssessment({
+  assessmentId: 'A-undetermined',
+  requirementRef: enterpriseEntityRef('REQUIREMENT', 'R-001'),
+  bidderRef: enterpriseEntityRef('BIDDER', 'B-001'),
+  result: 'UNDETERMINED',
+  sourceRefs: [{ id: 'source:bidder' }],
+  evidenceRefs: [],
+  missingReason: 'Required technical specification is absent from the supplied package.',
+});
+assert.equal(undetermined.payload.winnerSelectionAuthority, false);
+assert.equal(undetermined.payload.determinability, 'UNDETERMINED');
+
+const badRelation = validateEnterpriseRelationDraft({
+  relationKey: 'bad',
+  relationType: 'TICKET_AFFECTS_ASSET',
+  epistemicRole: 'RECORD',
+  from: enterpriseEntityRef('SUPPLIER', 'S-1'),
+  to: enterpriseEntityRef('ASSET', 'A-1'),
+});
+assert(badRelation.includes('ENTERPRISE_RELATION_FROM_TYPE_MISMATCH:TICKET'));
+
+const inferredWithoutEvidence = validateEnterpriseRelationDraft({
+  relationKey: 'inferred-bad',
+  relationType: 'SUPPLIER_PERFORMANCE_INFORMS_TENDER',
+  epistemicRole: 'INFERENCE',
+  from: enterpriseEntityRef('SUPPLIER_PERFORMANCE', 'SP-1'),
+  to: tender,
+});
+assert(inferredWithoutEvidence.includes('ENTERPRISE_INFERRED_RELATION_REQUIRES_EVIDENCE'));
+
+const supplierPerformance = buildSupplierPerformanceAssessment({
+  assessmentId: 'SP-1',
+  supplierRef: enterpriseEntityRef('SUPPLIER', 'S-1'),
+  evidenceRefs: [{ id: 'evidence:service-history' }],
+  recordRefs: [{ id: 'record:return-1' }],
+  metrics: { slaComplianceRate: 0.92, warrantyResolutionRate: 0.84 },
+});
+assert.equal(supplierPerformance.payload.compositeScore, null);
+assert.equal(supplierPerformance.payload.futureTenderDecisionAuthority, false);
+
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-ENTERPRISE-ASSURANCE-DOMAIN-1.0',
+  chain: 'TENDER→SUPPLIER→CONTRACT→ASSET/SERVICE→TICKET/SLA→WARRANTY→RETURN→SUPPLIER_PERFORMANCE→NEXT_TENDER',
+  clientRelations: 'RECORD_ONLY',
+  tenderWinnerAuthority: false,
+  automaticBreachDeclaration: false,
+  automaticSupplierRanking: false,
+  tenantGraphEqualsInstitutionalGraph: false,
+}, null, 2));

--- a/scripts/qa-sfi-operational-reset.ts
+++ b/scripts/qa-sfi-operational-reset.ts
@@ -17,7 +17,7 @@ const requiredRuntimeTables=[
   'root_evidence_entries','epistemic_events','sfi_evidence_ledger','graph_nodes','graph_edges',
   'sfi_cognitive_twin_memory','sfi_cognitive_twin_decisions','sfi_cognitive_twin_evaluations','sfi_cognitive_twin_runs',
   'sfi_operating_cycles','sfi_inference_traces','sfi_artifact_trajectory_events','sfi_lab_analyses',
-  'sfi_cases','sfi_case_objects','sfi_case_reports','sfi_case_audit_events',
+  'sfi_cases','sfi_case_objects','sfi_case_relations','sfi_case_reports','sfi_case_audit_events',
   'field_cases','field_case_evidence','field_moph_runs','field_mihm_readings','field_hypotheses','field_interventions','field_returns','field_outcomes',
   'studio_sessions','studio_objects','studio_uploads','studio_analysis_jobs','studio_audio_features','action_proposals','logbook_mutations',
 ];
@@ -49,7 +49,7 @@ console.log(JSON.stringify({ok:true,purgeTableCount:OPERATIONAL_DELETE_ORDER.len
   'full-cycle proof/export precedes reset',
   'runtime history is cleared child-first',
   'identity/access/authority including tenant membership are protected',
-  'Case Platform runtime is cleared while tenant identity survives',
+  'Case Platform objects, relations, reports and cases are cleared while tenant identity survives',
   'WorldSpect longitudinal observation corpus survives genesis',
   'optional/missing tables are skipped instead of making the reset unsafe',
   'empty post-reset organs report READY rather than DEGRADED',

--- a/src/app/api/cases/[caseId]/enterprise/intake/route.ts
+++ b/src/app/api/cases/[caseId]/enterprise/intake/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAuthenticatedUser } from '@/lib/system/access/server';
+import {
+  enterpriseEntityRef,
+  normalizeEnterpriseEntityRecord,
+  normalizeServiceTicketRecord,
+  normalizeTenderRequirementRecord,
+  normalizeWarrantyEventRecord,
+  type SfiEnterpriseIntakePackage,
+} from '@/core/case-platform';
+import { recordOperationalCaseObject } from '@/lib/sfi/case-platform/repository';
+import { recordOperationalEnterpriseRelation } from '@/lib/sfi/case-platform/enterpriseRepository';
+import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const refSchema = z.object({ id: z.string().trim().min(1).max(500), version: z.string().trim().max(120).nullable().optional(), hash: z.string().trim().max(256).nullable().optional() }).strict();
+const entityTypeSchema = z.enum(['TENDER','REQUIREMENT','BIDDER','BID_SUBMISSION','SUPPLIER','CONTRACT','OBLIGATION','ASSET','SERVICE','TICKET','SLA','WARRANTY','WARRANTY_EVENT','RETURN','SUPPLIER_PERFORMANCE']);
+const entityRefSchema = refSchema.extend({ entityType: entityTypeSchema }).strict();
+
+const entitySchema = z.object({ type: z.literal('ENTITY'), entityType: entityTypeSchema, entityId: z.string().trim().min(1).max(240), label: z.string().trim().max(500).nullable().optional(), attributes: z.record(z.string(), z.unknown()).optional(), observedAt: z.string().trim().max(80).nullable().optional(), sourceRefs: z.array(refSchema).max(500).optional() }).strict();
+const ticketSchema = z.object({ type: z.literal('SERVICE_TICKET'), ticketId: z.string().trim().min(1).max(240), openedAt: z.string().trim().min(1).max(80), closedAt: z.string().trim().max(80).nullable().optional(), status: z.string().trim().min(1).max(120), category: z.string().trim().max(240).nullable().optional(), priority: z.string().trim().max(120).nullable().optional(), responseMinutes: z.number().nonnegative().nullable().optional(), resolutionMinutes: z.number().nonnegative().nullable().optional(), recurrenceKey: z.string().trim().max(240).nullable().optional(), assetRef: entityRefSchema.nullable().optional(), serviceRef: entityRefSchema.nullable().optional(), slaRef: entityRefSchema.nullable().optional(), supplierRef: entityRefSchema.nullable().optional(), sourceRefs: z.array(refSchema).max(500).optional() }).strict();
+const warrantySchema = z.object({ type: z.literal('WARRANTY_EVENT'), eventId: z.string().trim().min(1).max(240), occurredAt: z.string().trim().min(1).max(80), eventType: z.string().trim().min(1).max(160), status: z.string().trim().min(1).max(120), assetRef: entityRefSchema, warrantyRef: entityRefSchema.nullable().optional(), supplierRef: entityRefSchema.nullable().optional(), responseDueAt: z.string().trim().max(80).nullable().optional(), resolvedAt: z.string().trim().max(80).nullable().optional(), sourceRefs: z.array(refSchema).max(500).optional() }).strict();
+const tenderRequirementSchema = z.object({ type: z.literal('TENDER_REQUIREMENT'), requirementId: z.string().trim().min(1).max(240), tenderRef: entityRefSchema, requirementText: z.string().trim().min(1).max(12000), requirementType: z.string().trim().max(240).nullable().optional(), frozenAt: z.string().trim().min(1).max(80), sourceRefs: z.array(refSchema).min(1).max(500), pageLocator: z.string().trim().max(240).nullable().optional() }).strict();
+const intakeSchema = z.discriminatedUnion('type', [entitySchema, ticketSchema, warrantySchema, tenderRequirementSchema]);
+
+type RouteContext = { params: Promise<{ caseId: string }> };
+
+async function persistPackage(caseId: string, userId: string, packet: SfiEnterpriseIntakePackage) {
+  const object = await recordOperationalCaseObject({ caseId, userId, ...packet.object });
+  const relations = [];
+  for (const relation of packet.relations) relations.push(await recordOperationalEnterpriseRelation({ caseId, userId, relation }));
+  return { object, relations };
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const { caseId } = await context.params;
+    const body = intakeSchema.parse(await request.json());
+    let packet: SfiEnterpriseIntakePackage;
+    if (body.type === 'ENTITY') {
+      packet = normalizeEnterpriseEntityRecord(body);
+    } else if (body.type === 'SERVICE_TICKET') {
+      packet = normalizeServiceTicketRecord(body);
+    } else if (body.type === 'WARRANTY_EVENT') {
+      packet = normalizeWarrantyEventRecord(body);
+    } else {
+      packet = normalizeTenderRequirementRecord(body);
+    }
+    const result = await persistPackage(caseId, user.id, packet);
+    return NextResponse.json({
+      ok: true,
+      contract: packet.contract,
+      ...result,
+      boundary: 'Enterprise intake persists records and declared relations only. It does not infer cause, contractual breach, tender winner, supplier rank, or SFI institutional truth.',
+    }, { status: 201 });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}

--- a/src/app/api/cases/[caseId]/internal/objects/route.ts
+++ b/src/app/api/cases/[caseId]/internal/objects/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireSfiMember } from '@/lib/system/access/server';
+import { recordOperationalCaseObject } from '@/lib/sfi/case-platform/repository';
+import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
+import type { SfiCaseObjectKind } from '@/core/case-platform';
+import type { SfiEpistemicClass } from '@/core/contracts/sfi';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const refSchema = z.object({ id: z.string().trim().min(1).max(500), version: z.string().trim().max(120).nullable().optional(), hash: z.string().trim().max(256).nullable().optional() }).strict();
+const schema = z.object({
+  kind: z.enum(['RECORD','EVIDENCE','SYSTEM_MODEL','OBSERVATION','FRICTION','PERTURBATION','TRAJECTORY','ATTRACTOR','EPISTEMIC_ASSESSMENT','HYPOTHESIS','INSTRUMENT_RUN','ANALYSIS','RECOMMENDATION','UNRESOLVED_QUESTION','CONTRADICTION']),
+  epistemicRole: z.enum(['RECORD','EVIDENCE','EPISTEMIC_ASSESSMENT','INFERENCE','SIMULATION','PROJECTION','COGNITIVE_EXECUTION']),
+  canonicalRef: refSchema,
+  sourceRefs: z.array(refSchema).max(500).optional(),
+  recordRefs: z.array(refSchema).max(500).optional(),
+  evidenceRefs: z.array(refSchema).max(500).optional(),
+  payload: z.record(z.string(), z.unknown()).optional(),
+  observedAt: z.string().trim().max(80).nullable().optional(),
+}).strict();
+
+type RouteContext = { params: Promise<{ caseId: string }> };
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { user } = await requireSfiMember();
+    const { caseId } = await context.params;
+    const body = schema.parse(await request.json());
+    const object = await recordOperationalCaseObject({
+      caseId,
+      userId: user.id,
+      kind: body.kind as SfiCaseObjectKind,
+      epistemicRole: body.epistemicRole as SfiEpistemicClass,
+      canonicalRef: body.canonicalRef,
+      sourceRefs: body.sourceRefs,
+      recordRefs: body.recordRefs,
+      evidenceRefs: body.evidenceRefs,
+      payload: body.payload,
+      observedAt: body.observedAt,
+    });
+    return NextResponse.json({
+      ok: true,
+      object,
+      boundary: 'Internal assessment can persist evidence/analysis only under existing lineage checks. It cannot create governance decisions, interventions, truth claims, or institutional-memory writes.',
+    }, { status: 201 });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}

--- a/src/app/api/cases/[caseId]/internal/relations/route.ts
+++ b/src/app/api/cases/[caseId]/internal/relations/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireSfiMember } from '@/lib/system/access/server';
+import { recordOperationalEnterpriseRelation } from '@/lib/sfi/case-platform/enterpriseRepository';
+import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
+import type { SfiEnterpriseRelationDraft } from '@/core/case-platform';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const canonicalRefSchema = z.object({ id: z.string().trim().min(1).max(500), version: z.string().trim().max(120).nullable().optional(), hash: z.string().trim().max(256).nullable().optional() }).strict();
+const entityTypeSchema = z.enum(['TENDER','REQUIREMENT','BIDDER','BID_SUBMISSION','SUPPLIER','CONTRACT','OBLIGATION','ASSET','SERVICE','TICKET','SLA','WARRANTY','WARRANTY_EVENT','RETURN','SUPPLIER_PERFORMANCE']);
+const entityRefSchema = canonicalRefSchema.extend({ entityType: entityTypeSchema }).strict();
+const relationTypeSchema = z.enum(['TENDER_HAS_REQUIREMENT','BIDDER_PARTICIPATES_IN_TENDER','BID_SUBMISSION_FOR_TENDER','BID_SUBMISSION_BY_BIDDER','BIDDER_MAPS_TO_SUPPLIER','TENDER_AWARDS_SUPPLIER','CONTRACT_ARISES_FROM_TENDER','CONTRACT_BINDS_SUPPLIER','CONTRACT_DEFINES_OBLIGATION','CONTRACT_COVERS_ASSET','CONTRACT_COVERS_SERVICE','ASSET_PROVIDED_BY_SUPPLIER','SERVICE_PROVIDED_BY_SUPPLIER','TICKET_AFFECTS_ASSET','TICKET_AFFECTS_SERVICE','TICKET_SUBJECT_TO_SLA','TICKET_ASSIGNED_TO_SUPPLIER','SLA_DERIVED_FROM_CONTRACT','WARRANTY_DEFINED_BY_CONTRACT','WARRANTY_COVERS_ASSET','WARRANTY_EVENT_AFFECTS_ASSET','WARRANTY_EVENT_UNDER_WARRANTY','WARRANTY_EVENT_ASSIGNED_TO_SUPPLIER','TICKET_TRIGGERS_WARRANTY_EVENT','RETURN_RESOLVES_WARRANTY_EVENT','RETURN_CLOSES_TICKET','SUPPLIER_PERFORMANCE_AGGREGATES_RETURN','SUPPLIER_PERFORMANCE_INFORMS_TENDER']);
+const relationSchema = z.object({
+  relationKey: z.string().trim().min(1).max(500),
+  relationType: relationTypeSchema,
+  epistemicRole: z.enum(['RECORD','INFERENCE','EPISTEMIC_ASSESSMENT']),
+  from: entityRefSchema,
+  to: entityRefSchema,
+  sourceRefs: z.array(canonicalRefSchema).max(500).optional(),
+  recordRefs: z.array(canonicalRefSchema).max(500).optional(),
+  evidenceRefs: z.array(canonicalRefSchema).max(500).optional(),
+  payload: z.record(z.string(), z.unknown()).optional(),
+  observedAt: z.string().trim().max(80).nullable().optional(),
+}).strict();
+
+type RouteContext = { params: Promise<{ caseId: string }> };
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { user } = await requireSfiMember();
+    const { caseId } = await context.params;
+    const body = relationSchema.parse(await request.json());
+    const relation = await recordOperationalEnterpriseRelation({ caseId, userId: user.id, relation: body as SfiEnterpriseRelationDraft });
+    return NextResponse.json({ ok: true, relation, truthAuthority: false, institutionalGraphWrite: false }, { status: 201 });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}

--- a/src/app/api/cases/[caseId]/internal/tender-assessments/route.ts
+++ b/src/app/api/cases/[caseId]/internal/tender-assessments/route.ts
@@ -9,11 +9,12 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 const refSchema = z.object({ id: z.string().trim().min(1).max(500), version: z.string().trim().max(120).nullable().optional(), hash: z.string().trim().max(256).nullable().optional() }).strict();
-const entityRefSchema = refSchema.extend({ entityType: z.enum(['REQUIREMENT','BIDDER']) }).strict();
+const requirementRefSchema = refSchema.extend({ entityType: z.literal('REQUIREMENT') }).strict();
+const bidderRefSchema = refSchema.extend({ entityType: z.literal('BIDDER') }).strict();
 const schema = z.object({
   assessmentId: z.string().trim().min(1).max(240),
-  requirementRef: entityRefSchema,
-  bidderRef: entityRefSchema,
+  requirementRef: requirementRefSchema,
+  bidderRef: bidderRefSchema,
   result: z.enum(['PASS','FAIL','UNDETERMINED']),
   sourceRefs: z.array(refSchema).min(1).max(500),
   recordRefs: z.array(refSchema).max(500).optional(),

--- a/src/app/api/cases/[caseId]/internal/tender-assessments/route.ts
+++ b/src/app/api/cases/[caseId]/internal/tender-assessments/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireSfiMember } from '@/lib/system/access/server';
+import { normalizeTenderAssessment } from '@/core/case-platform';
+import { recordOperationalCaseObject } from '@/lib/sfi/case-platform/repository';
+import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const refSchema = z.object({ id: z.string().trim().min(1).max(500), version: z.string().trim().max(120).nullable().optional(), hash: z.string().trim().max(256).nullable().optional() }).strict();
+const entityRefSchema = refSchema.extend({ entityType: z.enum(['REQUIREMENT','BIDDER']) }).strict();
+const schema = z.object({
+  assessmentId: z.string().trim().min(1).max(240),
+  requirementRef: entityRefSchema,
+  bidderRef: entityRefSchema,
+  result: z.enum(['PASS','FAIL','UNDETERMINED']),
+  sourceRefs: z.array(refSchema).min(1).max(500),
+  recordRefs: z.array(refSchema).max(500).optional(),
+  evidenceRefs: z.array(refSchema).max(500).optional(),
+  pageLocator: z.string().trim().max(240).nullable().optional(),
+  confidence: z.number().min(0).max(1).nullable().optional(),
+  missingReason: z.string().trim().max(2000).nullable().optional(),
+  contradictionRefs: z.array(refSchema).max(500).optional(),
+}).strict();
+
+type RouteContext = { params: Promise<{ caseId: string }> };
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { user } = await requireSfiMember();
+    const { caseId } = await context.params;
+    const body = schema.parse(await request.json());
+    const assessment = normalizeTenderAssessment(body as Parameters<typeof normalizeTenderAssessment>[0]);
+    const object = await recordOperationalCaseObject({ caseId, userId: user.id, ...assessment });
+    return NextResponse.json({
+      ok: true,
+      assessment: object,
+      winnerSelectionAuthority: false,
+      humanDecisionAuthorityPreserved: true,
+    }, { status: 201 });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}

--- a/src/app/api/cases/[caseId]/relations/route.ts
+++ b/src/app/api/cases/[caseId]/relations/route.ts
@@ -43,7 +43,7 @@ export async function POST(request: Request, context: RouteContext) {
     const body = relationSchema.parse(await request.json());
     const relation: SfiEnterpriseRelationDraft = { ...body, evidenceRefs: [], epistemicRole: 'RECORD' } as SfiEnterpriseRelationDraft;
     const saved = await recordOperationalEnterpriseRelation({ caseId, userId: user.id, relation });
-    return NextResponse.json({ ok: true, relation: saved, epistemicBoundary: 'Client-declared relations remain RECORD and cannot attach evidence claims or create inferred relations.' }, { status: 201 });
+    return NextResponse.json({ ok: true, relation: saved, epistemicBoundary: 'Client-declared relations remain RECORD; this endpoint cannot create inferred relations or attach evidence claims.' }, { status: 201 });
   } catch (error) {
     return sfiCaseApiFailure(error);
   }

--- a/src/app/api/cases/[caseId]/relations/route.ts
+++ b/src/app/api/cases/[caseId]/relations/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAuthenticatedUser } from '@/lib/system/access/server';
+import { listOperationalEnterpriseRelations, recordOperationalEnterpriseRelation } from '@/lib/sfi/case-platform/enterpriseRepository';
+import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
+import type { SfiEnterpriseRelationDraft } from '@/core/case-platform';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const canonicalRefSchema = z.object({ id: z.string().trim().min(1).max(500), version: z.string().trim().max(120).nullable().optional(), hash: z.string().trim().max(256).nullable().optional() }).strict();
+const entityTypeSchema = z.enum(['TENDER','REQUIREMENT','BIDDER','BID_SUBMISSION','SUPPLIER','CONTRACT','OBLIGATION','ASSET','SERVICE','TICKET','SLA','WARRANTY','WARRANTY_EVENT','RETURN','SUPPLIER_PERFORMANCE']);
+const entityRefSchema = canonicalRefSchema.extend({ entityType: entityTypeSchema }).strict();
+const relationTypeSchema = z.enum(['TENDER_HAS_REQUIREMENT','BIDDER_PARTICIPATES_IN_TENDER','BID_SUBMISSION_FOR_TENDER','BID_SUBMISSION_BY_BIDDER','BIDDER_MAPS_TO_SUPPLIER','TENDER_AWARDS_SUPPLIER','CONTRACT_ARISES_FROM_TENDER','CONTRACT_BINDS_SUPPLIER','CONTRACT_DEFINES_OBLIGATION','CONTRACT_COVERS_ASSET','CONTRACT_COVERS_SERVICE','ASSET_PROVIDED_BY_SUPPLIER','SERVICE_PROVIDED_BY_SUPPLIER','TICKET_AFFECTS_ASSET','TICKET_AFFECTS_SERVICE','TICKET_SUBJECT_TO_SLA','TICKET_ASSIGNED_TO_SUPPLIER','SLA_DERIVED_FROM_CONTRACT','WARRANTY_DEFINED_BY_CONTRACT','WARRANTY_COVERS_ASSET','WARRANTY_EVENT_AFFECTS_ASSET','WARRANTY_EVENT_UNDER_WARRANTY','WARRANTY_EVENT_ASSIGNED_TO_SUPPLIER','TICKET_TRIGGERS_WARRANTY_EVENT','RETURN_RESOLVES_WARRANTY_EVENT','RETURN_CLOSES_TICKET','SUPPLIER_PERFORMANCE_AGGREGATES_RETURN','SUPPLIER_PERFORMANCE_INFORMS_TENDER']);
+const relationSchema = z.object({
+  relationKey: z.string().trim().min(1).max(500),
+  relationType: relationTypeSchema,
+  from: entityRefSchema,
+  to: entityRefSchema,
+  sourceRefs: z.array(canonicalRefSchema).max(500).optional(),
+  recordRefs: z.array(canonicalRefSchema).max(500).optional(),
+  evidenceRefs: z.array(canonicalRefSchema).max(500).optional(),
+  payload: z.record(z.string(), z.unknown()).optional(),
+  observedAt: z.string().trim().max(80).nullable().optional(),
+}).strict();
+
+type RouteContext = { params: Promise<{ caseId: string }> };
+
+export async function GET(_: Request, context: RouteContext) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const { caseId } = await context.params;
+    const relations = await listOperationalEnterpriseRelations(caseId, user.id);
+    return NextResponse.json({ ok: true, contract: 'SFI-ENTERPRISE-ASSURANCE-DOMAIN-1.0', relations });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const { caseId } = await context.params;
+    const body = relationSchema.parse(await request.json());
+    const relation: SfiEnterpriseRelationDraft = { ...body, epistemicRole: 'RECORD' } as SfiEnterpriseRelationDraft;
+    const saved = await recordOperationalEnterpriseRelation({ caseId, userId: user.id, relation });
+    return NextResponse.json({ ok: true, relation: saved, epistemicBoundary: 'Client-declared relations remain RECORD; this endpoint cannot create inferred relations.' }, { status: 201 });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}

--- a/src/app/api/cases/[caseId]/relations/route.ts
+++ b/src/app/api/cases/[caseId]/relations/route.ts
@@ -19,7 +19,6 @@ const relationSchema = z.object({
   to: entityRefSchema,
   sourceRefs: z.array(canonicalRefSchema).max(500).optional(),
   recordRefs: z.array(canonicalRefSchema).max(500).optional(),
-  evidenceRefs: z.array(canonicalRefSchema).max(500).optional(),
   payload: z.record(z.string(), z.unknown()).optional(),
   observedAt: z.string().trim().max(80).nullable().optional(),
 }).strict();
@@ -42,9 +41,9 @@ export async function POST(request: Request, context: RouteContext) {
     const { user } = await requireAuthenticatedUser();
     const { caseId } = await context.params;
     const body = relationSchema.parse(await request.json());
-    const relation: SfiEnterpriseRelationDraft = { ...body, epistemicRole: 'RECORD' } as SfiEnterpriseRelationDraft;
+    const relation: SfiEnterpriseRelationDraft = { ...body, evidenceRefs: [], epistemicRole: 'RECORD' } as SfiEnterpriseRelationDraft;
     const saved = await recordOperationalEnterpriseRelation({ caseId, userId: user.id, relation });
-    return NextResponse.json({ ok: true, relation: saved, epistemicBoundary: 'Client-declared relations remain RECORD; this endpoint cannot create inferred relations.' }, { status: 201 });
+    return NextResponse.json({ ok: true, relation: saved, epistemicBoundary: 'Client-declared relations remain RECORD and cannot attach evidence claims or create inferred relations.' }, { status: 201 });
   } catch (error) {
     return sfiCaseApiFailure(error);
   }

--- a/src/app/api/cases/tenants/[tenantId]/enterprise-relations/route.ts
+++ b/src/app/api/cases/tenants/[tenantId]/enterprise-relations/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { requireAuthenticatedUser } from '@/lib/system/access/server';
+import { listTenantEnterpriseRelations } from '@/lib/sfi/case-platform/enterpriseRepository';
+import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+type RouteContext = { params: Promise<{ tenantId: string }> };
+
+export async function GET(_: Request, context: RouteContext) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const { tenantId } = await context.params;
+    const relations = await listTenantEnterpriseRelations(tenantId, user.id);
+    return NextResponse.json({
+      ok: true,
+      contract: 'SFI-ENTERPRISE-ASSURANCE-DOMAIN-1.0',
+      tenantId,
+      relations,
+      boundary: 'Tenant enterprise graph ≠ institutional SFI graph.',
+    });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}

--- a/src/core/case-platform/enterpriseAssurance.ts
+++ b/src/core/case-platform/enterpriseAssurance.ts
@@ -1,0 +1,436 @@
+import type { SfiCanonicalRef, SfiEpistemicClass } from '../contracts/sfi';
+import type { SfiCaseObjectKind } from './operational';
+
+export const SFI_ENTERPRISE_ASSURANCE_DOMAIN_CONTRACT = 'SFI-ENTERPRISE-ASSURANCE-DOMAIN-1.0' as const;
+
+export const SFI_ENTERPRISE_ENTITY_TYPES = [
+  'TENDER',
+  'REQUIREMENT',
+  'BIDDER',
+  'BID_SUBMISSION',
+  'SUPPLIER',
+  'CONTRACT',
+  'OBLIGATION',
+  'ASSET',
+  'SERVICE',
+  'TICKET',
+  'SLA',
+  'WARRANTY',
+  'WARRANTY_EVENT',
+  'RETURN',
+  'SUPPLIER_PERFORMANCE',
+] as const;
+
+export type SfiEnterpriseEntityType = (typeof SFI_ENTERPRISE_ENTITY_TYPES)[number];
+
+export const SFI_ENTERPRISE_RELATION_TYPES = [
+  'TENDER_HAS_REQUIREMENT',
+  'BIDDER_PARTICIPATES_IN_TENDER',
+  'BID_SUBMISSION_FOR_TENDER',
+  'BID_SUBMISSION_BY_BIDDER',
+  'BIDDER_MAPS_TO_SUPPLIER',
+  'TENDER_AWARDS_SUPPLIER',
+  'CONTRACT_ARISES_FROM_TENDER',
+  'CONTRACT_BINDS_SUPPLIER',
+  'CONTRACT_DEFINES_OBLIGATION',
+  'CONTRACT_COVERS_ASSET',
+  'CONTRACT_COVERS_SERVICE',
+  'ASSET_PROVIDED_BY_SUPPLIER',
+  'SERVICE_PROVIDED_BY_SUPPLIER',
+  'TICKET_AFFECTS_ASSET',
+  'TICKET_AFFECTS_SERVICE',
+  'TICKET_SUBJECT_TO_SLA',
+  'TICKET_ASSIGNED_TO_SUPPLIER',
+  'SLA_DERIVED_FROM_CONTRACT',
+  'WARRANTY_DEFINED_BY_CONTRACT',
+  'WARRANTY_COVERS_ASSET',
+  'WARRANTY_EVENT_AFFECTS_ASSET',
+  'WARRANTY_EVENT_UNDER_WARRANTY',
+  'WARRANTY_EVENT_ASSIGNED_TO_SUPPLIER',
+  'TICKET_TRIGGERS_WARRANTY_EVENT',
+  'RETURN_RESOLVES_WARRANTY_EVENT',
+  'RETURN_CLOSES_TICKET',
+  'SUPPLIER_PERFORMANCE_AGGREGATES_RETURN',
+  'SUPPLIER_PERFORMANCE_INFORMS_TENDER',
+] as const;
+
+export type SfiEnterpriseRelationType = (typeof SFI_ENTERPRISE_RELATION_TYPES)[number];
+export type SfiEnterpriseRelationEpistemicRole = Extract<SfiEpistemicClass, 'RECORD' | 'INFERENCE' | 'EPISTEMIC_ASSESSMENT'>;
+
+export type SfiEnterpriseEntityRef = SfiCanonicalRef & {
+  entityType: SfiEnterpriseEntityType;
+};
+
+export type SfiEnterpriseRelationDraft = {
+  relationKey: string;
+  relationType: SfiEnterpriseRelationType;
+  epistemicRole: SfiEnterpriseRelationEpistemicRole;
+  from: SfiEnterpriseEntityRef;
+  to: SfiEnterpriseEntityRef;
+  sourceRefs?: SfiCanonicalRef[];
+  recordRefs?: SfiCanonicalRef[];
+  evidenceRefs?: SfiCanonicalRef[];
+  payload?: Record<string, unknown>;
+  observedAt?: string | null;
+};
+
+export type SfiEnterpriseCaseObjectInput = {
+  kind: SfiCaseObjectKind;
+  epistemicRole: SfiEpistemicClass;
+  canonicalRef: SfiCanonicalRef;
+  sourceRefs?: SfiCanonicalRef[];
+  recordRefs?: SfiCanonicalRef[];
+  evidenceRefs?: SfiCanonicalRef[];
+  payload: Record<string, unknown>;
+  observedAt?: string | null;
+};
+
+export type SfiEnterpriseIntakePackage = {
+  contract: typeof SFI_ENTERPRISE_ASSURANCE_DOMAIN_CONTRACT;
+  object: SfiEnterpriseCaseObjectInput;
+  relations: SfiEnterpriseRelationDraft[];
+};
+
+type EndpointSpec = readonly [SfiEnterpriseEntityType, SfiEnterpriseEntityType];
+
+const ENDPOINTS: Record<SfiEnterpriseRelationType, EndpointSpec> = {
+  TENDER_HAS_REQUIREMENT: ['TENDER', 'REQUIREMENT'],
+  BIDDER_PARTICIPATES_IN_TENDER: ['BIDDER', 'TENDER'],
+  BID_SUBMISSION_FOR_TENDER: ['BID_SUBMISSION', 'TENDER'],
+  BID_SUBMISSION_BY_BIDDER: ['BID_SUBMISSION', 'BIDDER'],
+  BIDDER_MAPS_TO_SUPPLIER: ['BIDDER', 'SUPPLIER'],
+  TENDER_AWARDS_SUPPLIER: ['TENDER', 'SUPPLIER'],
+  CONTRACT_ARISES_FROM_TENDER: ['CONTRACT', 'TENDER'],
+  CONTRACT_BINDS_SUPPLIER: ['CONTRACT', 'SUPPLIER'],
+  CONTRACT_DEFINES_OBLIGATION: ['CONTRACT', 'OBLIGATION'],
+  CONTRACT_COVERS_ASSET: ['CONTRACT', 'ASSET'],
+  CONTRACT_COVERS_SERVICE: ['CONTRACT', 'SERVICE'],
+  ASSET_PROVIDED_BY_SUPPLIER: ['ASSET', 'SUPPLIER'],
+  SERVICE_PROVIDED_BY_SUPPLIER: ['SERVICE', 'SUPPLIER'],
+  TICKET_AFFECTS_ASSET: ['TICKET', 'ASSET'],
+  TICKET_AFFECTS_SERVICE: ['TICKET', 'SERVICE'],
+  TICKET_SUBJECT_TO_SLA: ['TICKET', 'SLA'],
+  TICKET_ASSIGNED_TO_SUPPLIER: ['TICKET', 'SUPPLIER'],
+  SLA_DERIVED_FROM_CONTRACT: ['SLA', 'CONTRACT'],
+  WARRANTY_DEFINED_BY_CONTRACT: ['WARRANTY', 'CONTRACT'],
+  WARRANTY_COVERS_ASSET: ['WARRANTY', 'ASSET'],
+  WARRANTY_EVENT_AFFECTS_ASSET: ['WARRANTY_EVENT', 'ASSET'],
+  WARRANTY_EVENT_UNDER_WARRANTY: ['WARRANTY_EVENT', 'WARRANTY'],
+  WARRANTY_EVENT_ASSIGNED_TO_SUPPLIER: ['WARRANTY_EVENT', 'SUPPLIER'],
+  TICKET_TRIGGERS_WARRANTY_EVENT: ['TICKET', 'WARRANTY_EVENT'],
+  RETURN_RESOLVES_WARRANTY_EVENT: ['RETURN', 'WARRANTY_EVENT'],
+  RETURN_CLOSES_TICKET: ['RETURN', 'TICKET'],
+  SUPPLIER_PERFORMANCE_AGGREGATES_RETURN: ['SUPPLIER_PERFORMANCE', 'RETURN'],
+  SUPPLIER_PERFORMANCE_INFORMS_TENDER: ['SUPPLIER_PERFORMANCE', 'TENDER'],
+};
+
+function requireText(value: string, field: string) {
+  const normalized = value.trim();
+  if (!normalized) throw new Error(`SFI_ENTERPRISE_INVALID:${field}`);
+  return normalized;
+}
+
+function dateOrNull(value: string | null | undefined, field: string) {
+  const normalized = value?.trim() || null;
+  if (normalized && Number.isNaN(Date.parse(normalized))) throw new Error(`SFI_ENTERPRISE_INVALID:${field}`);
+  return normalized;
+}
+
+function nonNegativeNumber(value: number | null | undefined, field: string) {
+  if (value === null || typeof value === 'undefined') return null;
+  if (!Number.isFinite(value) || value < 0) throw new Error(`SFI_ENTERPRISE_INVALID:${field}`);
+  return value;
+}
+
+export function enterpriseEntityRef(entityType: SfiEnterpriseEntityType, id: string): SfiEnterpriseEntityRef {
+  return {
+    entityType,
+    id: `enterprise:${entityType}:${requireText(id, 'entityId')}`,
+    version: '1.0',
+    hash: null,
+  };
+}
+
+export function validateEnterpriseRelationDraft(draft: SfiEnterpriseRelationDraft): string[] {
+  const violations: string[] = [];
+  if (!draft.relationKey.trim()) violations.push('ENTERPRISE_RELATION_KEY_REQUIRED');
+  const expected = ENDPOINTS[draft.relationType];
+  if (!expected) violations.push('ENTERPRISE_RELATION_TYPE_UNKNOWN');
+  if (expected && draft.from.entityType !== expected[0]) {
+    violations.push(`ENTERPRISE_RELATION_FROM_TYPE_MISMATCH:${expected[0]}`);
+  }
+  if (expected && draft.to.entityType !== expected[1]) {
+    violations.push(`ENTERPRISE_RELATION_TO_TYPE_MISMATCH:${expected[1]}`);
+  }
+  if (!draft.from.id.trim() || !draft.to.id.trim()) violations.push('ENTERPRISE_RELATION_ENDPOINT_REQUIRED');
+  if (draft.epistemicRole === 'INFERENCE' && (draft.evidenceRefs?.length ?? 0) === 0) {
+    violations.push('ENTERPRISE_INFERRED_RELATION_REQUIRES_EVIDENCE');
+  }
+  if (draft.observedAt && Number.isNaN(Date.parse(draft.observedAt))) {
+    violations.push('ENTERPRISE_RELATION_OBSERVED_AT_INVALID');
+  }
+  return violations;
+}
+
+function relation(input: Omit<SfiEnterpriseRelationDraft, 'epistemicRole'> & { epistemicRole?: SfiEnterpriseRelationEpistemicRole }): SfiEnterpriseRelationDraft {
+  const draft: SfiEnterpriseRelationDraft = { ...input, epistemicRole: input.epistemicRole ?? 'RECORD' };
+  const violations = validateEnterpriseRelationDraft(draft);
+  if (violations.length) throw new Error(`SFI_ENTERPRISE_RELATION_INVALID:${violations.join(',')}`);
+  return draft;
+}
+
+export function normalizeEnterpriseEntityRecord(input: {
+  entityType: SfiEnterpriseEntityType;
+  entityId: string;
+  label?: string | null;
+  attributes?: Record<string, unknown>;
+  observedAt?: string | null;
+  sourceRefs?: SfiCanonicalRef[];
+}): SfiEnterpriseIntakePackage {
+  const ref = enterpriseEntityRef(input.entityType, input.entityId);
+  return {
+    contract: SFI_ENTERPRISE_ASSURANCE_DOMAIN_CONTRACT,
+    object: {
+      kind: 'RECORD',
+      epistemicRole: 'RECORD',
+      canonicalRef: ref,
+      sourceRefs: input.sourceRefs ?? [],
+      payload: {
+        entityType: input.entityType,
+        label: input.label?.trim() || null,
+        attributes: input.attributes ?? {},
+      },
+      observedAt: dateOrNull(input.observedAt, 'observedAt'),
+    },
+    relations: [],
+  };
+}
+
+export function normalizeServiceTicketRecord(input: {
+  ticketId: string;
+  openedAt: string;
+  closedAt?: string | null;
+  status: string;
+  category?: string | null;
+  priority?: string | null;
+  responseMinutes?: number | null;
+  resolutionMinutes?: number | null;
+  recurrenceKey?: string | null;
+  assetRef?: SfiEnterpriseEntityRef | null;
+  serviceRef?: SfiEnterpriseEntityRef | null;
+  slaRef?: SfiEnterpriseEntityRef | null;
+  supplierRef?: SfiEnterpriseEntityRef | null;
+  sourceRefs?: SfiCanonicalRef[];
+}): SfiEnterpriseIntakePackage {
+  const ticketRef = enterpriseEntityRef('TICKET', input.ticketId);
+  const openedAt = dateOrNull(input.openedAt, 'openedAt');
+  if (!openedAt) throw new Error('SFI_ENTERPRISE_INVALID:openedAt');
+  const relations: SfiEnterpriseRelationDraft[] = [];
+  if (input.assetRef) relations.push(relation({ relationKey: `${ticketRef.id}:asset`, relationType: 'TICKET_AFFECTS_ASSET', from: ticketRef, to: input.assetRef, sourceRefs: input.sourceRefs, observedAt: openedAt }));
+  if (input.serviceRef) relations.push(relation({ relationKey: `${ticketRef.id}:service`, relationType: 'TICKET_AFFECTS_SERVICE', from: ticketRef, to: input.serviceRef, sourceRefs: input.sourceRefs, observedAt: openedAt }));
+  if (input.slaRef) relations.push(relation({ relationKey: `${ticketRef.id}:sla`, relationType: 'TICKET_SUBJECT_TO_SLA', from: ticketRef, to: input.slaRef, sourceRefs: input.sourceRefs, observedAt: openedAt }));
+  if (input.supplierRef) relations.push(relation({ relationKey: `${ticketRef.id}:supplier`, relationType: 'TICKET_ASSIGNED_TO_SUPPLIER', from: ticketRef, to: input.supplierRef, sourceRefs: input.sourceRefs, observedAt: openedAt }));
+  return {
+    contract: SFI_ENTERPRISE_ASSURANCE_DOMAIN_CONTRACT,
+    object: {
+      kind: 'RECORD',
+      epistemicRole: 'RECORD',
+      canonicalRef: ticketRef,
+      sourceRefs: input.sourceRefs ?? [],
+      payload: {
+        entityType: 'TICKET',
+        openedAt,
+        closedAt: dateOrNull(input.closedAt, 'closedAt'),
+        status: requireText(input.status, 'status'),
+        category: input.category?.trim() || null,
+        priority: input.priority?.trim() || null,
+        responseMinutes: nonNegativeNumber(input.responseMinutes, 'responseMinutes'),
+        resolutionMinutes: nonNegativeNumber(input.resolutionMinutes, 'resolutionMinutes'),
+        recurrenceKey: input.recurrenceKey?.trim() || null,
+        problemIdentityClaimed: false,
+      },
+      observedAt: openedAt,
+    },
+    relations,
+  };
+}
+
+export function normalizeWarrantyEventRecord(input: {
+  eventId: string;
+  occurredAt: string;
+  eventType: string;
+  status: string;
+  assetRef: SfiEnterpriseEntityRef;
+  warrantyRef?: SfiEnterpriseEntityRef | null;
+  supplierRef?: SfiEnterpriseEntityRef | null;
+  responseDueAt?: string | null;
+  resolvedAt?: string | null;
+  sourceRefs?: SfiCanonicalRef[];
+}): SfiEnterpriseIntakePackage {
+  const eventRef = enterpriseEntityRef('WARRANTY_EVENT', input.eventId);
+  const occurredAt = dateOrNull(input.occurredAt, 'occurredAt');
+  if (!occurredAt) throw new Error('SFI_ENTERPRISE_INVALID:occurredAt');
+  const relations: SfiEnterpriseRelationDraft[] = [
+    relation({ relationKey: `${eventRef.id}:asset`, relationType: 'WARRANTY_EVENT_AFFECTS_ASSET', from: eventRef, to: input.assetRef, sourceRefs: input.sourceRefs, observedAt: occurredAt }),
+  ];
+  if (input.warrantyRef) relations.push(relation({ relationKey: `${eventRef.id}:warranty`, relationType: 'WARRANTY_EVENT_UNDER_WARRANTY', from: eventRef, to: input.warrantyRef, sourceRefs: input.sourceRefs, observedAt: occurredAt }));
+  if (input.supplierRef) relations.push(relation({ relationKey: `${eventRef.id}:supplier`, relationType: 'WARRANTY_EVENT_ASSIGNED_TO_SUPPLIER', from: eventRef, to: input.supplierRef, sourceRefs: input.sourceRefs, observedAt: occurredAt }));
+  return {
+    contract: SFI_ENTERPRISE_ASSURANCE_DOMAIN_CONTRACT,
+    object: {
+      kind: 'RECORD',
+      epistemicRole: 'RECORD',
+      canonicalRef: eventRef,
+      sourceRefs: input.sourceRefs ?? [],
+      payload: {
+        entityType: 'WARRANTY_EVENT',
+        occurredAt,
+        eventType: requireText(input.eventType, 'eventType'),
+        status: requireText(input.status, 'status'),
+        responseDueAt: dateOrNull(input.responseDueAt, 'responseDueAt'),
+        resolvedAt: dateOrNull(input.resolvedAt, 'resolvedAt'),
+        contractualBreachDeclared: false,
+      },
+      observedAt: occurredAt,
+    },
+    relations,
+  };
+}
+
+export function normalizeTenderRequirementRecord(input: {
+  requirementId: string;
+  tenderRef: SfiEnterpriseEntityRef;
+  requirementText: string;
+  requirementType?: string | null;
+  frozenAt: string;
+  sourceRefs: SfiCanonicalRef[];
+  pageLocator?: string | null;
+}): SfiEnterpriseIntakePackage {
+  const requirementRef = enterpriseEntityRef('REQUIREMENT', input.requirementId);
+  const frozenAt = dateOrNull(input.frozenAt, 'frozenAt');
+  if (!frozenAt) throw new Error('SFI_ENTERPRISE_INVALID:frozenAt');
+  if (!input.sourceRefs.length) throw new Error('SFI_TENDER_REQUIREMENT_REQUIRES_SOURCE');
+  return {
+    contract: SFI_ENTERPRISE_ASSURANCE_DOMAIN_CONTRACT,
+    object: {
+      kind: 'RECORD',
+      epistemicRole: 'RECORD',
+      canonicalRef: requirementRef,
+      sourceRefs: input.sourceRefs,
+      payload: {
+        entityType: 'REQUIREMENT',
+        requirementText: requireText(input.requirementText, 'requirementText'),
+        requirementType: input.requirementType?.trim() || null,
+        frozenAt,
+        pageLocator: input.pageLocator?.trim() || null,
+        frozenBeforeEvaluation: true,
+      },
+      observedAt: frozenAt,
+    },
+    relations: [relation({
+      relationKey: `${input.tenderRef.id}:requirement:${requirementRef.id}`,
+      relationType: 'TENDER_HAS_REQUIREMENT',
+      from: input.tenderRef,
+      to: requirementRef,
+      sourceRefs: input.sourceRefs,
+      observedAt: frozenAt,
+    })],
+  };
+}
+
+export type SfiTenderAssessmentResult = 'PASS' | 'FAIL' | 'UNDETERMINED';
+
+export function normalizeTenderAssessment(input: {
+  assessmentId: string;
+  requirementRef: SfiEnterpriseEntityRef;
+  bidderRef: SfiEnterpriseEntityRef;
+  result: SfiTenderAssessmentResult;
+  sourceRefs: SfiCanonicalRef[];
+  recordRefs?: SfiCanonicalRef[];
+  evidenceRefs?: SfiCanonicalRef[];
+  pageLocator?: string | null;
+  confidence?: number | null;
+  missingReason?: string | null;
+  contradictionRefs?: SfiCanonicalRef[];
+}): SfiEnterpriseCaseObjectInput {
+  const confidence = input.confidence === null || typeof input.confidence === 'undefined' ? null : input.confidence;
+  if (confidence !== null && (!Number.isFinite(confidence) || confidence < 0 || confidence > 1)) throw new Error('SFI_TENDER_ASSESSMENT_CONFIDENCE_INVALID');
+  if (!input.sourceRefs.length) throw new Error('SFI_TENDER_ASSESSMENT_REQUIRES_SOURCE');
+  const evidenceRefs = input.evidenceRefs ?? [];
+  const pageLocator = input.pageLocator?.trim() || null;
+  if (input.result !== 'UNDETERMINED' && (!evidenceRefs.length || !pageLocator)) {
+    throw new Error('SFI_TENDER_DETERMINATION_REQUIRES_PAGE_AND_EVIDENCE');
+  }
+  if (input.result === 'UNDETERMINED' && !input.missingReason?.trim()) {
+    throw new Error('SFI_TENDER_UNDETERMINED_REQUIRES_REASON');
+  }
+  return {
+    kind: 'EPISTEMIC_ASSESSMENT',
+    epistemicRole: 'EPISTEMIC_ASSESSMENT',
+    canonicalRef: { id: `tender-assessment:${requireText(input.assessmentId, 'assessmentId')}`, version: '1.0', hash: null },
+    sourceRefs: input.sourceRefs,
+    recordRefs: input.recordRefs ?? [],
+    evidenceRefs,
+    payload: {
+      contract: SFI_ENTERPRISE_ASSURANCE_DOMAIN_CONTRACT,
+      assessmentType: 'REQUIREMENT_BY_BIDDER',
+      requirementRef: input.requirementRef,
+      bidderRef: input.bidderRef,
+      result: input.result,
+      determinability: input.result === 'UNDETERMINED' ? 'UNDETERMINED' : 'DETERMINED',
+      pageLocator,
+      confidence,
+      missingReason: input.missingReason?.trim() || null,
+      contradictionRefs: input.contradictionRefs ?? [],
+      winnerSelectionAuthority: false,
+      humanDecisionAuthorityPreserved: true,
+    },
+  };
+}
+
+export function buildSupplierPerformanceAssessment(input: {
+  assessmentId: string;
+  supplierRef: SfiEnterpriseEntityRef;
+  evidenceRefs: SfiCanonicalRef[];
+  recordRefs: SfiCanonicalRef[];
+  metrics: {
+    responseMinutesMedian?: number | null;
+    resolutionMinutesMedian?: number | null;
+    slaComplianceRate?: number | null;
+    recurrenceRate?: number | null;
+    warrantyResolutionRate?: number | null;
+  };
+}): SfiEnterpriseCaseObjectInput {
+  if (!input.evidenceRefs.length) throw new Error('SFI_SUPPLIER_PERFORMANCE_REQUIRES_EVIDENCE');
+  const normalizedMetrics = Object.fromEntries(Object.entries(input.metrics).map(([key, value]) => {
+    if (value === null || typeof value === 'undefined') return [key, null];
+    if (!Number.isFinite(value) || value < 0) throw new Error(`SFI_SUPPLIER_PERFORMANCE_METRIC_INVALID:${key}`);
+    return [key, value];
+  }));
+  return {
+    kind: 'EPISTEMIC_ASSESSMENT',
+    epistemicRole: 'EPISTEMIC_ASSESSMENT',
+    canonicalRef: { id: `supplier-performance:${requireText(input.assessmentId, 'assessmentId')}`, version: '1.0', hash: null },
+    evidenceRefs: input.evidenceRefs,
+    recordRefs: input.recordRefs,
+    payload: {
+      contract: SFI_ENTERPRISE_ASSURANCE_DOMAIN_CONTRACT,
+      assessmentType: 'SUPPLIER_PERFORMANCE',
+      supplierRef: input.supplierRef,
+      metrics: normalizedMetrics,
+      compositeScore: null,
+      rankingAuthority: false,
+      futureTenderDecisionAuthority: false,
+    },
+  };
+}
+
+export const SFI_ENTERPRISE_ASSURANCE_INVARIANTS = {
+  oneSharedCasePlatform: true,
+  ticketCountEqualsProblemCount: false,
+  aiSelectsTenderWinner: false,
+  warrantyEventEqualsContractualBreach: false,
+  supplierPerformanceAutomaticallyRanksBidder: false,
+  clientGraphEqualsInstitutionalGraph: false,
+  relationInferenceRequiresEvidence: true,
+} as const;

--- a/src/core/case-platform/index.ts
+++ b/src/core/case-platform/index.ts
@@ -6,3 +6,4 @@ export * from './architectureStatus';
 export * from './operational';
 export * from './sourceIntake';
 export * from './instrumentGate';
+export * from './enterpriseAssurance';

--- a/src/lib/sfi/case-platform/enterpriseRepository.ts
+++ b/src/lib/sfi/case-platform/enterpriseRepository.ts
@@ -1,0 +1,179 @@
+import 'server-only';
+
+import {
+  validateEnterpriseRelationDraft,
+  type SfiEnterpriseEntityRef,
+  type SfiEnterpriseRelationDraft,
+  type SfiEnterpriseRelationEpistemicRole,
+  type SfiEnterpriseRelationType,
+} from '@/core/case-platform';
+import type { SfiCanonicalRef } from '@/core/contracts/sfi';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+type Row = Record<string, unknown>;
+type TenantRole = 'OWNER' | 'ADMIN' | 'OPERATOR' | 'VIEWER' | 'AUDITOR';
+
+function text(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function object(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function refs(value: unknown): SfiCanonicalRef[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => {
+    const row = object(item);
+    return {
+      id: text(row.id),
+      version: text(row.version) || null,
+      hash: text(row.hash) || null,
+    };
+  }).filter((ref) => ref.id);
+}
+
+function entityRef(value: unknown): SfiEnterpriseEntityRef {
+  const row = object(value);
+  return {
+    id: text(row.id),
+    version: text(row.version) || null,
+    hash: text(row.hash) || null,
+    entityType: text(row.entityType) as SfiEnterpriseEntityRef['entityType'],
+  };
+}
+
+async function caseContext(caseId: string, userId: string, mode: 'READ' | 'WRITE') {
+  const service = createServiceSupabaseClient();
+  const caseResult = await service
+    .from('sfi_cases')
+    .select('id,owner_id,tenant_id,status')
+    .eq('id', caseId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (caseResult.error) throw new Error(`SFI_ENTERPRISE_CASE_READ_FAILED:${caseResult.error.message}`);
+  if (!caseResult.data) throw new Error('SFI_CASE_NOT_FOUND');
+  const membership = await service
+    .from('sfi_tenant_members')
+    .select('role,status')
+    .eq('tenant_id', caseResult.data.tenant_id)
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (membership.error) throw new Error(`SFI_ENTERPRISE_MEMBERSHIP_READ_FAILED:${membership.error.message}`);
+  if (!membership.data || membership.data.status !== 'ACTIVE') throw new Error('SFI_TENANT_FORBIDDEN');
+  const role = String(membership.data.role) as TenantRole;
+  if (mode === 'WRITE' && !['OWNER','ADMIN','OPERATOR'].includes(role)) throw new Error('SFI_TENANT_WRITE_FORBIDDEN');
+  return {
+    caseId,
+    ownerId: String(caseResult.data.owner_id),
+    tenantId: String(caseResult.data.tenant_id),
+    status: String(caseResult.data.status),
+    role,
+  };
+}
+
+async function assertTenantRead(tenantId: string, userId: string) {
+  const service = createServiceSupabaseClient();
+  const membership = await service
+    .from('sfi_tenant_members')
+    .select('role,status')
+    .eq('tenant_id', tenantId)
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (membership.error) throw new Error(`SFI_ENTERPRISE_MEMBERSHIP_READ_FAILED:${membership.error.message}`);
+  if (!membership.data || membership.data.status !== 'ACTIVE') throw new Error('SFI_TENANT_FORBIDDEN');
+}
+
+function relationFromRow(row: Row) {
+  return {
+    id: text(row.id),
+    relationKey: text(row.relation_key),
+    caseId: text(row.case_id),
+    tenantId: text(row.tenant_id),
+    relationType: text(row.relation_type) as SfiEnterpriseRelationType,
+    epistemicRole: text(row.epistemic_role) as SfiEnterpriseRelationEpistemicRole,
+    from: entityRef(row.from_ref),
+    to: entityRef(row.to_ref),
+    sourceRefs: refs(row.source_refs),
+    recordRefs: refs(row.record_refs),
+    evidenceRefs: refs(row.evidence_refs),
+    payload: object(row.payload),
+    observedAt: text(row.observed_at) || null,
+    createdAt: text(row.created_at),
+  };
+}
+
+export async function recordOperationalEnterpriseRelation(input: {
+  caseId: string;
+  userId: string;
+  relation: SfiEnterpriseRelationDraft;
+}) {
+  const context = await caseContext(input.caseId, input.userId, 'WRITE');
+  if (['CLOSED','REJECTED'].includes(context.status)) throw new Error(`SFI_ENTERPRISE_RELATION_WRITE_FORBIDDEN:${context.status}`);
+  const violations = validateEnterpriseRelationDraft(input.relation);
+  if (violations.length) throw new Error(`SFI_ENTERPRISE_RELATION_INVALID:${violations.join(',')}`);
+
+  const service = createServiceSupabaseClient();
+  const existing = await service
+    .from('sfi_case_relations')
+    .select('*')
+    .eq('case_id', input.caseId)
+    .eq('relation_key', input.relation.relationKey)
+    .maybeSingle();
+  if (existing.error) throw new Error(`SFI_ENTERPRISE_RELATION_IDENTITY_READ_FAILED:${existing.error.message}`);
+  if (existing.data) {
+    const row = relationFromRow(existing.data as Row);
+    if (row.relationType === input.relation.relationType && row.from.id === input.relation.from.id && row.to.id === input.relation.to.id && row.epistemicRole === input.relation.epistemicRole) return row;
+    throw new Error('SFI_ENTERPRISE_RELATION_KEY_CONFLICT');
+  }
+
+  const inserted = await service.from('sfi_case_relations').insert({
+    relation_key: input.relation.relationKey,
+    case_id: input.caseId,
+    owner_id: context.ownerId,
+    tenant_id: context.tenantId,
+    relation_type: input.relation.relationType,
+    epistemic_role: input.relation.epistemicRole,
+    from_ref: input.relation.from,
+    to_ref: input.relation.to,
+    source_refs: input.relation.sourceRefs ?? [],
+    record_refs: input.relation.recordRefs ?? [],
+    evidence_refs: input.relation.evidenceRefs ?? [],
+    payload: input.relation.payload ?? {},
+    observed_at: input.relation.observedAt ?? null,
+  }).select('*').single();
+  if (inserted.error || !inserted.data) throw new Error(`SFI_ENTERPRISE_RELATION_WRITE_FAILED:${inserted.error?.message ?? 'unknown'}`);
+  const result = relationFromRow(inserted.data as Row);
+  const audit = await service.from('sfi_case_audit_events').insert({
+    case_id: input.caseId,
+    tenant_id: context.tenantId,
+    actor_id: input.userId,
+    action: 'ENTERPRISE_RELATION_RECORDED',
+    after_state: {
+      relationKey: result.relationKey,
+      relationType: result.relationType,
+      epistemicRole: result.epistemicRole,
+      from: result.from,
+      to: result.to,
+    },
+    context: { contract: 'SFI-ENTERPRISE-ASSURANCE-DOMAIN-1.0' },
+  });
+  if (audit.error) throw new Error(`SFI_ENTERPRISE_RELATION_AUDIT_FAILED:${audit.error.message}`);
+  return result;
+}
+
+export async function listOperationalEnterpriseRelations(caseId: string, userId: string) {
+  await caseContext(caseId, userId, 'READ');
+  const service = createServiceSupabaseClient();
+  const result = await service.from('sfi_case_relations').select('*').eq('case_id', caseId).order('created_at', { ascending: true });
+  if (result.error) throw new Error(`SFI_ENTERPRISE_RELATION_LIST_FAILED:${result.error.message}`);
+  return ((result.data ?? []) as Row[]).map(relationFromRow);
+}
+
+export async function listTenantEnterpriseRelations(tenantId: string, userId: string) {
+  await assertTenantRead(tenantId, userId);
+  const service = createServiceSupabaseClient();
+  const result = await service.from('sfi_case_relations').select('*').eq('tenant_id', tenantId).order('created_at', { ascending: true });
+  if (result.error) throw new Error(`SFI_ENTERPRISE_TENANT_GRAPH_FAILED:${result.error.message}`);
+  return ((result.data ?? []) as Row[]).map(relationFromRow);
+}

--- a/supabase/migrations/20260816132000_sfi_enterprise_assurance_graph_v1.sql
+++ b/supabase/migrations/20260816132000_sfi_enterprise_assurance_graph_v1.sql
@@ -1,0 +1,78 @@
+-- SFI Enterprise Assurance Graph V1
+-- Tenant-scoped relational continuity across tender → supplier → contract → asset/service → ticket/SLA → warranty → return → performance.
+
+create table if not exists public.sfi_case_relations (
+  id uuid primary key default gen_random_uuid(),
+  relation_key text not null,
+  case_id uuid not null,
+  owner_id uuid not null,
+  tenant_id uuid not null,
+  relation_type text not null check (relation_type in (
+    'TENDER_HAS_REQUIREMENT',
+    'BIDDER_PARTICIPATES_IN_TENDER',
+    'BID_SUBMISSION_FOR_TENDER',
+    'BID_SUBMISSION_BY_BIDDER',
+    'BIDDER_MAPS_TO_SUPPLIER',
+    'TENDER_AWARDS_SUPPLIER',
+    'CONTRACT_ARISES_FROM_TENDER',
+    'CONTRACT_BINDS_SUPPLIER',
+    'CONTRACT_DEFINES_OBLIGATION',
+    'CONTRACT_COVERS_ASSET',
+    'CONTRACT_COVERS_SERVICE',
+    'ASSET_PROVIDED_BY_SUPPLIER',
+    'SERVICE_PROVIDED_BY_SUPPLIER',
+    'TICKET_AFFECTS_ASSET',
+    'TICKET_AFFECTS_SERVICE',
+    'TICKET_SUBJECT_TO_SLA',
+    'TICKET_ASSIGNED_TO_SUPPLIER',
+    'SLA_DERIVED_FROM_CONTRACT',
+    'WARRANTY_DEFINED_BY_CONTRACT',
+    'WARRANTY_COVERS_ASSET',
+    'WARRANTY_EVENT_AFFECTS_ASSET',
+    'WARRANTY_EVENT_UNDER_WARRANTY',
+    'WARRANTY_EVENT_ASSIGNED_TO_SUPPLIER',
+    'TICKET_TRIGGERS_WARRANTY_EVENT',
+    'RETURN_RESOLVES_WARRANTY_EVENT',
+    'RETURN_CLOSES_TICKET',
+    'SUPPLIER_PERFORMANCE_AGGREGATES_RETURN',
+    'SUPPLIER_PERFORMANCE_INFORMS_TENDER'
+  )),
+  epistemic_role text not null check (epistemic_role in ('RECORD','INFERENCE','EPISTEMIC_ASSESSMENT')),
+  from_ref jsonb not null,
+  to_ref jsonb not null,
+  source_refs jsonb not null default '[]'::jsonb,
+  record_refs jsonb not null default '[]'::jsonb,
+  evidence_refs jsonb not null default '[]'::jsonb,
+  payload jsonb not null default '{}'::jsonb,
+  observed_at timestamptz,
+  created_at timestamptz not null default now(),
+  foreign key (case_id, owner_id, tenant_id) references public.sfi_cases(id, owner_id, tenant_id) on delete cascade,
+  unique (case_id, relation_key),
+  check (coalesce(from_ref->>'id','') <> ''),
+  check (coalesce(from_ref->>'entityType','') <> ''),
+  check (coalesce(to_ref->>'id','') <> ''),
+  check (coalesce(to_ref->>'entityType','') <> ''),
+  check (epistemic_role <> 'INFERENCE' or jsonb_array_length(evidence_refs) > 0)
+);
+
+create index if not exists sfi_case_relations_case_created_idx
+  on public.sfi_case_relations(case_id, created_at);
+create index if not exists sfi_case_relations_tenant_type_idx
+  on public.sfi_case_relations(tenant_id, relation_type, created_at);
+create index if not exists sfi_case_relations_from_idx
+  on public.sfi_case_relations(tenant_id, ((from_ref->>'entityType')), ((from_ref->>'id')));
+create index if not exists sfi_case_relations_to_idx
+  on public.sfi_case_relations(tenant_id, ((to_ref->>'entityType')), ((to_ref->>'id')));
+
+alter table public.sfi_case_relations enable row level security;
+
+drop policy if exists sfi_case_relations_tenant_read on public.sfi_case_relations;
+create policy sfi_case_relations_tenant_read on public.sfi_case_relations
+for select to authenticated using (public.sfi_tenant_can_read(tenant_id));
+
+drop policy if exists sfi_case_relations_tenant_insert on public.sfi_case_relations;
+create policy sfi_case_relations_tenant_insert on public.sfi_case_relations
+for insert to authenticated with check (public.sfi_tenant_can_write(tenant_id));
+
+-- Deliberately no client-facing DELETE policy.
+-- Deliberately no trigger into institutional graph/evidence/memory/ROOT.


### PR DESCRIPTION
## Purpose

Operationalize Mesa de Ayuda, Seguimiento a Garantías and Evaluación de Licitantes as one tenant-scoped longitudinal domain over the shared SFI Case Platform — not as three separate SaaS products.

## Canonical chain

`TENDER → BIDDER/SUPPLIER → CONTRACT → OBLIGATION → ASSET/SERVICE → TICKET → SLA → WARRANTY_EVENT → RETURN → SUPPLIER_PERFORMANCE → NEXT_TENDER`

## What this adds

- tenant-scoped `sfi_case_relations` graph with membership RLS;
- typed enterprise entities and relation endpoint contracts;
- shared relation persistence/query across cases in a tenant;
- generic enterprise entity intake;
- Service/Help Desk ticket normalizer preserving asset/service/SLA/supplier relations;
- warranty-event normalizer without automatic breach declaration;
- frozen tender-requirement intake;
- institutional requirement×bidder assessment with PASS/FAIL/UNDETERMINED semantics;
- PASS/FAIL requires source + page locator + evidence;
- UNDETERMINED requires an explicit missing-information reason;
- supplier-performance assessment without an automatic composite score/ranking;
- internal SFI analytical-object endpoint that still cannot create governance decisions/interventions/truth claims;
- client relation writes remain `RECORD`; inferred relations require SFI-internal path and evidence;
- tenant-wide enterprise-relation read model for future observatories;
- terminal-reset classification for the new relation graph;
- dedicated CI gate.

## Boundaries

- `TICKET COUNT ≠ PROBLEM COUNT`;
- `WARRANTY EVENT ≠ CONTRACTUAL BREACH`;
- `AI ASSESSMENT ≠ WINNER SELECTION AUTHORITY`;
- `SUPPLIER PERFORMANCE ≠ AUTOMATIC FUTURE BIDDER RANKING`;
- `TENANT ENTERPRISE GRAPH ≠ SFI INSTITUTIONAL GRAPH`;
- inferred relations require evidence;
- no automatic institutional-memory write;
- no direct tenant→ROOT path.

## Non-goals

- no Observatory/dashboard screen design;
- no final production DB cleanup;
- no automatic procurement decision;
- no automatic legal/breach conclusion;
- no arbitrary supplier scoring formula;
- no product-specific databases.