### PR TITLE
Enforce SFI Case integrity and governed action loop

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -13,68 +13,98 @@ jobs:
   verify:
     name: Verify SFI boundaries and build
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
+
       - name: Install dependencies
         run: npm install --no-audit --no-fund
+
       - name: Verify SFI Verify parallel topology
         run: npx tsx scripts/qa-sfi-verify-parallelism.ts
+
       - name: Check domain boundaries
         run: npm run check:boundaries
+
       - name: Verify MIHM method selection
         run: npx tsx scripts/qa-sfi-method-selection.ts
+
       - name: Verify Cognitive Twin authority contract
         run: node --import tsx --test src/core/cognitive-twin/contract.test.ts
+
       - name: Verify 15 institutional contracts
         run: npm run qa:sfi-institutional-contracts
+
       - name: Verify cognitive agent convergence
         run: node --import tsx --test src/lib/sfi/cognitive-runtime/agentConvergence.test.ts
+
       - name: Verify Field and Observatory temporal surfaces
         run: npx tsx scripts/qa-sfi-temporal-surfaces.ts
+
       - name: Verify ROOT graph and navigation convergence
         run: npx tsx scripts/qa-sfi-root-graph-navigation.ts
+
       - name: Verify ROOT reports and runtime truth
         run: npx tsx scripts/qa-sfi-root-reports-runtime.ts
+
       - name: Verify ROOT ACP total convergence
         run: npx tsx scripts/qa-sfi-root-acp-total-convergence.ts
+
       - name: Verify SFI development registry
         run: npx tsx scripts/qa-sfi-development-registry.ts
+
       - name: Verify integrated SFI operating field
         run: npx tsx scripts/qa-sfi-operating-field-closure.ts
+
       - name: Verify clean-start reset safety
         run: npx tsx scripts/qa-sfi-operational-reset.ts
+
       - name: Verify SFI total proof circuit
         run: npx tsx scripts/qa-sfi-total-proof.ts
+
       - name: Verify Method Lab convergence
         run: npx tsx scripts/qa-sfi-method-lab-convergence.ts
+
       - name: Verify Cognitive Twin reentry and longitudinal integration
         run: npx tsx scripts/qa-sfi-cognitive-twin-reentry.ts
+
       - name: Verify Cognitive Twin decision transfer observatory
         run: npm run qa:sfi-ct-decision-transfer
+
       - name: Verify Decision Transfer operational wiring
         run: npx tsx scripts/qa-sfi-decision-transfer-operational.ts
+
       - name: Verify blind decision reconstruction protocol
         run: npx tsx scripts/qa-sfi-decision-transfer-blind.ts
+
       - name: Verify canonical Decision Transfer context materialization
         run: npx tsx scripts/qa-sfi-decision-transfer-context.ts
+
       - name: Verify post-cutoff Decision Transfer target timing
         run: npx tsx scripts/qa-sfi-decision-transfer-target-timing.ts
+
       - name: Verify final debt closure and EXP-001 freeze
         run: npx tsx scripts/qa-sfi-final-debt-closure.ts
+
       - name: Verify canonical evidence identity
         run: node --import tsx --test src/lib/evidence/canonicalEvidence.test.ts
+
       - name: Verify canonical evidence QA
         run: npx tsx scripts/qa-sfi-canonical-evidence.ts
+
       - name: Verify Studio Field surface
         run: npm run qa:sfi-studio-workspace
+
       - name: Verify Studio cognitive runtime
         run: npm run qa:sfi-studio-cognitive
+
       - name: Verify Studio capability inventory
         shell: bash
         run: |
@@ -86,16 +116,22 @@ jobs:
             echo "::error file=scripts/qa-sfi-studio-capability-inventory.ts,line=1::Studio capability QA failed: ${diagnostic}"
             exit "$status"
           fi
+
       - name: Verify SFI Architecture V1 constitutional boundary
         run: npx tsx scripts/qa-sfi-architecture-v1.ts
+
       - name: Verify SFI Case Platform V1 shared engine
         run: npx tsx scripts/qa-sfi-case-platform-v1.ts
+
       - name: Verify SFI Case Platform Operational V1
         run: npx tsx scripts/qa-sfi-case-platform-operational-v1.ts
+
       - name: Verify SFI Enterprise Assurance Domain V1
         run: npx tsx scripts/qa-sfi-enterprise-assurance-domain-v1.ts
+
       - name: Verify SFI Case Integrity and Governed Action V1
         run: npx tsx scripts/qa-sfi-case-integrity-action-v1.ts
+
       - name: Typecheck
         id: typecheck
         shell: bash
@@ -105,6 +141,7 @@ jobs:
           status=${PIPESTATUS[0]}
           echo "status=${status}" >> "$GITHUB_OUTPUT"
           exit "$status"
+
       - name: Upload typecheck diagnostics
         if: failure() && steps.typecheck.outcome == 'failure'
         uses: actions/upload-artifact@v4
@@ -113,27 +150,35 @@ jobs:
           path: typecheck.log
           if-no-files-found: error
           retention-days: 7
+
       - name: Build
         run: npm run build
 
   audio:
     name: Verify Studio audio gates
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
+
       - name: Install dependencies
         run: npm install --no-audit --no-fund
+
       - name: Verify Studio audio smoke path
         run: npm run qa:studio-audio
+
       - name: Verify Studio loudness
         run: npm run qa:sfi-studio-loudness
+
       - name: Verify Studio rhythm
         run: npm run qa:sfi-studio-rhythm
+
       - name: Verify Studio harmony
         run: npm run qa:sfi-studio-harmony

--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -13,98 +13,68 @@ jobs:
   verify:
     name: Verify SFI boundaries and build
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-
       - name: Install dependencies
         run: npm install --no-audit --no-fund
-
       - name: Verify SFI Verify parallel topology
         run: npx tsx scripts/qa-sfi-verify-parallelism.ts
-
       - name: Check domain boundaries
         run: npm run check:boundaries
-
       - name: Verify MIHM method selection
         run: npx tsx scripts/qa-sfi-method-selection.ts
-
       - name: Verify Cognitive Twin authority contract
         run: node --import tsx --test src/core/cognitive-twin/contract.test.ts
-
       - name: Verify 15 institutional contracts
         run: npm run qa:sfi-institutional-contracts
-
       - name: Verify cognitive agent convergence
         run: node --import tsx --test src/lib/sfi/cognitive-runtime/agentConvergence.test.ts
-
       - name: Verify Field and Observatory temporal surfaces
         run: npx tsx scripts/qa-sfi-temporal-surfaces.ts
-
       - name: Verify ROOT graph and navigation convergence
         run: npx tsx scripts/qa-sfi-root-graph-navigation.ts
-
       - name: Verify ROOT reports and runtime truth
         run: npx tsx scripts/qa-sfi-root-reports-runtime.ts
-
       - name: Verify ROOT ACP total convergence
         run: npx tsx scripts/qa-sfi-root-acp-total-convergence.ts
-
       - name: Verify SFI development registry
         run: npx tsx scripts/qa-sfi-development-registry.ts
-
       - name: Verify integrated SFI operating field
         run: npx tsx scripts/qa-sfi-operating-field-closure.ts
-
       - name: Verify clean-start reset safety
         run: npx tsx scripts/qa-sfi-operational-reset.ts
-
       - name: Verify SFI total proof circuit
         run: npx tsx scripts/qa-sfi-total-proof.ts
-
       - name: Verify Method Lab convergence
         run: npx tsx scripts/qa-sfi-method-lab-convergence.ts
-
       - name: Verify Cognitive Twin reentry and longitudinal integration
         run: npx tsx scripts/qa-sfi-cognitive-twin-reentry.ts
-
       - name: Verify Cognitive Twin decision transfer observatory
         run: npm run qa:sfi-ct-decision-transfer
-
       - name: Verify Decision Transfer operational wiring
         run: npx tsx scripts/qa-sfi-decision-transfer-operational.ts
-
       - name: Verify blind decision reconstruction protocol
         run: npx tsx scripts/qa-sfi-decision-transfer-blind.ts
-
       - name: Verify canonical Decision Transfer context materialization
         run: npx tsx scripts/qa-sfi-decision-transfer-context.ts
-
       - name: Verify post-cutoff Decision Transfer target timing
         run: npx tsx scripts/qa-sfi-decision-transfer-target-timing.ts
-
       - name: Verify final debt closure and EXP-001 freeze
         run: npx tsx scripts/qa-sfi-final-debt-closure.ts
-
       - name: Verify canonical evidence identity
         run: node --import tsx --test src/lib/evidence/canonicalEvidence.test.ts
-
       - name: Verify canonical evidence QA
         run: npx tsx scripts/qa-sfi-canonical-evidence.ts
-
       - name: Verify Studio Field surface
         run: npm run qa:sfi-studio-workspace
-
       - name: Verify Studio cognitive runtime
         run: npm run qa:sfi-studio-cognitive
-
       - name: Verify Studio capability inventory
         shell: bash
         run: |
@@ -116,19 +86,16 @@ jobs:
             echo "::error file=scripts/qa-sfi-studio-capability-inventory.ts,line=1::Studio capability QA failed: ${diagnostic}"
             exit "$status"
           fi
-
       - name: Verify SFI Architecture V1 constitutional boundary
         run: npx tsx scripts/qa-sfi-architecture-v1.ts
-
       - name: Verify SFI Case Platform V1 shared engine
         run: npx tsx scripts/qa-sfi-case-platform-v1.ts
-
       - name: Verify SFI Case Platform Operational V1
         run: npx tsx scripts/qa-sfi-case-platform-operational-v1.ts
-
       - name: Verify SFI Enterprise Assurance Domain V1
         run: npx tsx scripts/qa-sfi-enterprise-assurance-domain-v1.ts
-
+      - name: Verify SFI Case Integrity and Governed Action V1
+        run: npx tsx scripts/qa-sfi-case-integrity-action-v1.ts
       - name: Typecheck
         id: typecheck
         shell: bash
@@ -138,7 +105,6 @@ jobs:
           status=${PIPESTATUS[0]}
           echo "status=${status}" >> "$GITHUB_OUTPUT"
           exit "$status"
-
       - name: Upload typecheck diagnostics
         if: failure() && steps.typecheck.outcome == 'failure'
         uses: actions/upload-artifact@v4
@@ -147,35 +113,27 @@ jobs:
           path: typecheck.log
           if-no-files-found: error
           retention-days: 7
-
       - name: Build
         run: npm run build
 
   audio:
     name: Verify Studio audio gates
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-
       - name: Install dependencies
         run: npm install --no-audit --no-fund
-
       - name: Verify Studio audio smoke path
         run: npm run qa:studio-audio
-
       - name: Verify Studio loudness
         run: npm run qa:sfi-studio-loudness
-
       - name: Verify Studio rhythm
         run: npm run qa:sfi-studio-rhythm
-
       - name: Verify Studio harmony
         run: npm run qa:sfi-studio-harmony

--- a/docs/architecture/sfi/SFI-CASE-INTEGRITY-ACTION-1.0.md
+++ b/docs/architecture/sfi/SFI-CASE-INTEGRITY-ACTION-1.0.md
@@ -1,0 +1,58 @@
+# SFI Case Integrity & Governed Action 1.0
+
+Status: `OPERATIONAL_BACKEND`
+
+This block closes two gaps in the operational Case Platform: referenced objects must exist with the epistemic role claimed, and a recommendation/report cannot become an intervention without human case authority.
+
+## Reference integrity
+
+Case references are checked against persisted tenant/case objects before internal evidence, assessments, reports and inferred relations are accepted.
+
+```text
+sourceRef     → existing SOURCE
+recordRef     → existing RECORD-role object
+evidenceRef   → existing EVIDENCE
+assessmentRef → existing EPISTEMIC_ASSESSMENT
+```
+
+Enterprise entity relations may cross cases inside the same tenant, but their endpoint entities must exist in tenant-scoped Case Platform state.
+
+Tender assessment adds a stronger invariant: the requirement must exist in the case and must have been recorded through the frozen-requirement path before evaluation.
+
+## Governed action loop
+
+```text
+SFI REPORT
+   ↓
+RECOMMENDATION
+   ↓
+CASE ACTION PROPOSAL
+   ↓
+TENANT HUMAN AUTHORITY (OWNER / ADMIN)
+   ├─ REJECT
+   └─ APPROVE
+        ↓
+INTERVENTION RECORD
+        ↓
+RETURN RECORD
+```
+
+The case action decision is not ROOT governance and does not modify institutional truth. It is the commercial/operational human-authority gate for an intervention affecting the tenant system.
+
+The platform records an approved intervention but does not itself perform an external action in this version. Future connectors/adapters must consume only approved proposals.
+
+## Return semantics
+
+A return must reference the recorded intervention. The return is an observation record; it does not automatically prove that the intervention caused the observed outcome.
+
+`RETURN ≠ CAUSAL PROOF`.
+
+## Explicit prohibitions
+
+- report → direct execution;
+- recommendation → direct execution;
+- PENDING proposal → intervention;
+- OPERATOR approval of the proposal;
+- direct client creation of ungated RETURN objects;
+- case approval → ROOT decision;
+- recorded return → automatic causal claim.

