### PR TITLE
fix(fi001): accept Postgres microsecond timestamps

### DIFF
--- a/scripts/qa-fi001-autonomy.ts
+++ b/scripts/qa-fi001-autonomy.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { normalizeTimestamp } from '../src/core/cognitive-spine/serialization/canonicalSerialize';
 import { selectStudioAutonomyTransition } from '../src/lib/continuity/studioAutonomyPolicy';
 
 const base = {
@@ -44,5 +45,12 @@ assert.equal(selectStudioAutonomyTransition({ ...base, horizonReached: true }).a
 assert.equal(selectStudioAutonomyTransition({ ...base, recentExecutionFailure: true }).action, 'WAIT');
 assert.equal(selectStudioAutonomyTransition({ ...base, mode: 'EMERGENCY_HALT' }).action, 'WAIT');
 assert.equal(selectStudioAutonomyTransition({ ...base, mode: 'DEGRADED_SAFE' }).action, 'WAIT');
+
+assert.equal(normalizeTimestamp('2026-08-17T06:58:26.219332+00:00'), '2026-08-17T06:58:26.219Z');
+assert.equal(normalizeTimestamp('2026-08-17T06:58:26.219Z'), '2026-08-17T06:58:26.219Z');
+assert.throws(
+  () => normalizeTimestamp('2026-08-17T06:58:26.219332'),
+  /COGNITIVE_SPINE_TIMESTAMP_REQUIRES_EXPLICIT_ZONE/,
+);
 
 console.log('FI-001 autonomy policy QA: PASS');

--- a/src/core/cognitive-spine/serialization/canonicalSerialize.ts
+++ b/src/core/cognitive-spine/serialization/canonicalSerialize.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 
 type PlainObject = Record<string, unknown>;
 
-const ISO_TIMESTAMP_WITH_ZONE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+const ISO_TIMESTAMP_WITH_ZONE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?(?:Z|[+-]\d{2}:\d{2})$/;
 
 function isPlainObject(value: object): value is PlainObject {
   const prototype = Object.getPrototypeOf(value);
@@ -70,8 +70,10 @@ export function canonicalSha256(value: unknown): string {
 }
 
 /**
- * Only offset-aware ISO timestamps are admissible. This prevents host timezone
- * or locale from changing the semantic cutoff during reconstruction.
+ * Only offset-aware ISO timestamps are admissible. PostgreSQL may emit up to
+ * microsecond precision, which is normalized to the canonical millisecond ISO
+ * form after parsing. This prevents host timezone or locale from changing the
+ * semantic cutoff during reconstruction.
  */
 export function normalizeTimestamp(value: string): string {
   if (!ISO_TIMESTAMP_WITH_ZONE.test(value)) {


### PR DESCRIPTION
FI-001 autonomous continuation exposed a bounded operational incompatibility: Cognitive Spine timestamp normalization required explicit zones correctly, but limited fractional seconds to 3 digits while PostgreSQL/Supabase can emit 6-digit microsecond precision (for example `2026-08-17T06:58:26.219332+00:00`).

This change:
- keeps the explicit timezone requirement unchanged;
- accepts 1–6 fractional digits before normalization to canonical millisecond ISO;
- adds FI-001 QA coverage for the observed Postgres timestamp, standard millisecond timestamps, and rejection of timezone-naive timestamps.

No canon/formula, governance authority, publication, ROOT grant, external irreversible action, legal commitment, or economic commitment is changed.