### PR TITLE
Replace single-client OAuth ENV with persistent client registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ SFI_EXTERNAL_API_KEYS_JSON={}
 # These three values are now BOOTSTRAP/LEGACY CLIENT configuration only.
 # New external GPTs/apps register persistent clients in sfi_oauth_clients through
 # /api/oauth/clients, so adding a client or callback does not require a Vercel edit/redeploy.
+# Do not add one callback per end user here; user identity is resolved by SFI login.
 # The client ID/secret identify the external application, not the human user.
 SFI_OAUTH_CLIENT_ID=
 SFI_OAUTH_CLIENT_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -13,13 +13,15 @@ DATABASE_URL=
 SFI_EXTERNAL_API_KEYS_JSON={}
 
 # User-bound OAuth for ChatGPT Actions and other external clients.
-# The client ID/secret identify the SFI client application, not the human user.
-# The human principal comes from the existing authenticated SFI/Supabase session.
+# These three values are now BOOTSTRAP/LEGACY CLIENT configuration only.
+# New external GPTs/apps register persistent clients in sfi_oauth_clients through
+# /api/oauth/clients, so adding a client or callback does not require a Vercel edit/redeploy.
+# The client ID/secret identify the external application, not the human user.
 SFI_OAUTH_CLIENT_ID=
 SFI_OAUTH_CLIENT_SECRET=
-# Exact comma-separated redirect URI allowlist. Copy ChatGPT's callback URL exactly.
+# Exact redirect URI allowlist for the bootstrap client only. No wildcard callbacks.
 SFI_OAUTH_REDIRECT_URIS=
-# Independent random secret used only to sign short-lived SFI OAuth access tokens.
+# Required server-wide secret used to sign short-lived SFI OAuth access tokens.
 SFI_EXTERNAL_SESSION_SECRET=
 
 STRIPE_API_KEY=

--- a/.github/workflows/sfi-external-oauth.yml
+++ b/.github/workflows/sfi-external-oauth.yml
@@ -10,6 +10,7 @@ on:
       - 'src/lib/sfi/externalAuth.ts'
       - 'src/lib/sfi/externalSessionToken.ts'
       - 'src/lib/sfi/oauthConfig.ts'
+      - 'src/lib/sfi/oauthClientRegistry.ts'
       - 'src/lib/sfi/cognitive-runtime/**'
       - 'src/lib/sfi/personal/**'
       - 'src/lib/system/access/**'

--- a/scripts/qa-sfi-case-gpt-bridge.ts
+++ b/scripts/qa-sfi-case-gpt-bridge.ts
@@ -5,6 +5,7 @@ const read = (path: string) => readFileSync(path, 'utf8');
 const route = read('src/app/api/external/v1/cases/route.ts');
 const auth = read('src/lib/sfi/externalAuth.ts');
 const authorize = read('src/app/api/oauth/authorize/route.ts');
+const oauthConfig = read('src/lib/sfi/oauthConfig.ts');
 const observatoryApi = read('src/app/api/observatory/world/route.ts');
 const observatoryPage = read('src/app/observatory/page.tsx');
 const merge = read('scripts/merge-openapi-cases.mjs');