--- a/scripts/db/sfi-operational-reset-inventory.mjs
+++ b/scripts/db/sfi-operational-reset-inventory.mjs
@@ -1,30 +1,14 @@
 export const PROTECTED_TABLES = [
-  // Identity / access / billing / authority survive an operational clean start.
-  'profiles',
-  'system_accounts',
-  'system_roles',
-  'system_actor_roles',
-  'system_resources',
-  'system_permissions',
-  'system_access_grants',
-  'system_entitlements',
-  'system_subscriptions',
-  'system_payment_events',
-  'system_api_clients',
-  // Commercial tenant identity/membership is access/authority, not disposable case runtime.
-  'sfi_tenants',
-  'sfi_tenant_members',
-  // Longitudinal external observation is institutional evidence, not disposable runtime.
-  // It survives genesis so a clean SFI can still reconstruct the world it actually observed.
+  'profiles','system_accounts','system_roles','system_actor_roles','system_resources','system_permissions','system_access_grants','system_entitlements','system_subscriptions','system_payment_events','system_api_clients',
+  'sfi_tenants','sfi_tenant_members',
   'worldspect_snapshots',
-  // Schema migrations and canonical code/corpus are repository/Supabase metadata and are never reset here.
   'schema_migrations',
 ];
 
 export const OPERATIONAL_RESET_LAYERS = [
   { id:'operating-cycle-analysis', reason:'Derived cycle layers must be deleted before the cycle identity they reference.', tables:['sfi_artifact_trajectory_events','sfi_inference_traces'] },
-  { id:'case-platform-derived', reason:'Tenant-scoped commercial runtime is cleared child-first while tenant identity and membership survive as access/authority.', tables:['sfi_case_reports','sfi_case_audit_events','sfi_case_relations','sfi_case_objects'] },
-  { id:'case-platform-parent', reason:'Canonical commercial case runtime is removed only after its report, audit, relation and object children.', tables:['sfi_cases'] },
+  { id:'case-platform-derived', reason:'Tenant-scoped commercial runtime is cleared child-first while tenant identity and membership survive as access/authority.', tables:['sfi_case_action_decisions','sfi_case_action_proposals','sfi_case_reports','sfi_case_audit_events','sfi_case_relations','sfi_case_objects'] },
+  { id:'case-platform-parent', reason:'Canonical commercial case runtime is removed only after its action, report, audit, relation and object children.', tables:['sfi_cases'] },
   { id:'field-return', reason:'Field child records before cases; removes observed test/runtime history only after proof export.', tables:['field_outcomes','field_returns','field_interventions','field_hypotheses','field_mihm_readings','field_moph_runs','field_case_evidence'] },
   { id:'field-participant', reason:'Participant operational capture is longitudinal runtime, not identity/authority.', tables:['field_participant_actions','field_participant_sessions','field_participant_intakes','field_participant_consents','field_participant_profiles'] },
   { id:'field-cases', reason:'Parent Field cases after all child records.', tables:['field_cases'] },
@@ -41,9 +25,6 @@ export const OPERATIONAL_RESET_LAYERS = [
 ];
 
 export const OPERATIONAL_DELETE_ORDER = OPERATIONAL_RESET_LAYERS.flatMap(layer=>layer.tables);
-
 const duplicates=OPERATIONAL_DELETE_ORDER.filter((table,index,all)=>all.indexOf(table)!==index);
 if(duplicates.length) throw new Error(`Duplicate operational reset table(s): ${[...new Set(duplicates)].join(', ')}`);
-for(const table of PROTECTED_TABLES){
-  if(OPERATIONAL_DELETE_ORDER.includes(table)) throw new Error(`Protected table present in purge inventory: ${table}`);
-}
+for(const table of PROTECTED_TABLES){ if(OPERATIONAL_DELETE_ORDER.includes(table)) throw new Error(`Protected table present in purge inventory: ${table}`); }

--- a/scripts/qa-sfi-case-integrity-action-v1.ts
+++ b/scripts/qa-sfi-case-integrity-action-v1.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import assert from 'node:assert/strict';
+import { assertSfiCaseActionTransition, canSfiCaseActionTransition, SFI_CASE_ACTION_BOUNDARY } from '../src/core/case-platform';
+import { OPERATIONAL_DELETE_ORDER } from './db/sfi-operational-reset-inventory.mjs';
+
+const read = (path: string) => fs.readFileSync(path, 'utf8');
+const migration = read('supabase/migrations/20260816140000_sfi_case_governed_action_v1.sql');
+const integrity = read('src/lib/sfi/case-platform/integrity.ts');
+const actionRepo = read('src/lib/sfi/case-platform/actionRepository.ts');
+const objectsRoute = read('src/app/api/cases/[caseId]/objects/route.ts');
+const internalObjects = read('src/app/api/cases/[caseId]/internal/objects/route.ts');
+const reportsRoute = read('src/app/api/cases/[caseId]/reports/route.ts');
+const tenderRoute = read('src/app/api/cases/[caseId]/internal/tender-assessments/route.ts');
+const relationRoute = read('src/app/api/cases/[caseId]/relations/route.ts');
+const internalRelationRoute = read('src/app/api/cases/[caseId]/internal/relations/route.ts');
+
+assert(migration.includes('public.sfi_case_action_proposals'));
+assert(migration.includes('public.sfi_case_action_decisions'));
+assert(migration.includes("authority_role in ('OWNER','ADMIN')"));
+assert(migration.includes('No ROOT foreign key'));
+assert(migration.includes('No automatic execution trigger'));
+assert(!migration.includes('root_'));
+assert(OPERATIONAL_DELETE_ORDER.includes('sfi_case_action_decisions'));
+assert(OPERATIONAL_DELETE_ORDER.includes('sfi_case_action_proposals'));
+
+assert.equal(SFI_CASE_ACTION_BOUNDARY.reportHasExecutionAuthority, false);
+assert.equal(SFI_CASE_ACTION_BOUNDARY.automaticExternalExecution, false);
+assert.equal(SFI_CASE_ACTION_BOUNDARY.clientAddressesRoot, false);
+assert(canSfiCaseActionTransition('PENDING', 'APPROVED'));
+assert(canSfiCaseActionTransition('APPROVED', 'EXECUTED'));
+assert(canSfiCaseActionTransition('EXECUTED', 'RETURN_RECORDED'));
+assert(!canSfiCaseActionTransition('PENDING', 'EXECUTED'));
+assert.throws(() => assertSfiCaseActionTransition('REJECTED', 'EXECUTED'), /TRANSITION_FORBIDDEN/);
+
+assert(integrity.includes('SFI_CASE_REFERENCE_NOT_FOUND'));
+assert(integrity.includes('SFI_TENDER_REQUIREMENT_NOT_FROZEN'));
+assert(integrity.includes('SFI_ENTERPRISE_ENTITY_REFERENCE_NOT_FOUND'));
+assert(actionRepo.includes("['OWNER','ADMIN'].includes(authority.role)"), 'approval must require tenant owner/admin');
+assert(actionRepo.includes('platformPerformedExternalAction: false'));
+assert(actionRepo.includes('causalEffectClaimed: false'));
+assert(actionRepo.includes("kind: 'INTERVENTION'"));
+assert(actionRepo.includes("kind: 'RETURN'"));
+
+assert(!objectsRoute.includes("z.enum(['RECORD','OBSERVATION','RETURN'])"), 'generic client endpoint must not allow ungated RETURN writes');
+assert(internalObjects.includes('assertCaseReferenceIntegrity'));
+assert(reportsRoute.includes('assertReportClaimsIntegrity'));
+assert(tenderRoute.includes('assertTenderAssessmentPrerequisites'));
+assert(relationRoute.includes('assertTenantEnterpriseEntityRefs'));
+assert(internalRelationRoute.includes('assertTenantEnterpriseEntityRefs'));
+
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-CASE-ACTION-1.0',
+  referenceIntegrity: true,
+  reportExecutionAuthority: false,
+  approvalAuthority: ['OWNER','ADMIN'],
+  directPendingToExecuted: false,
+  externalExecutionPerformedByPlatform: false,
+  returnRequiresIntervention: true,
+  clientDirectReturnWrite: false,
+}, null, 2));

