### PR TITLE
feat(execution): retry governed queue hourly

### DIFF
--- a/scripts/qa-sfi-governed-execution-router.ts
+++ b/scripts/qa-sfi-governed-execution-router.ts
@@ -11,7 +11,9 @@ function forbid(source: string, needle: string, label: string) {
 const router = read('src/lib/execution/governedExecutionRouter.ts');
 const outcome = read('src/lib/governance/proposalOutcome.ts');
 const approve = read('src/app/api/acp/proposals/[id]/approve/route.ts');
-const cron = read('src/app/api/cron/continuity-report/route.ts');
+const dailyCron = read('src/app/api/cron/continuity-report/route.ts');
+const hourlyCron = read('src/app/api/cron/continuity-heartbeat/route.ts');
+const hourlyWorkflow = read('.github/workflows/sfi-continuity-hourly.yml');
 const rootRunner = read('src/lib/root/rootObservationRunner.ts');
 const externalExecute = read('src/app/api/external/v1/execute/route.ts');
 
@@ -43,7 +45,11 @@ if (approve.indexOf('queueApprovedProposal') > approve.indexOf('dispatchQueuedPr
   throw new Error('SFI_ROUTER_QA_ORDER:dispatch_must_follow_queue_authorization');
 }
 
-requireText(cron, 'runGovernedExecutionRouter({ limit: 10 })', 'continuity-retry-reroute');
+requireText(dailyCron, 'runGovernedExecutionRouter({ limit: 10 })', 'daily-continuity-retry-reroute');
+requireText(hourlyCron, 'runGovernedExecutionRouter({ limit: 10 })', 'hourly-continuity-retry-reroute');
+requireText(hourlyCron, 'verifyGitHubActionsOidcToken', 'hourly-router-auth-remains-oidc-governed');
+requireText(hourlyWorkflow, "cron: '15 * * * *'", 'reuse-existing-hourly-scheduler');
+requireText(hourlyWorkflow, 'workflow_dispatch:', 'existing-hourly-manual-trigger-retained');
 requireText(rootRunner, 'runGovernedExecutionRouter({ limit: 10 })', 'root-full-cycle-router');
 requireText(externalExecute, "error: declaredAdapter ? 'execution_dispatch_not_implemented' : 'execution_adapter_required'", 'external-generic-fail-closed');
 requireText(externalExecute, 'executedAtWritten: false', 'no-fake-execution');

--- a/src/app/api/cron/continuity-heartbeat/route.ts
+++ b/src/app/api/cron/continuity-heartbeat/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { runContinuityHeartbeat } from '@/lib/continuity/runtime';
 import { runStudioAutonomyContinuation } from '@/lib/continuity/studioAutonomy';
 import { verifyGitHubActionsOidcToken } from '@/lib/continuity/githubActionsOidc';
+import { runGovernedExecutionRouter } from '@/lib/execution/governedExecutionRouter';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -39,9 +40,8 @@ export async function GET(request: NextRequest) {
 
   try {
     const result = await runContinuityHeartbeat(authorization.trigger);
-    let studioAutonomy: Awaited<ReturnType<typeof runStudioAutonomyContinuation>> | { status: 'DEGRADED'; reason: string; targets: number; outcomes: [] };
-    try {
-      studioAutonomy = await runStudioAutonomyContinuation({
+    const [studioAutonomy, governedExecution] = await Promise.all([
+      runStudioAutonomyContinuation({
         mode: result.mode,
         continuityRunId: result.runId,
         observations: result.results.map((item) => ({
@@ -50,16 +50,28 @@ export async function GET(request: NextRequest) {
           latencyMs: item.latencyMs,
           errorCode: item.errorCode ?? null,
         })),
-      });
-    } catch (error) {
-      studioAutonomy = {
-        status: 'DEGRADED',
+      }).catch((error) => ({
+        status: 'DEGRADED' as const,
         reason: error instanceof Error ? error.message : String(error),
         targets: 0,
-        outcomes: [],
-      };
-    }
-    return NextResponse.json({ ok: result.status !== 'FAILED', trigger: authorization.trigger, ...result, studioAutonomy });
+        outcomes: [] as [],
+      })),
+      runGovernedExecutionRouter({ limit: 10 }).catch((error) => ({
+        ok: false as const,
+        processed: 0,
+        results: [],
+        error: error instanceof Error ? error.message : String(error),
+      })),
+    ]);
+
+    return NextResponse.json({
+      ok: result.status !== 'FAILED',
+      trigger: authorization.trigger,
+      ...result,
+      studioAutonomy,
+      governedExecution,
+      executionRule: 'Hourly continuity reuses the existing GitHub Actions OIDC heartbeat to retry/reroute governance-authorized queued work. No new scheduler, authority, external side effect, or canon permission is introduced.',
+    });
   } catch (error) {
     return NextResponse.json({ ok: false, error: 'continuity_heartbeat_failed', details: error instanceof Error ? error.message : String(error) }, { status: 500 });
   }


### PR DESCRIPTION
## SFI PRECHECK

Owner: `/pipeline` governed execution continuity.

Existing capability inspected: `runGovernedExecutionRouter`, `/api/cron/continuity-heartbeat`, existing GitHub Actions OIDC heartbeat (`sfi-continuity-hourly.yml`), daily continuity-report integration and ROOT full-cycle integration.

Absorb vs create decision: Reuse the already-deployed governed execution router and the already-existing hourly continuity scheduler. No new agent, queue, table, API surface, scheduler or authority layer.

Authoritative writer: Existing proposal/event writers remain authoritative. The hourly route only invokes `runGovernedExecutionRouter`; it does not write proposal state itself.

Persistence/lineage impact: Existing router semantics only: routing/execution/remediation/RETURN remain proposal-scoped and evidence-linked. No new persistence schema.

Front delta: NONE.

Back delta: The authorized queue is retried/rerouted from the existing hourly continuity heartbeat in addition to approval-time dispatch, daily continuity-report and ROOT full-cycle.

DB delta: NONE.

Redundancy removed: NONE. This removes a temporal gap by reusing the existing hourly trigger rather than creating a second scheduler.

Execution/ROOT boundary: Only already-governance-authorized `queued` work is processed. External/material actions still require a real adapter; missing capability remains fail-closed/remediation; no scope expansion, self-approval or automatic canon.

Rollback: Revert this PR. The router remains available at approval-time, daily continuity-report and ROOT full-cycle.

Verification: governed-router QA now requires hourly invocation, existing OIDC authorization and reuse of the existing `15 * * * *` workflow; SFI Verify/typecheck/build must remain green.

## Operational reason

The router and self-healing proposals are already ROOT-authorized and queued. After production deployment there was still no execution/RETURN because the backlog retry was attached to the daily report cycle. Hourly continuity is the existing persistent institutional pulse and is the correct bounded retry/reroute point.