### PR TITLE
Require post-platform carrier QA before verifying KXTXR returns

### DIFF
--- a/src/components/root/returns/RootReturnCertificates.tsx
+++ b/src/components/root/returns/RootReturnCertificates.tsx
@@ -14,6 +14,7 @@ type Certificate = {
   external_url?: string | null;
   canonical_url: string;
   asset_sha256: string;
+  watermark_token?: string | null;
   record_digest: string;
 };
 
@@ -33,7 +34,7 @@ const emptyCreate = {
   scheduledAt: '',
   assetSha256: '',
   payloadSha256: '',
-  watermarkScheme: 'SFI_DUAL_LAYER_V1',
+  watermarkScheme: 'SFI_DUAL_LAYER_V1:FSK64+GRID32',
   watermarkToken: '',
   notes: '',
 };
@@ -54,6 +55,13 @@ export function RootReturnCertificates() {
   const [createForm, setCreateForm] = useState(emptyCreate);
   const [publishId, setPublishId] = useState('');
   const [externalUrl, setExternalUrl] = useState('');
+  const [verifyId, setVerifyId] = useState('');
+  const [downloadedSha, setDownloadedSha] = useState('');
+  const [observedToken, setObservedToken] = useState('');
+  const [bitsChecked, setBitsChecked] = useState('64');
+  const [bitErrors, setBitErrors] = useState('');
+  const [externalObserved, setExternalObserved] = useState(false);
+  const [watermarkDetected, setWatermarkDetected] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
 
@@ -69,6 +77,14 @@ export function RootReturnCertificates() {
   const prepared = useMemo(
     () => workspace?.certificates.filter((item) => item.state === 'prepared') ?? [],
     [workspace],
+  );
+  const published = useMemo(
+    () => workspace?.certificates.filter((item) => item.state === 'published') ?? [],
+    [workspace],
+  );
+  const selectedVerificationCertificate = useMemo(
+    () => published.find((item) => item.certificate_id === verifyId) ?? null,
+    [published, verifyId],
   );
 
   async function createCertificate() {
@@ -90,15 +106,35 @@ export function RootReturnCertificates() {
     try {
       await mutate('publish', { certificateId: publishId, externalUrl });
       setExternalUrl('');
+      setPublishId('');
       await refresh();
     } catch (reason) { setError(reason instanceof Error ? reason.message : String(reason)); }
     finally { setBusy(false); }
   }
 
-  async function verifyCertificate(certificateId: string) {
+  async function verifyCertificate() {
+    if (!selectedVerificationCertificate) return;
     setBusy(true); setError('');
     try {
-      await mutate('verify', { certificateId });
+      await mutate('verify', {
+        certificateId: selectedVerificationCertificate.certificate_id,
+        watermarkVerification: {
+          downloaded_manifestation_sha256: downloadedSha.trim().toLowerCase(),
+          external_url_observed: externalObserved,
+          watermark_detected: watermarkDetected,
+          watermark_token: observedToken.trim().toUpperCase(),
+          bits_checked: Number(bitsChecked),
+          bit_errors: Number(bitErrors),
+          method: 'POST_PLATFORM_DOWNLOAD_QA',
+        },
+      });
+      setVerifyId('');
+      setDownloadedSha('');
+      setObservedToken('');
+      setBitsChecked('64');
+      setBitErrors('');
+      setExternalObserved(false);
+      setWatermarkDetected(false);
       await refresh();
     } catch (reason) { setError(reason instanceof Error ? reason.message : String(reason)); }
     finally { setBusy(false); }
@@ -109,7 +145,7 @@ export function RootReturnCertificates() {
       <header className="border-b border-white/10 pb-7">
         <p className="font-mono text-[9px] tracking-[0.2em] text-[#75aaa9]">ROOT · PUBLIC RETURN REGISTRY</p>
         <h1 className="mt-4 font-serif text-4xl tracking-[-0.04em] md:text-6xl">Return Certificates</h1>
-        <p className="mt-4 max-w-3xl font-serif text-sm leading-7 text-[#9f998e]">Register the asset before distribution. After Instagram/TikTok creates the external permalink, attach that URL here. Only then can the public certificate move from PREPARED to PUBLISHED and later VERIFIED.</p>
+        <p className="mt-4 max-w-3xl font-serif text-sm leading-7 text-[#9f998e]">Pre-register the retained asset before distribution. After Instagram/TikTok creates the permalink, attach the external URL. VERIFIED requires a post-platform retained manifestation, its SHA-256 and successful carrier recovery; a click alone cannot verify a certificate.</p>
       </header>
 
       {error ? <div className="mt-6 border border-[#a94c3b66] bg-[#a94c3b12] p-4 font-mono text-xs text-[#d99180]">{error}</div> : null}
@@ -137,12 +173,27 @@ export function RootReturnCertificates() {
         </div>
       </section>
 
+      <section className="mt-6 border border-white/10 bg-black/20 p-5">
+        <p className="font-mono text-[9px] tracking-[0.18em] text-[#75aaa9]">03 / VERIFY RETAINED MANIFESTATION</p>
+        <p className="mt-3 max-w-4xl font-serif text-sm leading-6 text-[#8f897e]">Download or otherwise retain the actual platform manifestation after publication. Verification records that retained file separately from the original asset because transcoding changes the file hash. The hidden carrier must still resolve to the pre-registered token within the allowed QA error rate.</p>
+        <div className="mt-5 grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+          <label className="font-mono text-[8px] text-[#817b70] lg:col-span-2">PUBLISHED CERTIFICATE<select className="mt-2 w-full border border-white/10 bg-[#070806] p-3 text-[#e8e2d5]" value={verifyId} onChange={(event) => { const id = event.target.value; setVerifyId(id); const selected = published.find((item) => item.certificate_id === id); setObservedToken(selected?.watermark_token ?? ''); }}><option value="">Select published certificate</option>{published.map((item) => <option key={item.certificate_id} value={item.certificate_id}>{item.certificate_id} · {item.platform}</option>)}</select></label>
+          <label className="font-mono text-[8px] text-[#817b70] lg:col-span-2">DOWNLOADED MANIFESTATION SHA-256<input className="mt-2 w-full border border-white/10 bg-[#070806] p-3 text-[10px] text-[#e8e2d5]" value={downloadedSha} onChange={(event) => setDownloadedSha(event.target.value)} placeholder="64 lowercase hex characters" /></label>
+          <label className="font-mono text-[8px] text-[#817b70]">OBSERVED WATERMARK TOKEN<input className="mt-2 w-full border border-white/10 bg-[#070806] p-3 text-[10px] text-[#e8e2d5]" value={observedToken} onChange={(event) => setObservedToken(event.target.value)} /></label>
+          <label className="font-mono text-[8px] text-[#817b70]">BITS CHECKED<input type="number" min="32" className="mt-2 w-full border border-white/10 bg-[#070806] p-3 text-[10px] text-[#e8e2d5]" value={bitsChecked} onChange={(event) => setBitsChecked(event.target.value)} /></label>
+          <label className="font-mono text-[8px] text-[#817b70]">BIT ERRORS<input type="number" min="0" className="mt-2 w-full border border-white/10 bg-[#070806] p-3 text-[10px] text-[#e8e2d5]" value={bitErrors} onChange={(event) => setBitErrors(event.target.value)} /></label>
+          <div className="flex flex-col justify-end gap-3 font-mono text-[8px] text-[#817b70]"><label className="flex items-center gap-2"><input type="checkbox" checked={externalObserved} onChange={(event) => setExternalObserved(event.target.checked)} /> EXTERNAL URL OBSERVED</label><label className="flex items-center gap-2"><input type="checkbox" checked={watermarkDetected} onChange={(event) => setWatermarkDetected(event.target.checked)} /> WATERMARK DETECTED</label></div>
+        </div>
+        <div className="mt-4 font-mono text-[8px] leading-5 text-[#716c62]">EXPECTED TOKEN · {selectedVerificationCertificate?.watermark_token ?? '—'} · ORIGINAL ASSET SHA-256 · {selectedVerificationCertificate?.asset_sha256 ?? '—'}</div>
+        <button disabled={busy || !selectedVerificationCertificate || !downloadedSha || !externalObserved || (!!selectedVerificationCertificate?.watermark_token && (!watermarkDetected || !observedToken)) || !bitsChecked || bitErrors === ''} onClick={verifyCertificate} className="mt-5 border border-[#75aaa966] px-4 py-3 font-mono text-[9px] tracking-[0.14em] text-[#9bc4c3] disabled:opacity-40">VERIFY POST-PLATFORM RETURN</button>
+      </section>
+
       <section className="mt-8 border border-white/10">
-        <div className="flex items-center justify-between border-b border-white/10 p-4"><span className="font-mono text-[9px] tracking-[0.18em] text-[#75aaa9]">03 / REGISTRY</span><button onClick={() => refresh().catch((reason) => setError(String(reason)))} className="font-mono text-[8px] text-[#817b70]">REFRESH</button></div>
+        <div className="flex items-center justify-between border-b border-white/10 p-4"><span className="font-mono text-[9px] tracking-[0.18em] text-[#75aaa9]">04 / REGISTRY</span><button onClick={() => refresh().catch((reason) => setError(String(reason)))} className="font-mono text-[8px] text-[#817b70]">REFRESH</button></div>
         <div className="overflow-x-auto">
           <table className="w-full min-w-[980px] border-collapse font-mono text-[9px]">
-            <thead className="text-left text-[#716c62]"><tr><th className="p-3">CERTIFICATE</th><th>TRACE</th><th>PLATFORM</th><th>STATE</th><th>SCHEDULED</th><th>EXTERNAL</th><th>INTEGRITY</th><th>ACTION</th></tr></thead>
-            <tbody>{workspace?.certificates.map((item) => <tr key={item.certificate_id} className="border-t border-white/5"><td className="p-3"><a className="text-[#e5c77f] underline" href={item.canonical_url} target="_blank" rel="noreferrer">{item.certificate_id}</a></td><td>{item.trace_id}</td><td>{item.platform}</td><td>{item.state.toUpperCase()}</td><td>{item.scheduled_at ?? '—'}</td><td>{item.external_url ? <a className="text-[#75aaa9] underline" href={item.external_url} target="_blank" rel="noreferrer">OPEN</a> : 'PENDING'}</td><td title={item.record_digest}>{item.record_digest.slice(0, 12)}…</td><td>{item.state === 'published' ? <button disabled={busy} onClick={() => verifyCertificate(item.certificate_id)} className="border border-white/10 px-2 py-1 text-[#d6d0c4]">VERIFY</button> : '—'}</td></tr>)}</tbody>
+            <thead className="text-left text-[#716c62]"><tr><th className="p-3">CERTIFICATE</th><th>TRACE</th><th>PLATFORM</th><th>STATE</th><th>SCHEDULED</th><th>EXTERNAL</th><th>INTEGRITY</th></tr></thead>
+            <tbody>{workspace?.certificates.map((item) => <tr key={item.certificate_id} className="border-t border-white/5"><td className="p-3"><a className="text-[#e5c77f] underline" href={item.canonical_url} target="_blank" rel="noreferrer">{item.certificate_id}</a></td><td>{item.trace_id}</td><td>{item.platform}</td><td>{item.state.toUpperCase()}</td><td>{item.scheduled_at ?? '—'}</td><td>{item.external_url ? <a className="text-[#75aaa9] underline" href={item.external_url} target="_blank" rel="noreferrer">OPEN</a> : 'PENDING'}</td><td title={item.record_digest}>{item.record_digest.slice(0, 12)}…</td></tr>)}</tbody>
           </table>
         </div>
       </section>

--- a/src/lib/returns/returnCertificateService.ts
+++ b/src/lib/returns/returnCertificateService.ts
@@ -46,6 +46,7 @@ function platformUrlMatches(platform: ReturnPlatform, urlValue: string) {
   if (!urlValue) return false;
   try {
     const url = new URL(urlValue);
+    if (url.protocol !== 'https:') return false;
     const host = url.hostname.toLowerCase().replace(/^www\./, '');
     if (platform === 'instagram') return host === 'instagram.com' || host.endsWith('.instagram.com');
     if (platform === 'tiktok') return host === 'tiktok.com' || host.endsWith('.tiktok.com');
@@ -53,7 +54,7 @@ function platformUrlMatches(platform: ReturnPlatform, urlValue: string) {
     if (platform === 'x') return host === 'x.com' || host.endsWith('.x.com') || host === 'twitter.com' || host.endsWith('.twitter.com');
     if (platform === 'linkedin') return host === 'linkedin.com' || host.endsWith('.linkedin.com');
     if (platform === 'medium') return host === 'medium.com' || host.endsWith('.medium.com');
-    return url.protocol === 'https:';
+    return true;
   } catch {
     return false;
   }
@@ -80,6 +81,62 @@ function canonicalCertificateFields(input: JsonRecord) {
     watermark_token: optionalText(input.watermark_token),
     watermark_verification: typeof input.watermark_verification === 'object' && input.watermark_verification ? input.watermark_verification : {},
     publication_snapshot: typeof input.publication_snapshot === 'object' && input.publication_snapshot ? input.publication_snapshot : {},
+  };
+}
+
+function objectRecord(value: unknown): JsonRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonRecord : null;
+}
+
+function validatePostPlatformVerification(current: JsonRecord, input: JsonRecord): ServiceResult<JsonRecord> {
+  const verification = objectRecord(input.watermarkVerification);
+  if (!verification) return { ok: false, error: 'return_post_platform_verification_required' };
+
+  const downloadedManifestationSha256 = sha256(verification.downloaded_manifestation_sha256);
+  if (!downloadedManifestationSha256) {
+    return { ok: false, error: 'return_downloaded_manifestation_sha256_required' };
+  }
+
+  if (verification.external_url_observed !== true) {
+    return { ok: false, error: 'return_external_url_not_observed' };
+  }
+
+  const expectedToken = text(current.watermark_token).toUpperCase();
+  if (expectedToken) {
+    if (verification.watermark_detected !== true) {
+      return { ok: false, error: 'return_watermark_not_detected' };
+    }
+
+    const observedToken = text(verification.watermark_token).toUpperCase();
+    if (observedToken !== expectedToken) {
+      return { ok: false, error: 'return_watermark_token_mismatch' };
+    }
+
+    const bitsChecked = Number(verification.bits_checked);
+    const bitErrors = Number(verification.bit_errors);
+    if (!Number.isInteger(bitsChecked) || bitsChecked < 32) {
+      return { ok: false, error: 'return_watermark_bits_checked_insufficient' };
+    }
+    if (!Number.isInteger(bitErrors) || bitErrors < 0 || bitErrors > Math.max(2, Math.floor(bitsChecked * 0.04))) {
+      return { ok: false, error: 'return_watermark_error_rate_exceeded' };
+    }
+  }
+
+  const externalUrl = text(current.external_url);
+  const platform = text(current.platform).toLowerCase() as ReturnPlatform;
+  if (!externalUrl || !RETURN_PLATFORMS.includes(platform) || !platformUrlMatches(platform, externalUrl)) {
+    return { ok: false, error: 'return_external_url_invalid_at_verification' };
+  }
+
+  return {
+    ok: true,
+    data: {
+      ...verification,
+      downloaded_manifestation_sha256: downloadedManifestationSha256,
+      verification_scope: 'POST_PLATFORM_RETAINED_MANIFESTATION',
+      verification_boundary: 'PROVENANCE_QA_NOT_CAUSAL_PROOF',
+      verified_at: new Date().toISOString(),
+    },
   };
 }
 
@@ -136,7 +193,7 @@ export async function createReturnCertificate(input: JsonRecord, actorId: string
     parent_trace_id: optionalText(input.parentTraceId),
     platform,
     state: 'prepared',
-    epistemic_class: text(input.epistemicClass, 'RECORD'),
+    epistemic_class: 'RECORD',
     scheduled_at: optionalText(input.scheduledAt),
     published_at: null,
     observed_at: null,
@@ -206,15 +263,15 @@ export async function verifyReturnCertificate(input: JsonRecord, actorId: string
   if (!current.data) return { ok: false, error: 'return_certificate_not_found' };
   if (current.data.state !== 'published') return { ok: false, error: 'return_certificate_not_published', details: String(current.data.state) };
 
+  const verification = validatePostPlatformVerification(current.data as JsonRecord, input);
+  if (!verification.ok) return verification;
+
   const now = new Date().toISOString();
-  const verification = typeof input.watermarkVerification === 'object' && input.watermarkVerification
-    ? input.watermarkVerification
-    : current.data.watermark_verification ?? {};
   const fields = canonicalCertificateFields({
     ...current.data,
     state: 'verified',
     observed_at: now,
-    watermark_verification: verification,
+    watermark_verification: verification.data,
   });
 
   const updated = await service.from('public_return_certificates').update({


### PR DESCRIPTION
## Purpose

Close an epistemic/provenance gap in the public return-certificate workflow already present on `main`.

A certificate could previously transition `PUBLISHED → VERIFIED` from ROOT without requiring evidence that the platform-retained manifestation had actually been inspected after Instagram/TikTok transcoding.

## Change

`PUBLISHED` continues to mean:

- a pre-registered certificate exists;
- the external platform permalink has been observed and attached;
- SFI has recorded that public manifestation as a RECORD.

`VERIFIED` now additionally requires post-platform QA:

- SHA-256 of the downloaded/retained platform manifestation;
- explicit confirmation that the external URL was observed;
- recovery of the pre-registered watermark token when the certificate uses a token;
- at least 32 checked carrier bits;
- bounded bit-error rate (max 2 errors or 4%, whichever is greater);
- retained QA scope recorded as `POST_PLATFORM_RETAINED_MANIFESTATION`.

The downloaded manifestation hash is intentionally **not required to equal the original asset hash** because platform transcoding creates a new binary manifestation.

## ROOT UX

`/root/returns` now has a dedicated post-platform verification chamber instead of a one-click VERIFY button. It records:

- downloaded manifestation SHA-256;
- observed token;
- bits checked;
- bit errors;
- external URL observed;
- watermark detected.

## Boundary

```text
PUBLISHED ≠ VERIFIED
ORIGINAL ASSET ≠ PLATFORM MANIFESTATION
WATERMARK VERIFICATION = PROVENANCE QA ≠ CAUSAL PROOF
PUBLICATION ≠ EVIDENCE
SFI CERTIFICATE ≠ TRUTH
```

This does not add publishing authority, social-platform automation, artistic authority or automatic evidence promotion.