### PR TITLE
Fix structured-result Action contract parity

### DIFF
--- a/.github/workflows/sfi-universal-signal.yml
+++ b/.github/workflows/sfi-universal-signal.yml
@@ -20,6 +20,7 @@ on:
       - 'src/app/ai-index.json/**'
       - 'src/components/sfi/ObservatoryConsole.tsx'
       - 'src/components/sfi/ObservatoryWorldLayer.css'
+      - 'scripts/merge-openapi-universal-cycle.mjs'
       - 'scripts/qa-sfi-universal-full-cycle.ts'
       - 'scripts/qa-sfi-governed-execution-router.ts'
       - 'scripts/qa-sfi-external-oauth.ts'
@@ -46,6 +47,7 @@ on:
       - 'src/app/ai-index.json/**'
       - 'src/components/sfi/ObservatoryConsole.tsx'
       - 'src/components/sfi/ObservatoryWorldLayer.css'
+      - 'scripts/merge-openapi-universal-cycle.mjs'
       - 'scripts/qa-sfi-universal-full-cycle.ts'
       - 'scripts/qa-sfi-governed-execution-router.ts'
       - 'scripts/qa-sfi-external-oauth.ts'
@@ -71,9 +73,41 @@ jobs:
       - run: npm ci
       - name: Typecheck
         run: npm run typecheck
-      - name: Validate OpenAPI JSON
+      - name: Materialize generated OpenAPI
         run: |
-          node -e "const fs=require('fs'); const o=JSON.parse(fs.readFileSync('public/openapi.json','utf8')); const p=o.paths||{}; const v=String(o.info?.version||'0.0.0').split('.').map(Number); const versionOk=(v[0]>1)||(v[0]===1&&v[1]>=8); const required=['/api/external/v1/signal','/api/external/v1/execution-contract','/api/external/v1/result','/api/external/v1/execute','/api/external/v1/cognitive','/api/external/v1/personal-lab']; if(!versionOk||required.some(path=>!p[path])) process.exit(1); console.log('openapi >=1.8 governed contracts ok')"
+          node scripts/merge-openapi-cases.mjs
+          node scripts/merge-openapi-universal-cycle.mjs
+          node scripts/merge-openapi-person-ct.mjs
+      - name: Validate OpenAPI JSON and structured-result Action parity
+        run: |
+          node - <<'NODE'
+          const fs=require('fs');
+          const o=JSON.parse(fs.readFileSync('public/openapi.json','utf8'));
+          const p=o.paths||{};
+          const s=o.components?.schemas||{};
+          const v=String(o.info?.version||'0.0.0').split('.').map(Number);
+          const versionOk=(v[0]>1)||(v[0]===1&&v[1]>=8);
+          const required=['/api/external/v1/signal','/api/external/v1/execution-contract','/api/external/v1/result','/api/external/v1/execute','/api/external/v1/cognitive','/api/external/v1/personal-lab'];
+          if(!versionOk||required.some(path=>!p[path])) throw new Error('SFI_OPENAPI_REQUIRED_PATHS_OR_VERSION_INVALID');
+
+          const request=s.StructuredResultRequest;
+          if(!request||!Array.isArray(request.required)||!request.required.includes('object')||!request.required.includes('result')) throw new Error('SFI_OPENAPI_STRUCTURED_RESULT_REQUEST_REQUIRED_FIELDS_MISSING');
+          if(request.properties?.object?.$ref!=='#/components/schemas/StructuredResultObject') throw new Error('SFI_OPENAPI_STRUCTURED_RESULT_OBJECT_NOT_EXPOSED');
+          if(request.properties?.result?.$ref!=='#/components/schemas/StructuredAnalysisResult') throw new Error('SFI_OPENAPI_STRUCTURED_RESULT_ANALYSIS_NOT_EXPOSED');
+
+          const analysis=s.StructuredAnalysisResult;
+          const actionFields=['measurements','epistemicPartition','hypotheses','rivals','risks','invariants','perturbation','prediction'];
+          if(!analysis?.properties||actionFields.some(field=>!analysis.properties[field])) throw new Error('SFI_OPENAPI_STRUCTURED_RESULT_ACTION_SURFACE_TRUNCATED');
+          if(analysis.properties.measurements?.$ref!=='#/components/schemas/StructuredMeasurementBundle') throw new Error('SFI_OPENAPI_MEASUREMENTS_SCHEMA_MISSING');
+          if(analysis.properties.epistemicPartition?.$ref!=='#/components/schemas/StructuredEpistemicPartition') throw new Error('SFI_OPENAPI_EPISTEMIC_PARTITION_SCHEMA_MISSING');
+
+          const object=s.StructuredResultObject;
+          for(const field of ['objectHash','contentHashBasis','logicalFilename','observedTransportFilename','materialIdentityVerified','provenance']) {
+            if(!object?.properties?.[field]) throw new Error(`SFI_OPENAPI_STRUCTURED_RESULT_OBJECT_FIELD_MISSING:${field}`);
+          }
+
+          console.log('openapi governed contracts + structured-result Action parity ok');
+          NODE
       - name: Verify 21 cognitive executors are wired
         run: |
           node --import tsx -e "import { SFI_AGENT_EXECUTION_MAP } from './src/lib/sfi/cognitive-runtime/agentExecutionMap.ts'; const ids=Object.keys(SFI_AGENT_EXECUTION_MAP); console.log(ids.length, ids); if(ids.length!==21) process.exit(1);"

