### PR TITLE
test(lab-bridge): verify read-only state transport

### DIFF
--- a/.github/workflows/sfi-github-lab-bridge.yml
+++ b/.github/workflows/sfi-github-lab-bridge.yml
@@ -73,7 +73,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          BASE_URL="${SFI_BASE_URL:-https://systemfriction.org}"
+          BASE_URL="${SFI_BASE_URL:-https://www.systemfriction.org}"
+          BASE_URL="${BASE_URL%/}"
+          # The public apex redirects to the canonical www host. Do not use
+          # curl -L for an authenticated request because Authorization can be
+          # stripped or forwarded across redirect hosts. Normalize only the
+          # institute's known canonical host before sending the bearer token.
+          if [ "$BASE_URL" = "https://systemfriction.org" ]; then
+            BASE_URL="https://www.systemfriction.org"
+          fi
           STATUS="$(curl --silent --show-error --output .lab-bridge-output/response.json --write-out '%{http_code}' \
             --request POST "$BASE_URL/api/external/v1/lab" \
             --header "Authorization: Bearer $SFI_LAB_TOKEN" \
@@ -88,6 +96,7 @@ jobs:
           NODE
 
       - name: Record bridge provenance
+        if: success()
         shell: bash
         run: |
           node - <<'NODE'
@@ -111,4 +120,5 @@ jobs:
           name: sfi-lab-bridge-${{ github.run_id }}
           path: .lab-bridge-output/
           if-no-files-found: ignore
+          include-hidden-files: true
           retention-days: 30

--- a/lab-bridge/commands/2026-08-24-state-smoke.json
+++ b/lab-bridge/commands/2026-08-24-state-smoke.json
@@ -1,0 +1,3 @@
+{
+  "operation": "state"
+}


### PR DESCRIPTION
Read-only operational probe for the existing GitHub → SFI Method Lab bridge.

The changed command file contains only `{ "operation": "state" }`. Because the bridge workflow is now present on `main` with a `pull_request` trigger, this PR should execute the same read-only state command using the configured bridge credential.

Expected evidence:
- workflow starts;
- bridge credential is present;
- `/api/external/v1/lab` returns JSON with `ok: true`;
- provenance artifact is uploaded;
- no Method Lab run, evidence mutation, proposal or canonical promotion is created.