### PR TITLE
fix(vercel): deploy main only

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
-  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in agent/root-runtime-reports-convergence|agent/method-lab-convergence|agent/cognitive-twin-reentry) exit 0 ;; *) exit 1 ;; esac",
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "*": false
+    }
+  },
   "crons": [
     {
       "path": "/api/cron/continuity-heartbeat",


### PR DESCRIPTION
## SFI PRECHECK

Owner: deployment configuration / Vercel Git integration.

Existing capability inspected: existing `vercel.json`, Vercel Git deployment configuration, current GitHub status showing `build-rate-limit`, and existing SFI Verify build/typecheck gates.

Absorb vs create decision: Reuse Vercel's supported `git.deploymentEnabled` branch matcher. Do not add a deployment service, workflow, scheduler or hosting surface.

Authoritative writer: `vercel.json` remains the repository-owned deployment configuration.

Persistence/lineage impact: NONE. This changes deployment triggering only; runtime evidence, proposal lineage and database state are untouched.

Front delta: NONE.

Back delta: NONE.

DB delta: NONE.

Redundancy removed: Removes the narrow legacy `ignoreCommand` branch list and replaces it with one explicit rule: production `main` deploys, all other Git branches do not auto-deploy.

Execution/ROOT boundary: Deployment configuration does not change ROOT authority, execution scopes, proposal governance, RETURN, calibration or canon. It only prevents feature/agent branches from consuming Vercel deployment quota.

Rollback: Revert this PR to restore prior automatic preview behavior.

Verification: JSON parses, existing crons remain byte-for-byte semantically unchanged, SFI Verify/typecheck/build remain authoritative code gates, and Vercel documentation supports glob branch rules where a matching `main:true` overrides matching `*:false` because any matching true rule permits deployment.

## Operational reason

The merged governed router is in `main`, but the GitHub Vercel status is currently `build-rate-limit` and public production remains on an older deployment. Feature/agent PR previews have been consuming the same deployment quota. This config keeps automatic production deployment for `main` while stopping branch preview storms.