--- a/scripts/qa-sfi-case-integrity-action-v1.ts
+++ b/scripts/qa-sfi-case-integrity-action-v1.ts
@@ -14,11 +14,57 @@ const tenderRoute = read('src/app/api/cases/[caseId]/internal/tender-assessments
 const relationRoute = read('src/app/api/cases/[caseId]/relations/route.ts');
 const internalRelationRoute = read('src/app/api/cases/[caseId]/internal/relations/route.ts');
 
-assert(migration.includes('public.sfi_case_action_proposals')); assert(migration.includes('public.sfi_case_action_decisions')); assert(migration.includes("authority_role in ('OWNER','ADMIN')")); assert(migration.includes('sfi_tenant_can_approve')); assert(migration.includes("object_kind in ('RECORD','OBSERVATION')")); assert(migration.includes('Report creation is server/institutional only')); assert(migration.includes('Audit events are server-generated only')); assert(migration.includes('No ROOT foreign key')); assert(migration.includes('No automatic execution trigger')); assert(!migration.includes('root_'));
-assert(OPERATIONAL_DELETE_ORDER.includes('sfi_case_action_decisions')); assert(OPERATIONAL_DELETE_ORDER.includes('sfi_case_action_proposals'));
-assert.equal(SFI_CASE_ACTION_BOUNDARY.reportHasExecutionAuthority, false); assert.equal(SFI_CASE_ACTION_BOUNDARY.automaticExternalExecution, false); assert.equal(SFI_CASE_ACTION_BOUNDARY.clientAddressesRoot, false); assert(canSfiCaseActionTransition('PENDING', 'APPROVED')); assert(canSfiCaseActionTransition('APPROVED', 'EXECUTED')); assert(canSfiCaseActionTransition('EXECUTED', 'RETURN_RECORDED')); assert(!canSfiCaseActionTransition('PENDING', 'EXECUTED')); assert.throws(() => assertSfiCaseActionTransition('REJECTED', 'EXECUTED'), /TRANSITION_FORBIDDEN/);
-assert(integrity.includes('SFI_CASE_REFERENCE_NOT_FOUND')); assert(integrity.includes('SFI_TENDER_REQUIREMENT_NOT_FROZEN')); assert(integrity.includes('SFI_ENTERPRISE_ENTITY_REFERENCE_NOT_FOUND'));
-assert(actionRepo.includes("['OWNER','ADMIN'].includes(authority.role)")); assert(actionRepo.includes('platformPerformedExternalAction: false')); assert(actionRepo.includes('causalEffectClaimed: false')); assert(actionRepo.includes("kind: 'INTERVENTION'")); assert(actionRepo.includes("kind: 'RETURN'"));
-assert(!objectsRoute.includes("z.enum(['RECORD','OBSERVATION','RETURN'])")); assert(!objectsRoute.includes('evidenceRefs: z.array')); assert(internalObjects.includes('assertCaseReferenceIntegrity')); assert(reportsRoute.includes('assertReportClaimsIntegrity')); assert(tenderRoute.includes('assertTenderAssessmentPrerequisites')); assert(relationRoute.includes('assertTenantEnterpriseEntityRefs')); assert(internalRelationRoute.includes('assertTenantEnterpriseEntityRefs'));
+assert(migration.includes('public.sfi_case_action_proposals'));
+assert(migration.includes('public.sfi_case_action_decisions'));
+assert(migration.includes("authority_role in ('OWNER','ADMIN')"));
+assert(migration.includes('authenticated clients receive no direct INSERT/UPDATE policy'));
+assert(migration.includes('Decision rows are server-generated'));
+assert(!migration.includes('create policy sfi_case_action_proposals_tenant_insert'));
+assert(!migration.includes('create policy sfi_case_action_decisions_tenant_insert'));
+assert(migration.includes("object_kind in ('RECORD','OBSERVATION')"));
+assert(migration.includes('Report creation is server/institutional only'));
+assert(migration.includes('Audit events are server-generated only'));
+assert(migration.includes('No ROOT foreign key'));
+assert(migration.includes('No automatic execution trigger'));
+assert(!migration.includes('root_'));
+assert(OPERATIONAL_DELETE_ORDER.includes('sfi_case_action_decisions'));
+assert(OPERATIONAL_DELETE_ORDER.includes('sfi_case_action_proposals'));
 
-console.log(JSON.stringify({ok:true,contract:'SFI-CASE-ACTION-1.0',referenceIntegrity:true,databaseDirectWriteHardening:true,reportExecutionAuthority:false,approvalAuthority:['OWNER','ADMIN'],directPendingToExecuted:false,externalExecutionPerformedByPlatform:false,returnRequiresIntervention:true,clientDirectReturnWrite:false},null,2));
+assert.equal(SFI_CASE_ACTION_BOUNDARY.reportHasExecutionAuthority, false);
+assert.equal(SFI_CASE_ACTION_BOUNDARY.automaticExternalExecution, false);
+assert.equal(SFI_CASE_ACTION_BOUNDARY.clientAddressesRoot, false);
+assert(canSfiCaseActionTransition('PENDING', 'APPROVED'));
+assert(canSfiCaseActionTransition('APPROVED', 'EXECUTED'));
+assert(canSfiCaseActionTransition('EXECUTED', 'RETURN_RECORDED'));
+assert(!canSfiCaseActionTransition('PENDING', 'EXECUTED'));
+assert.throws(() => assertSfiCaseActionTransition('REJECTED', 'EXECUTED'), /TRANSITION_FORBIDDEN/);
+
+assert(integrity.includes('SFI_CASE_REFERENCE_NOT_FOUND'));
+assert(integrity.includes('SFI_TENDER_REQUIREMENT_NOT_FROZEN'));
+assert(integrity.includes('SFI_ENTERPRISE_ENTITY_REFERENCE_NOT_FOUND'));
+assert(actionRepo.includes("['OWNER','ADMIN'].includes(authority.role)"));
+assert(actionRepo.includes('platformPerformedExternalAction: false'));
+assert(actionRepo.includes('causalEffectClaimed: false'));
+assert(actionRepo.includes("kind: 'INTERVENTION'"));
+assert(actionRepo.includes("kind: 'RETURN'"));
+assert(!objectsRoute.includes("z.enum(['RECORD','OBSERVATION','RETURN'])"));
+assert(!objectsRoute.includes('evidenceRefs: z.array'));
+assert(internalObjects.includes('assertCaseReferenceIntegrity'));
+assert(reportsRoute.includes('assertReportClaimsIntegrity'));
+assert(tenderRoute.includes('assertTenderAssessmentPrerequisites'));
+assert(relationRoute.includes('assertTenantEnterpriseEntityRefs'));
+assert(internalRelationRoute.includes('assertTenantEnterpriseEntityRefs'));
+
+console.log(JSON.stringify({
+  ok:true,
+  contract:'SFI-CASE-ACTION-1.0',
+  referenceIntegrity:true,
+  databaseDirectWriteHardening:true,
+  actionMutationsServerGoverned:true,
+  reportExecutionAuthority:false,
+  approvalAuthority:['OWNER','ADMIN'],
+  directPendingToExecuted:false,
+  externalExecutionPerformedByPlatform:false,
+  returnRequiresIntervention:true,
+  clientDirectReturnWrite:false,
+},null,2));

--- a/scripts/qa-sfi-case-integrity-action-v1.ts
+++ b/scripts/qa-sfi-case-integrity-action-v1.ts
@@ -14,48 +14,11 @@ const tenderRoute = read('src/app/api/cases/[caseId]/internal/tender-assessments
 const relationRoute = read('src/app/api/cases/[caseId]/relations/route.ts');
 const internalRelationRoute = read('src/app/api/cases/[caseId]/internal/relations/route.ts');
 
-assert(migration.includes('public.sfi_case_action_proposals'));
-assert(migration.includes('public.sfi_case_action_decisions'));
-assert(migration.includes("authority_role in ('OWNER','ADMIN')"));
-assert(migration.includes('No ROOT foreign key'));
-assert(migration.includes('No automatic execution trigger'));
-assert(!migration.includes('root_'));
-assert(OPERATIONAL_DELETE_ORDER.includes('sfi_case_action_decisions'));
-assert(OPERATIONAL_DELETE_ORDER.includes('sfi_case_action_proposals'));
+assert(migration.includes('public.sfi_case_action_proposals')); assert(migration.includes('public.sfi_case_action_decisions')); assert(migration.includes("authority_role in ('OWNER','ADMIN')")); assert(migration.includes('sfi_tenant_can_approve')); assert(migration.includes("object_kind in ('RECORD','OBSERVATION')")); assert(migration.includes('Report creation is server/institutional only')); assert(migration.includes('Audit events are server-generated only')); assert(migration.includes('No ROOT foreign key')); assert(migration.includes('No automatic execution trigger')); assert(!migration.includes('root_'));
+assert(OPERATIONAL_DELETE_ORDER.includes('sfi_case_action_decisions')); assert(OPERATIONAL_DELETE_ORDER.includes('sfi_case_action_proposals'));
+assert.equal(SFI_CASE_ACTION_BOUNDARY.reportHasExecutionAuthority, false); assert.equal(SFI_CASE_ACTION_BOUNDARY.automaticExternalExecution, false); assert.equal(SFI_CASE_ACTION_BOUNDARY.clientAddressesRoot, false); assert(canSfiCaseActionTransition('PENDING', 'APPROVED')); assert(canSfiCaseActionTransition('APPROVED', 'EXECUTED')); assert(canSfiCaseActionTransition('EXECUTED', 'RETURN_RECORDED')); assert(!canSfiCaseActionTransition('PENDING', 'EXECUTED')); assert.throws(() => assertSfiCaseActionTransition('REJECTED', 'EXECUTED'), /TRANSITION_FORBIDDEN/);
+assert(integrity.includes('SFI_CASE_REFERENCE_NOT_FOUND')); assert(integrity.includes('SFI_TENDER_REQUIREMENT_NOT_FROZEN')); assert(integrity.includes('SFI_ENTERPRISE_ENTITY_REFERENCE_NOT_FOUND'));
+assert(actionRepo.includes("['OWNER','ADMIN'].includes(authority.role)")); assert(actionRepo.includes('platformPerformedExternalAction: false')); assert(actionRepo.includes('causalEffectClaimed: false')); assert(actionRepo.includes("kind: 'INTERVENTION'")); assert(actionRepo.includes("kind: 'RETURN'"));
+assert(!objectsRoute.includes("z.enum(['RECORD','OBSERVATION','RETURN'])")); assert(!objectsRoute.includes('evidenceRefs: z.array')); assert(internalObjects.includes('assertCaseReferenceIntegrity')); assert(reportsRoute.includes('assertReportClaimsIntegrity')); assert(tenderRoute.includes('assertTenderAssessmentPrerequisites')); assert(relationRoute.includes('assertTenantEnterpriseEntityRefs')); assert(internalRelationRoute.includes('assertTenantEnterpriseEntityRefs'));
 
-assert.equal(SFI_CASE_ACTION_BOUNDARY.reportHasExecutionAuthority, false);
-assert.equal(SFI_CASE_ACTION_BOUNDARY.automaticExternalExecution, false);
-assert.equal(SFI_CASE_ACTION_BOUNDARY.clientAddressesRoot, false);
-assert(canSfiCaseActionTransition('PENDING', 'APPROVED'));
-assert(canSfiCaseActionTransition('APPROVED', 'EXECUTED'));
-assert(canSfiCaseActionTransition('EXECUTED', 'RETURN_RECORDED'));
-assert(!canSfiCaseActionTransition('PENDING', 'EXECUTED'));
-assert.throws(() => assertSfiCaseActionTransition('REJECTED', 'EXECUTED'), /TRANSITION_FORBIDDEN/);
-
-assert(integrity.includes('SFI_CASE_REFERENCE_NOT_FOUND'));
-assert(integrity.includes('SFI_TENDER_REQUIREMENT_NOT_FROZEN'));
-assert(integrity.includes('SFI_ENTERPRISE_ENTITY_REFERENCE_NOT_FOUND'));
-assert(actionRepo.includes("['OWNER','ADMIN'].includes(authority.role)"), 'approval must require tenant owner/admin');
-assert(actionRepo.includes('platformPerformedExternalAction: false'));
-assert(actionRepo.includes('causalEffectClaimed: false'));
-assert(actionRepo.includes("kind: 'INTERVENTION'"));
-assert(actionRepo.includes("kind: 'RETURN'"));
-
-assert(!objectsRoute.includes("z.enum(['RECORD','OBSERVATION','RETURN'])"), 'generic client endpoint must not allow ungated RETURN writes');
-assert(internalObjects.includes('assertCaseReferenceIntegrity'));
-assert(reportsRoute.includes('assertReportClaimsIntegrity'));
-assert(tenderRoute.includes('assertTenderAssessmentPrerequisites'));
-assert(relationRoute.includes('assertTenantEnterpriseEntityRefs'));
-assert(internalRelationRoute.includes('assertTenantEnterpriseEntityRefs'));
-
-console.log(JSON.stringify({
-  ok: true,
-  contract: 'SFI-CASE-ACTION-1.0',
-  referenceIntegrity: true,
-  reportExecutionAuthority: false,
-  approvalAuthority: ['OWNER','ADMIN'],
-  directPendingToExecuted: false,
-  externalExecutionPerformedByPlatform: false,
-  returnRequiresIntervention: true,
-  clientDirectReturnWrite: false,
-}, null, 2));
+console.log(JSON.stringify({ok:true,contract:'SFI-CASE-ACTION-1.0',referenceIntegrity:true,databaseDirectWriteHardening:true,reportExecutionAuthority:false,approvalAuthority:['OWNER','ADMIN'],directPendingToExecuted:false,externalExecutionPerformedByPlatform:false,returnRequiresIntervention:true,clientDirectReturnWrite:false},null,2));

--- a/scripts/qa-sfi-case-platform-operational-v1.ts
+++ b/scripts/qa-sfi-case-platform-operational-v1.ts
@@ -34,7 +34,9 @@ async function main() {
   assert(!repository.includes("from('institutional_memory')"), 'case repository must not address institutional memory directly');
   assert(!repository.includes("from('root_"), 'case repository must not address ROOT tables directly');
   assert(casesRoute.includes('requireAuthenticatedUser'), 'case API must authenticate');
-  assert(objectsRoute.includes("z.enum(['RECORD','OBSERVATION','RETURN'])"), 'client object endpoint must remain record-only');
+  assert(objectsRoute.includes("z.enum(['RECORD','OBSERVATION'])"), 'client object endpoint must remain record-only');
+  assert(!objectsRoute.includes("'RETURN'"), 'client object endpoint must not bypass governed return loop');
+  assert(!objectsRoute.includes('evidenceRefs: z.array'), 'client object endpoint must not accept evidence claims');
   assert(objectsRoute.includes('cannot create EVIDENCE'), 'client epistemic boundary must be explicit');
   assert(reportsRoute.includes('requireSfiMember'), 'report generation must remain institutional in Operational V1');
   assert(reportsRoute.includes('executionAuthority: false'), 'report API must not expose action authority');
@@ -106,6 +108,7 @@ async function main() {
     contract: 'SFI-CASE-PLATFORM-OPERATIONAL-1.0',
     tenantIsolation: true,
     clientRecordOnlyWrites: true,
+    clientDirectReturnWrite: false,
     reportExecutionAuthority: false,
     institutionalMemoryDirectWrite: false,
     requiredSourceGate: true,

--- a/scripts/qa-sfi-operational-reset.ts
+++ b/scripts/qa-sfi-operational-reset.ts
@@ -17,7 +17,7 @@ const requiredRuntimeTables=[
   'root_evidence_entries','epistemic_events','sfi_evidence_ledger','graph_nodes','graph_edges',
   'sfi_cognitive_twin_memory','sfi_cognitive_twin_decisions','sfi_cognitive_twin_evaluations','sfi_cognitive_twin_runs',
   'sfi_operating_cycles','sfi_inference_traces','sfi_artifact_trajectory_events','sfi_lab_analyses',
-  'sfi_cases','sfi_case_objects','sfi_case_relations','sfi_case_reports','sfi_case_audit_events',
+  'sfi_cases','sfi_case_objects','sfi_case_relations','sfi_case_reports','sfi_case_audit_events','sfi_case_action_proposals','sfi_case_action_decisions',
   'field_cases','field_case_evidence','field_moph_runs','field_mihm_readings','field_hypotheses','field_interventions','field_returns','field_outcomes',
   'studio_sessions','studio_objects','studio_uploads','studio_analysis_jobs','studio_audio_features','action_proposals','logbook_mutations',
 ];
@@ -28,29 +28,8 @@ assert.ok(!OPERATIONAL_DELETE_ORDER.includes('worldspect_snapshots'),'worldspect
 assert.ok(!OPERATIONAL_DELETE_ORDER.includes('sfi_tenants'),'tenant_identity_must_survive_runtime_reset');
 assert.ok(!OPERATIONAL_DELETE_ORDER.includes('sfi_tenant_members'),'tenant_membership_authority_must_survive_runtime_reset');
 
-assert.match(reset,/CLEAN_RUNTIME_AFTER_VERIFIED_PROOF/);
-assert.match(reset,/LATEST_EXPORT\.txt/);
-assert.match(reset,/SFI_CLEANUP_PLAN_/);
-assert.match(reset,/SFI_FULL_CYCLE_PROOF_/);
-assert.match(reset,/SKIPPED_NOT_PRESENT/);
-assert.match(reset,/protected_checks/);
-assert.match(reset,/countTable/);
-assert.doesNotMatch(reset,/DELETE_ORDER from '.\/sfi-db-tables\.mjs'/);
-
-assert.match(readiness,/EMPTY_READY:no_field_cycles_yet/);
-assert.match(readiness,/EMPTY_READY:no_studio_objects_yet/);
-assert.match(readiness,/EMPTY_READY:no_evidence_yet/);
-assert.match(readiness,/EMPTY_READY:no_relations_yet/);
-assert.match(proof,/REAL_PERSISTED_EVIDENCE_REPLAY/);
-assert.match(proof,/Field return is never fabricated/);
+assert.match(reset,/CLEAN_RUNTIME_AFTER_VERIFIED_PROOF/); assert.match(reset,/LATEST_EXPORT\.txt/); assert.match(reset,/SFI_CLEANUP_PLAN_/); assert.match(reset,/SFI_FULL_CYCLE_PROOF_/); assert.match(reset,/SKIPPED_NOT_PRESENT/); assert.match(reset,/protected_checks/); assert.match(reset,/countTable/); assert.doesNotMatch(reset,/DELETE_ORDER from '.\/sfi-db-tables\.mjs'/);
+assert.match(readiness,/EMPTY_READY:no_field_cycles_yet/); assert.match(readiness,/EMPTY_READY:no_studio_objects_yet/); assert.match(readiness,/EMPTY_READY:no_evidence_yet/); assert.match(readiness,/EMPTY_READY:no_relations_yet/); assert.match(proof,/REAL_PERSISTED_EVIDENCE_REPLAY/); assert.match(proof,/Field return is never fabricated/);
 for(const source of [cycle,field,studio,lab])assert.ok(source.length>100,'runtime_source_unexpectedly_empty');
 
-console.log(JSON.stringify({ok:true,purgeTableCount:OPERATIONAL_DELETE_ORDER.length,protectedTableCount:PROTECTED_TABLES.length,invariants:[
-  'full-cycle proof/export precedes reset',
-  'runtime history is cleared child-first',
-  'identity/access/authority including tenant membership are protected',
-  'Case Platform objects, relations, reports and cases are cleared while tenant identity survives',
-  'WorldSpect longitudinal observation corpus survives genesis',
-  'optional/missing tables are skipped instead of making the reset unsafe',
-  'empty post-reset organs report READY rather than DEGRADED',
-]},null,2));
+console.log(JSON.stringify({ok:true,purgeTableCount:OPERATIONAL_DELETE_ORDER.length,protectedTableCount:PROTECTED_TABLES.length,invariants:['full-cycle proof/export precedes reset','runtime history is cleared child-first','identity/access/authority including tenant membership are protected','Case Platform actions, reports, relations, objects and cases are cleared while tenant identity survives','WorldSpect longitudinal observation corpus survives genesis','optional/missing tables are skipped instead of making the reset unsafe','empty post-reset organs report READY rather than DEGRADED']},null,2));

--- a/src/app/api/cases/[caseId]/actions/[proposalId]/decision/route.ts
+++ b/src/app/api/cases/[caseId]/actions/[proposalId]/decision/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAuthenticatedUser } from '@/lib/system/access/server';
+import { decideCaseActionProposal } from '@/lib/sfi/case-platform/actionRepository';
+import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const schema = z.object({ decision: z.enum(['APPROVE','REJECT']), rationale: z.string().trim().max(4000).nullable().optional() }).strict();
+type RouteContext = { params: Promise<{ caseId: string; proposalId: string }> };
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const { caseId, proposalId } = await context.params;
+    const body = schema.parse(await request.json());
+    const proposal = await decideCaseActionProposal({ caseId, proposalId, userId: user.id, decision: body.decision, rationale: body.rationale });
+    return NextResponse.json({ ok: true, proposal, humanTenantAuthority: true, rootAddressed: false });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}

--- a/src/app/api/cases/[caseId]/actions/[proposalId]/intervention/route.ts
+++ b/src/app/api/cases/[caseId]/actions/[proposalId]/intervention/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAuthenticatedUser } from '@/lib/system/access/server';
+import { recordApprovedCaseIntervention } from '@/lib/sfi/case-platform/actionRepository';
+import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const schema = z.object({ observedAt: z.string().trim().min(1).max(80), executionDetails: z.record(z.string(), z.unknown()).optional() }).strict();
+type RouteContext = { params: Promise<{ caseId: string; proposalId: string }> };
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const { caseId, proposalId } = await context.params;
+    const body = schema.parse(await request.json());
+    const result = await recordApprovedCaseIntervention({ caseId, proposalId, userId: user.id, observedAt: body.observedAt, executionDetails: body.executionDetails });
+    return NextResponse.json({ ok: true, ...result, platformPerformedExternalAction: false }, { status: 201 });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}

--- a/src/app/api/cases/[caseId]/actions/[proposalId]/return/route.ts
+++ b/src/app/api/cases/[caseId]/actions/[proposalId]/return/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAuthenticatedUser } from '@/lib/system/access/server';
+import { recordCaseActionReturn } from '@/lib/sfi/case-platform/actionRepository';
+import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const schema = z.object({ observedAt: z.string().trim().min(1).max(80), outcome: z.string().trim().min(1).max(8000), measurements: z.record(z.string(), z.unknown()).optional() }).strict();
+type RouteContext = { params: Promise<{ caseId: string; proposalId: string }> };
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const { caseId, proposalId } = await context.params;
+    const body = schema.parse(await request.json());
+    const result = await recordCaseActionReturn({ caseId, proposalId, userId: user.id, observedAt: body.observedAt, outcome: body.outcome, measurements: body.measurements });
+    return NextResponse.json({ ok: true, ...result, causalEffectClaimed: false }, { status: 201 });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}

