### PR TITLE
SFI external OAuth identity for ChatGPT Actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,21 @@ SUPABASE_SERVICE_ROLE_KEY=
 DATABASE_URL=
 
 # Governed external-agent gateway.
-# Example:
+# Static token example (server-to-server / legacy):
 # {"replace-with-long-random-token":{"label":"ChatGPT Lab","role":"root_delegate","actorId":"external:chatgpt-github-lab","scopes":["observe","propose","execute","lab:read","lab:write","lab:run"]}}
 # execute can only realize a proposal already authorized and queued by governance.
 # lab:run additionally requires role=root_delegate, confirm=true and persisted evidence IDs.
 SFI_EXTERNAL_API_KEYS_JSON={}
+
+# User-bound OAuth for ChatGPT Actions and other external clients.
+# The client ID/secret identify the SFI client application, not the human user.
+# The human principal comes from the existing authenticated SFI/Supabase session.
+SFI_OAUTH_CLIENT_ID=
+SFI_OAUTH_CLIENT_SECRET=
+# Exact comma-separated redirect URI allowlist. Copy ChatGPT's callback URL exactly.
+SFI_OAUTH_REDIRECT_URIS=
+# Independent random secret used only to sign short-lived SFI OAuth access tokens.
+SFI_EXTERNAL_SESSION_SECRET=
 
 STRIPE_API_KEY=
 STRIPE_WEBHOOK_SECRET=
@@ -50,5 +60,5 @@ GOOGLE_VIDEO_ASPECT_RATIO=9:16
 GOOGLE_VIDEO_DURATION_SECONDS=4
 GOOGLE_VIDEO_RESOLUTION=720p
 GOOGLE_VIDEO_TIMEOUT_MS=360000
-GOOGLE_VIDEO_POLL_MS=10000
+GOOGLE_VIDEO_POLL_MS=1000
 SFI_MEDIA_OUTPUT_DIR=public/generated/sfi

--- a/.github/workflows/sfi-external-oauth.yml
+++ b/.github/workflows/sfi-external-oauth.yml
@@ -1,0 +1,44 @@
+name: SFI External OAuth
+
+on:
+  pull_request:
+    paths:
+      - 'src/app/api/oauth/**'
+      - 'src/app/api/external/v1/**'
+      - 'src/lib/sfi/externalAuth.ts'
+      - 'src/lib/sfi/externalSessionToken.ts'
+      - 'src/lib/sfi/oauthConfig.ts'
+      - 'src/components/sfi/LoginSurface.tsx'
+      - 'src/lib/system/access/institutionalMembers.ts'
+      - 'supabase/migrations/*oauth*'
+      - 'public/openapi.json'
+      - 'scripts/qa-sfi-external-oauth.ts'
+      - '.github/workflows/sfi-external-oauth.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify user-bound external OAuth
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Verify OAuth governance contract
+        run: npx tsx scripts/qa-sfi-external-oauth.ts
+
+      - name: Typecheck
+        run: npm run typecheck

--- a/.github/workflows/sfi-external-oauth.yml
+++ b/.github/workflows/sfi-external-oauth.yml
@@ -23,7 +23,7 @@ jobs:
   verify:
     name: Verify user-bound external OAuth
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,3 +42,6 @@ jobs:
 
       - name: Typecheck
         run: npm run typecheck
+
+      - name: Build
+        run: npm run build

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "System Friction Institute External Agent API",
-    "version": "1.3.0",
-    "description": "Governed machine interface for authorized AI clients. Observation, consolidated console inspection, proposal, execution and laboratory operations remain scope-bound and auditable.",
+    "version": "1.4.0",
+    "description": "Governed machine interface for authorized AI clients. Supports user-bound OAuth authorization_code credentials and scoped static credentials. Observation, proposal, execution and laboratory operations remain distinct and auditable.",
     "termsOfService": "https://systemfriction.org/privacy"
   },
   "externalDocs": {
@@ -14,6 +14,7 @@
     { "url": "https://systemfriction.org" }
   ],
   "security": [
+    { "sfiOAuth": [] },
     { "sfiToken": [] }
   ],
   "paths": {
@@ -31,6 +32,10 @@
         "summary": "Read the consolidated governed SFI machine console",
         "description": "Returns Method Lab state, report health and recent reports, Cognitive Twin runs/evaluations, governance proposals, recent evidence, recent lab runs and agentic capability contracts. This operation is read-only.",
         "x-sfi-scope": "observe",
+        "security": [
+          { "sfiOAuth": ["observe"] },
+          { "sfiToken": [] }
+        ],
         "responses": {
           "200": { "description": "Consolidated governed console state", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GenericResponse" } } } },
           "401": { "description": "Unauthorized" }
@@ -42,6 +47,10 @@
         "operationId": "observeSfi",
         "summary": "Read an allowlisted governed SFI state surface",
         "x-sfi-scope": "observe",
+        "security": [
+          { "sfiOAuth": ["observe"] },
+          { "sfiToken": [] }
+        ],
         "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ObserveRequest" } } } },
         "responses": {
           "200": { "description": "Governed observation result", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GenericResponse" } } } },
@@ -55,6 +64,10 @@
         "operationId": "proposeSfiAction",
         "summary": "Submit a governed action proposal for ROOT review",
         "x-sfi-scope": "propose",
+        "security": [
+          { "sfiOAuth": ["propose"] },
+          { "sfiToken": [] }
+        ],
         "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ProposeRequest" } } } },
         "responses": {
           "201": { "description": "Proposal registered for ROOT review", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GenericResponse" } } } },
@@ -69,6 +82,10 @@
         "operationId": "executeAuthorizedSfiAction",
         "summary": "Execute an already-authorized internal SFI action",
         "x-sfi-scope": "execute",
+        "security": [
+          { "sfiOAuth": ["execute"] },
+          { "sfiToken": [] }
+        ],
         "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ExecuteRequest" } } } },
         "responses": {
           "200": { "description": "Execution result and provenance", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GenericResponse" } } } },
@@ -82,6 +99,11 @@
       "post": {
         "operationId": "operateSfiLab",
         "summary": "Read, persist or run Method Lab operations according to scope",
+        "description": "Required OAuth scope depends on body.operation: state/report=lab:read, persist=lab:write, run=lab:run. lab:run also requires root_delegate.",
+        "security": [
+          { "sfiOAuth": [] },
+          { "sfiToken": [] }
+        ],
         "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/LabRequest" } } } },
         "responses": {
           "200": { "description": "Method Lab result with governance/provenance metadata", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GenericResponse" } } } },
@@ -158,11 +180,29 @@
       }
     },
     "securitySchemes": {
+      "sfiOAuth": {
+        "type": "oauth2",
+        "description": "User-bound SFI institutional identity. The OAuth client identifies the application; the bearer token identifies the authenticated SFI principal.",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://systemfriction.org/api/oauth/authorize",
+            "tokenUrl": "https://systemfriction.org/api/oauth/token",
+            "scopes": {
+              "observe": "Read governed SFI state and consolidated console.",
+              "propose": "Submit governed proposals for ROOT review.",
+              "execute": "Realize already-authorized internal proposals.",
+              "lab:read": "Read Method Lab state and reports.",
+              "lab:write": "Persist Method Lab observations with provenance.",
+              "lab:run": "Run supported Method Lab runtimes; root_delegate remains separately required."
+            }
+          }
+        }
+      },
       "sfiToken": {
         "type": "apiKey",
         "in": "header",
         "name": "X-SFI-Token",
-        "description": "Scoped SFI credential. Send the raw token value only."
+        "description": "Scoped static SFI credential for server-to-server or legacy integrations. Prefer OAuth for human users."
       }
     }
   },
