### PR TITLE
fix(ci): deploy production for application source changes

### DIFF
--- a/.github/workflows/sfi-vercel-prebuilt-production.yml
+++ b/.github/workflows/sfi-vercel-prebuilt-production.yml
@@ -6,9 +6,14 @@ on:
       - main
     paths:
       - .github/workflows/sfi-vercel-prebuilt-production.yml
+      - package.json
+      - package-lock.json
+      - next.config.*
+      - tsconfig.json
+      - vercel.json
+      - 'public/**'
+      - 'src/**'
       - 'scripts/merge-openapi-*.mjs'
-      - 'src/app/api/external/openapi/**'
-      - 'src/app/api/external/v1/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Production deployment currently ignores most application changes because `SFI Vercel Prebuilt Production` only watches the external API/OpenAPI paths. PR #337 therefore merged successfully without triggering the production deploy, even though it changed `src/**` interface/runtime code.

This change keeps the existing prebuilt Vercel deployment path and credentials untouched, but broadens the main-branch trigger to application-bearing changes:

- `src/**`
- `public/**`
- `package.json` / `package-lock.json`
- `next.config.*`
- `tsconfig.json`
- `vercel.json`
- existing OpenAPI merge script path
- the deployment workflow itself

Documentation-only changes still do not deploy production. No second deployment mechanism is introduced.

## SFI PRECHECK

Owner: ROOT / repository deployment governance
Existing capability inspected: `.github/workflows/sfi-vercel-prebuilt-production.yml` and its existing main-only prebuilt production deployment
Absorb vs create decision: ABSORB — widen the existing deployment trigger; do not create another deploy workflow
Authoritative writer: existing `SFI Vercel Prebuilt Production` workflow remains the sole explicit prebuilt production writer
Persistence/lineage impact: NONE; deployment lineage remains GitHub main SHA → existing Vercel production workflow
Front delta: NONE directly; enables already-merged application/UI changes to reach production
Back delta: NONE directly; source/runtime changes on future main merges now correctly trigger the existing production deployment
DB delta: NONE
Redundancy removed: removes the trigger blind spot that required route-specific edits to cause production deploy
Execution/ROOT boundary: no authority change; production execution remains main-only with existing Vercel secrets and project-scope verification
Rollback: revert this workflow-only commit to restore the prior path filter
Verification: canonical PR checks, exact final head verification, squash merge, then observe the existing production workflow on the resulting main SHA and verify live site reachability/content
