### PR TITLE
QA: validate Edwing OAuth Studio authority

### DIFF
--- a/src/app/api/external/v1/QA_TRIGGER.md
+++ b/src/app/api/external/v1/QA_TRIGGER.md
@@ -1,0 +1,3 @@
+# SFI External OAuth validation trigger
+
+Ephemeral branch-only marker used to run the repository's OAuth governance, typecheck, and build workflow against the current main code.


### PR DESCRIPTION
Validation-only PR. The functional changes are already on main; this branch adds only a markdown trigger so the existing SFI External OAuth workflow runs QA governance, typecheck, and build against the current main state. Do not merge the trigger file.