--- a/src/app/api/cases/[caseId]/actions/route.ts
+++ b/src/app/api/cases/[caseId]/actions/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAuthenticatedUser, requireSfiMember } from '@/lib/system/access/server';
+import { createCaseActionProposal, listCaseActionProposals } from '@/lib/sfi/case-platform/actionRepository';
+import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const refSchema = z.object({ id: z.string().trim().min(1).max(500), version: z.string().trim().max(120).nullable().optional(), hash: z.string().trim().max(256).nullable().optional() }).strict();
+const proposalSchema = z.object({
+  recommendationRef: refSchema,
+  action: z.string().trim().min(1).max(8000),
+  details: z.record(z.string(), z.unknown()).optional(),
+  riskLevel: z.enum(['LOW','MEDIUM','HIGH','CRITICAL']),
+  reversibility: z.enum(['REVERSIBLE','PARTIALLY_REVERSIBLE','IRREVERSIBLE','UNKNOWN']),
+}).strict();
+
+type RouteContext = { params: Promise<{ caseId: string }> };
+
+export async function GET(_: Request, context: RouteContext) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const { caseId } = await context.params;
+    return NextResponse.json({ ok: true, actions: await listCaseActionProposals(caseId, user.id), reportExecutionAuthority: false });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  try {
+    const { user } = await requireSfiMember();
+    const { caseId } = await context.params;
+    const body = proposalSchema.parse(await request.json());
+    const proposal = await createCaseActionProposal({ caseId, userId: user.id, ...body });
+    return NextResponse.json({ ok: true, proposal, status: 'PENDING', requiresTenantHumanAuthority: true, rootAddressed: false }, { status: 201 });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}

--- a/src/app/api/cases/[caseId]/enterprise/intake/route.ts
+++ b/src/app/api/cases/[caseId]/enterprise/intake/route.ts
@@ -1,63 +1,44 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { requireAuthenticatedUser } from '@/lib/system/access/server';
-import {
-  enterpriseEntityRef,
-  normalizeEnterpriseEntityRecord,
-  normalizeServiceTicketRecord,
-  normalizeTenderRequirementRecord,
-  normalizeWarrantyEventRecord,
-  type SfiEnterpriseIntakePackage,
-} from '@/core/case-platform';
+import { normalizeEnterpriseEntityRecord, normalizeServiceTicketRecord, normalizeTenderRequirementRecord, normalizeWarrantyEventRecord, type SfiEnterpriseIntakePackage } from '@/core/case-platform';
 import { recordOperationalCaseObject } from '@/lib/sfi/case-platform/repository';
 import { recordOperationalEnterpriseRelation } from '@/lib/sfi/case-platform/enterpriseRepository';
+import { assertCaseReferenceIntegrity, assertTenantEnterpriseEntityRefs } from '@/lib/sfi/case-platform/integrity';
 import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
 
-export const dynamic = 'force-dynamic';
-export const runtime = 'nodejs';
-
+export const dynamic = 'force-dynamic'; export const runtime = 'nodejs';
 const refSchema = z.object({ id: z.string().trim().min(1).max(500), version: z.string().trim().max(120).nullable().optional(), hash: z.string().trim().max(256).nullable().optional() }).strict();
 const entityTypeSchema = z.enum(['TENDER','REQUIREMENT','BIDDER','BID_SUBMISSION','SUPPLIER','CONTRACT','OBLIGATION','ASSET','SERVICE','TICKET','SLA','WARRANTY','WARRANTY_EVENT','RETURN','SUPPLIER_PERFORMANCE']);
 const entityRefSchema = refSchema.extend({ entityType: entityTypeSchema }).strict();
-
 const entitySchema = z.object({ type: z.literal('ENTITY'), entityType: entityTypeSchema, entityId: z.string().trim().min(1).max(240), label: z.string().trim().max(500).nullable().optional(), attributes: z.record(z.string(), z.unknown()).optional(), observedAt: z.string().trim().max(80).nullable().optional(), sourceRefs: z.array(refSchema).max(500).optional() }).strict();
 const ticketSchema = z.object({ type: z.literal('SERVICE_TICKET'), ticketId: z.string().trim().min(1).max(240), openedAt: z.string().trim().min(1).max(80), closedAt: z.string().trim().max(80).nullable().optional(), status: z.string().trim().min(1).max(120), category: z.string().trim().max(240).nullable().optional(), priority: z.string().trim().max(120).nullable().optional(), responseMinutes: z.number().nonnegative().nullable().optional(), resolutionMinutes: z.number().nonnegative().nullable().optional(), recurrenceKey: z.string().trim().max(240).nullable().optional(), assetRef: entityRefSchema.nullable().optional(), serviceRef: entityRefSchema.nullable().optional(), slaRef: entityRefSchema.nullable().optional(), supplierRef: entityRefSchema.nullable().optional(), sourceRefs: z.array(refSchema).max(500).optional() }).strict();
 const warrantySchema = z.object({ type: z.literal('WARRANTY_EVENT'), eventId: z.string().trim().min(1).max(240), occurredAt: z.string().trim().min(1).max(80), eventType: z.string().trim().min(1).max(160), status: z.string().trim().min(1).max(120), assetRef: entityRefSchema, warrantyRef: entityRefSchema.nullable().optional(), supplierRef: entityRefSchema.nullable().optional(), responseDueAt: z.string().trim().max(80).nullable().optional(), resolvedAt: z.string().trim().max(80).nullable().optional(), sourceRefs: z.array(refSchema).max(500).optional() }).strict();
 const tenderRequirementSchema = z.object({ type: z.literal('TENDER_REQUIREMENT'), requirementId: z.string().trim().min(1).max(240), tenderRef: entityRefSchema, requirementText: z.string().trim().min(1).max(12000), requirementType: z.string().trim().max(240).nullable().optional(), frozenAt: z.string().trim().min(1).max(80), sourceRefs: z.array(refSchema).min(1).max(500), pageLocator: z.string().trim().max(240).nullable().optional() }).strict();
 const intakeSchema = z.discriminatedUnion('type', [entitySchema, ticketSchema, warrantySchema, tenderRequirementSchema]);
-
 type RouteContext = { params: Promise<{ caseId: string }> };
 
 async function persistPackage(caseId: string, userId: string, packet: SfiEnterpriseIntakePackage) {
+  await assertCaseReferenceIntegrity({ caseId, userId, sourceRefs: packet.object.sourceRefs, recordRefs: packet.object.recordRefs, evidenceRefs: packet.object.evidenceRefs });
   const object = await recordOperationalCaseObject({ caseId, userId, ...packet.object });
   const relations = [];
-  for (const relation of packet.relations) relations.push(await recordOperationalEnterpriseRelation({ caseId, userId, relation }));
+  for (const relation of packet.relations) {
+    await assertCaseReferenceIntegrity({ caseId, userId, sourceRefs: relation.sourceRefs, recordRefs: relation.recordRefs, evidenceRefs: relation.evidenceRefs });
+    await assertTenantEnterpriseEntityRefs({ caseId, userId, entityRefs: [relation.from, relation.to] });
+    relations.push(await recordOperationalEnterpriseRelation({ caseId, userId, relation }));
+  }
   return { object, relations };
 }
 
 export async function POST(request: Request, context: RouteContext) {
   try {
-    const { user } = await requireAuthenticatedUser();
-    const { caseId } = await context.params;
-    const body = intakeSchema.parse(await request.json());
+    const { user } = await requireAuthenticatedUser(); const { caseId } = await context.params; const body = intakeSchema.parse(await request.json());
     let packet: SfiEnterpriseIntakePackage;
-    if (body.type === 'ENTITY') {
-      packet = normalizeEnterpriseEntityRecord(body);
-    } else if (body.type === 'SERVICE_TICKET') {
-      packet = normalizeServiceTicketRecord(body);
-    } else if (body.type === 'WARRANTY_EVENT') {
-      packet = normalizeWarrantyEventRecord(body);
-    } else {
-      packet = normalizeTenderRequirementRecord(body);
-    }
+    if (body.type === 'ENTITY') packet = normalizeEnterpriseEntityRecord(body);
+    else if (body.type === 'SERVICE_TICKET') packet = normalizeServiceTicketRecord(body);
+    else if (body.type === 'WARRANTY_EVENT') packet = normalizeWarrantyEventRecord(body);
+    else packet = normalizeTenderRequirementRecord(body);
     const result = await persistPackage(caseId, user.id, packet);
-    return NextResponse.json({
-      ok: true,
-      contract: packet.contract,
-      ...result,
-      boundary: 'Enterprise intake persists records and declared relations only. It does not infer cause, contractual breach, tender winner, supplier rank, or SFI institutional truth.',
-    }, { status: 201 });
-  } catch (error) {
-    return sfiCaseApiFailure(error);
-  }
+    return NextResponse.json({ ok: true, contract: packet.contract, ...result, boundary: 'Enterprise intake persists records and declared relations only after referenced lineage/entities resolve. It does not infer cause, contractual breach, tender winner, supplier rank, or SFI institutional truth.' }, { status: 201 });
+  } catch (error) { return sfiCaseApiFailure(error); }
 }

--- a/src/app/api/cases/[caseId]/internal/objects/route.ts
+++ b/src/app/api/cases/[caseId]/internal/objects/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { requireSfiMember } from '@/lib/system/access/server';
 import { recordOperationalCaseObject } from '@/lib/sfi/case-platform/repository';
+import { assertCaseReferenceIntegrity } from '@/lib/sfi/case-platform/integrity';
 import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
 import type { SfiCaseObjectKind } from '@/core/case-platform';
 import type { SfiEpistemicClass } from '@/core/contracts/sfi';
