### PR TITLE
fix(root): summarize only post-decision proposals still awaiting realization

### DIFF
--- a/src/components/sfi/SfiConsole.tsx
+++ b/src/components/sfi/SfiConsole.tsx
@@ -9,7 +9,7 @@ import './SfiConsole.css';
 
 type Proposal={id:string;title?:string;status?:string;risk_level?:string;proposalType?:string;created_at?:string};
 const ACTIONABLE_PROPOSAL_STATES=new Set(['proposed','waiting_evidence','needs_evidence']);
-const POST_DECISION_STATES=new Set(['design_approved','queued','accepted']);
+const POST_DECISION_STATES=new Set(['design_approved','queued']);
 function summarize(v:unknown){ if(Array.isArray(v))return `${v.length} elementos`; if(v&&typeof v==='object')return `${Object.keys(v as object).length} campos`; return String(v??'—'); }
 function Instrument({scene}:{scene:SceneKey}){return <><div className="atmosphere"/><div className="vectorField"/><div className="sceneObject" aria-hidden="true"><div className="halo"/><div className="ring"/><div className="ring2"/><div className="ring3"/><div className="core"/></div><div className="dataNode dn1"/><div className="dataNode dn2"/><div className="dataNode dn3"/><div className="dataNode dn4"/><div className="grain"/></>}
 


### PR DESCRIPTION
Follow-up to #279. Keeps the ROOT decision queue semantics precise after filtering already-decided proposals.

Production state currently has 0 `proposed`, 5 `design_approved`, 17 `accepted`, 12 `rejected`, and 1 legacy `needs_evidence` row.

`accepted` means authorized internal realization was recorded, so it must not be described as still pending execution/realization.

This change narrows the post-decision summary to `design_approved` and `queued` only. No lifecycle, database, authority, or execution semantics change.