--- a/scripts/merge-openapi-universal-cycle.mjs
+++ b/scripts/merge-openapi-universal-cycle.mjs
@@ -9,6 +9,289 @@ api.paths ??= {};
 const signalRequest = api.components.schemas.SignalRequest;
 if (!signalRequest?.properties) throw new Error('SFI_OPENAPI_SIGNAL_REQUEST_MISSING');
 
+// GPT/Action clients must be able to transport the same structured-result
+// contract that the backend accepts. Generic additionalProperties-only objects
+// are intentionally avoided here because some Action compilers collapse them
+// out of the callable tool surface.
+api.components.schemas.StructuredResultObject = {
+  type: 'object',
+  description: 'Sanitized identity/provenance envelope for the materially inspected object. Raw content, bytes, blobs and base64 are forbidden.',
+  properties: {
+    objectKey: { type: 'string', description: 'Stable methodological object identity used to match/open/resume cycles.' },
+    id: { type: 'string' },
+    kind: { type: 'string', description: 'Representation kind such as dataset, document, text, image, audio, video, json, csv or conversation.' },
+    name: { type: 'string' },
+    mimeType: { type: 'string' },
+    logicalFilename: { type: 'string', description: 'Logical/original filename when known.' },
+    observedTransportFilename: { type: 'string', description: 'Filename exposed by the transport/client; preserve alias differences rather than silently renaming.' },
+    size: { type: 'integer', minimum: 0 },
+    objectHash: { type: 'string', description: 'Client-computed material/content fingerprint when available; SHA-256 is preferred.' },
+    contentHash: { type: 'string', description: 'Alias for a material/content fingerprint when objectHash is not used.' },
+    fingerprint: { type: 'string', description: 'Alternative client content fingerprint.' },
+    contentHashBasis: { type: 'string', description: 'Hash basis such as SHA256 or CLIENT_CONTENT_FINGERPRINT. Reference identity must remain distinct from content identity.' },
+    materialIdentityVerified: { type: 'boolean' },
+    sourceUrl: { type: 'string' },
+    assetRef: { type: 'string' },
+    metadata: {
+      type: 'object',
+      description: 'Sanitized non-raw metadata only.',
+      additionalProperties: true,
+    },
+    provenance: {
+      type: 'object',
+      description: 'Sanitized provenance/lineage metadata. Do not place raw object content here.',
+      properties: {
+        sourceRef: { type: 'string' },
+        caseId: { type: 'string' },
+        acquisitionMethod: { type: 'string' },
+        observedAt: { type: 'string' },
+        logicalFilename: { type: 'string' },
+        observedTransportFilename: { type: 'string' },
+      },
+      additionalProperties: true,
+    },
+  },
+  additionalProperties: true,
+};
+
+api.components.schemas.StructuredEpistemicEntry = {
+  type: 'object',
+  required: ['statement'],
+  properties: {
+    statement: { type: 'string' },
+    basis: { type: 'string' },
+    confidence: { type: 'number', minimum: 0, maximum: 1 },
+    refs: { type: 'array', items: { type: 'string' } },
+  },
+  additionalProperties: false,
+};
+
+api.components.schemas.StructuredEpistemicPartition = {
+  type: 'object',
+  description: 'Keep observed/declared/derived/inferred/simulated/missing categories distinct. Nothing in this object is automatically ACCEPTED EVIDENCE.',
+  properties: {
+    observed: { type: 'array', items: { $ref: '#/components/schemas/StructuredEpistemicEntry' } },
+    declared: { type: 'array', items: { $ref: '#/components/schemas/StructuredEpistemicEntry' } },
+    derived: { type: 'array', items: { $ref: '#/components/schemas/StructuredEpistemicEntry' } },
+    inferred: { type: 'array', items: { $ref: '#/components/schemas/StructuredEpistemicEntry' } },
+    simulated: { type: 'array', items: { $ref: '#/components/schemas/StructuredEpistemicEntry' } },
+    missing: { type: 'array', items: { $ref: '#/components/schemas/StructuredEpistemicEntry' } },
+    unresolved: { type: 'array', items: { $ref: '#/components/schemas/StructuredEpistemicEntry' } },
+  },
+  additionalProperties: false,
+};
+
+api.components.schemas.StructuredHypothesis = {
+  type: 'object',
+  required: ['statement'],
+  properties: {
+    id: { type: 'string' },
+    statement: { type: 'string' },
+    role: { type: 'string', enum: ['primary', 'rival'] },
+    confidence: { type: 'number', minimum: 0, maximum: 1 },
+    supportRefs: { type: 'array', items: { type: 'string' } },
+    contradictionRefs: { type: 'array', items: { type: 'string' } },
+    discriminatingTest: { type: 'string' },
+  },
+  additionalProperties: true,
+};
+
+api.components.schemas.StructuredRisk = {
+  type: 'object',
+  required: ['statement'],
+  properties: {
+    id: { type: 'string' },
+    statement: { type: 'string' },
+    likelihood: { type: 'number', minimum: 0, maximum: 1 },
+    impact: { type: 'number', minimum: 0, maximum: 1 },
+    basis: { type: 'string' },
+    refs: { type: 'array', items: { type: 'string' } },
+  },
+  additionalProperties: true,
+};
+
+api.components.schemas.StructuredMeasurementBundle = {
+  type: 'object',
+  description: 'Sanitized material measurements. Use the explicit common fields when applicable and custom only for additional bounded measurements.',
+  properties: {
+    summary: { type: 'string' },
+    sheetCount: { type: 'integer', minimum: 0 },
+    rowCount: { type: 'integer', minimum: 0 },
+    analyzableRowCount: { type: 'integer', minimum: 0 },
+    malformedRows: { type: 'integer', minimum: 0 },
+    headers: { type: 'array', items: { type: 'string' } },
+    fields: { type: 'array', items: { type: 'string' } },
+    timeCoverage: {
+      type: 'object',
+      properties: {
+        start: { type: 'string' },
+        end: { type: 'string' },
+        basis: { type: 'string' },
+      },
+      additionalProperties: true,
+    },
+    missingness: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          field: { type: 'string' },
+          missing: { type: 'integer', minimum: 0 },
+          share: { type: 'number', minimum: 0, maximum: 1 },
+        },
+        additionalProperties: true,
+      },
+    },
+    categories: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          dimension: { type: 'string' },
+          value: { type: 'string' },
+          count: { type: 'integer', minimum: 0 },
+          share: { type: 'number', minimum: 0, maximum: 1 },
+        },
+        additionalProperties: true,
+      },
+    },
+    temporalConsistency: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          key: { type: 'string' },
+          leftColumn: { type: 'string' },
+          rightColumn: { type: 'string' },
+          comparableRows: { type: 'integer', minimum: 0 },
+          violations: { type: 'integer', minimum: 0 },
+          violationShare: { type: 'number', minimum: 0, maximum: 1 },
+          interpretation: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+    durations: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          key: { type: 'string' },
+          startColumn: { type: 'string' },
+          endColumn: { type: 'string' },
+          comparableRows: { type: 'integer', minimum: 0 },
+          negativeRows: { type: 'integer', minimum: 0 },
+          medianHours: { type: 'number' },
+          p90Hours: { type: 'number' },
+          meanHours: { type: 'number' },
+          maxHours: { type: 'number' },
+        },
+        additionalProperties: true,
+      },
+    },
+    recurrence: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          key: { type: 'string' },
+          count: { type: 'integer', minimum: 0 },
+          share: { type: 'number', minimum: 0, maximum: 1 },
+          basis: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+    },
+    measurementLimitations: { type: 'array', items: { type: 'string' } },
+    custom: { type: 'object', additionalProperties: true },
+  },
+  additionalProperties: true,
+};
+
+api.components.schemas.StructuredPerturbation = {
+  type: 'object',
+  properties: {
+    action: { type: 'string' },
+    rationale: { type: 'string' },
+    reversibility: { type: 'string' },
+    riskLevel: { type: 'string' },
+    expectedEffect: { type: 'string' },
+    constraints: { type: 'array', items: { type: 'string' } },
+  },
+  additionalProperties: true,
+};
+
+api.components.schemas.StructuredPrediction = {
+  type: 'object',
+  properties: {
+    statement: { type: 'string' },
+    confidence: { type: 'number', minimum: 0, maximum: 1 },
+    expectedSignals: { type: 'array', items: { type: 'string' } },
+    contradictionSignals: { type: 'array', items: { type: 'string' } },
+    observationWindow: { type: 'string' },
+  },
+  additionalProperties: true,
+};
+
+api.components.schemas.StructuredAnalysisResult = {
+  type: 'object',
+  required: ['measurements', 'epistemicPartition'],
+  description: 'Sanitized structured analysis returned by an authorized extractor. This is a DERIVED result, not ACCEPTED EVIDENCE or canonical truth.',
+  properties: {
+    summary: { type: 'string' },
+    measurements: { $ref: '#/components/schemas/StructuredMeasurementBundle' },
+    epistemicPartition: { $ref: '#/components/schemas/StructuredEpistemicPartition' },
+    hypotheses: { type: 'array', items: { $ref: '#/components/schemas/StructuredHypothesis' } },
+    rivals: { type: 'array', items: { $ref: '#/components/schemas/StructuredHypothesis' } },
+    risks: { type: 'array', items: { $ref: '#/components/schemas/StructuredRisk' } },
+    invariants: { type: 'array', items: { type: 'string' } },
+    perturbation: { $ref: '#/components/schemas/StructuredPerturbation' },
+    prediction: { $ref: '#/components/schemas/StructuredPrediction' },
+    unresolved: { type: 'array', items: { type: 'string' } },
+    metadata: { type: 'object', additionalProperties: true },
+  },
+  additionalProperties: true,
+};
+
+api.components.schemas.StructuredResultAnalyzer = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    provider: { type: 'string' },
+    model: { type: 'string' },
+    method: { type: 'string' },
+    version: { type: 'string' },
+  },
+  additionalProperties: true,
+};
+
+api.components.schemas.StructuredResultRequest = {
+  type: 'object',
+  required: ['object', 'result'],
+  description: 'Persist one sanitized structured material-analysis result. object/result are mandatory; raw content must never be embedded.',
+  properties: {
+    cycleId: { type: 'string' },
+    question: { type: 'string' },
+    objective: { type: 'string' },
+    confidence: { type: 'number', minimum: 0, maximum: 1 },
+    lineage: { type: 'array', items: { type: 'string' } },
+    object: { $ref: '#/components/schemas/StructuredResultObject' },
+    result: { $ref: '#/components/schemas/StructuredAnalysisResult' },
+    analyzer: { $ref: '#/components/schemas/StructuredResultAnalyzer' },
+  },
+  additionalProperties: false,
+};
+
+const structuredResultPath = api.paths['/api/external/v1/result']?.post;
+if (!structuredResultPath) throw new Error('SFI_OPENAPI_STRUCTURED_RESULT_PATH_MISSING');
+structuredResultPath.summary = 'Persist a sanitized structured material-analysis result without raw object persistence';
+structuredResultPath.description = [
+  'Persists one structured DERIVED analysis result associated with a cycle/object.',
+  'The Action surface explicitly exposes object identity/provenance, measurements, epistemic partition, primary/rival hypotheses, risks, invariants and optional perturbation/prediction.',
+  'Raw binary/file/bytes/blob/base64 content remains forbidden and is stripped server-side.',
+  'This operation does not create ACCEPTED EVIDENCE, canonical truth, RETURN, closure or learning promotion.',
+].join(' ');
+
 signalRequest.properties.continueWithOpenCycles = {
   type: 'boolean',
   description: 'Explicitly allow an independent parallel cycle for the same object. Do not use this to continue the same methodological question; use resumeCycleId instead.',
@@ -77,6 +360,8 @@ api['x-sfi-governance'].learningQuarantineBoundary =
   'SFI_STRUCTURED_ANALYSIS_RESULT_RECEIVED and closed cycles do not directly enter the Cognitive Spine. TEST_SYNTHETIC, FAILED_EXPERIMENT and unpromoted OPERATIONAL_EVIDENCE remain outside institutional learning. Only ROOT-governed SFI_UNIVERSAL_LEARNING_PROMOTED records derived from CALIBRATED_RETURN may enter the universal-cycle learning source plane.';
 api['x-sfi-governance'].cognitiveBootstrapBoundary =
   'Bootstrap exposes a sealed bounded institutional context for an authorized session. It does not mint evidence, authorize actions, inherit PERSON_CT into institutional state, or promote learning.';
+api['x-sfi-governance'].structuredResultActionBoundary =
+  'The structured-result Action schema must expose the backend-required object + result payload, including measurements and epistemic partition. Tool-schema truncation is a blocking contract failure, not permission to degrade the payload into lineage or metadata.';
 api['x-sfi-governance'].preferredObjectFlow = [
   'cognitive-bootstrap',
   'case-intake-resolution',
@@ -95,4 +380,15 @@ api['x-sfi-governance'].preferredObjectFlow = [
 ];
 
 writeFileSync(path, `${JSON.stringify(api, null, 2)}\n`);
-console.log(JSON.stringify({ ok: true, openapi: path, universalCycle: true, sameCycleResume: true, aiSynthesis: true, closureGate: true, cognitiveBootstrap: true, learningQuarantine: true, version: api.info?.version ?? null }));
+console.log(JSON.stringify({
+  ok: true,
+  openapi: path,
+  universalCycle: true,
+  structuredResultActionContract: true,
+  sameCycleResume: true,
+  aiSynthesis: true,
+  closureGate: true,
+  cognitiveBootstrap: true,
+  learningQuarantine: true,
+  version: api.info?.version ?? null,
+}));


### PR DESCRIPTION
Repairs the existing SFI structured-result Action surface without adding routes, tables, workers or cognitive components.

Changes:
- Makes `persistSfiStructuredResult` explicitly expose the backend-required `object + result` payload instead of generic additionalProperties-only objects that GPT Actions can collapse.
- Exposes sanitized object identity/provenance, measurements, epistemic partition, hypotheses/rivals, risks, invariants, perturbation and prediction.
- Preserves REFERENCE_ONLY/raw-object-forbidden semantics.
- Adds CI parity validation so a future OpenAPI/tool-schema truncation fails closed.
- Adds the existing OpenAPI merge script to the Universal Signal workflow trigger and validates the generated artifact.

No changes to agents, Cognitive Runtime, Twin/Spine, Case tables, `/result` persistence semantics, evidence authority, RETURN, closure or learning promotion.