@@ -171,6 +211,11 @@
     "rootReserved": ["approval", "canonical promotion", "unguarded external action"],
     "privacyPolicy": "https://systemfriction.org/privacy",
     "console": "/api/external/v1/console",
+    "oauth": {
+      "authorizationUrl": "/api/oauth/authorize",
+      "tokenUrl": "/api/oauth/token",
+      "recommendedScopes": ["observe", "propose", "lab:read"]
+    },
     "discovery": ["/llms.txt", "/llms-full.txt", "/ai-index.json", "/field-schema.json", "/privacy", "/api/external/v1/manifest"]
   }
 }

--- a/scripts/qa-sfi-external-oauth.ts
+++ b/scripts/qa-sfi-external-oauth.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+function text(path: string) {
+  return readFileSync(path, 'utf8');
+}
+
+const authorize = text('src/app/api/oauth/authorize/route.ts');
+const token = text('src/app/api/oauth/token/route.ts');
+const externalAuth = text('src/lib/sfi/externalAuth.ts');
+const sessionToken = text('src/lib/sfi/externalSessionToken.ts');
+const login = text('src/components/sfi/LoginSurface.tsx');
+const migration = text('supabase/migrations/20260822214500_create_sfi_oauth_authorization_codes.sql');
+const openapi = JSON.parse(text('public/openapi.json')) as Record<string, any>;
+const members = text('src/lib/system/access/institutionalMembers.ts');
+
+assert.match(authorize, /requireSfiMember\(\)/, 'oauth_authorize_must_bind_to_authenticated_sfi_member');
+assert.match(authorize, /DEFAULT_SCOPES = \['observe', 'propose', 'lab:read'\]/, 'non_root_oauth_scopes_must_be_bounded');
+assert.match(authorize, /rootDelegate \? 'root_delegate' : 'agent'/, 'root_delegate_must_not_be_default');
+assert.match(authorize, /codeHash\(code\)/, 'authorization_code_must_be_stored_as_hash');
+assert.match(authorize, /code_challenge/, 'oauth_authorize_must_support_pkce');
+
+assert.match(token, /grantType !== 'authorization_code'/, 'token_endpoint_must_reject_other_grants');
+assert.match(token, /is\('consumed_at', null\)/, 'authorization_code_must_be_single_use');
+assert.match(token, /PKCE verification failed/, 'token_exchange_must_verify_pkce_when_present');
+assert.match(token, /mintExternalAccessToken/, 'token_exchange_must_issue_sfi_access_token');
+
+assert.match(externalAuth, /verifyExternalAccessToken\(token\)/, 'external_gateway_must_accept_user_bound_oauth_tokens');
+assert.match(externalAuth, /authMethod: 'oauth'/, 'oauth_principal_must_be_auditable');
+assert.match(externalAuth, /authMethod: 'static_token'/, 'static_token_backward_compatibility_must_remain');
+
+assert.match(sessionToken, /createHmac\('sha256'/, 'access_tokens_must_be_signed');
+assert.match(sessionToken, /exp <= now/, 'access_tokens_must_expire');
+assert.match(sessionToken, /aud: 'sfi-external-v1'/, 'access_token_audience_must_be_bound');
+
+assert.match(login, /safeNextPath/, 'login_must_preserve_oauth_return_path');
+assert.match(login, /!candidate\.startsWith\('\/\/'\)/, 'login_return_path_must_reject_protocol_relative_redirects');
+
+assert.match(migration, /enable row level security/i, 'oauth_code_table_must_enable_rls');
+assert.match(migration, /code_hash text not null unique/i, 'oauth_codes_must_not_be_stored_in_plaintext');
+assert.match(migration, /consumed_at timestamptz/i, 'oauth_codes_must_track_consumption');
+
+assert.equal(openapi.components?.securitySchemes?.sfiOAuth?.type, 'oauth2', 'openapi_must_publish_oauth2');
+assert.equal(
+  openapi.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode?.authorizationUrl,
+  'https://systemfriction.org/api/oauth/authorize',
+  'openapi_authorization_url_must_be_canonical',
+);
+assert.equal(
+  openapi.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode?.tokenUrl,
+  'https://systemfriction.org/api/oauth/token',
+  'openapi_token_url_must_be_canonical',
+);
+
+assert.match(members, /email: 'edwin\.tzolkin@gmail\.com'/, 'edwin_must_resolve_through_existing_institutional_identity');
+assert.match(members, /displayName: 'Edwin'[\s\S]*?role: 'observer'/, 'edwin_must_not_inherit_root_delegate_from_oauth');
+
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-EXTERNAL-OAUTH-1.0',
+  flow: 'authorization_code',
+  pkce: 'S256',
+  nonRootScopes: ['observe', 'propose', 'lab:read'],
+  staticTokenCompatibility: true,
+}, null, 2));