@@ -28,6 +29,7 @@ export async function POST(request: Request, context: RouteContext) {
     const { user } = await requireSfiMember();
     const { caseId } = await context.params;
     const body = schema.parse(await request.json());
+    await assertCaseReferenceIntegrity({ caseId, userId: user.id, sourceRefs: body.sourceRefs, recordRefs: body.recordRefs, evidenceRefs: body.evidenceRefs });
     const object = await recordOperationalCaseObject({
       caseId,
       userId: user.id,
@@ -43,7 +45,7 @@ export async function POST(request: Request, context: RouteContext) {
     return NextResponse.json({
       ok: true,
       object,
-      boundary: 'Internal assessment can persist evidence/analysis only under existing lineage checks. It cannot create governance decisions, interventions, truth claims, or institutional-memory writes.',
+      boundary: 'Internal assessment can persist evidence/analysis only after referenced objects resolve with the claimed epistemic role. It cannot create governance decisions, interventions, truth claims, or institutional-memory writes.',
     }, { status: 201 });
   } catch (error) {
     return sfiCaseApiFailure(error);

--- a/src/app/api/cases/[caseId]/internal/relations/route.ts
+++ b/src/app/api/cases/[caseId]/internal/relations/route.ts
@@ -2,29 +2,16 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { requireSfiMember } from '@/lib/system/access/server';
 import { recordOperationalEnterpriseRelation } from '@/lib/sfi/case-platform/enterpriseRepository';
+import { assertCaseReferenceIntegrity, assertTenantEnterpriseEntityRefs } from '@/lib/sfi/case-platform/integrity';
 import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
 import type { SfiEnterpriseRelationDraft } from '@/core/case-platform';
 
-export const dynamic = 'force-dynamic';
-export const runtime = 'nodejs';
-
+export const dynamic = 'force-dynamic'; export const runtime = 'nodejs';
 const canonicalRefSchema = z.object({ id: z.string().trim().min(1).max(500), version: z.string().trim().max(120).nullable().optional(), hash: z.string().trim().max(256).nullable().optional() }).strict();
 const entityTypeSchema = z.enum(['TENDER','REQUIREMENT','BIDDER','BID_SUBMISSION','SUPPLIER','CONTRACT','OBLIGATION','ASSET','SERVICE','TICKET','SLA','WARRANTY','WARRANTY_EVENT','RETURN','SUPPLIER_PERFORMANCE']);
 const entityRefSchema = canonicalRefSchema.extend({ entityType: entityTypeSchema }).strict();
 const relationTypeSchema = z.enum(['TENDER_HAS_REQUIREMENT','BIDDER_PARTICIPATES_IN_TENDER','BID_SUBMISSION_FOR_TENDER','BID_SUBMISSION_BY_BIDDER','BIDDER_MAPS_TO_SUPPLIER','TENDER_AWARDS_SUPPLIER','CONTRACT_ARISES_FROM_TENDER','CONTRACT_BINDS_SUPPLIER','CONTRACT_DEFINES_OBLIGATION','CONTRACT_COVERS_ASSET','CONTRACT_COVERS_SERVICE','ASSET_PROVIDED_BY_SUPPLIER','SERVICE_PROVIDED_BY_SUPPLIER','TICKET_AFFECTS_ASSET','TICKET_AFFECTS_SERVICE','TICKET_SUBJECT_TO_SLA','TICKET_ASSIGNED_TO_SUPPLIER','SLA_DERIVED_FROM_CONTRACT','WARRANTY_DEFINED_BY_CONTRACT','WARRANTY_COVERS_ASSET','WARRANTY_EVENT_AFFECTS_ASSET','WARRANTY_EVENT_UNDER_WARRANTY','WARRANTY_EVENT_ASSIGNED_TO_SUPPLIER','TICKET_TRIGGERS_WARRANTY_EVENT','RETURN_RESOLVES_WARRANTY_EVENT','RETURN_CLOSES_TICKET','SUPPLIER_PERFORMANCE_AGGREGATES_RETURN','SUPPLIER_PERFORMANCE_INFORMS_TENDER']);
-const relationSchema = z.object({
-  relationKey: z.string().trim().min(1).max(500),
-  relationType: relationTypeSchema,
-  epistemicRole: z.enum(['RECORD','INFERENCE','EPISTEMIC_ASSESSMENT']),
-  from: entityRefSchema,
-  to: entityRefSchema,
-  sourceRefs: z.array(canonicalRefSchema).max(500).optional(),
-  recordRefs: z.array(canonicalRefSchema).max(500).optional(),
-  evidenceRefs: z.array(canonicalRefSchema).max(500).optional(),
-  payload: z.record(z.string(), z.unknown()).optional(),
-  observedAt: z.string().trim().max(80).nullable().optional(),
-}).strict();
-
+const relationSchema = z.object({ relationKey: z.string().trim().min(1).max(500), relationType: relationTypeSchema, epistemicRole: z.enum(['RECORD','INFERENCE','EPISTEMIC_ASSESSMENT']), from: entityRefSchema, to: entityRefSchema, sourceRefs: z.array(canonicalRefSchema).max(500).optional(), recordRefs: z.array(canonicalRefSchema).max(500).optional(), evidenceRefs: z.array(canonicalRefSchema).max(500).optional(), payload: z.record(z.string(), z.unknown()).optional(), observedAt: z.string().trim().max(80).nullable().optional() }).strict();
 type RouteContext = { params: Promise<{ caseId: string }> };
 
 export async function POST(request: Request, context: RouteContext) {
@@ -32,9 +19,9 @@ export async function POST(request: Request, context: RouteContext) {
     const { user } = await requireSfiMember();
     const { caseId } = await context.params;
     const body = relationSchema.parse(await request.json());
+    await assertCaseReferenceIntegrity({ caseId, userId: user.id, sourceRefs: body.sourceRefs, recordRefs: body.recordRefs, evidenceRefs: body.evidenceRefs });
+    await assertTenantEnterpriseEntityRefs({ caseId, userId: user.id, entityRefs: [body.from, body.to] });
     const relation = await recordOperationalEnterpriseRelation({ caseId, userId: user.id, relation: body as SfiEnterpriseRelationDraft });
     return NextResponse.json({ ok: true, relation, truthAuthority: false, institutionalGraphWrite: false }, { status: 201 });
-  } catch (error) {
-    return sfiCaseApiFailure(error);
-  }
+  } catch (error) { return sfiCaseApiFailure(error); }
 }

--- a/src/app/api/cases/[caseId]/internal/tender-assessments/route.ts
+++ b/src/app/api/cases/[caseId]/internal/tender-assessments/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { requireSfiMember } from '@/lib/system/access/server';
 import { normalizeTenderAssessment } from '@/core/case-platform';
 import { recordOperationalCaseObject } from '@/lib/sfi/case-platform/repository';
+import { assertTenderAssessmentPrerequisites } from '@/lib/sfi/case-platform/integrity';
 import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
 
 export const dynamic = 'force-dynamic';
@@ -11,20 +12,7 @@ export const runtime = 'nodejs';
 const refSchema = z.object({ id: z.string().trim().min(1).max(500), version: z.string().trim().max(120).nullable().optional(), hash: z.string().trim().max(256).nullable().optional() }).strict();
 const requirementRefSchema = refSchema.extend({ entityType: z.literal('REQUIREMENT') }).strict();
 const bidderRefSchema = refSchema.extend({ entityType: z.literal('BIDDER') }).strict();
-const schema = z.object({
-  assessmentId: z.string().trim().min(1).max(240),
-  requirementRef: requirementRefSchema,
-  bidderRef: bidderRefSchema,
-  result: z.enum(['PASS','FAIL','UNDETERMINED']),
-  sourceRefs: z.array(refSchema).min(1).max(500),
-  recordRefs: z.array(refSchema).max(500).optional(),
-  evidenceRefs: z.array(refSchema).max(500).optional(),
-  pageLocator: z.string().trim().max(240).nullable().optional(),
-  confidence: z.number().min(0).max(1).nullable().optional(),
-  missingReason: z.string().trim().max(2000).nullable().optional(),
-  contradictionRefs: z.array(refSchema).max(500).optional(),
-}).strict();
-
+const schema = z.object({ assessmentId: z.string().trim().min(1).max(240), requirementRef: requirementRefSchema, bidderRef: bidderRefSchema, result: z.enum(['PASS','FAIL','UNDETERMINED']), sourceRefs: z.array(refSchema).min(1).max(500), recordRefs: z.array(refSchema).max(500).optional(), evidenceRefs: z.array(refSchema).max(500).optional(), pageLocator: z.string().trim().max(240).nullable().optional(), confidence: z.number().min(0).max(1).nullable().optional(), missingReason: z.string().trim().max(2000).nullable().optional(), contradictionRefs: z.array(refSchema).max(500).optional() }).strict();
 type RouteContext = { params: Promise<{ caseId: string }> };
 
 export async function POST(request: Request, context: RouteContext) {
@@ -32,14 +20,10 @@ export async function POST(request: Request, context: RouteContext) {
     const { user } = await requireSfiMember();
     const { caseId } = await context.params;
     const body = schema.parse(await request.json());
+    await assertTenderAssessmentPrerequisites({ caseId, userId: user.id, requirementRef: body.requirementRef, bidderRef: body.bidderRef, sourceRefs: body.sourceRefs, recordRefs: body.recordRefs, evidenceRefs: body.evidenceRefs });
     const assessment = normalizeTenderAssessment(body as Parameters<typeof normalizeTenderAssessment>[0]);
     const object = await recordOperationalCaseObject({ caseId, userId: user.id, ...assessment });
-    return NextResponse.json({
-      ok: true,
-      assessment: object,
-      winnerSelectionAuthority: false,
-      humanDecisionAuthorityPreserved: true,
-    }, { status: 201 });
+    return NextResponse.json({ ok: true, assessment: object, winnerSelectionAuthority: false, humanDecisionAuthorityPreserved: true }, { status: 201 });
   } catch (error) {
     return sfiCaseApiFailure(error);
   }

--- a/src/app/api/cases/[caseId]/objects/route.ts
+++ b/src/app/api/cases/[caseId]/objects/route.ts
@@ -14,11 +14,10 @@ const refSchema = z.object({
 }).strict();
 
 const clientWriteSchema = z.object({
-  kind: z.enum(['RECORD','OBSERVATION','RETURN']),
+  kind: z.enum(['RECORD','OBSERVATION']),
   canonicalRef: refSchema,
   sourceRefs: z.array(refSchema).max(500).optional(),
   recordRefs: z.array(refSchema).max(500).optional(),
-  evidenceRefs: z.array(refSchema).max(500).optional(),
   payload: z.record(z.string(), z.unknown()).optional(),
   observedAt: z.string().trim().max(80).nullable().optional(),
 }).strict();
@@ -49,14 +48,14 @@ export async function POST(request: Request, context: RouteContext) {
       canonicalRef: body.canonicalRef,
       sourceRefs: body.sourceRefs,
       recordRefs: body.recordRefs,
-      evidenceRefs: body.evidenceRefs,
+      evidenceRefs: [],
       payload: body.payload,
       observedAt: body.observedAt,
     });
     return NextResponse.json({
       ok: true,
       object,
-      epistemicBoundary: 'Client-submitted records remain RECORD. This endpoint cannot create EVIDENCE, ANALYSIS, GOVERNANCE_DECISION or TRUTH_CLAIM objects.',
+      epistemicBoundary: 'Client-submitted objects remain RECORD. This endpoint cannot create EVIDENCE, ANALYSIS, GOVERNANCE_DECISION, INTERVENTION, RETURN or TRUTH_CLAIM objects and cannot attach evidence claims.',
     }, { status: 201 });
   } catch (error) {
     return sfiCaseApiFailure(error);

--- a/src/app/api/cases/[caseId]/relations/route.ts
+++ b/src/app/api/cases/[caseId]/relations/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { requireAuthenticatedUser } from '@/lib/system/access/server';
 import { listOperationalEnterpriseRelations, recordOperationalEnterpriseRelation } from '@/lib/sfi/case-platform/enterpriseRepository';
+import { assertCaseReferenceIntegrity, assertTenantEnterpriseEntityRefs } from '@/lib/sfi/case-platform/integrity';
 import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
 import type { SfiEnterpriseRelationDraft } from '@/core/case-platform';
 
@@ -12,28 +13,11 @@ const canonicalRefSchema = z.object({ id: z.string().trim().min(1).max(500), ver
 const entityTypeSchema = z.enum(['TENDER','REQUIREMENT','BIDDER','BID_SUBMISSION','SUPPLIER','CONTRACT','OBLIGATION','ASSET','SERVICE','TICKET','SLA','WARRANTY','WARRANTY_EVENT','RETURN','SUPPLIER_PERFORMANCE']);
 const entityRefSchema = canonicalRefSchema.extend({ entityType: entityTypeSchema }).strict();
 const relationTypeSchema = z.enum(['TENDER_HAS_REQUIREMENT','BIDDER_PARTICIPATES_IN_TENDER','BID_SUBMISSION_FOR_TENDER','BID_SUBMISSION_BY_BIDDER','BIDDER_MAPS_TO_SUPPLIER','TENDER_AWARDS_SUPPLIER','CONTRACT_ARISES_FROM_TENDER','CONTRACT_BINDS_SUPPLIER','CONTRACT_DEFINES_OBLIGATION','CONTRACT_COVERS_ASSET','CONTRACT_COVERS_SERVICE','ASSET_PROVIDED_BY_SUPPLIER','SERVICE_PROVIDED_BY_SUPPLIER','TICKET_AFFECTS_ASSET','TICKET_AFFECTS_SERVICE','TICKET_SUBJECT_TO_SLA','TICKET_ASSIGNED_TO_SUPPLIER','SLA_DERIVED_FROM_CONTRACT','WARRANTY_DEFINED_BY_CONTRACT','WARRANTY_COVERS_ASSET','WARRANTY_EVENT_AFFECTS_ASSET','WARRANTY_EVENT_UNDER_WARRANTY','WARRANTY_EVENT_ASSIGNED_TO_SUPPLIER','TICKET_TRIGGERS_WARRANTY_EVENT','RETURN_RESOLVES_WARRANTY_EVENT','RETURN_CLOSES_TICKET','SUPPLIER_PERFORMANCE_AGGREGATES_RETURN','SUPPLIER_PERFORMANCE_INFORMS_TENDER']);
-const relationSchema = z.object({
-  relationKey: z.string().trim().min(1).max(500),
-  relationType: relationTypeSchema,
-  from: entityRefSchema,
-  to: entityRefSchema,
-  sourceRefs: z.array(canonicalRefSchema).max(500).optional(),
-  recordRefs: z.array(canonicalRefSchema).max(500).optional(),
-  payload: z.record(z.string(), z.unknown()).optional(),
-  observedAt: z.string().trim().max(80).nullable().optional(),
-}).strict();
-
+const relationSchema = z.object({ relationKey: z.string().trim().min(1).max(500), relationType: relationTypeSchema, from: entityRefSchema, to: entityRefSchema, sourceRefs: z.array(canonicalRefSchema).max(500).optional(), recordRefs: z.array(canonicalRefSchema).max(500).optional(), payload: z.record(z.string(), z.unknown()).optional(), observedAt: z.string().trim().max(80).nullable().optional() }).strict();
 type RouteContext = { params: Promise<{ caseId: string }> };
 
 export async function GET(_: Request, context: RouteContext) {
-  try {
-    const { user } = await requireAuthenticatedUser();
-    const { caseId } = await context.params;
-    const relations = await listOperationalEnterpriseRelations(caseId, user.id);
-    return NextResponse.json({ ok: true, contract: 'SFI-ENTERPRISE-ASSURANCE-DOMAIN-1.0', relations });
-  } catch (error) {
-    return sfiCaseApiFailure(error);
-  }
+  try { const { user } = await requireAuthenticatedUser(); const { caseId } = await context.params; return NextResponse.json({ ok: true, contract: 'SFI-ENTERPRISE-ASSURANCE-DOMAIN-1.0', relations: await listOperationalEnterpriseRelations(caseId, user.id) }); } catch (error) { return sfiCaseApiFailure(error); }
 }
 
 export async function POST(request: Request, context: RouteContext) {
@@ -41,10 +25,10 @@ export async function POST(request: Request, context: RouteContext) {
     const { user } = await requireAuthenticatedUser();
     const { caseId } = await context.params;
     const body = relationSchema.parse(await request.json());
+    await assertCaseReferenceIntegrity({ caseId, userId: user.id, sourceRefs: body.sourceRefs, recordRefs: body.recordRefs });
+    await assertTenantEnterpriseEntityRefs({ caseId, userId: user.id, entityRefs: [body.from, body.to] });
     const relation: SfiEnterpriseRelationDraft = { ...body, evidenceRefs: [], epistemicRole: 'RECORD' } as SfiEnterpriseRelationDraft;
     const saved = await recordOperationalEnterpriseRelation({ caseId, userId: user.id, relation });
-    return NextResponse.json({ ok: true, relation: saved, epistemicBoundary: 'Client-declared relations remain RECORD; this endpoint cannot create inferred relations or attach evidence claims.' }, { status: 201 });
-  } catch (error) {
-    return sfiCaseApiFailure(error);
-  }
+    return NextResponse.json({ ok: true, relation: saved, epistemicBoundary: 'Client-declared relations remain RECORD; endpoints and lineage refs must resolve, and this endpoint cannot create inferred relations or attach evidence claims.' }, { status: 201 });
+  } catch (error) { return sfiCaseApiFailure(error); }
 }

--- a/src/app/api/cases/[caseId]/reports/route.ts
+++ b/src/app/api/cases/[caseId]/reports/route.ts
@@ -2,18 +2,14 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { requireAuthenticatedUser, requireSfiMember } from '@/lib/system/access/server';
 import { generateOperationalReport, listOperationalReports } from '@/lib/sfi/case-platform/repository';
+import { assertReportClaimsIntegrity } from '@/lib/sfi/case-platform/integrity';
 import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
 import type { SfiReportClaimV1 } from '@/core/contracts/sfi';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
-const refSchema = z.object({
-  id: z.string().trim().min(1).max(500),
-  version: z.string().trim().max(120).nullable().optional(),
-  hash: z.string().trim().max(256).nullable().optional(),
-}).strict();
-
+const refSchema = z.object({ id: z.string().trim().min(1).max(500), version: z.string().trim().max(120).nullable().optional(), hash: z.string().trim().max(256).nullable().optional() }).strict();
 const claimSchema = z.object({
   id: z.string().trim().min(1).max(240),
   statement: z.string().trim().min(1).max(8000),
@@ -24,21 +20,14 @@ const claimSchema = z.object({
   determinability: z.enum(['DETERMINED','PARTIALLY_DETERMINED','UNDETERMINED']),
   confidence: z.number().min(0).max(1).nullable(),
 }).strict();
-
-const reportSchema = z.object({
-  claims: z.array(claimSchema).max(500).optional(),
-  deliveryFormats: z.array(z.enum(['JSON','WEB','PDF','DASHBOARD'])).min(1).max(4).optional(),
-  limitations: z.array(z.string().trim().min(1).max(2000)).max(100).optional(),
-}).strict();
-
+const reportSchema = z.object({ claims: z.array(claimSchema).max(500).optional(), deliveryFormats: z.array(z.enum(['JSON','WEB','PDF','DASHBOARD'])).min(1).max(4).optional(), limitations: z.array(z.string().trim().min(1).max(2000)).max(100).optional() }).strict();
 type RouteContext = { params: Promise<{ caseId: string }> };
 
 export async function GET(_: Request, context: RouteContext) {
   try {
     const { user } = await requireAuthenticatedUser();
     const { caseId } = await context.params;
-    const reports = await listOperationalReports(caseId, user.id);
-    return NextResponse.json({ ok: true, reports });
+    return NextResponse.json({ ok: true, reports: await listOperationalReports(caseId, user.id) });
   } catch (error) {
     return sfiCaseApiFailure(error);
   }
@@ -49,13 +38,9 @@ export async function POST(request: Request, context: RouteContext) {
     const { user } = await requireSfiMember();
     const { caseId } = await context.params;
     const body = reportSchema.parse(await request.json());
-    const report = await generateOperationalReport({
-      caseId,
-      userId: user.id,
-      claims: body.claims as SfiReportClaimV1[] | undefined,
-      deliveryFormats: body.deliveryFormats,
-      limitations: body.limitations,
-    });
+    const claims = (body.claims ?? []) as SfiReportClaimV1[];
+    await assertReportClaimsIntegrity({ caseId, userId: user.id, claims });
+    const report = await generateOperationalReport({ caseId, userId: user.id, claims, deliveryFormats: body.deliveryFormats, limitations: body.limitations });
     return NextResponse.json({ ok: true, report, executionAuthority: false }, { status: 201 });
   } catch (error) {
     return sfiCaseApiFailure(error);

--- a/src/core/case-platform/caseAction.ts
+++ b/src/core/case-platform/caseAction.ts
@@ -1,0 +1,47 @@
+export const SFI_CASE_ACTION_CONTRACT = 'SFI-CASE-ACTION-1.0' as const;
+
+export const SFI_CASE_ACTION_STATUSES = [
+  'PENDING',
+  'APPROVED',
+  'REJECTED',
+  'CANCELLED',
+  'EXECUTED',
+  'RETURN_RECORDED',
+] as const;
+
+export type SfiCaseActionStatus = (typeof SFI_CASE_ACTION_STATUSES)[number];
+export type SfiCaseActionDecision = 'APPROVE' | 'REJECT';
+export type SfiCaseActionRisk = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+export type SfiCaseActionReversibility = 'REVERSIBLE' | 'PARTIALLY_REVERSIBLE' | 'IRREVERSIBLE' | 'UNKNOWN';
+
+const TRANSITIONS: Record<SfiCaseActionStatus, readonly SfiCaseActionStatus[]> = {
+  PENDING: ['APPROVED', 'REJECTED', 'CANCELLED'],
+  APPROVED: ['EXECUTED', 'CANCELLED'],
+  REJECTED: [],
+  CANCELLED: [],
+  EXECUTED: ['RETURN_RECORDED'],
+  RETURN_RECORDED: [],
+};
+
+export function canSfiCaseActionTransition(from: SfiCaseActionStatus, to: SfiCaseActionStatus) {
+  return from === to || (TRANSITIONS[from] as readonly string[]).includes(to);
+}
+
+export function assertSfiCaseActionTransition(from: SfiCaseActionStatus, to: SfiCaseActionStatus) {
+  if (!canSfiCaseActionTransition(from, to)) {
+    throw new Error(`SFI_CASE_ACTION_TRANSITION_FORBIDDEN:${from}:${to}`);
+  }
+}
+
+export const SFI_CASE_ACTION_BOUNDARY = {
+  contract: SFI_CASE_ACTION_CONTRACT,
+  reportHasExecutionAuthority: false,
+  recommendationHasExecutionAuthority: false,
+  automaticExternalExecution: false,
+  humanTenantAuthorityRequired: true,
+  approvalRoles: ['OWNER', 'ADMIN'] as const,
+  operatorMayRecordApprovedIntervention: true,
+  clientAddressesRoot: false,
+  caseDecisionEqualsInstitutionalGovernance: false,
+  returnRequiredForLongitudinalClosure: true,
+} as const;

--- a/src/core/case-platform/index.ts
+++ b/src/core/case-platform/index.ts
@@ -7,3 +7,4 @@ export * from './operational';
 export * from './sourceIntake';
 export * from './instrumentGate';
 export * from './enterpriseAssurance';
+export * from './caseAction';

--- a/src/lib/sfi/case-platform/actionRepository.ts
+++ b/src/lib/sfi/case-platform/actionRepository.ts
@@ -1,6 +1,5 @@
 import 'server-only';
 
-import { randomUUID } from 'node:crypto';
 import {
   assertSfiCaseActionTransition,
   type SfiCaseActionDecision,
@@ -147,10 +146,10 @@ export async function recordApprovedCaseIntervention(input: {
     kind: 'INTERVENTION',
     epistemicRole: 'RECORD',
     canonicalRef: interventionRef,
-    recordRefs: [proposal.recommendationRef],
     payload: {
       contract: 'SFI-CASE-ACTION-1.0',
       proposalId: input.proposalId,
+      recommendationRef: proposal.recommendationRef,
       approved: true,
       action: proposal.action,
       executionDetails: input.executionDetails ?? {},
@@ -161,7 +160,7 @@ export async function recordApprovedCaseIntervention(input: {
   const service = createServiceSupabaseClient();
   const updated = await service.from('sfi_case_action_proposals').update({ status: 'EXECUTED', intervention_ref: intervention.canonicalRef }).eq('id', input.proposalId).eq('status', 'APPROVED').select('*').maybeSingle();
   if (updated.error || !updated.data) throw new Error(`SFI_CASE_INTERVENTION_STATE_WRITE_FAILED:${updated.error?.message ?? 'status_changed'}`);
-  await audit(input.caseId, authority.tenantId, input.userId, 'CASE_INTERVENTION_RECORDED', { proposalId: input.proposalId, interventionRef: intervention.canonicalRef, platformPerformedExternalAction: false });
+  await audit(input.caseId, authority.tenantId, input.userId, 'CASE_INTERVENTION_RECORDED', { proposalId: input.proposalId, recommendationRef: proposal.recommendationRef, interventionRef: intervention.canonicalRef, platformPerformedExternalAction: false });
   return { proposal: proposalFromRow(updated.data as Row), intervention };
 }
 

--- a/src/lib/sfi/case-platform/actionRepository.ts
+++ b/src/lib/sfi/case-platform/actionRepository.ts
@@ -1,0 +1,207 @@
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+import {
+  assertSfiCaseActionTransition,
+  type SfiCaseActionDecision,
+  type SfiCaseActionReversibility,
+  type SfiCaseActionRisk,
+  type SfiCaseActionStatus,
+} from '@/core/case-platform';
+import type { SfiCanonicalRef } from '@/core/contracts/sfi';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { recordOperationalCaseObject } from './repository';
+import { assertCaseReferenceIntegrity, readCaseAuthorityRole } from './integrity';
+
+type Row = Record<string, unknown>;
+
+function text(value: unknown) { return typeof value === 'string' ? value.trim() : ''; }
+function object(value: unknown): Record<string, unknown> { return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}; }
+function canonicalRef(value: unknown): SfiCanonicalRef {
+  const row = object(value);
+  return { id: text(row.id), version: text(row.version) || null, hash: text(row.hash) || null };
+}
+
+function proposalFromRow(row: Row) {
+  return {
+    id: text(row.id),
+    caseId: text(row.case_id),
+    tenantId: text(row.tenant_id),
+    recommendationRef: canonicalRef(row.recommendation_ref),
+    action: object(row.action_payload),
+    riskLevel: text(row.risk_level) as SfiCaseActionRisk,
+    reversibility: text(row.reversibility) as SfiCaseActionReversibility,
+    status: text(row.status) as SfiCaseActionStatus,
+    proposedBy: text(row.proposed_by),
+    interventionRef: row.intervention_ref ? canonicalRef(row.intervention_ref) : null,
+    returnRef: row.return_ref ? canonicalRef(row.return_ref) : null,
+    createdAt: text(row.created_at),
+    updatedAt: text(row.updated_at),
+  };
+}
+
+async function proposalRow(caseId: string, proposalId: string) {
+  const service = createServiceSupabaseClient();
+  const result = await service.from('sfi_case_action_proposals').select('*').eq('id', proposalId).eq('case_id', caseId).maybeSingle();
+  if (result.error) throw new Error(`SFI_CASE_ACTION_READ_FAILED:${result.error.message}`);
+  if (!result.data) throw new Error('SFI_CASE_ACTION_NOT_FOUND');
+  return result.data as Row;
+}
+
+async function audit(caseId: string, tenantId: string, actorId: string, action: string, afterState: unknown) {
+  const service = createServiceSupabaseClient();
+  const result = await service.from('sfi_case_audit_events').insert({ case_id: caseId, tenant_id: tenantId, actor_id: actorId, action, after_state: afterState, context: { contract: 'SFI-CASE-ACTION-1.0' } });
+  if (result.error) throw new Error(`SFI_CASE_ACTION_AUDIT_FAILED:${result.error.message}`);
+}
+
+export async function listCaseActionProposals(caseId: string, userId: string) {
+  await readCaseAuthorityRole(caseId, userId);
+  const service = createServiceSupabaseClient();
+  const result = await service.from('sfi_case_action_proposals').select('*').eq('case_id', caseId).order('created_at', { ascending: true });
+  if (result.error) throw new Error(`SFI_CASE_ACTION_LIST_FAILED:${result.error.message}`);
+  return ((result.data ?? []) as Row[]).map(proposalFromRow);
+}
+
+export async function createCaseActionProposal(input: {
+  caseId: string;
+  userId: string;
+  recommendationRef: SfiCanonicalRef;
+  action: string;
+  details?: Record<string, unknown>;
+  riskLevel: SfiCaseActionRisk;
+  reversibility: SfiCaseActionReversibility;
+}) {
+  const authority = await readCaseAuthorityRole(input.caseId, input.userId);
+  if (!['OWNER','ADMIN','OPERATOR'].includes(authority.role)) throw new Error('SFI_TENANT_WRITE_FORBIDDEN');
+  if (['CLOSED','REJECTED'].includes(authority.status)) throw new Error(`SFI_CASE_ACTION_PROPOSAL_FORBIDDEN:${authority.status}`);
+  await assertCaseReferenceIntegrity({ caseId: input.caseId, userId: input.userId, recommendationRefs: [input.recommendationRef] });
+  if (!input.action.trim()) throw new Error('SFI_CASE_ACTION_REQUIRED');
+  const service = createServiceSupabaseClient();
+  const inserted = await service.from('sfi_case_action_proposals').insert({
+    case_id: input.caseId,
+    owner_id: authority.ownerId,
+    tenant_id: authority.tenantId,
+    recommendation_ref: input.recommendationRef,
+    action_payload: { action: input.action.trim(), details: input.details ?? {}, externalExecutionRequested: false },
+    risk_level: input.riskLevel,
+    reversibility: input.reversibility,
+    status: 'PENDING',
+    proposed_by: input.userId,
+  }).select('*').single();
+  if (inserted.error || !inserted.data) throw new Error(`SFI_CASE_ACTION_PROPOSAL_WRITE_FAILED:${inserted.error?.message ?? 'unknown'}`);
+  const proposal = proposalFromRow(inserted.data as Row);
+  await audit(input.caseId, authority.tenantId, input.userId, 'CASE_ACTION_PROPOSED', proposal);
+  return proposal;
+}
+
+export async function decideCaseActionProposal(input: {
+  caseId: string;
+  proposalId: string;
+  userId: string;
+  decision: SfiCaseActionDecision;
+  rationale?: string | null;
+}) {
+  const authority = await readCaseAuthorityRole(input.caseId, input.userId);
+  if (!['OWNER','ADMIN'].includes(authority.role)) throw new Error('SFI_CASE_ACTION_AUTHORITY_REQUIRED');
+  const row = await proposalRow(input.caseId, input.proposalId);
+  const proposal = proposalFromRow(row);
+  const next: SfiCaseActionStatus = input.decision === 'APPROVE' ? 'APPROVED' : 'REJECTED';
+  assertSfiCaseActionTransition(proposal.status, next);
+  const service = createServiceSupabaseClient();
+  const updated = await service.from('sfi_case_action_proposals').update({ status: next }).eq('id', input.proposalId).eq('status', 'PENDING').select('*').maybeSingle();
+  if (updated.error || !updated.data) throw new Error(`SFI_CASE_ACTION_DECISION_CONFLICT:${updated.error?.message ?? 'status_changed'}`);
+  const decisionInsert = await service.from('sfi_case_action_decisions').insert({
+    proposal_id: input.proposalId,
+    case_id: input.caseId,
+    tenant_id: authority.tenantId,
+    decision: input.decision,
+    authority_role: authority.role,
+    decided_by: input.userId,
+    rationale: input.rationale?.trim() || null,
+  }).select('id').single();
+  if (decisionInsert.error || !decisionInsert.data?.id) {
+    await service.from('sfi_case_action_proposals').update({ status: 'PENDING' }).eq('id', input.proposalId).eq('status', next);
+    throw new Error(`SFI_CASE_ACTION_DECISION_WRITE_FAILED:${decisionInsert.error?.message ?? 'unknown'}`);
+  }
+  const result = proposalFromRow(updated.data as Row);
+  await audit(input.caseId, authority.tenantId, input.userId, `CASE_ACTION_${next}`, { proposalId: input.proposalId, decisionId: String(decisionInsert.data.id), authorityRole: authority.role });
+  return result;
+}
+
+export async function recordApprovedCaseIntervention(input: {
+  caseId: string;
+  proposalId: string;
+  userId: string;
+  observedAt: string;
+  executionDetails?: Record<string, unknown>;
+}) {
+  const authority = await readCaseAuthorityRole(input.caseId, input.userId);
+  if (!['OWNER','ADMIN','OPERATOR'].includes(authority.role)) throw new Error('SFI_TENANT_WRITE_FORBIDDEN');
+  const proposal = proposalFromRow(await proposalRow(input.caseId, input.proposalId));
+  assertSfiCaseActionTransition(proposal.status, 'EXECUTED');
+  if (Number.isNaN(Date.parse(input.observedAt))) throw new Error('SFI_CASE_INTERVENTION_TIME_INVALID');
+  const interventionRef: SfiCanonicalRef = { id: `case-intervention:${input.proposalId}`, version: '1.0', hash: null };
+  const intervention = await recordOperationalCaseObject({
+    caseId: input.caseId,
+    userId: input.userId,
+    kind: 'INTERVENTION',
+    epistemicRole: 'RECORD',
+    canonicalRef: interventionRef,
+    recordRefs: [proposal.recommendationRef],
+    payload: {
+      contract: 'SFI-CASE-ACTION-1.0',
+      proposalId: input.proposalId,
+      approved: true,
+      action: proposal.action,
+      executionDetails: input.executionDetails ?? {},
+      platformPerformedExternalAction: false,
+    },
+    observedAt: input.observedAt,
+  });
+  const service = createServiceSupabaseClient();
+  const updated = await service.from('sfi_case_action_proposals').update({ status: 'EXECUTED', intervention_ref: intervention.canonicalRef }).eq('id', input.proposalId).eq('status', 'APPROVED').select('*').maybeSingle();
+  if (updated.error || !updated.data) throw new Error(`SFI_CASE_INTERVENTION_STATE_WRITE_FAILED:${updated.error?.message ?? 'status_changed'}`);
+  await audit(input.caseId, authority.tenantId, input.userId, 'CASE_INTERVENTION_RECORDED', { proposalId: input.proposalId, interventionRef: intervention.canonicalRef, platformPerformedExternalAction: false });
+  return { proposal: proposalFromRow(updated.data as Row), intervention };
+}
+
+export async function recordCaseActionReturn(input: {
+  caseId: string;
+  proposalId: string;
+  userId: string;
+  observedAt: string;
+  outcome: string;
+  measurements?: Record<string, unknown>;
+}) {
+  const authority = await readCaseAuthorityRole(input.caseId, input.userId);
+  if (!['OWNER','ADMIN','OPERATOR'].includes(authority.role)) throw new Error('SFI_TENANT_WRITE_FORBIDDEN');
+  const proposal = proposalFromRow(await proposalRow(input.caseId, input.proposalId));
+  assertSfiCaseActionTransition(proposal.status, 'RETURN_RECORDED');
+  if (!proposal.interventionRef) throw new Error('SFI_CASE_RETURN_INTERVENTION_REQUIRED');
+  if (Number.isNaN(Date.parse(input.observedAt))) throw new Error('SFI_CASE_RETURN_TIME_INVALID');
+  if (!input.outcome.trim()) throw new Error('SFI_CASE_RETURN_OUTCOME_REQUIRED');
+  await assertCaseReferenceIntegrity({ caseId: input.caseId, userId: input.userId, interventionRefs: [proposal.interventionRef] });
+  const returnRef: SfiCanonicalRef = { id: `case-return:${input.proposalId}`, version: '1.0', hash: null };
+  const returnRecord = await recordOperationalCaseObject({
+    caseId: input.caseId,
+    userId: input.userId,
+    kind: 'RETURN',
+    epistemicRole: 'RECORD',
+    canonicalRef: returnRef,
+    recordRefs: [proposal.interventionRef],
+    payload: {
+      contract: 'SFI-CASE-ACTION-1.0',
+      proposalId: input.proposalId,
+      interventionRef: proposal.interventionRef,
+      outcome: input.outcome.trim(),
+      measurements: input.measurements ?? {},
+      causalEffectClaimed: false,
+    },
+    observedAt: input.observedAt,
+  });
+  const service = createServiceSupabaseClient();
+  const updated = await service.from('sfi_case_action_proposals').update({ status: 'RETURN_RECORDED', return_ref: returnRecord.canonicalRef }).eq('id', input.proposalId).eq('status', 'EXECUTED').select('*').maybeSingle();
+  if (updated.error || !updated.data) throw new Error(`SFI_CASE_RETURN_STATE_WRITE_FAILED:${updated.error?.message ?? 'status_changed'}`);
+  await audit(input.caseId, authority.tenantId, input.userId, 'CASE_RETURN_RECORDED', { proposalId: input.proposalId, returnRef: returnRecord.canonicalRef, causalEffectClaimed: false });
+  return { proposal: proposalFromRow(updated.data as Row), returnRecord };
+}

--- a/src/lib/sfi/case-platform/integrity.ts
+++ b/src/lib/sfi/case-platform/integrity.ts
@@ -1,0 +1,152 @@
+import 'server-only';
+
+import type { SfiCanonicalRef, SfiReportClaimV1 } from '@/core/contracts/sfi';
+import type { SfiEnterpriseEntityRef } from '@/core/case-platform';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+type Row = Record<string, unknown>;
+type TenantRole = 'OWNER' | 'ADMIN' | 'OPERATOR' | 'VIEWER' | 'AUDITOR';
+
+function text(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function object(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function refId(value: unknown) {
+  return text(object(value).id);
+}
+
+function refHash(value: unknown) {
+  return text(object(value).hash) || null;
+}
+
+async function accessContext(caseId: string, userId: string, mode: 'READ' | 'WRITE' = 'READ') {
+  const service = createServiceSupabaseClient();
+  const caseResult = await service.from('sfi_cases').select('id,owner_id,tenant_id,status').eq('id', caseId).is('deleted_at', null).maybeSingle();
+  if (caseResult.error) throw new Error(`SFI_CASE_INTEGRITY_CASE_READ_FAILED:${caseResult.error.message}`);
+  if (!caseResult.data) throw new Error('SFI_CASE_NOT_FOUND');
+  const membership = await service.from('sfi_tenant_members').select('role,status').eq('tenant_id', caseResult.data.tenant_id).eq('user_id', userId).maybeSingle();
+  if (membership.error) throw new Error(`SFI_CASE_INTEGRITY_MEMBERSHIP_READ_FAILED:${membership.error.message}`);
+  if (!membership.data || membership.data.status !== 'ACTIVE') throw new Error('SFI_TENANT_FORBIDDEN');
+  const role = String(membership.data.role) as TenantRole;
+  if (mode === 'WRITE' && !['OWNER','ADMIN','OPERATOR'].includes(role)) throw new Error('SFI_TENANT_WRITE_FORBIDDEN');
+  return { tenantId: String(caseResult.data.tenant_id), ownerId: String(caseResult.data.owner_id), status: String(caseResult.data.status), role };
+}
+
+async function caseObjects(caseId: string) {
+  const service = createServiceSupabaseClient();
+  const result = await service.from('sfi_case_objects').select('object_kind,epistemic_role,canonical_ref,payload').eq('case_id', caseId);
+  if (result.error) throw new Error(`SFI_CASE_INTEGRITY_OBJECT_READ_FAILED:${result.error.message}`);
+  return (result.data ?? []) as Row[];
+}
+
+function matchingRow(rows: Row[], ref: SfiCanonicalRef, predicate: (row: Row) => boolean) {
+  return rows.find((row) => {
+    if (refId(row.canonical_ref) !== ref.id) return false;
+    const expectedHash = ref.hash?.trim() || null;
+    if (expectedHash && refHash(row.canonical_ref) !== expectedHash) return false;
+    return predicate(row);
+  });
+}
+
+function assertRefs(rows: Row[], refs: SfiCanonicalRef[], label: string, predicate: (row: Row) => boolean) {
+  for (const ref of refs) {
+    if (!matchingRow(rows, ref, predicate)) throw new Error(`SFI_CASE_REFERENCE_NOT_FOUND:${label}:${ref.id}`);
+  }
+}
+
+export async function assertCaseReferenceIntegrity(input: {
+  caseId: string;
+  userId: string;
+  sourceRefs?: SfiCanonicalRef[];
+  recordRefs?: SfiCanonicalRef[];
+  evidenceRefs?: SfiCanonicalRef[];
+  assessmentRefs?: SfiCanonicalRef[];
+  recommendationRefs?: SfiCanonicalRef[];
+  interventionRefs?: SfiCanonicalRef[];
+}) {
+  await accessContext(input.caseId, input.userId, 'READ');
+  const rows = await caseObjects(input.caseId);
+  assertRefs(rows, input.sourceRefs ?? [], 'SOURCE', (row) => text(row.object_kind) === 'SOURCE' && text(row.epistemic_role) === 'SOURCE');
+  assertRefs(rows, input.recordRefs ?? [], 'RECORD', (row) => text(row.epistemic_role) === 'RECORD');
+  assertRefs(rows, input.evidenceRefs ?? [], 'EVIDENCE', (row) => text(row.object_kind) === 'EVIDENCE' && text(row.epistemic_role) === 'EVIDENCE');
+  assertRefs(rows, input.assessmentRefs ?? [], 'EPISTEMIC_ASSESSMENT', (row) => text(row.object_kind) === 'EPISTEMIC_ASSESSMENT' && text(row.epistemic_role) === 'EPISTEMIC_ASSESSMENT');
+  assertRefs(rows, input.recommendationRefs ?? [], 'RECOMMENDATION', (row) => text(row.object_kind) === 'RECOMMENDATION');
+  assertRefs(rows, input.interventionRefs ?? [], 'INTERVENTION', (row) => text(row.object_kind) === 'INTERVENTION' && text(row.epistemic_role) === 'RECORD');
+  return true;
+}
+
+export async function assertTenantEnterpriseEntityRefs(input: {
+  caseId: string;
+  userId: string;
+  entityRefs: SfiEnterpriseEntityRef[];
+}) {
+  const context = await accessContext(input.caseId, input.userId, 'READ');
+  if (!input.entityRefs.length) return true;
+  const service = createServiceSupabaseClient();
+  const result = await service.from('sfi_case_objects').select('canonical_ref,payload').eq('tenant_id', context.tenantId);
+  if (result.error) throw new Error(`SFI_ENTERPRISE_ENTITY_REFERENCE_READ_FAILED:${result.error.message}`);
+  const rows = (result.data ?? []) as Row[];
+  for (const ref of input.entityRefs) {
+    const found = rows.some((row) => {
+      if (refId(row.canonical_ref) !== ref.id) return false;
+      const expectedHash = ref.hash?.trim() || null;
+      if (expectedHash && refHash(row.canonical_ref) !== expectedHash) return false;
+      return text(object(row.payload).entityType) === ref.entityType;
+    });
+    if (!found) throw new Error(`SFI_ENTERPRISE_ENTITY_REFERENCE_NOT_FOUND:${ref.entityType}:${ref.id}`);
+  }
+  return true;
+}
+
+export async function assertTenderAssessmentPrerequisites(input: {
+  caseId: string;
+  userId: string;
+  requirementRef: SfiEnterpriseEntityRef;
+  bidderRef: SfiEnterpriseEntityRef;
+  sourceRefs: SfiCanonicalRef[];
+  recordRefs?: SfiCanonicalRef[];
+  evidenceRefs?: SfiCanonicalRef[];
+}) {
+  if (input.requirementRef.entityType !== 'REQUIREMENT') throw new Error('SFI_TENDER_REQUIREMENT_REF_TYPE_INVALID');
+  if (input.bidderRef.entityType !== 'BIDDER') throw new Error('SFI_TENDER_BIDDER_REF_TYPE_INVALID');
+  await assertCaseReferenceIntegrity({
+    caseId: input.caseId,
+    userId: input.userId,
+    sourceRefs: input.sourceRefs,
+    recordRefs: input.recordRefs,
+    evidenceRefs: input.evidenceRefs,
+  });
+  await assertTenantEnterpriseEntityRefs({ caseId: input.caseId, userId: input.userId, entityRefs: [input.requirementRef, input.bidderRef] });
+  const rows = await caseObjects(input.caseId);
+  const requirement = rows.find((row) => refId(row.canonical_ref) === input.requirementRef.id && text(object(row.payload).entityType) === 'REQUIREMENT');
+  if (!requirement) throw new Error('SFI_TENDER_REQUIREMENT_NOT_IN_CASE');
+  if (object(requirement.payload).frozenBeforeEvaluation !== true) throw new Error('SFI_TENDER_REQUIREMENT_NOT_FROZEN');
+  return true;
+}
+
+export async function assertReportClaimsIntegrity(input: {
+  caseId: string;
+  userId: string;
+  claims: SfiReportClaimV1[];
+}) {
+  for (const claim of input.claims) {
+    await assertCaseReferenceIntegrity({
+      caseId: input.caseId,
+      userId: input.userId,
+      assessmentRefs: [claim.assessmentRef],
+      evidenceRefs: claim.evidenceRefs,
+      recordRefs: claim.recordRefs,
+      sourceRefs: claim.sourceRefs,
+    });
+  }
+  return true;
+}
+
+export async function readCaseAuthorityRole(caseId: string, userId: string) {
+  const context = await accessContext(caseId, userId, 'READ');
+  return { tenantId: context.tenantId, ownerId: context.ownerId, role: context.role, status: context.status };
+}

--- a/supabase/migrations/20260816140000_sfi_case_governed_action_v1.sql
+++ b/supabase/migrations/20260816140000_sfi_case_governed_action_v1.sql
@@ -41,32 +41,19 @@ create or replace function public.sfi_case_action_touch_updated_at() returns tri
 drop trigger if exists sfi_case_action_proposals_touch on public.sfi_case_action_proposals;
 create trigger sfi_case_action_proposals_touch before update on public.sfi_case_action_proposals for each row execute function public.sfi_case_action_touch_updated_at();
 
-create or replace function public.sfi_tenant_can_approve(target_tenant uuid)
-returns boolean language sql stable security definer set search_path = public, auth as $$
-  select exists (
-    select 1 from public.sfi_tenant_members m
-    where m.tenant_id = target_tenant and m.user_id = auth.uid() and m.status = 'ACTIVE' and m.role in ('OWNER','ADMIN')
-  );
-$$;
-revoke all on function public.sfi_tenant_can_approve(uuid) from public;
-grant execute on function public.sfi_tenant_can_approve(uuid) to authenticated;
-
 alter table public.sfi_case_action_proposals enable row level security;
 alter table public.sfi_case_action_decisions enable row level security;
 
 drop policy if exists sfi_case_action_proposals_tenant_read on public.sfi_case_action_proposals;
 create policy sfi_case_action_proposals_tenant_read on public.sfi_case_action_proposals for select to authenticated using (public.sfi_tenant_can_read(tenant_id));
 drop policy if exists sfi_case_action_proposals_tenant_insert on public.sfi_case_action_proposals;
-create policy sfi_case_action_proposals_tenant_insert on public.sfi_case_action_proposals for insert to authenticated with check (public.sfi_tenant_can_write(tenant_id) and proposed_by = auth.uid());
 drop policy if exists sfi_case_action_proposals_tenant_update on public.sfi_case_action_proposals;
--- Proposal state transitions are server-governed; authenticated clients receive no direct UPDATE policy.
+-- Proposal creation and state transitions are server-governed; authenticated clients receive no direct INSERT/UPDATE policy.
 
 drop policy if exists sfi_case_action_decisions_tenant_read on public.sfi_case_action_decisions;
 create policy sfi_case_action_decisions_tenant_read on public.sfi_case_action_decisions for select to authenticated using (public.sfi_tenant_can_read(tenant_id));
 drop policy if exists sfi_case_action_decisions_tenant_insert on public.sfi_case_action_decisions;
-create policy sfi_case_action_decisions_tenant_insert on public.sfi_case_action_decisions for insert to authenticated with check (
-  public.sfi_tenant_can_approve(tenant_id) and decided_by = auth.uid() and authority_role in ('OWNER','ADMIN')
-);
+-- Decision rows are server-generated after repository-level OWNER/ADMIN verification.
 
 -- Harden pre-existing Case Platform tables against direct Supabase writes that would bypass Next/API semantic gates.
 drop policy if exists sfi_case_objects_tenant_insert on public.sfi_case_objects;

--- a/supabase/migrations/20260816140000_sfi_case_governed_action_v1.sql
+++ b/supabase/migrations/20260816140000_sfi_case_governed_action_v1.sql
@@ -33,49 +33,61 @@ create table if not exists public.sfi_case_action_decisions (
   created_at timestamptz not null default now()
 );
 
-create index if not exists sfi_case_action_proposals_case_status_idx
-  on public.sfi_case_action_proposals(case_id, status, created_at);
-create index if not exists sfi_case_action_proposals_tenant_status_idx
-  on public.sfi_case_action_proposals(tenant_id, status, created_at);
-create index if not exists sfi_case_action_decisions_case_idx
-  on public.sfi_case_action_decisions(case_id, created_at);
+create index if not exists sfi_case_action_proposals_case_status_idx on public.sfi_case_action_proposals(case_id, status, created_at);
+create index if not exists sfi_case_action_proposals_tenant_status_idx on public.sfi_case_action_proposals(tenant_id, status, created_at);
+create index if not exists sfi_case_action_decisions_case_idx on public.sfi_case_action_decisions(case_id, created_at);
 
-create or replace function public.sfi_case_action_touch_updated_at()
-returns trigger
-language plpgsql
-as $$
-begin
-  new.updated_at = now();
-  return new;
-end;
-$$;
-
+create or replace function public.sfi_case_action_touch_updated_at() returns trigger language plpgsql as $$ begin new.updated_at = now(); return new; end; $$;
 drop trigger if exists sfi_case_action_proposals_touch on public.sfi_case_action_proposals;
-create trigger sfi_case_action_proposals_touch
-before update on public.sfi_case_action_proposals
-for each row execute function public.sfi_case_action_touch_updated_at();
+create trigger sfi_case_action_proposals_touch before update on public.sfi_case_action_proposals for each row execute function public.sfi_case_action_touch_updated_at();
+
+create or replace function public.sfi_tenant_can_approve(target_tenant uuid)
+returns boolean language sql stable security definer set search_path = public, auth as $$
+  select exists (
+    select 1 from public.sfi_tenant_members m
+    where m.tenant_id = target_tenant and m.user_id = auth.uid() and m.status = 'ACTIVE' and m.role in ('OWNER','ADMIN')
+  );
+$$;
+revoke all on function public.sfi_tenant_can_approve(uuid) from public;
+grant execute on function public.sfi_tenant_can_approve(uuid) to authenticated;
 
 alter table public.sfi_case_action_proposals enable row level security;
 alter table public.sfi_case_action_decisions enable row level security;
 
 drop policy if exists sfi_case_action_proposals_tenant_read on public.sfi_case_action_proposals;
-create policy sfi_case_action_proposals_tenant_read on public.sfi_case_action_proposals
-for select to authenticated using (public.sfi_tenant_can_read(tenant_id));
-
+create policy sfi_case_action_proposals_tenant_read on public.sfi_case_action_proposals for select to authenticated using (public.sfi_tenant_can_read(tenant_id));
 drop policy if exists sfi_case_action_proposals_tenant_insert on public.sfi_case_action_proposals;
-create policy sfi_case_action_proposals_tenant_insert on public.sfi_case_action_proposals
-for insert to authenticated with check (public.sfi_tenant_can_write(tenant_id));
-
+create policy sfi_case_action_proposals_tenant_insert on public.sfi_case_action_proposals for insert to authenticated with check (public.sfi_tenant_can_write(tenant_id) and proposed_by = auth.uid());
 drop policy if exists sfi_case_action_proposals_tenant_update on public.sfi_case_action_proposals;
-create policy sfi_case_action_proposals_tenant_update on public.sfi_case_action_proposals
-for update to authenticated using (public.sfi_tenant_can_write(tenant_id)) with check (public.sfi_tenant_can_write(tenant_id));
+-- Proposal state transitions are server-governed; authenticated clients receive no direct UPDATE policy.
 
 drop policy if exists sfi_case_action_decisions_tenant_read on public.sfi_case_action_decisions;
-create policy sfi_case_action_decisions_tenant_read on public.sfi_case_action_decisions
-for select to authenticated using (public.sfi_tenant_can_read(tenant_id));
-
+create policy sfi_case_action_decisions_tenant_read on public.sfi_case_action_decisions for select to authenticated using (public.sfi_tenant_can_read(tenant_id));
 drop policy if exists sfi_case_action_decisions_tenant_insert on public.sfi_case_action_decisions;
-create policy sfi_case_action_decisions_tenant_insert on public.sfi_case_action_decisions
-for insert to authenticated with check (public.sfi_tenant_can_write(tenant_id));
+create policy sfi_case_action_decisions_tenant_insert on public.sfi_case_action_decisions for insert to authenticated with check (
+  public.sfi_tenant_can_approve(tenant_id) and decided_by = auth.uid() and authority_role in ('OWNER','ADMIN')
+);
+
+-- Harden pre-existing Case Platform tables against direct Supabase writes that would bypass Next/API semantic gates.
+drop policy if exists sfi_case_objects_tenant_insert on public.sfi_case_objects;
+create policy sfi_case_objects_tenant_insert on public.sfi_case_objects for insert to authenticated with check (
+  public.sfi_tenant_can_write(tenant_id)
+  and object_kind in ('RECORD','OBSERVATION')
+  and epistemic_role = 'RECORD'
+  and jsonb_array_length(evidence_refs) = 0
+);
+
+drop policy if exists sfi_case_relations_tenant_insert on public.sfi_case_relations;
+create policy sfi_case_relations_tenant_insert on public.sfi_case_relations for insert to authenticated with check (
+  public.sfi_tenant_can_write(tenant_id)
+  and epistemic_role = 'RECORD'
+  and jsonb_array_length(evidence_refs) = 0
+);
+
+drop policy if exists sfi_case_reports_tenant_insert on public.sfi_case_reports;
+-- Report creation is server/institutional only in Operational V1.
+
+drop policy if exists sfi_case_audit_tenant_insert on public.sfi_case_audit_events;
+-- Audit events are server-generated only.
 
 -- No DELETE policies. No ROOT foreign key. No automatic execution trigger.

--- a/supabase/migrations/20260816140000_sfi_case_governed_action_v1.sql
+++ b/supabase/migrations/20260816140000_sfi_case_governed_action_v1.sql
@@ -1,0 +1,81 @@
+-- SFI Case Governed Action V1
+-- REPORT ≠ ACTION. Case-level human authority gates interventions without routing clients to ROOT.
+
+create table if not exists public.sfi_case_action_proposals (
+  id uuid primary key default gen_random_uuid(),
+  case_id uuid not null,
+  owner_id uuid not null,
+  tenant_id uuid not null,
+  recommendation_ref jsonb not null,
+  action_payload jsonb not null,
+  risk_level text not null default 'MEDIUM' check (risk_level in ('LOW','MEDIUM','HIGH','CRITICAL')),
+  reversibility text not null default 'UNKNOWN' check (reversibility in ('REVERSIBLE','PARTIALLY_REVERSIBLE','IRREVERSIBLE','UNKNOWN')),
+  status text not null default 'PENDING' check (status in ('PENDING','APPROVED','REJECTED','CANCELLED','EXECUTED','RETURN_RECORDED')),
+  proposed_by uuid not null references auth.users(id) on delete restrict,
+  intervention_ref jsonb,
+  return_ref jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  foreign key (case_id, owner_id, tenant_id) references public.sfi_cases(id, owner_id, tenant_id) on delete cascade,
+  check (coalesce(recommendation_ref->>'id','') <> ''),
+  check (coalesce(action_payload->>'action','') <> '')
+);
+
+create table if not exists public.sfi_case_action_decisions (
+  id uuid primary key default gen_random_uuid(),
+  proposal_id uuid not null unique references public.sfi_case_action_proposals(id) on delete cascade,
+  case_id uuid not null references public.sfi_cases(id) on delete cascade,
+  tenant_id uuid not null references public.sfi_tenants(id) on delete cascade,
+  decision text not null check (decision in ('APPROVE','REJECT')),
+  authority_role text not null check (authority_role in ('OWNER','ADMIN')),
+  decided_by uuid not null references auth.users(id) on delete restrict,
+  rationale text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists sfi_case_action_proposals_case_status_idx
+  on public.sfi_case_action_proposals(case_id, status, created_at);
+create index if not exists sfi_case_action_proposals_tenant_status_idx
+  on public.sfi_case_action_proposals(tenant_id, status, created_at);
+create index if not exists sfi_case_action_decisions_case_idx
+  on public.sfi_case_action_decisions(case_id, created_at);
+
+create or replace function public.sfi_case_action_touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists sfi_case_action_proposals_touch on public.sfi_case_action_proposals;
+create trigger sfi_case_action_proposals_touch
+before update on public.sfi_case_action_proposals
+for each row execute function public.sfi_case_action_touch_updated_at();
+
+alter table public.sfi_case_action_proposals enable row level security;
+alter table public.sfi_case_action_decisions enable row level security;
+
+drop policy if exists sfi_case_action_proposals_tenant_read on public.sfi_case_action_proposals;
+create policy sfi_case_action_proposals_tenant_read on public.sfi_case_action_proposals
+for select to authenticated using (public.sfi_tenant_can_read(tenant_id));
+
+drop policy if exists sfi_case_action_proposals_tenant_insert on public.sfi_case_action_proposals;
+create policy sfi_case_action_proposals_tenant_insert on public.sfi_case_action_proposals
+for insert to authenticated with check (public.sfi_tenant_can_write(tenant_id));
+
+drop policy if exists sfi_case_action_proposals_tenant_update on public.sfi_case_action_proposals;
+create policy sfi_case_action_proposals_tenant_update on public.sfi_case_action_proposals
+for update to authenticated using (public.sfi_tenant_can_write(tenant_id)) with check (public.sfi_tenant_can_write(tenant_id));
+
+drop policy if exists sfi_case_action_decisions_tenant_read on public.sfi_case_action_decisions;
+create policy sfi_case_action_decisions_tenant_read on public.sfi_case_action_decisions
+for select to authenticated using (public.sfi_tenant_can_read(tenant_id));
+
+drop policy if exists sfi_case_action_decisions_tenant_insert on public.sfi_case_action_decisions;
+create policy sfi_case_action_decisions_tenant_insert on public.sfi_case_action_decisions
+for insert to authenticated with check (public.sfi_tenant_can_write(tenant_id));
+
+-- No DELETE policies. No ROOT foreign key. No automatic execution trigger.


### PR DESCRIPTION
## Purpose

Close the last non-visual Case Platform gap: persisted references must resolve with the epistemic role claimed, and neither reports nor recommendations may become interventions without explicit human case authority.

## Reference integrity

Internal analytical writes now verify persisted case/tenant references before accepting:

- SOURCE refs → existing SOURCE objects;
- RECORD refs → existing RECORD-role objects;
- EVIDENCE refs → existing EVIDENCE objects;
- assessment refs → existing EPISTEMIC_ASSESSMENT objects;
- enterprise relation endpoints → existing same-tenant enterprise entities;
- tender assessments → requirement exists in the current case and was frozen before evaluation;
- report claims → assessment/evidence/record/source lineage resolves before report generation.

## Governed action loop

`REPORT → RECOMMENDATION → PENDING ACTION PROPOSAL → OWNER/ADMIN APPROVAL → INTERVENTION RECORD → RETURN RECORD`

- report execution authority remains false;
- recommendation execution authority remains false;
- tenant OWNER/ADMIN is required for approval/rejection;
- OPERATOR can record an already-approved intervention/return but cannot approve it;
- the platform records the intervention but performs no external action in V1;
- RETURN requires a persisted intervention and does not claim causal effect;
- case approval is not ROOT/institutional governance.

## Direct-write hardening

RLS is tightened so direct authenticated Supabase access cannot bypass server semantics:

- generic case-object inserts are limited to RECORD/OBSERVATION with RECORD role and no evidence claims;
- client relation inserts remain RECORD-only with no evidence claims;
- reports and audit events are server-generated;
- action proposals/decisions/state transitions are server-governed;
- no direct RETURN/INTERVENTION/EVIDENCE/governance/truth insert path is exposed to authenticated clients.

## Persistence

Adds tenant-scoped:

- `sfi_case_action_proposals`
- `sfi_case_action_decisions`

Both are included in the reserved terminal-reset inventory while tenant identity/membership remains protected.

## Non-goals

- no external action connector;
- no Observatory/dashboard UI;
- no ROOT access from clients;
- no automatic institutional-memory admission;
- no causal claim from a recorded return;
- no final production DB cleanup.