### PR TITLE
fix(lab-bridge): enforce main-only idempotent writes

### DIFF
--- a/.github/workflows/sfi-github-lab-bridge.yml
+++ b/.github/workflows/sfi-github-lab-bridge.yml
@@ -2,6 +2,8 @@ name: SFI GitHub Lab Bridge
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'lab-bridge/commands/*.json'
   pull_request:

--- a/scripts/qa-sfi-method-lab-convergence.ts
+++ b/scripts/qa-sfi-method-lab-convergence.ts
@@ -60,6 +60,17 @@ for (const route of [
 assert.ok(methodLabHub.includes('SIMULATED ≠ OBSERVED'), 'Method Lab native hub must state its epistemic boundary.');
 assert.ok(methodLabHub.includes('FOUNDER_AUTHORIZATION no equivale a FOUNDER_ORIGINATED'), 'CRL provenance boundary must remain visible to ROOT.');
 
+const externalLab = read('src/app/api/external/v1/lab/route.ts');
+assert.match(externalLab, /persistEventId\(commandId: string\)/, 'External Method Lab persist must derive a deterministic event id from commandId.');
+assert.match(externalLab, /\.contains\('payload', \{ commandId \}\)/, 'External Method Lab persist must reread prior commandId records before appending.');
+assert.match(externalLab, /idempotent: true/, 'External Method Lab persist must expose idempotent reuse explicitly.');
+assert.match(externalLab, /eventId: commandId \? persistEventId\(commandId\) : undefined/, 'Database UNIQUE(event_id) must back commandId idempotency under races.');
+
+const bridgeWorkflow = read('.github/workflows/sfi-github-lab-bridge.yml');
+assert.match(bridgeWorkflow, /push:\s*\n\s*branches:\s*\n\s*- main\s*\n\s*paths:/, 'GitHub Method Lab write-triggered push must be restricted to main.');
+assert.match(bridgeWorkflow, /pull_request:[\s\S]*\{"operation":"state"\}/, 'Pull-request bridge verification must remain read-only.');
+assert.match(bridgeWorkflow, /https:\/\/www\.systemfriction\.org/, 'Authenticated bridge calls must normalize the known SFI canonical host before sending Authorization.');
+
 const runner = read('src/lib/method-lab/simulationRun.ts');
 assert.match(runner, /executeRegisteredAgent/, 'Method Lab simulations must use isolated registered executors rather than productive runtime event emission.');
 assert.match(runner, /METHOD_LAB_SIMULATION_CONTAMINATED_EVIDENCE/, 'Method Lab must abort if a simulator mutates observed evidence.');
@@ -98,6 +109,8 @@ console.log(JSON.stringify({
     'simulators cannot append SIMULATED output to observed evidence',
     'ROOT/Models/GenAI remain canonical live navigation while the declared Method Lab instrument is operationally reachable',
     'Method Lab protocol controls use governed APIs and server-owned evidence readers rather than direct interface persistence',
+    'GitHub Method Lab branch PRs are read-only; write-triggered pushes execute only on main',
+    'external Method Lab persist is idempotent by commandId and database-unique deterministic event id',
     'no additional Vercel cron',
   ],
 }, null, 2));

--- a/src/app/api/external/v1/lab/route.ts
+++ b/src/app/api/external/v1/lab/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 import { readMethodLabState } from '@/lib/method-lab/readModel';
 import { runMethodLabSimulation } from '@/lib/method-lab/simulationRun';
 import { appendEpistemicEvent } from '@/lib/events/eventStore';
-import { appendOperationalEvent } from '@/lib/operational/common';
+import { appendOperationalEvent, recordValue, sha256 } from '@/lib/operational/common';
 import { createServiceSupabaseClient } from '@/runtime/supabase/server';
 import { authorizeExternalRequest, externalActor } from '@/lib/sfi/externalAuth';
 
@@ -12,6 +12,14 @@ export const runtime = 'nodejs';
 export const maxDuration = 60;
 
 type LabOperation = 'state' | 'report' | 'persist' | 'run';
+type PersistSemanticInput = {
+  title: string;
+  content: string;
+  source: unknown;
+  refs: string[];
+  metadata: Record<string, unknown>;
+  confidence: number;
+};
 
 function operationScope(operation: LabOperation) {
   if (operation === 'state' || operation === 'report') return 'lab:read';
@@ -27,6 +35,24 @@ function persistEventId(commandId: string) {
   return `external-method-lab-persist:${createHash('sha256').update(commandId).digest('hex')}`;
 }
 
+function persistFingerprint(input: PersistSemanticInput) {
+  return sha256(input);
+}
+
+function existingPersistFingerprint(row: Record<string, unknown>) {
+  const payload = recordValue(row.payload);
+  const stored = typeof payload.commandFingerprint === 'string' ? payload.commandFingerprint : '';
+  if (stored) return stored;
+  return persistFingerprint({
+    title: typeof payload.title === 'string' ? payload.title : '',
+    content: typeof payload.content === 'string' ? payload.content : '',
+    source: payload.source ?? 'github_lab_bridge',
+    refs: Array.isArray(payload.refs) ? payload.refs.filter((value): value is string => typeof value === 'string') : [],
+    metadata: recordValue(payload.metadata),
+    confidence: typeof row.confidence === 'number' ? row.confidence : Number(row.confidence ?? 0),
+  });
+}
+
 async function readExistingPersist(commandId: string) {
   const db = createServiceSupabaseClient();
   return db.from('epistemic_events')
@@ -36,6 +62,25 @@ async function readExistingPersist(commandId: string) {
     .order('sequence', { ascending: true })
     .limit(1)
     .maybeSingle();
+}
+
+function idempotentPersistResponse(input: {
+  operation: LabOperation;
+  actorId: string;
+  commandId: string;
+  incomingFingerprint: string;
+  existing: Record<string, unknown>;
+}) {
+  const existingFingerprint = existingPersistFingerprint(input.existing);
+  if (existingFingerprint !== input.incomingFingerprint) {
+    return NextResponse.json({
+      ok: false,
+      error: 'method_lab_persist_command_id_conflict',
+      commandId: input.commandId,
+      existingEventId: input.existing.event_id ?? null,
+    }, { status: 409 });
+  }
+  return NextResponse.json({ ok: true, operation: input.operation, actor: input.actorId, idempotent: true, event: input.existing }, { status: 200 });
 }
 
 export async function POST(req: Request) {
@@ -81,27 +126,32 @@ export async function POST(req: Request) {
     if (!title || !content) return NextResponse.json({ ok: false, error: 'title_and_content_required' }, { status: 400 });
 
     const commandId = normalizedCommandId(body.commandId);
+    const requestedConfidence = typeof body.confidence === 'number' ? body.confidence : 1;
+    const confidenceIsValid = Number.isFinite(requestedConfidence) && requestedConfidence >= 0 && requestedConfidence <= 1;
+    const confidence = confidenceIsValid ? requestedConfidence : 0;
+    const refs = Array.isArray(body.refs) ? body.refs.filter((value): value is string => typeof value === 'string') : [];
+    const metadata = body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata) ? body.metadata as Record<string, unknown> : {};
+    const source = body.source ?? 'github_lab_bridge';
+    const incomingFingerprint = persistFingerprint({ title, content, source, refs, metadata, confidence });
+
     if (commandId) {
       const existing = await readExistingPersist(commandId);
       if (existing.error) {
         return NextResponse.json({ ok: false, error: 'method_lab_persist_idempotency_lookup_failed', details: existing.error.message }, { status: 500 });
       }
       if (existing.data) {
-        return NextResponse.json({ ok: true, operation, actor: actorId, idempotent: true, event: existing.data }, { status: 200 });
+        return idempotentPersistResponse({ operation, actorId, commandId, incomingFingerprint, existing: existing.data as Record<string, unknown> });
       }
     }
 
-    const requestedConfidence = typeof body.confidence === 'number' ? body.confidence : 1;
-    const confidenceIsValid = Number.isFinite(requestedConfidence) && requestedConfidence >= 0 && requestedConfidence <= 1;
-    const confidence = confidenceIsValid ? requestedConfidence : 0;
-    const refs = Array.isArray(body.refs) ? body.refs.filter((value): value is string => typeof value === 'string') : [];
     const payload = {
       title,
       content,
-      source: body.source ?? 'github_lab_bridge',
+      source,
       commandId: commandId || null,
-      refs: Array.isArray(body.refs) ? body.refs : [],
-      metadata: body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata) ? body.metadata : {},
+      commandFingerprint: incomingFingerprint,
+      refs,
+      metadata,
       credentialLabel: cred.label ?? null,
       delegatedRole: cred.role ?? 'agent',
       confidenceState: confidenceIsValid ? 'EXPLICIT' : 'UNASSESSED',
@@ -123,10 +173,11 @@ export async function POST(req: Request) {
     if (!event.ok && commandId) {
       // `event_id` is UNIQUE. If two requests race with the same commandId,
       // the deterministic event id lets the database reject the duplicate;
-      // reread the winning event and return an idempotent success.
+      // reread the winning event and return idempotent success only when the
+      // semantic command fingerprint is identical.
       const existing = await readExistingPersist(commandId);
       if (!existing.error && existing.data) {
-        return NextResponse.json({ ok: true, operation, actor: actorId, idempotent: true, event: existing.data }, { status: 200 });
+        return idempotentPersistResponse({ operation, actorId, commandId, incomingFingerprint, existing: existing.data as Record<string, unknown> });
       }
     }
 

--- a/src/app/api/external/v1/lab/route.ts
+++ b/src/app/api/external/v1/lab/route.ts
@@ -1,6 +1,8 @@
+import { createHash } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { readMethodLabState } from '@/lib/method-lab/readModel';
 import { runMethodLabSimulation } from '@/lib/method-lab/simulationRun';
+import { appendEpistemicEvent } from '@/lib/events/eventStore';
 import { appendOperationalEvent } from '@/lib/operational/common';
 import { createServiceSupabaseClient } from '@/runtime/supabase/server';
 import { authorizeExternalRequest, externalActor } from '@/lib/sfi/externalAuth';
@@ -15,6 +17,25 @@ function operationScope(operation: LabOperation) {
   if (operation === 'state' || operation === 'report') return 'lab:read';
   if (operation === 'persist') return 'lab:write';
   return 'lab:run';
+}
+
+function normalizedCommandId(value: unknown) {
+  return typeof value === 'string' ? value.trim().slice(0, 240) : '';
+}
+
+function persistEventId(commandId: string) {
+  return `external-method-lab-persist:${createHash('sha256').update(commandId).digest('hex')}`;
+}
+
+async function readExistingPersist(commandId: string) {
+  const db = createServiceSupabaseClient();
+  return db.from('epistemic_events')
+    .select('id,sequence,event_id,event_name,epistemic_class,source,confidence,payload,lineage,occurred_at,created_at,hash_self')
+    .eq('event_name', 'external.method_lab.record.persisted')
+    .contains('payload', { commandId })
+    .order('sequence', { ascending: true })
+    .limit(1)
+    .maybeSingle();
 }
 
 export async function POST(req: Request) {
@@ -58,23 +79,58 @@ export async function POST(req: Request) {
     const title = String(body.title || '').trim();
     const content = String(body.content || '').trim();
     if (!title || !content) return NextResponse.json({ ok: false, error: 'title_and_content_required' }, { status: 400 });
-    const event = await appendOperationalEvent({
+
+    const commandId = normalizedCommandId(body.commandId);
+    if (commandId) {
+      const existing = await readExistingPersist(commandId);
+      if (existing.error) {
+        return NextResponse.json({ ok: false, error: 'method_lab_persist_idempotency_lookup_failed', details: existing.error.message }, { status: 500 });
+      }
+      if (existing.data) {
+        return NextResponse.json({ ok: true, operation, actor: actorId, idempotent: true, event: existing.data }, { status: 200 });
+      }
+    }
+
+    const requestedConfidence = typeof body.confidence === 'number' ? body.confidence : 1;
+    const confidenceIsValid = Number.isFinite(requestedConfidence) && requestedConfidence >= 0 && requestedConfidence <= 1;
+    const confidence = confidenceIsValid ? requestedConfidence : 0;
+    const refs = Array.isArray(body.refs) ? body.refs.filter((value): value is string => typeof value === 'string') : [];
+    const payload = {
+      title,
+      content,
+      source: body.source ?? 'github_lab_bridge',
+      commandId: commandId || null,
+      refs: Array.isArray(body.refs) ? body.refs : [],
+      metadata: body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata) ? body.metadata : {},
+      credentialLabel: cred.label ?? null,
+      delegatedRole: cred.role ?? 'agent',
+      confidenceState: confidenceIsValid ? 'EXPLICIT' : 'UNASSESSED',
+    };
+
+    const event = await appendEpistemicEvent({
+      eventId: commandId ? persistEventId(commandId) : undefined,
       eventName: 'external.method_lab.record.persisted',
-      actorId,
-      confidence: typeof body.confidence === 'number' ? body.confidence : 1,
-      payload: {
-        title,
-        content,
-        source: body.source ?? 'github_lab_bridge',
-        commandId: body.commandId ?? null,
-        refs: Array.isArray(body.refs) ? body.refs : [],
-        metadata: body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata) ? body.metadata : {},
-        credentialLabel: cred.label ?? null,
-        delegatedRole: cred.role ?? 'agent',
-      },
-      lineage: Array.isArray(body.refs) ? body.refs.filter((value): value is string => typeof value === 'string') : [],
+      epistemicClass: 'derived',
+      confidence,
+      payload,
+      occurredAt: new Date().toISOString(),
+      source: { sourceId: 'SYSTEM_FRICTION_INSTITUTE', sourceType: 'operational_runtime' },
+      logbookId: 'BR',
+      lineage: refs,
+      uncertainty: confidenceIsValid ? undefined : 'Confidence not assessed; numeric zero is a schema sentinel, not a measurement.',
     });
-    return NextResponse.json(event.ok ? { ok: true, operation, actor: actorId, event: event.data } : event, { status: event.ok ? 201 : 500 });
+
+    if (!event.ok && commandId) {
+      // `event_id` is UNIQUE. If two requests race with the same commandId,
+      // the deterministic event id lets the database reject the duplicate;
+      // reread the winning event and return an idempotent success.
+      const existing = await readExistingPersist(commandId);
+      if (!existing.error && existing.data) {
+        return NextResponse.json({ ok: true, operation, actor: actorId, idempotent: true, event: existing.data }, { status: 200 });
+      }
+    }
+
+    return NextResponse.json(event.ok ? { ok: true, operation, actor: actorId, idempotent: false, event: event.data } : event, { status: event.ok ? 201 : 500 });
   }
 
   if (cred.role !== 'root_delegate') return NextResponse.json({ ok: false, error: 'root_delegate_required_for_lab_runtime' }, { status: 403 });


### PR DESCRIPTION
Closes the governance defect observed after the GitHub→Method Lab write-path proof produced the same `commandId` twice.

Observed cause:
- command pushes were accepted from every branch;
- the command branch executed `persist` once;
- merge to `main` executed it again;
- `/api/external/v1/lab` had no `commandId` idempotency.

This PR fixes both layers without adding schema or a new persistence owner:
- write-triggered `push` is restricted to `main`;
- PR bridge runs remain read-only `operation: state`;
- non-empty `commandId` gets a deterministic `event_id` backed by the existing `epistemic_events.event_id UNIQUE` constraint;
- prior commandId is checked through JSONB containment;
- a concurrent duplicate that loses the UNIQUE race rereads and returns `idempotent: true` instead of appending another event;
- Method Lab convergence QA now enforces these invariants.

The two existing duplicate proof events are deliberately retained as immutable evidence of the defect; this change prevents recurrence.