### PR TITLE
Bind external GPT OpenAPI to request host

### DIFF
--- a/.github/workflows/sfi-external-oauth.yml
+++ b/.github/workflows/sfi-external-oauth.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'src/app/api/oauth/**'
       - 'src/app/api/external/v1/**'
+      - 'src/app/api/external/openapi/**'
       - 'src/app/api/acp/proposals/route.ts'
       - 'src/components/sfi/SfiConsole.tsx'
       - 'src/lib/sfi/externalAuth.ts'
@@ -21,6 +22,7 @@ on:
       - 'supabase/migrations/*personal_cognitive*'
       - 'public/openapi.json'
       - 'scripts/qa-sfi-external-oauth.ts'
+      - 'scripts/qa-sfi-host-bound-openapi.ts'
       - 'scripts/qa-sfi-cognitive-automation-workspaces.ts'
       - '.github/workflows/sfi-external-oauth.yml'
   workflow_dispatch:
@@ -48,6 +50,9 @@ jobs:
 
       - name: Verify OAuth governance contract
         run: npx tsx scripts/qa-sfi-external-oauth.ts
+
+      - name: Verify host-bound external OpenAPI
+        run: npx tsx scripts/qa-sfi-host-bound-openapi.ts
 
       - name: Verify cognitive automation and personal workspace closure
         run: npx tsx scripts/qa-sfi-cognitive-automation-workspaces.ts

--- a/scripts/qa-sfi-host-bound-openapi.ts
+++ b/scripts/qa-sfi-host-bound-openapi.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const route = readFileSync('src/app/api/external/openapi/route.ts', 'utf8');
+
+assert.match(route, /sourceDocument from ['"]\.\.\/\.\.\/\.\.\/\.\.\/\.\.\/public\/openapi\.json['"]/, 'host_bound_schema_must_reuse_canonical_openapi');
+assert.match(route, /request\.nextUrl\.origin/, 'host_bound_schema_must_bind_to_request_origin');
+assert.match(route, /document\.servers = \[\{ url: origin \}\]/, 'host_bound_schema_must_rewrite_server_origin');
+assert.match(route, /authorizationCode\.authorizationUrl = `\$\{origin\}\/api\/oauth\/authorize`/, 'host_bound_schema_must_rewrite_authorization_url');
+assert.match(route, /authorizationCode\.tokenUrl = `\$\{origin\}\/api\/oauth\/token`/, 'host_bound_schema_must_rewrite_token_url');
+assert.match(route, /document\.info\.termsOfService = `\$\{origin\}\/privacy`/, 'host_bound_schema_must_keep_terms_reachable_on_same_origin');
+assert.match(route, /document\.externalDocs\.url = `\$\{origin\}\/privacy`/, 'host_bound_schema_must_keep_external_docs_reachable_on_same_origin');
+assert.match(route, /schemaBinding = 'REQUEST_ORIGIN'/, 'host_bound_schema_must_publish_binding_mode');
+assert.match(route, /'Cache-Control': 'no-store, max-age=0'/, 'host_bound_schema_must_not_cache_stale_host_binding');
+
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-HOST-BOUND-OPENAPI-1.0',
+  route: '/api/external/openapi',
+  binding: 'REQUEST_ORIGIN',
+  canonicalDocumentReused: true,
+  oauthUrlsRewritten: true,
+}, null, 2));

--- a/src/app/api/external/openapi/route.ts
+++ b/src/app/api/external/openapi/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import sourceDocument from '../../../../../public/openapi.json';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+type JsonRecord = Record<string, any>;
+
+export async function GET(request: NextRequest) {
+  const origin = request.nextUrl.origin.replace(/\/$/, '');
+  const document = structuredClone(sourceDocument) as JsonRecord;
+
+  document.servers = [{ url: origin }];
+
+  if (document.info && typeof document.info === 'object') {
+    document.info.termsOfService = `${origin}/privacy`;
+  }
+
+  if (document.externalDocs && typeof document.externalDocs === 'object') {
+    document.externalDocs.url = `${origin}/privacy`;
+  }
+
+  const authorizationCode = document.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode;
+  if (authorizationCode && typeof authorizationCode === 'object') {
+    authorizationCode.authorizationUrl = `${origin}/api/oauth/authorize`;
+    authorizationCode.tokenUrl = `${origin}/api/oauth/token`;
+  }
+
+  if (document['x-sfi-governance'] && typeof document['x-sfi-governance'] === 'object') {
+    document['x-sfi-governance'].privacyPolicy = `${origin}/privacy`;
+    document['x-sfi-governance'].schemaBinding = 'REQUEST_ORIGIN';
+  }
+
+  return NextResponse.json(document, {
+    headers: {
+      'Cache-Control': 'no-store, max-age=0',
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}


### PR DESCRIPTION
## Why
The static OpenAPI still declares `systemfriction.org` as its server and OAuth host. The current GPT connection is intentionally using `system-friction.vercel.app`, and `systemfriction.org` is blocked as Unrated on at least one enterprise network. A GPT importing the static schema could therefore authenticate through Vercel but still attempt API calls against the blocked custom domain.

## Change
- add public `GET /api/external/openapi`;
- reuse the canonical built `public/openapi.json` rather than maintaining a second schema;
- bind `servers[0].url`, OAuth authorization/token URLs and privacy URLs to the request origin;
- preserve build-time Case Platform schema augmentation because the route imports the same canonical OpenAPI after the build merge step;
- add a regression QA and include it in the External OAuth workflow.

## Operational result
Importing `https://system-friction.vercel.app/api/external/openapi` into the GPT yields a schema whose API server, Authorization URL and Token URL all point to `https://system-friction.vercel.app`. Importing the same route through a future canonical domain binds to that domain without another schema fork.

## SFI PRECHECK
Owner: External API / OAuth integration boundary.
Existing capability inspected: canonical `public/openapi.json`, build-time Case Platform schema merge, OAuth authorization/token routes and current GPT configuration.
Absorb vs create decision: absorb and project the existing canonical OpenAPI; create only a thin host-binding read route and regression gate. No second API schema is persisted.
Authoritative writer: canonical `public/openapi.json` remains authoritative; `/api/external/openapi` is a read-only projection.
Persistence/lineage impact: none; no database or canonical state mutation.
Front delta: none.
Back delta: one unauthenticated read-only schema projection route.
DB delta: none.
Redundancy removed: avoids maintaining separate Vercel and custom-domain OpenAPI documents.
Execution/ROOT boundary: no execution, proposal, evidence, governance or ROOT authority added.
Rollback: remove the projection route and return GPT schema imports to static `/openapi.json`.
Verification: host-bound schema regression QA, External OAuth QA, TypeScript, build and SFI Verify.