--- a/src/app/api/external/v1/console/route.ts
+++ b/src/app/api/external/v1/console/route.ts
@@ -88,10 +88,12 @@ export async function GET(req: Request) {
     generatedAt: new Date().toISOString(),
     principal: {
       actorId,
+      subjectId: credential.subjectId ?? null,
       label: credential.label ?? null,
       role: credential.role ?? 'agent',
       tenantId: credential.tenantId ?? 'sfi',
       scopes: credential.scopes ?? [],
+      authMethod: credential.authMethod ?? 'static_token',
     },
     console: {
       purpose: 'Governed machine console for current SFI state. Read-only through this operation; writes remain separate governed operations.',

--- a/src/app/api/external/v1/manifest/route.ts
+++ b/src/app/api/external/v1/manifest/route.ts
@@ -6,8 +6,8 @@ export async function GET() {
   return NextResponse.json({
     ok: true,
     name: 'SFI External Agent Gateway',
-    version: '1.3.2',
-    auth: 'X-SFI-Token or Bearer token',
+    version: '1.4.0',
+    auth: 'OAuth 2.0 authorization_code (user-bound) or X-SFI-Token/Bearer static token',
     base: '/api/external/v1',
     discovery: {
       openapi: '/openapi.json',
@@ -20,6 +20,19 @@ export async function GET() {
       publicHistory: '/api/public/history',
       historySurface: '/history',
       privacy: '/privacy',
+      oauthAuthorize: '/api/oauth/authorize',
+      oauthToken: '/api/oauth/token',
+    },
+    oauth: {
+      flow: 'authorization_code',
+      authorizationUrl: '/api/oauth/authorize',
+      tokenUrl: '/api/oauth/token',
+      tokenType: 'Bearer',
+      accessTokenTtlSeconds: 3600,
+      authorizationCodeTtlSeconds: 120,
+      pkce: 'S256 supported',
+      identity: 'Authenticated SFI institutional member session; client credentials identify the application, not the human principal.',
+      recommendedScopes: ['observe', 'propose', 'lab:read'],
     },
     operations: [
       { id: 'console', method: 'GET', path: '/console', scope: 'observe', description: 'Read a consolidated governed machine console: Method Lab, reports, Cognitive Twin runs/evaluations, proposals, evidence and agentic capabilities.' },
@@ -40,6 +53,6 @@ export async function GET() {
       commandPath: 'lab-bridge/commands/*.json',
       result: 'GitHub Actions artifact containing command, response and provenance',
     },
-    governance: 'External agents may observe, inspect the consolidated console, propose and realize already-authorized internal actions. Method Lab runtime delegation is explicit and auditable; lab:run requires root_delegate. Approval and canonical promotion remain distinct ROOT decisions.',
+    governance: 'External agents may observe, inspect the consolidated console, propose and realize already-authorized internal actions. OAuth user sessions preserve the authenticated SFI principal. Method Lab runtime delegation is explicit and auditable; lab:run requires root_delegate. Approval and canonical promotion remain distinct ROOT decisions.',
   });
 }

--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -9,7 +9,7 @@ export const runtime = 'nodejs';
 
 const DEFAULT_SCOPES = ['observe', 'propose', 'lab:read'] as const;
 const ROOT_SCOPES = ['observe', 'propose', 'execute', 'lab:read', 'lab:write', 'lab:run'] as const;
-const SUPPORTED_SCOPES = new Set(ROOT_SCOPES);
+const SUPPORTED_SCOPES = new Set<string>(ROOT_SCOPES);
 
 function codeHash(code: string) {
   return createHash('sha256').update(code).digest('hex');
@@ -57,7 +57,7 @@ export async function GET(req: NextRequest) {
     return redirectOAuthError(redirectUri, state, 'invalid_request', 'Only PKCE S256 is supported.');
   }
 
-  const requestedScopes = [...new Set(rawScope.split(/\s+/).filter(Boolean))];
+  const requestedScopes = [...new Set<string>(rawScope.split(/\s+/).filter(Boolean))];
   if (requestedScopes.some((scope) => !SUPPORTED_SCOPES.has(scope))) {
     return redirectOAuthError(redirectUri, state, 'invalid_scope', 'One or more requested SFI scopes are not supported.');
   }
@@ -78,7 +78,7 @@ export async function GET(req: NextRequest) {
 
   const profileRole = String(context.profile.role || 'observer').toLowerCase();
   const rootDelegate = profileRole === 'root' || profileRole === 'system';
-  const allowedScopes = new Set(rootDelegate ? ROOT_SCOPES : DEFAULT_SCOPES);
+  const allowedScopes = new Set<string>(rootDelegate ? ROOT_SCOPES : DEFAULT_SCOPES);
   if (requestedScopes.some((scope) => !allowedScopes.has(scope))) {
     return redirectOAuthError(redirectUri, state, 'invalid_scope', 'The authenticated SFI principal is not allowed to receive one or more requested scopes.');
   }

--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -1,0 +1,116 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { AccessDeniedError, requireSfiMember } from '@/lib/system/access/server';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { isAllowedOAuthRedirect, readSfiOAuthConfig, validateOAuthClient } from '@/lib/sfi/oauthConfig';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const DEFAULT_SCOPES = ['observe', 'propose', 'lab:read'] as const;
+const ROOT_SCOPES = ['observe', 'propose', 'execute', 'lab:read', 'lab:write', 'lab:run'] as const;
+const SUPPORTED_SCOPES = new Set(ROOT_SCOPES);
+
+function codeHash(code: string) {
+  return createHash('sha256').update(code).digest('hex');
+}
+
+function actorSlug(value: string) {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+}
+
+function redirectOAuthError(redirectUri: string, state: string | null, error: string, description: string) {
+  const url = new URL(redirectUri);
+  url.searchParams.set('error', error);
+  url.searchParams.set('error_description', description);
+  if (state) url.searchParams.set('state', state);
+  return NextResponse.redirect(url);
+}
+
+export async function GET(req: NextRequest) {
+  const config = readSfiOAuthConfig();
+  if (!config) {
+    return NextResponse.json({ ok: false, error: 'oauth_not_configured' }, { status: 503 });
+  }
+
+  const clientId = req.nextUrl.searchParams.get('client_id')?.trim() || '';
+  const redirectUri = req.nextUrl.searchParams.get('redirect_uri')?.trim() || '';
+  const responseType = req.nextUrl.searchParams.get('response_type')?.trim() || '';
+  const state = req.nextUrl.searchParams.get('state');
+  const rawScope = req.nextUrl.searchParams.get('scope')?.trim() || DEFAULT_SCOPES.join(' ');
+  const codeChallenge = req.nextUrl.searchParams.get('code_challenge')?.trim() || null;
+  const codeChallengeMethod = req.nextUrl.searchParams.get('code_challenge_method')?.trim() || null;
+
+  if (!validateOAuthClient(config, clientId) || !redirectUri || !isAllowedOAuthRedirect(config, redirectUri)) {
+    return NextResponse.json({ ok: false, error: 'invalid_client_or_redirect' }, { status: 400 });
+  }
+  if (responseType !== 'code') {
+    return redirectOAuthError(redirectUri, state, 'unsupported_response_type', 'SFI supports OAuth authorization_code only.');
+  }
+  if (codeChallenge && codeChallengeMethod !== 'S256') {
+    return redirectOAuthError(redirectUri, state, 'invalid_request', 'Only PKCE S256 is supported.');
+  }
+
+  const requestedScopes = [...new Set(rawScope.split(/\s+/).filter(Boolean))];
+  if (requestedScopes.some((scope) => !SUPPORTED_SCOPES.has(scope))) {
+    return redirectOAuthError(redirectUri, state, 'invalid_scope', 'One or more requested SFI scopes are not supported.');
+  }
+
+  let context: Awaited<ReturnType<typeof requireSfiMember>>;
+  try {
+    context = await requireSfiMember();
+  } catch (error) {
+    if (error instanceof AccessDeniedError && error.status === 401) {
+      const next = `${req.nextUrl.pathname}${req.nextUrl.search}`;
+      return NextResponse.redirect(new URL(`/login?next=${encodeURIComponent(next)}`, req.url));
+    }
+    if (error instanceof AccessDeniedError) {
+      return redirectOAuthError(redirectUri, state, 'access_denied', 'An active SFI institutional membership is required.');
+    }
+    throw error;
+  }
+
+  const profileRole = String(context.profile.role || 'observer').toLowerCase();
+  const rootDelegate = profileRole === 'root' || profileRole === 'system';
+  const allowedScopes = new Set(rootDelegate ? ROOT_SCOPES : DEFAULT_SCOPES);
+  if (requestedScopes.some((scope) => !allowedScopes.has(scope))) {
+    return redirectOAuthError(redirectUri, state, 'invalid_scope', 'The authenticated SFI principal is not allowed to receive one or more requested scopes.');
+  }
+
+  const label = context.member?.displayName || String(context.profile.alias || context.user.email || 'SFI member');
+  const slug = actorSlug(context.member?.displayName || String(context.profile.alias || ''));
+  const actorId = slug ? `external:${slug}` : `external:user:${context.user.id}`;
+  const code = randomBytes(32).toString('base64url');
+  const expiresAt = new Date(Date.now() + 2 * 60 * 1000).toISOString();
+
+  const db = createServiceSupabaseClient();
+  const stored = await db.from('sfi_oauth_authorization_codes').insert({
+    code_hash: codeHash(code),
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    subject_id: context.user.id,
+    actor_id: actorId,
+    label,
+    role: rootDelegate ? 'root_delegate' : 'agent',
+    tenant_id: 'sfi',
+    scopes: requestedScopes,
+    code_challenge: codeChallenge,
+    code_challenge_method: codeChallenge ? 'S256' : null,
+    expires_at: expiresAt,
+  });
+
+  if (stored.error) {
+    return redirectOAuthError(redirectUri, state, 'server_error', 'SFI could not issue an authorization code.');
+  }
+
+  const callback = new URL(redirectUri);
+  callback.searchParams.set('code', code);
+  if (state) callback.searchParams.set('state', state);
+  return NextResponse.redirect(callback);
+}

--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -1,0 +1,112 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { mintExternalAccessToken } from '@/lib/sfi/externalSessionToken';
+import { isAllowedOAuthRedirect, readSfiOAuthConfig, validateOAuthClient } from '@/lib/sfi/oauthConfig';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+function codeHash(code: string) {
+  return createHash('sha256').update(code).digest('hex');
+}
+
+function safeEqual(a: string, b: string) {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+function parseBasicAuth(value: string | null) {
+  if (!value?.startsWith('Basic ')) return null;
+  try {
+    const decoded = Buffer.from(value.slice(6), 'base64').toString('utf8');
+    const separator = decoded.indexOf(':');
+    if (separator < 0) return null;
+    return { clientId: decoded.slice(0, separator), clientSecret: decoded.slice(separator + 1) };
+  } catch {
+    return null;
+  }
+}
+
+function oauthError(error: string, description: string, status = 400) {
+  return NextResponse.json(
+    { error, error_description: description },
+    { status, headers: { 'Cache-Control': 'no-store', Pragma: 'no-cache' } },
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const config = readSfiOAuthConfig();
+  if (!config) return oauthError('server_error', 'SFI OAuth is not configured.', 503);
+
+  const form = await req.formData().catch(() => null);
+  if (!form) return oauthError('invalid_request', 'Expected application/x-www-form-urlencoded body.');
+
+  const basic = parseBasicAuth(req.headers.get('authorization'));
+  const clientId = String(form.get('client_id') || basic?.clientId || '').trim();
+  const clientSecret = String(form.get('client_secret') || basic?.clientSecret || '').trim();
+  const grantType = String(form.get('grant_type') || '').trim();
+  const code = String(form.get('code') || '').trim();
+  const redirectUri = String(form.get('redirect_uri') || '').trim();
+  const codeVerifier = String(form.get('code_verifier') || '').trim();
+
+  if (!validateOAuthClient(config, clientId, clientSecret)) {
+    return oauthError('invalid_client', 'Client authentication failed.', 401);
+  }
+  if (grantType !== 'authorization_code') {
+    return oauthError('unsupported_grant_type', 'SFI supports authorization_code only.');
+  }
+  if (!code || !redirectUri || !isAllowedOAuthRedirect(config, redirectUri)) {
+    return oauthError('invalid_grant', 'Authorization code or redirect URI is invalid.');
+  }
+
+  const db = createServiceSupabaseClient();
+  const now = new Date().toISOString();
+  const consumed = await db
+    .from('sfi_oauth_authorization_codes')
+    .update({ consumed_at: now })
+    .eq('code_hash', codeHash(code))
+    .eq('client_id', clientId)
+    .eq('redirect_uri', redirectUri)
+    .is('consumed_at', null)
+    .gt('expires_at', now)
+    .select('subject_id,actor_id,label,role,tenant_id,scopes,code_challenge,code_challenge_method')
+    .maybeSingle();
+
+  if (consumed.error || !consumed.data) {
+    return oauthError('invalid_grant', 'Authorization code is invalid, expired, or already consumed.');
+  }
+
+  if (consumed.data.code_challenge) {
+    if (!codeVerifier) return oauthError('invalid_grant', 'PKCE code_verifier is required.');
+    const calculated = createHash('sha256').update(codeVerifier).digest('base64url');
+    if (!safeEqual(calculated, String(consumed.data.code_challenge))) {
+      return oauthError('invalid_grant', 'PKCE verification failed.');
+    }
+  }
+
+  const scopes = Array.isArray(consumed.data.scopes)
+    ? consumed.data.scopes.filter((value): value is string => typeof value === 'string')
+    : [];
+
+  const accessToken = mintExternalAccessToken({
+    subjectId: String(consumed.data.subject_id),
+    actorId: String(consumed.data.actor_id),
+    label: consumed.data.label ? String(consumed.data.label) : undefined,
+    role: String(consumed.data.role || 'agent'),
+    tenantId: String(consumed.data.tenant_id || 'sfi'),
+    scopes,
+    ttlSeconds: 3600,
+  });
+
+  return NextResponse.json(
+    {
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: 3600,
+      scope: scopes.join(' '),
+    },
+    { headers: { 'Cache-Control': 'no-store', Pragma: 'no-cache' } },
+  );
+}

--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -63,39 +63,52 @@ export async function POST(req: NextRequest) {
 
   const db = createServiceSupabaseClient();
   const now = new Date().toISOString();
-  const consumed = await db
+  const found = await db
     .from('sfi_oauth_authorization_codes')
-    .update({ consumed_at: now })
+    .select('id,subject_id,actor_id,label,role,tenant_id,scopes,code_challenge,code_challenge_method')
     .eq('code_hash', codeHash(code))
     .eq('client_id', clientId)
     .eq('redirect_uri', redirectUri)
     .is('consumed_at', null)
     .gt('expires_at', now)
-    .select('subject_id,actor_id,label,role,tenant_id,scopes,code_challenge,code_challenge_method')
     .maybeSingle();
 
-  if (consumed.error || !consumed.data) {
+  if (found.error || !found.data) {
     return oauthError('invalid_grant', 'Authorization code is invalid, expired, or already consumed.');
   }
 
-  if (consumed.data.code_challenge) {
+  if (found.data.code_challenge) {
     if (!codeVerifier) return oauthError('invalid_grant', 'PKCE code_verifier is required.');
     const calculated = createHash('sha256').update(codeVerifier).digest('base64url');
-    if (!safeEqual(calculated, String(consumed.data.code_challenge))) {
+    if (!safeEqual(calculated, String(found.data.code_challenge))) {
       return oauthError('invalid_grant', 'PKCE verification failed.');
     }
   }
 
-  const scopes = Array.isArray(consumed.data.scopes)
-    ? consumed.data.scopes.filter((value): value is string => typeof value === 'string')
+  // Mark the code consumed only after client and optional PKCE verification. The
+  // conditional update keeps the code single-use if two exchanges race.
+  const consumed = await db
+    .from('sfi_oauth_authorization_codes')
+    .update({ consumed_at: now })
+    .eq('id', found.data.id)
+    .is('consumed_at', null)
+    .select('id')
+    .maybeSingle();
+
+  if (consumed.error || !consumed.data) {
+    return oauthError('invalid_grant', 'Authorization code was already consumed.');
+  }
+
+  const scopes = Array.isArray(found.data.scopes)
+    ? found.data.scopes.filter((value): value is string => typeof value === 'string')
     : [];
 
   const accessToken = mintExternalAccessToken({
-    subjectId: String(consumed.data.subject_id),
-    actorId: String(consumed.data.actor_id),
-    label: consumed.data.label ? String(consumed.data.label) : undefined,
-    role: String(consumed.data.role || 'agent'),
-    tenantId: String(consumed.data.tenant_id || 'sfi'),
+    subjectId: String(found.data.subject_id),
+    actorId: String(found.data.actor_id),
+    label: found.data.label ? String(found.data.label) : undefined,
+    role: String(found.data.role || 'agent'),
+    tenantId: String(found.data.tenant_id || 'sfi'),
     scopes,
     ttlSeconds: 3600,
   });

--- a/src/components/sfi/LoginSurface.tsx
+++ b/src/components/sfi/LoginSurface.tsx
@@ -1,4 +1,40 @@
 'use client';
+
 import { FormEvent, useMemo, useState } from 'react';
 import { createBrowserSupabaseClient } from '@/runtime/supabase/client';
-export function LoginSurface(){const sb=useMemo(()=>createBrowserSupabaseClient(),[]);const [error,setError]=useState('');const submit=async(e:FormEvent<HTMLFormElement>)=>{e.preventDefault();if(!sb)return setError('Supabase no configurado');const f=new FormData(e.currentTarget);const {error}=await sb.auth.signInWithPassword({email:String(f.get('email')||''),password:String(f.get('password')||'')});if(error)setError(error.message);else location.href='/root'};return <main className="login"><form onSubmit={submit}><div className="sigil">SFI.</div><h1>Acceso al instituto</h1><p>Observación, evidencia, decisión y retorno.</p><input name="email" type="email" placeholder="correo" required/><input name="password" type="password" placeholder="contraseña" required/><button>ENTRAR</button>{error&&<small>{error}</small>}</form></main>}
+
+function safeNextPath() {
+  const candidate = new URLSearchParams(window.location.search).get('next') || '';
+  return candidate.startsWith('/') && !candidate.startsWith('//') ? candidate : '/root';
+}
+
+export function LoginSurface() {
+  const sb = useMemo(() => createBrowserSupabaseClient(), []);
+  const [error, setError] = useState('');
+
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!sb) return setError('Supabase no configurado');
+    const form = new FormData(event.currentTarget);
+    const { error: signInError } = await sb.auth.signInWithPassword({
+      email: String(form.get('email') || ''),
+      password: String(form.get('password') || ''),
+    });
+    if (signInError) setError(signInError.message);
+    else window.location.href = safeNextPath();
+  };
+
+  return (
+    <main className="login">
+      <form onSubmit={submit}>
+        <div className="sigil">SFI.</div>
+        <h1>Acceso al instituto</h1>
+        <p>Observación, evidencia, decisión y retorno.</p>
+        <input name="email" type="email" placeholder="correo" required />
+        <input name="password" type="password" placeholder="contraseña" required />
+        <button>ENTRAR</button>
+        {error && <small>{error}</small>}
+      </form>
+    </main>
+  );
+}

--- a/src/lib/sfi/externalAuth.ts
+++ b/src/lib/sfi/externalAuth.ts
@@ -1,9 +1,13 @@
+import { verifyExternalAccessToken } from './externalSessionToken';
+
 export type ExternalCredential = {
   label?: string;
   scopes?: string[];
   role?: 'agent' | 'root_delegate' | string;
   actorId?: string;
   tenantId?: string;
+  subjectId?: string;
+  authMethod?: 'static_token' | 'oauth';
 };
 
 export type ExternalAuthResult = {
@@ -21,11 +25,34 @@ function readPresentedToken(req: Request) {
   return authorization.replace(/^Bearer\s+/i, '').trim();
 }
 
+function credentialAllowsScope(credential: ExternalCredential, scope: string) {
+  const scopes = credential.scopes ?? [];
+  return scopes.includes(scope) || scopes.includes('*');
+}
+
 export function authorizeExternalRequest(req: Request, scope: string): ExternalAuthResult {
   const token = readPresentedToken(req);
   const raw = process.env.SFI_EXTERNAL_API_KEYS_JSON || '';
   if (!token) {
     return { credential: null, tokenPresent: false, registryConfigured: Boolean(raw.trim()), scopeAllowed: false };
+  }
+
+  // OAuth access tokens are short-lived, user-bound credentials issued by SFI after
+  // an authenticated institutional login. They are verified before static API keys
+  // so a ChatGPT Action can operate as the actual SFI member rather than a shared bot.
+  const session = verifyExternalAccessToken(token);
+  if (session) {
+    const credential: ExternalCredential = {
+      label: session.label,
+      scopes: session.scopes,
+      role: session.role,
+      actorId: session.actorId,
+      tenantId: session.tenantId,
+      subjectId: session.sub,
+      authMethod: 'oauth',
+    };
+    const scopeAllowed = credentialAllowsScope(credential, scope);
+    return { credential: scopeAllowed ? credential : null, tokenPresent: true, registryConfigured: Boolean(raw.trim()), scopeAllowed };
   }
 
   try {
@@ -34,9 +61,9 @@ export function authorizeExternalRequest(req: Request, scope: string): ExternalA
     if (!credential) {
       return { credential: null, tokenPresent: true, registryConfigured: Object.keys(registry).length > 0, scopeAllowed: false };
     }
-    const scopes = credential.scopes ?? [];
-    const scopeAllowed = scopes.includes(scope) || scopes.includes('*');
-    return { credential: scopeAllowed ? credential : null, tokenPresent: true, registryConfigured: true, scopeAllowed };
+    const normalized: ExternalCredential = { ...credential, authMethod: 'static_token' };
+    const scopeAllowed = credentialAllowsScope(normalized, scope);
+    return { credential: scopeAllowed ? normalized : null, tokenPresent: true, registryConfigured: true, scopeAllowed };
   } catch {
     return { credential: null, tokenPresent: true, registryConfigured: false, scopeAllowed: false };
   }

--- a/src/lib/sfi/externalSessionToken.ts
+++ b/src/lib/sfi/externalSessionToken.ts
@@ -1,0 +1,112 @@
+import 'server-only';
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export type ExternalSessionClaims = {
+  v: 1;
+  kind: 'access_token';
+  iss: 'systemfriction.org';
+  aud: 'sfi-external-v1';
+  sub: string;
+  actorId: string;
+  label?: string;
+  role: 'agent' | 'root_delegate' | string;
+  tenantId: string;
+  scopes: string[];
+  iat: number;
+  exp: number;
+};
+
+function signingSecret() {
+  return (process.env.SFI_EXTERNAL_SESSION_SECRET || '').trim();
+}
+
+function base64url(value: string) {
+  return Buffer.from(value, 'utf8').toString('base64url');
+}
+
+function decodeBase64url(value: string) {
+  return Buffer.from(value, 'base64url').toString('utf8');
+}
+
+function signature(payload: string, secret: string) {
+  return createHmac('sha256', secret).update(payload).digest('base64url');
+}
+
+function safeEqual(a: string, b: string) {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+export function mintExternalAccessToken(input: {
+  subjectId: string;
+  actorId: string;
+  label?: string;
+  role: 'agent' | 'root_delegate' | string;
+  tenantId?: string;
+  scopes: string[];
+  ttlSeconds?: number;
+}) {
+  const secret = signingSecret();
+  if (!secret) throw new Error('SFI_EXTERNAL_SESSION_SECRET is not configured.');
+
+  const now = Math.floor(Date.now() / 1000);
+  const claims: ExternalSessionClaims = {
+    v: 1,
+    kind: 'access_token',
+    iss: 'systemfriction.org',
+    aud: 'sfi-external-v1',
+    sub: input.subjectId,
+    actorId: input.actorId,
+    label: input.label,
+    role: input.role,
+    tenantId: input.tenantId || 'sfi',
+    scopes: [...new Set(input.scopes)].sort(),
+    iat: now,
+    exp: now + Math.max(60, Math.min(input.ttlSeconds ?? 3600, 3600)),
+  };
+
+  const encoded = base64url(JSON.stringify(claims));
+  const signed = `sfiat.v1.${encoded}`;
+  return `${signed}.${signature(signed, secret)}`;
+}
+
+export function verifyExternalAccessToken(token: string): ExternalSessionClaims | null {
+  const secret = signingSecret();
+  if (!secret || !token.startsWith('sfiat.v1.')) return null;
+
+  const parts = token.split('.');
+  if (parts.length !== 4) return null;
+
+  const signed = parts.slice(0, 3).join('.');
+  const providedSignature = parts[3] || '';
+  const expectedSignature = signature(signed, secret);
+  if (!safeEqual(providedSignature, expectedSignature)) return null;
+
+  try {
+    const claims = JSON.parse(decodeBase64url(parts[2])) as Partial<ExternalSessionClaims>;
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      claims.v !== 1 ||
+      claims.kind !== 'access_token' ||
+      claims.iss !== 'systemfriction.org' ||
+      claims.aud !== 'sfi-external-v1' ||
+      typeof claims.sub !== 'string' ||
+      typeof claims.actorId !== 'string' ||
+      typeof claims.role !== 'string' ||
+      typeof claims.tenantId !== 'string' ||
+      !Array.isArray(claims.scopes) ||
+      !claims.scopes.every((scope) => typeof scope === 'string') ||
+      typeof claims.iat !== 'number' ||
+      typeof claims.exp !== 'number' ||
+      claims.exp <= now ||
+      claims.iat > now + 60
+    ) {
+      return null;
+    }
+    return claims as ExternalSessionClaims;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/sfi/oauthConfig.ts
+++ b/src/lib/sfi/oauthConfig.ts
@@ -11,12 +11,13 @@ export type SfiOAuthConfig = {
 export function readSfiOAuthConfig(): SfiOAuthConfig | null {
   const clientId = (process.env.SFI_OAUTH_CLIENT_ID || '').trim();
   const clientSecret = (process.env.SFI_OAUTH_CLIENT_SECRET || '').trim();
+  const sessionSecret = (process.env.SFI_EXTERNAL_SESSION_SECRET || '').trim();
   const redirectUris = (process.env.SFI_OAUTH_REDIRECT_URIS || '')
     .split(',')
     .map((value) => value.trim())
     .filter(Boolean);
 
-  if (!clientId || !clientSecret || redirectUris.length === 0) return null;
+  if (!clientId || !clientSecret || !sessionSecret || redirectUris.length === 0) return null;
   return { clientId, clientSecret, redirectUris };
 }
 

--- a/src/lib/sfi/oauthConfig.ts
+++ b/src/lib/sfi/oauthConfig.ts
@@ -1,0 +1,37 @@
+import 'server-only';
+
+import { timingSafeEqual } from 'node:crypto';
+
+export type SfiOAuthConfig = {
+  clientId: string;
+  clientSecret: string;
+  redirectUris: string[];
+};
+
+export function readSfiOAuthConfig(): SfiOAuthConfig | null {
+  const clientId = (process.env.SFI_OAUTH_CLIENT_ID || '').trim();
+  const clientSecret = (process.env.SFI_OAUTH_CLIENT_SECRET || '').trim();
+  const redirectUris = (process.env.SFI_OAUTH_REDIRECT_URIS || '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  if (!clientId || !clientSecret || redirectUris.length === 0) return null;
+  return { clientId, clientSecret, redirectUris };
+}
+
+function safeEqual(a: string, b: string) {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+export function isAllowedOAuthRedirect(config: SfiOAuthConfig, redirectUri: string) {
+  return config.redirectUris.includes(redirectUri);
+}
+
+export function validateOAuthClient(config: SfiOAuthConfig, clientId: string, clientSecret?: string | null) {
+  if (!safeEqual(clientId, config.clientId)) return false;
+  if (clientSecret === undefined || clientSecret === null) return true;
+  return safeEqual(clientSecret, config.clientSecret);
+}

--- a/supabase/migrations/20260822214500_create_sfi_oauth_authorization_codes.sql
+++ b/supabase/migrations/20260822214500_create_sfi_oauth_authorization_codes.sql
@@ -1,0 +1,30 @@
+create table if not exists public.sfi_oauth_authorization_codes (
+  id uuid primary key default gen_random_uuid(),
+  code_hash text not null unique,
+  client_id text not null,
+  redirect_uri text not null,
+  subject_id uuid not null,
+  actor_id text not null,
+  label text,
+  role text not null default 'agent',
+  tenant_id text not null default 'sfi',
+  scopes text[] not null default '{}',
+  code_challenge text,
+  code_challenge_method text,
+  expires_at timestamptz not null,
+  consumed_at timestamptz,
+  created_at timestamptz not null default now(),
+  constraint sfi_oauth_code_challenge_method_check
+    check (code_challenge_method is null or code_challenge_method = 'S256')
+);
+
+alter table public.sfi_oauth_authorization_codes enable row level security;
+
+create index if not exists sfi_oauth_authorization_codes_expires_at_idx
+  on public.sfi_oauth_authorization_codes (expires_at);
+
+create index if not exists sfi_oauth_authorization_codes_subject_id_idx
+  on public.sfi_oauth_authorization_codes (subject_id, created_at desc);
+
+comment on table public.sfi_oauth_authorization_codes is
+  'Short-lived, one-time authorization codes for governed external SFI OAuth clients. Service-role access only; no RLS policies are intentionally granted.';


### PR DESCRIPTION
Implements user-bound OAuth authorization_code authentication for the existing SFI External Agent Gateway.

Key changes:
- Reuses the existing SFI/Supabase institutional login as the human identity source.
- Adds /api/oauth/authorize and /api/oauth/token.
- Issues one-time authorization codes stored only as SHA-256 hashes.
- Supports optional PKCE S256.
- Issues short-lived signed bearer access tokens (1 hour).
- Extends external gateway auth to accept OAuth bearer tokens while preserving static token compatibility.
- Preserves login `next` so OAuth can return after SFI sign-in.
- Exposes principal subject/auth method in /api/external/v1/console.
- Adds OAuth security scheme to public/openapi.json and discovery metadata to the external manifest.
- Adds migration for sfi_oauth_authorization_codes.

Default non-ROOT scopes are deliberately limited to: observe, propose, lab:read. Existing institutional member Edwin therefore authenticates as a normal agent rather than root_delegate.

Deployment requirements:
- Apply the Supabase migration.
- Configure SFI_OAUTH_CLIENT_ID, SFI_OAUTH_CLIENT_SECRET, SFI_OAUTH_REDIRECT_URIS and SFI_EXTERNAL_SESSION_SECRET in production.
- Copy the exact callback URL generated by the ChatGPT GPT Action editor into SFI_OAUTH_REDIRECT_URIS.

No OAuth client secret or user token is committed to the repository.