@@ -42,8 +43,10 @@ assert.equal(route.includes("epistemicRole: 'EVIDENCE'"), false, 'external_case_
 assert.equal(route.includes("epistemicRole: 'GOVERNANCE_DECISION'"), false, 'external_case_bridge_must_not_mint_governance');
 
 assert.match(auth, /scope\.startsWith\('cases:'\).*\/api\/external\/v1\/cases/s, 'personal_case_scope_must_be_route_bound');
+assert.match(authorize, /SFI_ROOT_SCOPES/, 'oauth_authorize_must_use_central_scope_registry');
+assert.match(authorize, /SFI_PERSONAL_SCOPES/, 'oauth_authorize_must_use_personal_scope_registry');
 for (const scope of ['cases:read', 'cases:write']) {
-  assert.ok(authorize.includes(`'${scope}'`), `oauth_case_scope_missing:${scope}`);
+  assert.ok(oauthConfig.includes(`'${scope}'`), `oauth_case_scope_missing:${scope}`);
   assert.ok(merge.includes(`oauth.scopes['${scope}']`), `openapi_merge_scope_missing:${scope}`);
 }
 

--- a/scripts/qa-sfi-external-oauth.ts
+++ b/scripts/qa-sfi-external-oauth.ts
@@ -37,6 +37,7 @@ assert.match(authorize, /codeHash\(code\)/, 'authorization_code_must_be_stored_a
 assert.match(authorize, /code_challenge/, 'oauth_authorize_must_support_pkce');
 assert.match(authorize, /resolveSfiOAuthClient\(clientId\)/, 'oauth_authorize_must_resolve_persistent_client');
 assert.match(authorize, /isAllowedSfiOAuthRedirect\(client, redirectUri\)/, 'oauth_authorize_must_exact_match_registered_redirect');
+assert.match(authorize, /canSfiOAuthClientAuthorizeSubject\(client, context\.user\.id\)/, 'owner_only_client_must_be_bound_to_authenticated_subject');
 assert.match(authorize, /clientScopes\.has\(scope\)/, 'oauth_authorize_must_enforce_client_scope_ceiling');
 for (const scope of ['observe', 'propose', 'execute', 'cases:read', 'cases:write', 'lab:read', 'lab:write', 'lab:run', 'studio:read', 'studio:content', 'studio:run']) {
   assert.match(oauthConfig, new RegExp(`'${scope.replace(':', '\\:')}'`), `supported_scope_missing:${scope}`);
@@ -55,10 +56,14 @@ assert.match(sessionToken, /exp <= now/, 'access_tokens_must_expire');
 assert.match(oauthRegistryMigration, /create table if not exists public\.sfi_oauth_clients/i, 'oauth_client_registry_table_required');
 assert.match(oauthRegistryMigration, /client_secret_hash text not null/i, 'oauth_registry_must_store_secret_hash_only');
 assert.match(oauthRegistryMigration, /redirect_uris text\[\] not null/i, 'oauth_registry_must_store_redirect_allowlist');
+assert.match(oauthRegistryMigration, /audience text not null default 'OWNER_ONLY'/i, 'self_service_clients_must_default_owner_only');
+assert.match(oauthRegistryMigration, /TRUSTED_MULTI_USER/i, 'registry_must_distinguish_trusted_multi_user_clients');
 assert.match(oauthRegistryMigration, /revoke all[\s\S]*anon, authenticated/i, 'oauth_registry_must_not_be_browser_readable');
 assert.match(oauthRegistryMigration, /grant select, insert, update, delete[\s\S]*service_role/i, 'oauth_registry_service_role_grant_required');
 assert.match(oauthRegistry, /redirectUris\.includes\(redirectUri\)/, 'redirect_match_must_remain_exact_not_wildcard');
 assert.match(oauthRegistry, /hashSfiOAuthClientSecret/, 'oauth_client_secret_must_be_hashed');
+assert.match(oauthRegistry, /audience: 'OWNER_ONLY'/, 'new_self_service_clients_must_be_owner_only');
+assert.match(oauthRegistry, /audience: 'TRUSTED_MULTI_USER'/, 'legacy_institutional_client_must_be_explicitly_trusted_multi_user');
 assert.match(oauthRegistry, /source: 'legacy_env'/, 'legacy_env_client_must_remain_backward_compatible');
 assert.match(oauthRegistry, /adoptLegacySfiOAuthClient/, 'root_must_be_able_to_adopt_bootstrap_client_into_registry');
 assert.match(oauthClients, /requireUserProfile\(\)/, 'oauth_client_registration_must_require_authenticated_sfi_account');
@@ -145,6 +150,8 @@ console.log(JSON.stringify({
   pkce: 'S256',
   clientRegistry: 'PERSISTENT_SELF_SERVICE',
   redirectMatching: 'EXACT',
+  selfServiceAudience: 'OWNER_ONLY',
+  trustedMultiUser: 'INSTITUTIONAL_ONLY',
   legacyClient: 'BACKWARD_COMPATIBLE_ADOPTABLE',
   personalTenant: 'user:<oauth_subject_id>',
   personalScopes: ['cases:read', 'cases:write', 'lab:read', 'lab:write', 'lab:run', 'studio:read', 'studio:content', 'studio:run'],

--- a/scripts/qa-sfi-external-oauth.ts
+++ b/scripts/qa-sfi-external-oauth.ts
@@ -7,6 +7,10 @@ function text(path: string) {
 
 const authorize = text('src/app/api/oauth/authorize/route.ts');
 const token = text('src/app/api/oauth/token/route.ts');
+const oauthConfig = text('src/lib/sfi/oauthConfig.ts');
+const oauthRegistry = text('src/lib/sfi/oauthClientRegistry.ts');
+const oauthClients = text('src/app/api/oauth/clients/route.ts');
+const oauthRegistryMigration = text('supabase/migrations/20260827220000_sfi_oauth_client_registry.sql');
 const externalAuth = text('src/lib/sfi/externalAuth.ts');
 const sessionToken = text('src/lib/sfi/externalSessionToken.ts');
 const access = text('src/lib/system/access/server.ts');
@@ -23,24 +27,44 @@ const openapi = JSON.parse(text('public/openapi.json')) as Record<string, any>;
 // OAuth binds to an authenticated account. Institutional authority is resolved
 // separately from the account/profile and normal accounts receive an owner-only tenant.
 assert.match(authorize, /requireUserProfile\(\)/, 'oauth_must_bind_to_authenticated_account_profile');
-assert.match(authorize, /PERSONAL_SCOPES/, 'oauth_must_define_personal_scope_set');
+assert.match(authorize, /SFI_PERSONAL_SCOPES/, 'oauth_must_use_personal_scope_set');
 assert.match(authorize, /context\.member\?\.external\?\.scopes/, 'institutional_scopes_must_come_from_member_registry');
 assert.match(authorize, /personalPrincipal = !rootDelegate && !context\.member/, 'normal_account_detection_must_not_infer_institutional_membership');
-assert.match(authorize, /requestedScopes\.filter\(\(scope\) => allowedScopes\.has\(scope\)\)/, 'normal_accounts_must_receive_scope_intersection_not_institutional_superset');
+assert.match(authorize, /principalScopes\.has\(scope\) && clientScopes\.has\(scope\)/, 'normal_accounts_must_receive_principal_client_intersection');
 assert.match(authorize, /tenantId = personalPrincipal \? `user:\$\{context\.user\.id\}` : 'sfi'/, 'personal_oauth_tenant_must_be_subject_bound');
 assert.match(authorize, /role.*personal_operator/s, 'personal_oauth_role_must_be_non_sovereign');
 assert.match(authorize, /codeHash\(code\)/, 'authorization_code_must_be_stored_as_hash');
 assert.match(authorize, /code_challenge/, 'oauth_authorize_must_support_pkce');
-for (const scope of ['observe', 'propose', 'execute', 'lab:read', 'lab:write', 'lab:run', 'studio:read', 'studio:content', 'studio:run']) {
-  assert.match(authorize, new RegExp(`'${scope.replace(':', '\\:')}'`), `supported_scope_missing:${scope}`);
+assert.match(authorize, /resolveSfiOAuthClient\(clientId\)/, 'oauth_authorize_must_resolve_persistent_client');
+assert.match(authorize, /isAllowedSfiOAuthRedirect\(client, redirectUri\)/, 'oauth_authorize_must_exact_match_registered_redirect');
+assert.match(authorize, /clientScopes\.has\(scope\)/, 'oauth_authorize_must_enforce_client_scope_ceiling');
+for (const scope of ['observe', 'propose', 'execute', 'cases:read', 'cases:write', 'lab:read', 'lab:write', 'lab:run', 'studio:read', 'studio:content', 'studio:run']) {
+  assert.match(oauthConfig, new RegExp(`'${scope.replace(':', '\\:')}'`), `supported_scope_missing:${scope}`);
 }
 
 assert.match(token, /grantType !== 'authorization_code'/, 'token_endpoint_must_reject_other_grants');
 assert.match(token, /is\('consumed_at', null\)/, 'authorization_code_must_be_single_use');
 assert.match(token, /PKCE verification failed/, 'token_exchange_must_verify_pkce_when_present');
 assert.match(token, /mintExternalAccessToken/, 'token_exchange_must_issue_signed_sfi_access_token');
+assert.match(token, /validateSfiOAuthClientSecret\(client, clientSecret\)/, 'token_exchange_must_validate_registry_client_secret');
 assert.match(sessionToken, /createHmac\('sha256'/, 'access_tokens_must_be_signed');
 assert.match(sessionToken, /exp <= now/, 'access_tokens_must_expire');
+
+// Client registry eliminates per-client Vercel ENV edits while retaining exact
+// callback matching, hashed secrets and user ownership.
+assert.match(oauthRegistryMigration, /create table if not exists public\.sfi_oauth_clients/i, 'oauth_client_registry_table_required');
+assert.match(oauthRegistryMigration, /client_secret_hash text not null/i, 'oauth_registry_must_store_secret_hash_only');
+assert.match(oauthRegistryMigration, /redirect_uris text\[\] not null/i, 'oauth_registry_must_store_redirect_allowlist');
+assert.match(oauthRegistryMigration, /revoke all[\s\S]*anon, authenticated/i, 'oauth_registry_must_not_be_browser_readable');
+assert.match(oauthRegistryMigration, /grant select, insert, update, delete[\s\S]*service_role/i, 'oauth_registry_service_role_grant_required');
+assert.match(oauthRegistry, /redirectUris\.includes\(redirectUri\)/, 'redirect_match_must_remain_exact_not_wildcard');
+assert.match(oauthRegistry, /hashSfiOAuthClientSecret/, 'oauth_client_secret_must_be_hashed');
+assert.match(oauthRegistry, /source: 'legacy_env'/, 'legacy_env_client_must_remain_backward_compatible');
+assert.match(oauthRegistry, /adoptLegacySfiOAuthClient/, 'root_must_be_able_to_adopt_bootstrap_client_into_registry');
+assert.match(oauthClients, /requireUserProfile\(\)/, 'oauth_client_registration_must_require_authenticated_sfi_account');
+assert.match(oauthClients, /ROOT_REQUIRED_FOR_LEGACY_ADOPTION/, 'legacy_adoption_must_be_root_only');
+assert.match(oauthClients, /secretDisclosure: 'ONE_TIME_ONLY'/, 'new_client_secret_must_be_disclosed_once');
+assert.match(oauthClients, /scopeCeiling\(context\)/, 'oauth_client_registration_must_not_expand_principal_authority');
 
 // Account provisioning is not institutional promotion.
 assert.match(access, /role: 'operator'/, 'normal_account_profile_must_be_operator');
@@ -116,12 +140,15 @@ for (const path of [
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-EXTERNAL-OAUTH-1.8',
+  contract: 'SFI-EXTERNAL-OAUTH-1.9',
   flow: 'authorization_code',
   pkce: 'S256',
+  clientRegistry: 'PERSISTENT_SELF_SERVICE',
+  redirectMatching: 'EXACT',
+  legacyClient: 'BACKWARD_COMPATIBLE_ADOPTABLE',
   personalTenant: 'user:<oauth_subject_id>',
-  personalScopes: ['lab:read', 'lab:write', 'lab:run', 'studio:read', 'studio:content', 'studio:run'],
-  personalRoutes: ['/api/external/v1/cognitive', '/api/external/v1/personal-lab', '/api/external/v1/studio'],
+  personalScopes: ['cases:read', 'cases:write', 'lab:read', 'lab:write', 'lab:run', 'studio:read', 'studio:content', 'studio:run'],
+  personalRoutes: ['/api/external/v1/cases', '/api/external/v1/cognitive', '/api/external/v1/personal-lab', '/api/external/v1/studio'],
   institutionalSovereignty: ['proposal_authorization', 'root_evidence', 'canonical_promotion'],
   runtime: 'runtimeAgentExecutor -> agentExecutionMap',
 }, null, 2));

--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -2,35 +2,16 @@ import { createHash, randomBytes } from 'node:crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { AccessDeniedError, requireUserProfile } from '@/lib/system/access/server';
 import { createServiceSupabaseClient } from '@/runtime/supabase/server';
-import { isAllowedOAuthRedirect, readSfiOAuthConfig, validateOAuthClient } from '@/lib/sfi/oauthConfig';
+import {
+  isSfiOAuthServerConfigured,
+  SFI_PERSONAL_SCOPES,
+  SFI_ROOT_SCOPES,
+  SFI_SUPPORTED_SCOPES,
+} from '@/lib/sfi/oauthConfig';
+import { isAllowedSfiOAuthRedirect, resolveSfiOAuthClient } from '@/lib/sfi/oauthClientRegistry';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
-
-const ROOT_SCOPES = [
-  'observe',
-  'propose',
-  'execute',
-  'cases:read',
-  'cases:write',
-  'lab:read',
-  'lab:write',
-  'lab:run',
-  'studio:read',
-  'studio:content',
-  'studio:run',
-] as const;
-const PERSONAL_SCOPES = [
-  'cases:read',
-  'cases:write',
-  'lab:read',
-  'lab:write',
-  'lab:run',
-  'studio:read',
-  'studio:content',
-  'studio:run',
-] as const;
-const SUPPORTED_SCOPES = new Set<string>(ROOT_SCOPES);
 
 function codeHash(code: string) {
   return createHash('sha256').update(code).digest('hex');
@@ -55,8 +36,7 @@ function redirectOAuthError(redirectUri: string, state: string | null, error: st
 }
 
 export async function GET(req: NextRequest) {
-  const config = readSfiOAuthConfig();
-  if (!config) {
+  if (!isSfiOAuthServerConfigured()) {
     return NextResponse.json({ ok: false, error: 'oauth_not_configured' }, { status: 503 });
   }
 
@@ -68,7 +48,14 @@ export async function GET(req: NextRequest) {
   const codeChallenge = req.nextUrl.searchParams.get('code_challenge')?.trim() || null;
   const codeChallengeMethod = req.nextUrl.searchParams.get('code_challenge_method')?.trim() || null;
 
-  if (!validateOAuthClient(config, clientId) || !redirectUri || !isAllowedOAuthRedirect(config, redirectUri)) {
+  let client: Awaited<ReturnType<typeof resolveSfiOAuthClient>>;
+  try {
+    client = await resolveSfiOAuthClient(clientId);
+  } catch {
+    return NextResponse.json({ ok: false, error: 'oauth_client_registry_unavailable' }, { status: 503 });
+  }
+
+  if (!client || !redirectUri || !isAllowedSfiOAuthRedirect(client, redirectUri)) {
     return NextResponse.json({ ok: false, error: 'invalid_client_or_redirect' }, { status: 400 });
   }
   if (responseType !== 'code') {
@@ -81,8 +68,12 @@ export async function GET(req: NextRequest) {
   const explicitlyRequestedScopes = rawScope
     ? [...new Set<string>(rawScope.split(/\s+/).filter(Boolean))]
     : null;
-  if (explicitlyRequestedScopes?.some((scope) => !SUPPORTED_SCOPES.has(scope))) {
+  if (explicitlyRequestedScopes?.some((scope) => !SFI_SUPPORTED_SCOPES.has(scope))) {
     return redirectOAuthError(redirectUri, state, 'invalid_scope', 'One or more requested SFI scopes are not supported.');
+  }
+  const clientScopes = new Set(client.allowedScopes);
+  if (explicitlyRequestedScopes?.some((scope) => !clientScopes.has(scope))) {
+    return redirectOAuthError(redirectUri, state, 'invalid_scope', 'The OAuth client is not registered for one or more requested SFI scopes.');
   }
 
   let context: Awaited<ReturnType<typeof requireUserProfile>>;
@@ -104,28 +95,28 @@ export async function GET(req: NextRequest) {
   const institutionalScopes = context.member?.external?.scopes ?? null;
   const personalPrincipal = !rootDelegate && !context.member;
 
-  const allowedScopes = new Set<string>(
+  const principalScopes = new Set<string>(
     rootDelegate
-      ? ROOT_SCOPES
+      ? SFI_ROOT_SCOPES
       : institutionalScopes?.length
         ? institutionalScopes
-        : PERSONAL_SCOPES,
+        : SFI_PERSONAL_SCOPES,
   );
 
-  const requestedScopes = explicitlyRequestedScopes ?? [...allowedScopes];
+  const defaultRequestedScopes = [...principalScopes].filter((scope) => clientScopes.has(scope));
+  const requestedScopes = explicitlyRequestedScopes ?? defaultRequestedScopes;
   let grantedScopes: string[];
 
   if (personalPrincipal) {
-    // One ChatGPT OAuth client can request the institutional superset. A normal
-    // account receives only the safe owner-scoped intersection. The returned
-    // token therefore cannot propose or execute institutional actions.
-    grantedScopes = requestedScopes.filter((scope) => allowedScopes.has(scope));
+    // A client may advertise a broader institutional scope set, but a normal
+    // account receives only the owner-scoped principal/client intersection.
+    grantedScopes = requestedScopes.filter((scope) => principalScopes.has(scope) && clientScopes.has(scope));
     if (!grantedScopes.length) {
       return redirectOAuthError(redirectUri, state, 'invalid_scope', 'The requested scopes do not include a personal workspace capability.');
     }
   } else {
-    if (requestedScopes.some((scope) => !allowedScopes.has(scope))) {
-      return redirectOAuthError(redirectUri, state, 'invalid_scope', 'The authenticated SFI principal is not allowed to receive one or more requested scopes.');
+    if (requestedScopes.some((scope) => !principalScopes.has(scope) || !clientScopes.has(scope))) {
+      return redirectOAuthError(redirectUri, state, 'invalid_scope', 'The authenticated SFI principal or OAuth client is not allowed to receive one or more requested scopes.');
     }
     grantedScopes = requestedScopes;
   }

--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -8,7 +8,11 @@ import {
   SFI_ROOT_SCOPES,
   SFI_SUPPORTED_SCOPES,
 } from '@/lib/sfi/oauthConfig';
-import { isAllowedSfiOAuthRedirect, resolveSfiOAuthClient } from '@/lib/sfi/oauthClientRegistry';
+import {
+  canSfiOAuthClientAuthorizeSubject,
+  isAllowedSfiOAuthRedirect,
+  resolveSfiOAuthClient,
+} from '@/lib/sfi/oauthClientRegistry';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -88,6 +92,15 @@ export async function GET(req: NextRequest) {
       return redirectOAuthError(redirectUri, state, 'access_denied', 'An active SFI account is required.');
     }
     throw error;
+  }
+
+  if (!canSfiOAuthClientAuthorizeSubject(client, context.user.id)) {
+    return redirectOAuthError(
+      redirectUri,
+      state,
+      'access_denied',
+      'This self-service OAuth client is bound to a different SFI account.',
+    );
   }
 
   const profileRole = String(context.profile.role || 'operator').toLowerCase();

--- a/src/app/api/oauth/clients/route.ts
+++ b/src/app/api/oauth/clients/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from 'next/server';
+import { AccessDeniedError, requireUserProfile } from '@/lib/system/access/server';
+import {
+  SFI_PERSONAL_SCOPES,
+  SFI_ROOT_SCOPES,
+} from '@/lib/sfi/oauthConfig';
+import {
+  adoptLegacySfiOAuthClient,
+  createOwnedSfiOAuthClient,
+  listOwnedSfiOAuthClients,
+  revokeOwnedSfiOAuthClient,
+  updateOwnedSfiOAuthClient,
+} from '@/lib/sfi/oauthClientRegistry';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+type Row = Record<string, unknown>;
+
+function row(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function jsonError(error: unknown) {
+  if (error instanceof AccessDeniedError) {
+    return NextResponse.json({ ok: false, error: error.code }, { status: error.status });
+  }
+  const message = error instanceof Error ? error.message : 'SFI_OAUTH_CLIENT_OPERATION_FAILED';
+  const status = /NOT_FOUND/.test(message) ? 404 : /REQUIRED|INVALID|NOT_ALLOWED|HTTPS|FRAGMENT|COUNT/.test(message) ? 400 : 500;
+  return NextResponse.json({ ok: false, error: message }, { status });
+}
+
+function scopeCeiling(context: Awaited<ReturnType<typeof requireUserProfile>>) {
+  const role = String(context.profile.role || 'operator').toLowerCase();
+  if (role === 'root' || role === 'system') return [...SFI_ROOT_SCOPES];
+  if (context.member?.external?.scopes?.length) return [...context.member.external.scopes];
+  return [...SFI_PERSONAL_SCOPES];
+}
+
+export async function GET() {
+  try {
+    const context = await requireUserProfile();
+    return NextResponse.json({
+      ok: true,
+      clients: await listOwnedSfiOAuthClients(context.user.id),
+      scopeCeiling: scopeCeiling(context),
+      boundary: 'OAuth clients are owned by the authenticated SFI account. Client registration does not grant scopes beyond the principal authority ceiling.',
+    });
+  } catch (error) {
+    return jsonError(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const context = await requireUserProfile();
+    const body = row(await request.json().catch(() => ({})));
+    const operation = text(body.operation) || 'create';
+    const ceiling = scopeCeiling(context);
+
+    if (operation === 'adopt_legacy') {
+      const role = String(context.profile.role || '').toLowerCase();
+      if (role !== 'root' && role !== 'system') {
+        return NextResponse.json({ ok: false, error: 'ROOT_REQUIRED_FOR_LEGACY_ADOPTION' }, { status: 403 });
+      }
+      const client = await adoptLegacySfiOAuthClient({
+        userId: context.user.id,
+        name: text(body.name) || 'SFI ChatGPT Actions',
+        redirectUris: body.redirectUris,
+      });
+      return NextResponse.json({
+        ok: true,
+        operation,
+        client,
+        clientSecretReturned: false,
+        note: 'The existing ENV client secret was hashed into the registry; the secret itself was not returned.',
+      }, { status: 201 });
+    }
+
+    if (operation !== 'create') {
+      return NextResponse.json({ ok: false, error: 'UNSUPPORTED_OAUTH_CLIENT_OPERATION' }, { status: 400 });
+    }
+
+    const created = await createOwnedSfiOAuthClient({
+      userId: context.user.id,
+      name: text(body.name),
+      redirectUris: body.redirectUris,
+      scopes: body.scopes,
+      scopeCeiling: ceiling,
+      metadata: { registeredVia: 'SFI_OAUTH_SELF_SERVICE' },
+    });
+
+    return NextResponse.json({
+      ok: true,
+      operation,
+      client: created.client,
+      clientSecret: created.clientSecret,
+      secretDisclosure: 'ONE_TIME_ONLY',
+      next: 'Copy the client ID and client secret into the external GPT/application. Future callback changes can be made through PATCH without editing Vercel environment variables.',
+    }, { status: 201 });
+  } catch (error) {
+    return jsonError(error);
+  }
+}
+
+export async function PATCH(request: Request) {
+  try {
+    const context = await requireUserProfile();
+    const body = row(await request.json().catch(() => ({})));
+    const clientId = text(body.clientId);
+    if (!clientId) return NextResponse.json({ ok: false, error: 'SFI_OAUTH_CLIENT_ID_REQUIRED' }, { status: 400 });
+
+    const updated = await updateOwnedSfiOAuthClient({
+      userId: context.user.id,
+      clientId,
+      redirectUris: body.redirectUris,
+      scopes: body.scopes,
+      scopeCeiling: scopeCeiling(context),
+      rotateSecret: body.rotateSecret === true,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      client: updated.client,
+      clientSecret: updated.clientSecret,
+      secretDisclosure: updated.clientSecret ? 'ONE_TIME_ONLY' : null,
+    });
+  } catch (error) {
+    return jsonError(error);
+  }
+}
+
+export async function DELETE(request: Request) {
+  try {
+    const context = await requireUserProfile();
+    const clientId = new URL(request.url).searchParams.get('client_id')?.trim() || '';
+    if (!clientId) return NextResponse.json({ ok: false, error: 'SFI_OAUTH_CLIENT_ID_REQUIRED' }, { status: 400 });
+    return NextResponse.json({
+      ok: true,
+      client: await revokeOwnedSfiOAuthClient(context.user.id, clientId),
+    });
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/oauth/token/route.ts
+++ b/src/app/api/oauth/token/route.ts
@@ -2,7 +2,13 @@ import { createHash, timingSafeEqual } from 'node:crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { createServiceSupabaseClient } from '@/runtime/supabase/server';
 import { mintExternalAccessToken } from '@/lib/sfi/externalSessionToken';
-import { isAllowedOAuthRedirect, readSfiOAuthConfig, validateOAuthClient } from '@/lib/sfi/oauthConfig';
+import { isSfiOAuthServerConfigured } from '@/lib/sfi/oauthConfig';
+import {
+  isAllowedSfiOAuthRedirect,
+  resolveSfiOAuthClient,
+  touchSfiOAuthClient,
+  validateSfiOAuthClientSecret,
+} from '@/lib/sfi/oauthClientRegistry';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -37,8 +43,7 @@ function oauthError(error: string, description: string, status = 400) {
 }
 
 export async function POST(req: NextRequest) {
-  const config = readSfiOAuthConfig();
-  if (!config) return oauthError('server_error', 'SFI OAuth is not configured.', 503);
+  if (!isSfiOAuthServerConfigured()) return oauthError('server_error', 'SFI OAuth is not configured.', 503);
 
   const form = await req.formData().catch(() => null);
   if (!form) return oauthError('invalid_request', 'Expected application/x-www-form-urlencoded body.');
@@ -51,13 +56,19 @@ export async function POST(req: NextRequest) {
   const redirectUri = String(form.get('redirect_uri') || '').trim();
   const codeVerifier = String(form.get('code_verifier') || '').trim();
 
-  if (!validateOAuthClient(config, clientId, clientSecret)) {
+  let client: Awaited<ReturnType<typeof resolveSfiOAuthClient>>;
+  try {
+    client = await resolveSfiOAuthClient(clientId);
+  } catch {
+    return oauthError('temporarily_unavailable', 'SFI OAuth client registry is unavailable.', 503);
+  }
+  if (!client || !validateSfiOAuthClientSecret(client, clientSecret)) {
     return oauthError('invalid_client', 'Client authentication failed.', 401);
   }
   if (grantType !== 'authorization_code') {
     return oauthError('unsupported_grant_type', 'SFI supports authorization_code only.');
   }
-  if (!code || !redirectUri || !isAllowedOAuthRedirect(config, redirectUri)) {
+  if (!code || !redirectUri || !isAllowedSfiOAuthRedirect(client, redirectUri)) {
     return oauthError('invalid_grant', 'Authorization code or redirect URI is invalid.');
   }
 
@@ -112,6 +123,8 @@ export async function POST(req: NextRequest) {
     scopes,
     ttlSeconds: 3600,
   });
+
+  await touchSfiOAuthClient(client).catch(() => undefined);
 
   return NextResponse.json(
     {

--- a/src/lib/sfi/oauthClientRegistry.ts
+++ b/src/lib/sfi/oauthClientRegistry.ts
@@ -15,6 +15,8 @@ export type ResolvedSfiOAuthClient = {
   name: string;
   redirectUris: string[];
   allowedScopes: string[];
+  audience: 'OWNER_ONLY' | 'TRUSTED_MULTI_USER';
+  ownerId: string | null;
   source: 'registry' | 'legacy_env';
   secretHash?: string;
   legacySecret?: string;
@@ -44,6 +46,8 @@ function legacyClient() {
     name: 'SFI legacy/bootstrap OAuth client',
     redirectUris: legacy.redirectUris,
     allowedScopes: [...SFI_ROOT_SCOPES],
+    audience: 'TRUSTED_MULTI_USER' as const,
+    ownerId: null,
     source: 'legacy_env' as const,
     legacySecret: legacy.clientSecret,
   } satisfies ResolvedSfiOAuthClient;
@@ -88,7 +92,7 @@ async function readRegisteredClient(clientId: string): Promise<ResolvedSfiOAuthC
   const db = createServiceSupabaseClient();
   const result = await db
     .from('sfi_oauth_clients')
-    .select('client_id,client_secret_hash,name,redirect_uris,allowed_scopes,status')
+    .select('client_id,client_secret_hash,name,created_by,redirect_uris,allowed_scopes,audience,status')
     .eq('client_id', clientId)
     .eq('status', 'ACTIVE')
     .maybeSingle();
@@ -101,6 +105,8 @@ async function readRegisteredClient(clientId: string): Promise<ResolvedSfiOAuthC
     name: text(row.name) || text(row.client_id),
     redirectUris: stringArray(row.redirect_uris),
     allowedScopes: stringArray(row.allowed_scopes),
+    audience: text(row.audience) === 'TRUSTED_MULTI_USER' ? 'TRUSTED_MULTI_USER' : 'OWNER_ONLY',
+    ownerId: text(row.created_by) || null,
     source: 'registry',
     secretHash: text(row.client_secret_hash),
   };
@@ -128,6 +134,10 @@ export function isAllowedSfiOAuthRedirect(client: ResolvedSfiOAuthClient, redire
   return client.redirectUris.includes(redirectUri);
 }
 
+export function canSfiOAuthClientAuthorizeSubject(client: ResolvedSfiOAuthClient, subjectId: string) {
+  return client.audience === 'TRUSTED_MULTI_USER' || client.ownerId === subjectId;
+}
+
 export function validateSfiOAuthClientSecret(client: ResolvedSfiOAuthClient, clientSecret: string) {
   if (!clientSecret) return false;
   if (client.source === 'legacy_env') return safeEqual(clientSecret, client.legacySecret || '');
@@ -138,7 +148,7 @@ export async function listOwnedSfiOAuthClients(userId: string) {
   const db = createServiceSupabaseClient();
   const result = await db
     .from('sfi_oauth_clients')
-    .select('client_id,name,redirect_uris,allowed_scopes,status,last_used_at,created_at,updated_at')
+    .select('client_id,name,redirect_uris,allowed_scopes,audience,status,last_used_at,created_at,updated_at')
     .eq('created_by', userId)
     .order('created_at', { ascending: false });
   if (result.error) throw new Error(`SFI_OAUTH_CLIENT_LIST_FAILED:${result.error.message}`);
@@ -167,9 +177,10 @@ export async function createOwnedSfiOAuthClient(input: {
     created_by: input.userId,
     redirect_uris: redirectUris,
     allowed_scopes: allowedScopes,
+    audience: 'OWNER_ONLY',
     status: 'ACTIVE',
     metadata: input.metadata ?? {},
-  }).select('client_id,name,redirect_uris,allowed_scopes,status,created_at').single();
+  }).select('client_id,name,redirect_uris,allowed_scopes,audience,status,created_at').single();
   if (result.error || !result.data) throw new Error(`SFI_OAUTH_CLIENT_CREATE_FAILED:${result.error?.message ?? 'unknown'}`);
   return { client: result.data, clientSecret };
 }
@@ -191,10 +202,11 @@ export async function adoptLegacySfiOAuthClient(input: {
     created_by: input.userId,
     redirect_uris: redirectUris,
     allowed_scopes: [...SFI_ROOT_SCOPES],
+    audience: 'TRUSTED_MULTI_USER',
     status: 'ACTIVE',
     metadata: { adoptedFrom: 'SFI_OAUTH_CLIENT_ID' },
     updated_at: now,
-  }, { onConflict: 'client_id' }).select('client_id,name,redirect_uris,allowed_scopes,status,created_at,updated_at').single();
+  }, { onConflict: 'client_id' }).select('client_id,name,redirect_uris,allowed_scopes,audience,status,created_at,updated_at').single();
   if (result.error || !result.data) throw new Error(`SFI_OAUTH_CLIENT_ADOPT_FAILED:${result.error?.message ?? 'unknown'}`);
   return result.data;
 }
@@ -221,7 +233,7 @@ export async function updateOwnedSfiOAuthClient(input: {
     .eq('client_id', input.clientId)
     .eq('created_by', input.userId)
     .eq('status', 'ACTIVE')
-    .select('client_id,name,redirect_uris,allowed_scopes,status,updated_at')
+    .select('client_id,name,redirect_uris,allowed_scopes,audience,status,updated_at')
     .maybeSingle();
   if (result.error) throw new Error(`SFI_OAUTH_CLIENT_UPDATE_FAILED:${result.error.message}`);
   if (!result.data) throw new Error('SFI_OAUTH_CLIENT_NOT_FOUND');

--- a/src/lib/sfi/oauthClientRegistry.ts
+++ b/src/lib/sfi/oauthClientRegistry.ts
@@ -1,0 +1,244 @@
+import 'server-only';
+
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import {
+  readSfiOAuthConfig,
+  SFI_ROOT_SCOPES,
+  SFI_SUPPORTED_SCOPES,
+} from '@/lib/sfi/oauthConfig';
+
+type Row = Record<string, unknown>;
+
+export type ResolvedSfiOAuthClient = {
+  clientId: string;
+  name: string;
+  redirectUris: string[];
+  allowedScopes: string[];
+  source: 'registry' | 'legacy_env';
+  secretHash?: string;
+  legacySecret?: string;
+};
+
+function text(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function stringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string').map((item) => item.trim()).filter(Boolean)
+    : [];
+}
+
+function safeEqual(a: string, b: string) {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+export function hashSfiOAuthClientSecret(secret: string) {
+  return createHash('sha256').update(secret, 'utf8').digest('hex');
+}
+
+export function normalizeSfiOAuthRedirectUri(value: string) {
+  const raw = value.trim();
+  if (!raw) throw new Error('SFI_OAUTH_REDIRECT_URI_REQUIRED');
+  const parsed = new URL(raw);
+  const localhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '::1';
+  if (parsed.protocol !== 'https:' && !(localhost && parsed.protocol === 'http:')) {
+    throw new Error('SFI_OAUTH_REDIRECT_URI_HTTPS_REQUIRED');
+  }
+  if (parsed.hash) throw new Error('SFI_OAUTH_REDIRECT_URI_FRAGMENT_FORBIDDEN');
+  return raw;
+}
+
+export function normalizeSfiOAuthRedirectUris(values: unknown) {
+  if (!Array.isArray(values)) throw new Error('SFI_OAUTH_REDIRECT_URIS_REQUIRED');
+  const normalized = [...new Set(values.map((value) => normalizeSfiOAuthRedirectUri(String(value))))];
+  if (!normalized.length || normalized.length > 10) throw new Error('SFI_OAUTH_REDIRECT_URIS_COUNT_INVALID');
+  return normalized;
+}
+
+export function normalizeSfiOAuthScopes(values: unknown, ceiling: readonly string[]) {
+  const ceilingSet = new Set<string>(ceiling);
+  const requested = Array.isArray(values)
+    ? [...new Set(values.map((value) => String(value).trim()).filter(Boolean))]
+    : [...ceiling];
+  if (!requested.length) throw new Error('SFI_OAUTH_SCOPES_REQUIRED');
+  if (requested.some((scope) => !SFI_SUPPORTED_SCOPES.has(scope) || !ceilingSet.has(scope))) {
+    throw new Error('SFI_OAUTH_SCOPE_NOT_ALLOWED');
+  }
+  return requested;
+}
+
+async function readRegisteredClient(clientId: string): Promise<ResolvedSfiOAuthClient | null> {
+  const db = createServiceSupabaseClient();
+  const result = await db
+    .from('sfi_oauth_clients')
+    .select('client_id,client_secret_hash,name,redirect_uris,allowed_scopes,status')
+    .eq('client_id', clientId)
+    .eq('status', 'ACTIVE')
+    .maybeSingle();
+
+  if (result.error) {
+    // During the migration window the legacy ENV client must remain usable even
+    // if the registry table has not been applied yet.
+    if (/relation .*sfi_oauth_clients.* does not exist/i.test(result.error.message)) return null;
+    throw new Error(`SFI_OAUTH_CLIENT_REGISTRY_READ_FAILED:${result.error.message}`);
+  }
+  if (!result.data) return null;
+  const row = result.data as Row;
+  return {
+    clientId: text(row.client_id),
+    name: text(row.name) || text(row.client_id),
+    redirectUris: stringArray(row.redirect_uris),
+    allowedScopes: stringArray(row.allowed_scopes),
+    source: 'registry',
+    secretHash: text(row.client_secret_hash),
+  };
+}
+
+export async function resolveSfiOAuthClient(clientId: string): Promise<ResolvedSfiOAuthClient | null> {
+  if (!clientId) return null;
+
+  const registered = await readRegisteredClient(clientId);
+  if (registered) return registered;
+
+  const legacy = readSfiOAuthConfig();
+  if (!legacy || !safeEqual(clientId, legacy.clientId)) return null;
+  return {
+    clientId: legacy.clientId,
+    name: 'SFI legacy/bootstrap OAuth client',
+    redirectUris: legacy.redirectUris,
+    allowedScopes: [...SFI_ROOT_SCOPES],
+    source: 'legacy_env',
+    legacySecret: legacy.clientSecret,
+  };
+}
+
+export function isAllowedSfiOAuthRedirect(client: ResolvedSfiOAuthClient, redirectUri: string) {
+  return client.redirectUris.includes(redirectUri);
+}
+
+export function validateSfiOAuthClientSecret(client: ResolvedSfiOAuthClient, clientSecret: string) {
+  if (!clientSecret) return false;
+  if (client.source === 'legacy_env') return safeEqual(clientSecret, client.legacySecret || '');
+  return safeEqual(hashSfiOAuthClientSecret(clientSecret), client.secretHash || '');
+}
+
+export async function listOwnedSfiOAuthClients(userId: string) {
+  const db = createServiceSupabaseClient();
+  const result = await db
+    .from('sfi_oauth_clients')
+    .select('client_id,name,redirect_uris,allowed_scopes,status,last_used_at,created_at,updated_at')
+    .eq('created_by', userId)
+    .order('created_at', { ascending: false });
+  if (result.error) throw new Error(`SFI_OAUTH_CLIENT_LIST_FAILED:${result.error.message}`);
+  return result.data ?? [];
+}
+
+export async function createOwnedSfiOAuthClient(input: {
+  userId: string;
+  name: string;
+  redirectUris: unknown;
+  scopes: unknown;
+  scopeCeiling: readonly string[];
+  metadata?: Record<string, unknown>;
+}) {
+  const name = input.name.trim();
+  if (!name) throw new Error('SFI_OAUTH_CLIENT_NAME_REQUIRED');
+  const redirectUris = normalizeSfiOAuthRedirectUris(input.redirectUris);
+  const allowedScopes = normalizeSfiOAuthScopes(input.scopes, input.scopeCeiling);
+  const clientId = `sfi_ext_${randomBytes(12).toString('base64url')}`;
+  const clientSecret = `sfi_sec_${randomBytes(32).toString('base64url')}`;
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_oauth_clients').insert({
+    client_id: clientId,
+    client_secret_hash: hashSfiOAuthClientSecret(clientSecret),
+    name,
+    created_by: input.userId,
+    redirect_uris: redirectUris,
+    allowed_scopes: allowedScopes,
+    status: 'ACTIVE',
+    metadata: input.metadata ?? {},
+  }).select('client_id,name,redirect_uris,allowed_scopes,status,created_at').single();
+  if (result.error || !result.data) throw new Error(`SFI_OAUTH_CLIENT_CREATE_FAILED:${result.error?.message ?? 'unknown'}`);
+  return { client: result.data, clientSecret };
+}
+
+export async function adoptLegacySfiOAuthClient(input: {
+  userId: string;
+  name: string;
+  redirectUris: unknown;
+}) {
+  const legacy = readSfiOAuthConfig();
+  if (!legacy) throw new Error('SFI_OAUTH_LEGACY_CLIENT_NOT_CONFIGURED');
+  const redirectUris = normalizeSfiOAuthRedirectUris(input.redirectUris);
+  const now = new Date().toISOString();
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_oauth_clients').upsert({
+    client_id: legacy.clientId,
+    client_secret_hash: hashSfiOAuthClientSecret(legacy.clientSecret),
+    name: input.name.trim() || 'SFI ChatGPT Actions',
+    created_by: input.userId,
+    redirect_uris: redirectUris,
+    allowed_scopes: [...SFI_ROOT_SCOPES],
+    status: 'ACTIVE',
+    metadata: { adoptedFrom: 'SFI_OAUTH_CLIENT_ID' },
+    updated_at: now,
+  }, { onConflict: 'client_id' }).select('client_id,name,redirect_uris,allowed_scopes,status,created_at,updated_at').single();
+  if (result.error || !result.data) throw new Error(`SFI_OAUTH_CLIENT_ADOPT_FAILED:${result.error?.message ?? 'unknown'}`);
+  return result.data;
+}
+
+export async function updateOwnedSfiOAuthClient(input: {
+  userId: string;
+  clientId: string;
+  redirectUris?: unknown;
+  scopes?: unknown;
+  scopeCeiling: readonly string[];
+  rotateSecret?: boolean;
+}) {
+  const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (input.redirectUris !== undefined) patch.redirect_uris = normalizeSfiOAuthRedirectUris(input.redirectUris);
+  if (input.scopes !== undefined) patch.allowed_scopes = normalizeSfiOAuthScopes(input.scopes, input.scopeCeiling);
+  let clientSecret: string | null = null;
+  if (input.rotateSecret) {
+    clientSecret = `sfi_sec_${randomBytes(32).toString('base64url')}`;
+    patch.client_secret_hash = hashSfiOAuthClientSecret(clientSecret);
+  }
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_oauth_clients')
+    .update(patch)
+    .eq('client_id', input.clientId)
+    .eq('created_by', input.userId)
+    .eq('status', 'ACTIVE')
+    .select('client_id,name,redirect_uris,allowed_scopes,status,updated_at')
+    .maybeSingle();
+  if (result.error) throw new Error(`SFI_OAUTH_CLIENT_UPDATE_FAILED:${result.error.message}`);
+  if (!result.data) throw new Error('SFI_OAUTH_CLIENT_NOT_FOUND');
+  return { client: result.data, clientSecret };
+}
+
+export async function revokeOwnedSfiOAuthClient(userId: string, clientId: string) {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('sfi_oauth_clients')
+    .update({ status: 'REVOKED', updated_at: new Date().toISOString() })
+    .eq('client_id', clientId)
+    .eq('created_by', userId)
+    .eq('status', 'ACTIVE')
+    .select('client_id,status,updated_at')
+    .maybeSingle();
+  if (result.error) throw new Error(`SFI_OAUTH_CLIENT_REVOKE_FAILED:${result.error.message}`);
+  if (!result.data) throw new Error('SFI_OAUTH_CLIENT_NOT_FOUND');
+  return result.data;
+}
+
+export async function touchSfiOAuthClient(client: ResolvedSfiOAuthClient) {
+  if (client.source !== 'registry') return;
+  const db = createServiceSupabaseClient();
+  await db.from('sfi_oauth_clients')
+    .update({ last_used_at: new Date().toISOString() })
+    .eq('client_id', client.clientId)
+    .eq('status', 'ACTIVE');
+}

--- a/src/lib/sfi/oauthClientRegistry.ts
+++ b/src/lib/sfi/oauthClientRegistry.ts
@@ -36,6 +36,19 @@ function safeEqual(a: string, b: string) {
   return left.length === right.length && timingSafeEqual(left, right);
 }
 
+function legacyClient() {
+  const legacy = readSfiOAuthConfig();
+  if (!legacy) return null;
+  return {
+    clientId: legacy.clientId,
+    name: 'SFI legacy/bootstrap OAuth client',
+    redirectUris: legacy.redirectUris,
+    allowedScopes: [...SFI_ROOT_SCOPES],
+    source: 'legacy_env' as const,
+    legacySecret: legacy.clientSecret,
+  } satisfies ResolvedSfiOAuthClient;
+}
+
 export function hashSfiOAuthClientSecret(secret: string) {
   return createHash('sha256').update(secret, 'utf8').digest('hex');
 }
@@ -80,12 +93,7 @@ async function readRegisteredClient(clientId: string): Promise<ResolvedSfiOAuthC
     .eq('status', 'ACTIVE')
     .maybeSingle();
 
-  if (result.error) {
-    // During the migration window the legacy ENV client must remain usable even
-    // if the registry table has not been applied yet.
-    if (/relation .*sfi_oauth_clients.* does not exist/i.test(result.error.message)) return null;
-    throw new Error(`SFI_OAUTH_CLIENT_REGISTRY_READ_FAILED:${result.error.message}`);
-  }
+  if (result.error) throw new Error(`SFI_OAUTH_CLIENT_REGISTRY_READ_FAILED:${result.error.message}`);
   if (!result.data) return null;
   const row = result.data as Row;
   return {
@@ -101,19 +109,19 @@ async function readRegisteredClient(clientId: string): Promise<ResolvedSfiOAuthC
 export async function resolveSfiOAuthClient(clientId: string): Promise<ResolvedSfiOAuthClient | null> {
   if (!clientId) return null;
 
-  const registered = await readRegisteredClient(clientId);
-  if (registered) return registered;
+  const legacy = legacyClient();
+  const legacyMatch = legacy && safeEqual(clientId, legacy.clientId) ? legacy : null;
 
-  const legacy = readSfiOAuthConfig();
-  if (!legacy || !safeEqual(clientId, legacy.clientId)) return null;
-  return {
-    clientId: legacy.clientId,
-    name: 'SFI legacy/bootstrap OAuth client',
-    redirectUris: legacy.redirectUris,
-    allowedScopes: [...SFI_ROOT_SCOPES],
-    source: 'legacy_env',
-    legacySecret: legacy.clientSecret,
-  };
+  try {
+    const registered = await readRegisteredClient(clientId);
+    if (registered) return registered;
+    return legacyMatch;
+  } catch (error) {
+    // Deploying code and applying the registry migration are separate operations.
+    // The bootstrap client must not go offline if the registry is not yet readable.
+    if (legacyMatch) return legacyMatch;
+    throw error;
+  }
 }
 
 export function isAllowedSfiOAuthRedirect(client: ResolvedSfiOAuthClient, redirectUri: string) {

--- a/src/lib/sfi/oauthConfig.ts
+++ b/src/lib/sfi/oauthConfig.ts
@@ -1,6 +1,31 @@
 import 'server-only';
 
-import { timingSafeEqual } from 'node:crypto';
+export const SFI_ROOT_SCOPES = [
+  'observe',
+  'propose',
+  'execute',
+  'cases:read',
+  'cases:write',
+  'lab:read',
+  'lab:write',
+  'lab:run',
+  'studio:read',
+  'studio:content',
+  'studio:run',
+] as const;
+
+export const SFI_PERSONAL_SCOPES = [
+  'cases:read',
+  'cases:write',
+  'lab:read',
+  'lab:write',
+  'lab:run',
+  'studio:read',
+  'studio:content',
+  'studio:run',
+] as const;
+
+export const SFI_SUPPORTED_SCOPES = new Set<string>(SFI_ROOT_SCOPES);
 
 export type SfiOAuthConfig = {
   clientId: string;
@@ -8,31 +33,20 @@ export type SfiOAuthConfig = {
   redirectUris: string[];
 };
 
+// Legacy/bootstrap OAuth client. This remains supported so the existing SFI GPT
+// keeps working while client registration moves to the persistent registry.
 export function readSfiOAuthConfig(): SfiOAuthConfig | null {
   const clientId = (process.env.SFI_OAUTH_CLIENT_ID || '').trim();
   const clientSecret = (process.env.SFI_OAUTH_CLIENT_SECRET || '').trim();
-  const sessionSecret = (process.env.SFI_EXTERNAL_SESSION_SECRET || '').trim();
   const redirectUris = (process.env.SFI_OAUTH_REDIRECT_URIS || '')
     .split(',')
     .map((value) => value.trim())
     .filter(Boolean);
 
-  if (!clientId || !clientSecret || !sessionSecret || redirectUris.length === 0) return null;
+  if (!clientId || !clientSecret || redirectUris.length === 0) return null;
   return { clientId, clientSecret, redirectUris };
 }
 
-function safeEqual(a: string, b: string) {
-  const left = Buffer.from(a);
-  const right = Buffer.from(b);
-  return left.length === right.length && timingSafeEqual(left, right);
-}
-
-export function isAllowedOAuthRedirect(config: SfiOAuthConfig, redirectUri: string) {
-  return config.redirectUris.includes(redirectUri);
-}
-
-export function validateOAuthClient(config: SfiOAuthConfig, clientId: string, clientSecret?: string | null) {
-  if (!safeEqual(clientId, config.clientId)) return false;
-  if (clientSecret === undefined || clientSecret === null) return true;
-  return safeEqual(clientSecret, config.clientSecret);
+export function isSfiOAuthServerConfigured() {
+  return Boolean((process.env.SFI_EXTERNAL_SESSION_SECRET || '').trim());
 }

--- a/supabase/migrations/20260827220000_sfi_oauth_client_registry.sql
+++ b/supabase/migrations/20260827220000_sfi_oauth_client_registry.sql
@@ -6,6 +6,7 @@ create table if not exists public.sfi_oauth_clients (
   created_by uuid not null,
   redirect_uris text[] not null,
   allowed_scopes text[] not null default '{}',
+  audience text not null default 'OWNER_ONLY',
   status text not null default 'ACTIVE',
   metadata jsonb not null default '{}'::jsonb,
   last_used_at timestamptz,
@@ -13,6 +14,8 @@ create table if not exists public.sfi_oauth_clients (
   updated_at timestamptz not null default now(),
   constraint sfi_oauth_clients_status_check
     check (status in ('ACTIVE', 'REVOKED')),
+  constraint sfi_oauth_clients_audience_check
+    check (audience in ('OWNER_ONLY', 'TRUSTED_MULTI_USER')),
   constraint sfi_oauth_clients_redirect_uris_check
     check (cardinality(redirect_uris) between 1 and 10)
 );
@@ -31,4 +34,4 @@ create index if not exists sfi_oauth_clients_status_idx
   on public.sfi_oauth_clients (status, created_at desc);
 
 comment on table public.sfi_oauth_clients is
-  'Persistent registry for external OAuth clients. Redirect URIs are exact-match allowlists; secrets are stored only as hashes. Service-role access only.';
+  'Persistent registry for external OAuth clients. Self-service clients are OWNER_ONLY by default; trusted multi-user clients require institutional provisioning. Redirect URIs are exact-match allowlists and secrets are stored only as hashes. Service-role access only.';

--- a/supabase/migrations/20260827220000_sfi_oauth_client_registry.sql
+++ b/supabase/migrations/20260827220000_sfi_oauth_client_registry.sql
@@ -1,0 +1,34 @@
+create table if not exists public.sfi_oauth_clients (
+  id uuid primary key default gen_random_uuid(),
+  client_id text not null unique,
+  client_secret_hash text not null,
+  name text not null,
+  created_by uuid not null,
+  redirect_uris text[] not null,
+  allowed_scopes text[] not null default '{}',
+  status text not null default 'ACTIVE',
+  metadata jsonb not null default '{}'::jsonb,
+  last_used_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint sfi_oauth_clients_status_check
+    check (status in ('ACTIVE', 'REVOKED')),
+  constraint sfi_oauth_clients_redirect_uris_check
+    check (cardinality(redirect_uris) between 1 and 10)
+);
+
+alter table public.sfi_oauth_clients enable row level security;
+
+-- The application accesses this registry only through the server-side service
+-- client. No browser/user role receives direct table access.
+revoke all on table public.sfi_oauth_clients from anon, authenticated;
+grant select, insert, update, delete on table public.sfi_oauth_clients to service_role;
+
+create index if not exists sfi_oauth_clients_created_by_idx
+  on public.sfi_oauth_clients (created_by, created_at desc);
+
+create index if not exists sfi_oauth_clients_status_idx
+  on public.sfi_oauth_clients (status, created_at desc);
+
+comment on table public.sfi_oauth_clients is
+  'Persistent registry for external OAuth clients. Redirect URIs are exact-match allowlists; secrets are stored only as hashes. Service-role access only.';


### PR DESCRIPTION
## Why
The current SFI OAuth bootstrap supports one client/callback through `SFI_OAUTH_CLIENT_ID`, `SFI_OAUTH_CLIENT_SECRET` and `SFI_OAUTH_REDIRECT_URIS`. That makes every new GPT/agent callback an environment-variable edit + redeploy.

## Change
- add persistent `sfi_oauth_clients` registry;
- exact-match redirect URI allowlists (no wildcard callbacks);
- hashed client secrets, returned only once at registration/rotation;
- self-service authenticated client registration API at `/api/oauth/clients`;
- principal/client scope intersection so registering an app cannot expand user authority;
- self-service clients are OWNER_ONLY by default;
- trusted multi-user clients remain institutional-only;
- ROOT-only `adopt_legacy` path to move the existing `sfi-chatgpt-actions-prod` ENV client into the registry without changing its secret;
- update authorize/token endpoints to resolve registry clients first and retain legacy ENV fallback during migration;
- keep authorization codes single-use and PKCE S256 behavior unchanged;
- add QA assertions and workflow coverage.

## Operational result
Once deployed and the migration is applied, adding or changing an external GPT/application callback no longer requires editing Vercel environment variables or redeploying SFI. The legacy ENV client remains a bootstrap/fallback only.

## Security
- redirect URIs remain exact-match;
- no wildcard OpenAI callback acceptance;
- registry table is RLS-enabled, browser roles revoked, service-role only;
- OAuth client scope ceiling cannot exceed the authenticated SFI principal's authority;
- a self-service OAuth client cannot be used by a different SFI account.

## SFI PRECHECK
Owner: ROOT / authenticated SFI account for self-service clients; institutional authority remains separate.
Existing capability inspected: existing ENV-backed SFI OAuth authorization-code flow, PKCE S256, signed external access tokens, user-bound profile resolution, Case/Lab/Studio scope boundaries.
Absorb vs create decision: absorb OAuth authorization/token flow; create only the missing persistent OAuth client registry and registration endpoint.
Authoritative writer: server-side OAuth client registry service using Supabase service role; browser roles have no direct table access.
Persistence/lineage impact: adds `sfi_oauth_clients`; existing authorization-code persistence and access-token claims remain unchanged.
Front delta: none in this PR; API is ready for a later small Integrations UI.
Back delta: authorize/token resolve registered clients; legacy ENV client remains migration fallback.
DB delta: one RLS-enabled registry table with exact redirect allowlists, hashed secrets, owner/audience/status metadata.
Redundancy removed: future per-client Vercel ENV callback edits and redeploys are removed from the normal integration path.
Execution/ROOT boundary: client registration cannot expand principal scopes; self-service audience is OWNER_ONLY; trusted multi-user adoption is ROOT/institutional only; no canonical promotion authority added.
Rollback: revoke registry clients and fall back to the existing legacy ENV OAuth client; migration is additive.
Verification: SFI External OAuth QA, Case GPT bridge QA, TypeScript typecheck, build, Universal Signal, MIHM and SFI Verify gates.