### PR TITLE
fix(deploy): publish external API route changes

### DIFF
--- a/.github/workflows/sfi-vercel-prebuilt-production.yml
+++ b/.github/workflows/sfi-vercel-prebuilt-production.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/sfi-vercel-prebuilt-production.yml
       - 'scripts/merge-openapi-*.mjs'
       - 'src/app/api/external/openapi/**'
+      - 'src/app/api/external/v1/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Closes the production gap exposed by the SFI same-cycle transport repair. The canonical prebuilt production workflow already deploys generated external OpenAPI changes, but not runtime changes under src/app/api/external/v1. Add that existing external API surface to the same production path filter. No deployment mechanism, credentials, runtime semantics or epistemic contract changes.