### PR TITLE
fix(sfi): make universal cycles durable across runtime timeouts

### DIFF
--- a/docs/architecture/sfi/ADR-SFI-DURABLE-UNIVERSAL-CYCLE-002.md
+++ b/docs/architecture/sfi/ADR-SFI-DURABLE-UNIVERSAL-CYCLE-002.md
@@ -32,6 +32,10 @@ This ADR extends `ADR-SFI-ARCHITECTURE-001` without creating a second institute,
 
 The event store remains the sole durable execution trace for this mechanism. No raw XLSX rows are persisted by the checkpoint layer.
 
+## Canonical preflight record
+
+The change is owned by the existing universal signal runtime and continuity heartbeat. Existing capabilities inspected before implementation were `universalSignalCycle`, `cognitiveCycle`, the canonical observation hydrator, the governed execution router, the epistemic event store and the existing GitHub-OIDC continuity heartbeat. The decision is to absorb continuation into those owners; the only new helper is bounded orchestration for reconstructing unfinished universal-cycle execution. There is no frontend delta, database delta, migration, alternate writer, new scheduler, new agent, new Case surface or second memory store. Rollback consists of reverting this change; the new checkpoint and RETURN-plan events are derived/non-authoritative and can be ignored safely by the prior runtime.
+
 ## Failure semantics
 
 A deployment timeout becomes an interrupted execution window, not loss of cycle identity. The next authorized continuity run resumes from the latest durable checkpoint.

--- a/docs/architecture/sfi/ADR-SFI-DURABLE-UNIVERSAL-CYCLE-002.md
+++ b/docs/architecture/sfi/ADR-SFI-DURABLE-UNIVERSAL-CYCLE-002.md
@@ -1,0 +1,53 @@
+# ADR-SFI-DURABLE-UNIVERSAL-CYCLE-002 — Durable universal-cycle continuation
+
+**Status:** PROPOSED FOR IMPLEMENTATION  
+**Version:** 1.0  
+**Date:** 2026-08-31
+
+## Context
+
+The universal signal runtime can preserve cycle identity and individual agent execution events, but a deployment timeout may terminate the request before `SFI_UNIVERSAL_COGNITIVE_CYCLE_EXECUTED` and AI synthesis are persisted. `AWAITING_RETURN` is also a lifecycle classification, not proof that a process is actively acquiring a RETURN.
+
+This creates two operational ambiguities:
+
+1. a caller can become the implicit scheduler by repeatedly resuming a cycle after runtime timeouts;
+2. a caller can become the implicit RETURN provider without SFI first declaring what observation is required and whether SFI can acquire it.
+
+## Decision
+
+SFI will make universal cognitive execution durable using the existing epistemic event store and the existing hourly continuity heartbeat.
+
+1. The cognitive runtime persists `SFI_UNIVERSAL_COGNITIVE_CHECKPOINT` after bounded agent steps.
+2. Checkpoints contain only the bounded cognitive execution state needed to continue. They do not authorize raw-source row persistence and do not change epistemic class.
+3. A later invocation restores the latest unfinalized checkpoint for the same `cycleId`/logbook and skips already processed agents.
+4. Partial `SFI_UNIVERSAL_COGNITIVE_CYCLE_EXECUTED` records with `completed:false` do not finalize a checkpoint.
+5. The existing hourly continuity heartbeat is the recovery scheduler. It may resume unfinished same-cycle cognitive work but may not open a new Case, create a parallel cycle, expand external authority, fabricate RETURN, close the cycle, or promote learning.
+6. Pre-checkpoint interrupted cycles may be bootstrapped only from their persisted same-cycle resume identity plus canonical structured-result hydration. Raw source objects are not re-uploaded or reprocessed.
+7. On cognitive completion SFI persists `SFI_UNIVERSAL_RETURN_PLAN_RECORDED`. The plan declares expected/contradictory signals, observation window when available, source requirement, responsibility and the rule for human escalation.
+8. Human input is not the default scheduler or RETURN mechanism. It is requested only when the required source, credential, authorization or observation cannot be obtained through an already-authorized SFI capability.
+
+## Constitutional compatibility
+
+This ADR extends `ADR-SFI-ARCHITECTURE-001` without creating a second institute, second memory store, new table, direct client access to ROOT, or new epistemic authority. Cognitive Spine/runtime output remains non-canonical unless existing evidence and governance gates promote it.
+
+The event store remains the sole durable execution trace for this mechanism. No raw XLSX rows are persisted by the checkpoint layer.
+
+## Failure semantics
+
+A deployment timeout becomes an interrupted execution window, not loss of cycle identity. The next authorized continuity run resumes from the latest durable checkpoint.
+
+If a single agent itself cannot complete within the deployment window, that agent remains retryable from the prior checkpoint; its unpersisted output is not assumed to exist.
+
+## Acceptance criteria
+
+A governed test must demonstrate all of the following:
+
+- same `cycleId` before and after interruption;
+- no new Case and no parallel cycle;
+- no raw source re-upload or raw-row persistence;
+- at least one interruption with a persisted checkpoint;
+- later execution skips already processed agents;
+- eventual `SFI_UNIVERSAL_COGNITIVE_CYCLE_EXECUTED` with `completed:true`;
+- AI synthesis after the completed runtime;
+- an explicit RETURN plan;
+- no RETURN, CONTRAST, closure or learning promotion without real evidence.

--- a/src/app/api/cron/continuity-heartbeat/route.ts
+++ b/src/app/api/cron/continuity-heartbeat/route.ts
@@ -3,6 +3,7 @@ import { runContinuityHeartbeat, runOperationalTransitionWatchdog } from '@/lib/
 import { runStudioAutonomyContinuation } from '@/lib/continuity/studioAutonomy';
 import { verifyGitHubActionsOidcToken } from '@/lib/continuity/githubActionsOidc';
 import { runGovernedExecutionRouter } from '@/lib/execution/governedExecutionRouter';
+import { runUniversalCycleContinuation } from '@/lib/sfi/universalCycleContinuation';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -41,7 +42,7 @@ export async function GET(request: NextRequest) {
   try {
     const result = await runContinuityHeartbeat(authorization.trigger);
     const emergencyHalt = result.mode === 'EMERGENCY_HALT';
-    const [studioAutonomy, transitionWatchdog, governedExecution] = await Promise.all([
+    const [studioAutonomy, transitionWatchdog, governedExecution, universalCycleContinuation] = await Promise.all([
       runStudioAutonomyContinuation({
         mode: result.mode,
         continuityRunId: result.runId,
@@ -74,6 +75,14 @@ export async function GET(request: NextRequest) {
             results: [],
             error: error instanceof Error ? error.message : String(error),
           })),
+      emergencyHalt
+        ? Promise.resolve({ ok: true as const, halted: true as const, processed: 0, results: [] })
+        : runUniversalCycleContinuation({ limit: 2 }).catch((error) => ({
+            ok: false as const,
+            processed: 0,
+            results: [],
+            error: error instanceof Error ? error.message : String(error),
+          })),
     ]);
 
     return NextResponse.json({
@@ -83,9 +92,10 @@ export async function GET(request: NextRequest) {
       studioAutonomy,
       transitionWatchdog,
       governedExecution,
+      universalCycleContinuation,
       executionRule: emergencyHalt
-        ? 'EMERGENCY_HALT suppresses transition writes and governed execution dispatch. Continuity probes may record the halted heartbeat only.'
-        : 'Hourly continuity reuses the existing heartbeat: waiting_evidence can acquire candidates, unknown risk is assessed, and already-authorized queued work is retried/rerouted. Evidence acceptance, governance decisions, material external scope expansion and canon remain human-gated.',
+        ? 'EMERGENCY_HALT suppresses transition writes, governed execution dispatch and universal-cycle continuation. Continuity probes may record the halted heartbeat only.'
+        : 'Hourly continuity reuses the existing heartbeat: waiting_evidence can acquire candidates, unknown risk is assessed, already-authorized queued work is retried/rerouted, and interrupted universal cognitive cycles resume from durable checkpoints. Evidence acceptance, governance decisions, material external scope expansion, RETURN fabrication and canon remain prohibited.',
     });
   } catch (error) {
     return NextResponse.json({ ok: false, error: 'continuity_heartbeat_failed', details: error instanceof Error ? error.message : String(error) }, { status: 500 });

--- a/src/lib/sfi/cognitive-runtime/cognitiveCycle.ts
+++ b/src/lib/sfi/cognitive-runtime/cognitiveCycle.ts
@@ -1,11 +1,47 @@
-import type { KernelContext } from './kernelContext';
+import { appendEpistemicEvent } from '@/lib/events/eventStore';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import type { KernelContext, KernelEvidence } from './kernelContext';
 import { runCognitiveAgent } from './runtimeAgentExecutor';
+
+export const SFI_UNIVERSAL_COGNITIVE_CHECKPOINT = 'SFI_UNIVERSAL_COGNITIVE_CHECKPOINT' as const;
+export const SFI_UNIVERSAL_RETURN_PLAN_RECORDED = 'SFI_UNIVERSAL_RETURN_PLAN_RECORDED' as const;
 
 export interface CognitiveCycleResult {
   context: KernelContext;
   executedAgents: string[];
   missingAgents: string[];
   completed: boolean;
+}
+
+export interface CognitiveCycleOptions {
+  maxAgentsPerInvocation?: number;
+  continuationSource?: string;
+}
+
+type Row = Record<string, unknown>;
+
+type DurableCheckpoint = {
+  eventId: string | null;
+  sequence: number;
+  context: KernelContext;
+  processedAgents: string[];
+  executedAgents: string[];
+  missingAgents: string[];
+  completed: boolean;
+};
+
+function row(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function stringList(value: unknown) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0).map((item) => item.trim())
+    : [];
 }
 
 function plannedAgents(context: KernelContext) {
@@ -18,53 +54,260 @@ function plannedAgents(context: KernelContext) {
     : [];
 }
 
-export async function executeCognitiveCycle(context: KernelContext): Promise<CognitiveCycleResult> {
-  const executedAgents: string[] = [];
-  let currentContext = context;
-  const queue: string[] = ['meta_orchestrator'];
-  const processedAgents = new Set<string>();
+function mergeEvidence(base: KernelEvidence[], checkpoint: KernelEvidence[]) {
+  const merged = new Map<string, KernelEvidence>();
+  for (const item of [...base, ...checkpoint]) {
+    if (item && typeof item.id === 'string' && item.id) merged.set(item.id, item);
+  }
+  return [...merged.values()];
+}
 
-  while (queue.length > 0) {
+function mergeCheckpointContext(base: KernelContext, checkpoint: KernelContext): KernelContext {
+  return {
+    ...base,
+    ...checkpoint,
+    cycleId: base.cycleId,
+    logbookId: base.logbookId,
+    taskId: base.taskId ?? checkpoint.taskId,
+    evidence: mergeEvidence(base.evidence ?? [], checkpoint.evidence ?? []),
+    hypotheses: checkpoint.hypotheses ?? base.hypotheses,
+    contradictions: checkpoint.contradictions ?? base.contradictions,
+    simulations: checkpoint.simulations ?? base.simulations,
+    predictions: checkpoint.predictions ?? base.predictions,
+    risks: checkpoint.risks ?? base.risks,
+    opportunities: checkpoint.opportunities ?? base.opportunities,
+    metadata: {
+      ...base.metadata,
+      ...checkpoint.metadata,
+      durableContinuation: {
+        restored: true,
+        restoredAt: new Date().toISOString(),
+        rule: 'Continue the same cycle from the latest unfinalized checkpoint; never promote checkpoint state to observed truth.',
+      },
+    },
+  };
+}
+
+async function readLatestUnfinalizedCheckpoint(context: KernelContext): Promise<DurableCheckpoint | null> {
+  const db = createServiceSupabaseClient();
+  const latest = await db.from('epistemic_events')
+    .select('sequence,event_id,payload')
+    .eq('event_name', SFI_UNIVERSAL_COGNITIVE_CHECKPOINT)
+    .eq('logbook_id', context.logbookId)
+    .order('sequence', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (latest.error || !latest.data) return null;
+
+  const sequence = Number(latest.data.sequence ?? 0);
+  const payload = row(latest.data.payload);
+  if (text(payload.cycleId) !== context.cycleId) return null;
+
+  const finalized = await db.from('epistemic_events')
+    .select('sequence')
+    .eq('event_name', 'SFI_UNIVERSAL_COGNITIVE_CYCLE_EXECUTED')
+    .eq('logbook_id', context.logbookId)
+    .gt('sequence', sequence)
+    .order('sequence', { ascending: false })
+    .limit(1);
+  if (!finalized.error && (finalized.data?.length ?? 0) > 0) return null;
+
+  const storedContext = row(payload.context) as unknown as KernelContext;
+  if (!storedContext || storedContext.cycleId !== context.cycleId) return null;
+  return {
+    eventId: text(latest.data.event_id),
+    sequence,
+    context: storedContext,
+    processedAgents: stringList(payload.processedAgents),
+    executedAgents: stringList(payload.executedAgents),
+    missingAgents: stringList(payload.missingAgents),
+    completed: payload.completed === true,
+  };
+}
+
+function returnPlan(context: KernelContext) {
+  const expectedSignals = [...new Set(context.predictions.flatMap((item) => item.expectedSignals ?? []))];
+  const contradictionSignals = [...new Set(context.predictions.flatMap((item) => item.contradictionSignals ?? []))];
+  const observationWindows = [...new Set(context.predictions.map((item) => item.observationWindow).filter((item): item is string => typeof item === 'string' && item.length > 0))];
+  const unresolved = context.metadata?.materialUnresolved ?? null;
+  const hasPrediction = context.predictions.length > 0;
+
+  return {
+    contract: 'SFI-UNIVERSAL-RETURN-PLAN-1.0',
+    cycleId: context.cycleId,
+    status: hasPrediction ? 'RETURN_REQUIRED' : 'RETURN_REQUIREMENT_UNDETERMINED',
+    acquisitionState: hasPrediction ? 'CAPABILITY_RESOLUTION_REQUIRED' : 'MISSING_DISCRIMINATING_PREDICTION',
+    responsibility: 'SFI',
+    humanInputRequired: false,
+    humanEscalationRule: 'Ask the operator only when the required source, credential, authorization or material observation cannot be obtained through an already-authorized SFI capability.',
+    expectedSignals,
+    contradictionSignals,
+    observationWindows,
+    unresolved,
+    sourceRequirement: 'Use an authoritative or directly observed source appropriate to the persisted prediction. Do not manufacture RETURN from model output.',
+    next: hasPrediction
+      ? 'Resolve the minimum governed acquisition capability, obtain the observation, persist RETURN, then CONTRAST.'
+      : 'Do not fabricate RETURN. Resolve missing evidence or a discriminating prediction first.',
+  };
+}
+
+async function persistCheckpoint(input: {
+  context: KernelContext;
+  processedAgents: string[];
+  executedAgents: string[];
+  missingAgents: string[];
+  completed: boolean;
+  source: string;
+}) {
+  return appendEpistemicEvent({
+    eventName: SFI_UNIVERSAL_COGNITIVE_CHECKPOINT,
+    epistemicClass: 'derived',
+    confidence: 1,
+    occurredAt: new Date().toISOString(),
+    source: { sourceId: input.source, sourceType: 'cognitive_runtime_checkpoint' },
+    logbookId: input.context.logbookId,
+    lineage: [input.context.cycleId],
+    payload: {
+      cycleId: input.context.cycleId,
+      taskId: input.context.taskId ?? null,
+      processedAgents: input.processedAgents,
+      executedAgents: input.executedAgents,
+      missingAgents: input.missingAgents,
+      completed: input.completed,
+      context: input.context,
+      storagePolicy: 'DURABLE_COGNITIVE_STATE_NO_RAW_SOURCE_ROWS',
+      epistemicBoundary: 'Checkpoint persistence preserves execution continuity only. It does not promote derived, inferred or simulated content to observed evidence.',
+    },
+  });
+}
+
+async function persistReturnPlan(context: KernelContext, source: string) {
+  const db = createServiceSupabaseClient();
+  const latest = await db.from('epistemic_events')
+    .select('payload')
+    .eq('event_name', SFI_UNIVERSAL_RETURN_PLAN_RECORDED)
+    .eq('logbook_id', context.logbookId)
+    .order('sequence', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const latestTaskId = latest.data ? text(row(latest.data.payload).taskId) : null;
+  if (!latest.error && latestTaskId && latestTaskId === (context.taskId ?? null)) return;
+
+  const plan = returnPlan(context);
+  context.metadata = { ...context.metadata, returnPlan: plan };
+  await appendEpistemicEvent({
+    eventName: SFI_UNIVERSAL_RETURN_PLAN_RECORDED,
+    epistemicClass: 'derived',
+    confidence: 1,
+    occurredAt: new Date().toISOString(),
+    source: { sourceId: source, sourceType: 'return_requirement_resolver' },
+    logbookId: context.logbookId,
+    lineage: [context.cycleId],
+    payload: {
+      cycleId: context.cycleId,
+      taskId: context.taskId ?? null,
+      plan,
+      canonicalPromotionAllowed: false,
+    },
+  });
+}
+
+export async function executeCognitiveCycle(
+  context: KernelContext,
+  options: CognitiveCycleOptions = {},
+): Promise<CognitiveCycleResult> {
+  const checkpoint = await readLatestUnfinalizedCheckpoint(context);
+  let currentContext = checkpoint ? mergeCheckpointContext(context, checkpoint.context) : context;
+  const executedAgents: string[] = checkpoint ? [...checkpoint.executedAgents] : [];
+  const processedAgents = new Set<string>(checkpoint?.processedAgents ?? []);
+  const source = options.continuationSource ?? 'sfi_cognitive_runtime';
+
+  if (checkpoint?.completed) {
+    const missingAgents = plannedAgents(currentContext).filter((agentId) => !executedAgents.includes(agentId));
+    await persistReturnPlan(currentContext, source);
+    return { context: currentContext, executedAgents, missingAgents, completed: missingAgents.length === 0 && executedAgents.includes('meta_orchestrator') };
+  }
+
+  const queue: string[] = processedAgents.has('meta_orchestrator')
+    ? stringList(currentContext.metadata?.cognitivePlan && typeof currentContext.metadata.cognitivePlan === 'object'
+        ? (currentContext.metadata.cognitivePlan as Record<string, unknown>).executionOrder
+        : null)
+    : ['meta_orchestrator'];
+  let processedThisInvocation = 0;
+  const maxAgents = Math.max(1, Math.min(25, options.maxAgentsPerInvocation ?? 25));
+
+  while (queue.length > 0 && processedThisInvocation < maxAgents) {
     const agentId = queue.shift()!;
     if (processedAgents.has(agentId)) continue;
     processedAgents.add(agentId);
+    processedThisInvocation += 1;
 
     const result = await runCognitiveAgent(agentId, currentContext);
     currentContext = result.context;
-    if (result.executed) executedAgents.push(agentId);
+    if (result.executed && !executedAgents.includes(agentId)) executedAgents.push(agentId);
 
     const executionOrder = currentContext.metadata?.cognitivePlan?.executionOrder;
     if (Array.isArray(executionOrder)) {
       for (const nextAgent of executionOrder) {
-        if (typeof nextAgent === 'string' && !processedAgents.has(nextAgent)) queue.push(nextAgent);
+        if (typeof nextAgent === 'string' && !processedAgents.has(nextAgent) && !queue.includes(nextAgent)) queue.push(nextAgent);
       }
     }
+
+    const requiredNow = plannedAgents(currentContext);
+    const missingNow = requiredNow.filter((id) => !executedAgents.includes(id));
+    await persistCheckpoint({
+      context: currentContext,
+      processedAgents: [...processedAgents],
+      executedAgents,
+      missingAgents: missingNow,
+      completed: false,
+      source,
+    });
   }
 
   const requiredAgents = plannedAgents(currentContext);
   const missingAgents = requiredAgents.filter((agentId) => !executedAgents.includes(agentId));
   const metaExecuted = executedAgents.includes('meta_orchestrator');
-  const completed = metaExecuted && missingAgents.length === 0;
+  const queueExhausted = queue.length === 0;
+  const completed = metaExecuted && missingAgents.length === 0 && queueExhausted;
+  const paused = !completed && !queueExhausted && processedThisInvocation >= maxAgents;
   const taskGraph = currentContext.metadata?.taskGraph;
 
+  if (completed) {
+    currentContext.metadata = { ...currentContext.metadata, returnPlan: returnPlan(currentContext) };
+  }
   currentContext.metadata = {
     ...currentContext.metadata,
     taskGraph: taskGraph && typeof taskGraph === 'object' && !Array.isArray(taskGraph)
-      ? { ...taskGraph, status: completed ? 'completed' : 'degraded' }
+      ? { ...taskGraph, status: completed ? 'completed' : paused ? 'paused' : 'degraded' }
       : undefined,
     taskGraphExecution: {
-      status: completed ? 'completed' : 'degraded',
+      status: completed ? 'completed' : paused ? 'paused' : 'degraded',
       executedAgents,
       missingAgents,
-      completedAt: new Date().toISOString(),
+      processedAgents: [...processedAgents],
+      checkpointed: true,
+      completedAt: completed ? new Date().toISOString() : null,
     },
     cognitiveCycle: {
       completed,
+      paused,
       executedAgents,
       missingAgents,
+      processedAgents: [...processedAgents],
       finishedAt: new Date().toISOString(),
     },
   };
+
+  await persistCheckpoint({
+    context: currentContext,
+    processedAgents: [...processedAgents],
+    executedAgents,
+    missingAgents,
+    completed,
+    source,
+  });
+  if (completed) await persistReturnPlan(currentContext, source);
 
   return { context: currentContext, executedAgents, missingAgents, completed };
 }

--- a/src/lib/sfi/cognitive-runtime/cognitiveCycle.ts
+++ b/src/lib/sfi/cognitive-runtime/cognitiveCycle.ts
@@ -265,7 +265,10 @@ export async function executeCognitiveCycle(
         : null)
     : ['meta_orchestrator'];
   let processedThisInvocation = 0;
-  const maxAgents = Math.max(1, Math.min(25, options.maxAgentsPerInvocation ?? 6));
+  const continuationConfig = row(row(currentContext.metadata?.caseContext).durableContinuation);
+  const configuredBudget = Number(continuationConfig.maxAgentsPerInvocation);
+  const defaultBudget = Number.isFinite(configuredBudget) && configuredBudget > 0 ? configuredBudget : 25;
+  const maxAgents = Math.max(1, Math.min(25, options.maxAgentsPerInvocation ?? defaultBudget));
 
   while (queue.length > 0 && processedThisInvocation < maxAgents) {
     const agentId = queue.shift()!;

--- a/src/lib/sfi/cognitive-runtime/cognitiveCycle.ts
+++ b/src/lib/sfi/cognitive-runtime/cognitiveCycle.ts
@@ -104,13 +104,14 @@ async function readLatestUnfinalizedCheckpoint(context: KernelContext): Promise<
   if (text(payload.cycleId) !== context.cycleId) return null;
 
   const finalized = await db.from('epistemic_events')
-    .select('sequence')
+    .select('sequence,payload')
     .eq('event_name', 'SFI_UNIVERSAL_COGNITIVE_CYCLE_EXECUTED')
     .eq('logbook_id', context.logbookId)
     .gt('sequence', sequence)
     .order('sequence', { ascending: false })
-    .limit(1);
-  if (!finalized.error && (finalized.data?.length ?? 0) > 0) return null;
+    .limit(10);
+  const hasCompletedFinalization = !finalized.error && (finalized.data ?? []).some((item) => row(item.payload).completed === true);
+  if (hasCompletedFinalization) return null;
 
   const storedContext = row(payload.context) as unknown as KernelContext;
   if (!storedContext || storedContext.cycleId !== context.cycleId) return null;
@@ -234,7 +235,7 @@ export async function executeCognitiveCycle(
         : null)
     : ['meta_orchestrator'];
   let processedThisInvocation = 0;
-  const maxAgents = Math.max(1, Math.min(25, options.maxAgentsPerInvocation ?? 25));
+  const maxAgents = Math.max(1, Math.min(25, options.maxAgentsPerInvocation ?? 6));
 
   while (queue.length > 0 && processedThisInvocation < maxAgents) {
     const agentId = queue.shift()!;

--- a/src/lib/sfi/cognitive-runtime/cognitiveCycle.ts
+++ b/src/lib/sfi/cognitive-runtime/cognitiveCycle.ts
@@ -88,6 +88,36 @@ function mergeCheckpointContext(base: KernelContext, checkpoint: KernelContext):
   };
 }
 
+function checkpointContextProjection(context: KernelContext): KernelContext {
+  const signalType = text(context.metadata?.signalType)?.toLowerCase() ?? '';
+  const tabular = ['dataset', 'csv'].includes(signalType);
+  const evidence = (context.evidence ?? []).map((item) => {
+    if (!tabular || item.source !== 'UniversalSignalGateway') return item;
+    const payload = row(item.payload);
+    if (!('materialContent' in payload)) return item;
+    return {
+      ...item,
+      payload: {
+        ...payload,
+        materialContent: null,
+        materialContentBoundary: 'OMITTED_FROM_DURABLE_CHECKPOINT_RAW_TABULAR_MATERIAL_NOT_PERSISTED',
+      },
+    };
+  });
+  const metadata = tabular
+    ? {
+        ...context.metadata,
+        declaredExtraction: null,
+        checkpointOmissions: [
+          ...stringList(context.metadata?.checkpointOmissions),
+          'RAW_TABULAR_MATERIAL',
+          'CALLER_DECLARED_EXTRACTION_PAYLOAD',
+        ],
+      }
+    : context.metadata;
+  return { ...context, evidence, metadata };
+}
+
 async function readLatestUnfinalizedCheckpoint(context: KernelContext): Promise<DurableCheckpoint | null> {
   const db = createServiceSupabaseClient();
   const latest = await db.from('epistemic_events')
@@ -175,7 +205,7 @@ async function persistCheckpoint(input: {
       executedAgents: input.executedAgents,
       missingAgents: input.missingAgents,
       completed: input.completed,
-      context: input.context,
+      context: checkpointContextProjection(input.context),
       storagePolicy: 'DURABLE_COGNITIVE_STATE_NO_RAW_SOURCE_ROWS',
       epistemicBoundary: 'Checkpoint persistence preserves execution continuity only. It does not promote derived, inferred or simulated content to observed evidence.',
     },

--- a/src/lib/sfi/universalCycleContinuation.ts
+++ b/src/lib/sfi/universalCycleContinuation.ts
@@ -1,0 +1,321 @@
+import 'server-only';
+
+import { appendEpistemicEvent } from '@/lib/events/eventStore';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { executeCognitiveCycle, SFI_UNIVERSAL_COGNITIVE_CHECKPOINT } from '@/lib/sfi/cognitive-runtime/cognitiveCycle';
+import type { KernelContext } from '@/lib/sfi/cognitive-runtime/kernelContext';
+import { hydrateUniversalCycleInput } from '@/lib/sfi/universalObservationHydrator';
+import { synthesizeUniversalCycleWithAi } from '@/lib/sfi/universalAiSynthesis';
+import { runUniversalCognitiveCycle, type UniversalCycleInput } from '@/lib/sfi/universalSignalCycle';
+
+const SYSTEM_ACTOR = 'sfi_universal_continuation';
+const EVENT_SCAN_LIMIT = 500;
+
+type Row = Record<string, unknown>;
+
+type LifecycleEvent = {
+  sequence: number;
+  eventId: string;
+  eventName: string;
+  payload: Row;
+  logbookId: string | null;
+};
+
+type CycleTrack = {
+  cycleId: string;
+  resume: LifecycleEvent | null;
+  checkpoint: LifecycleEvent | null;
+  cognitive: LifecycleEvent | null;
+  synthesis: LifecycleEvent | null;
+  closed: LifecycleEvent | null;
+};
+
+function row(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function numberValue(value: unknown) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function eventRow(value: unknown): LifecycleEvent | null {
+  const item = row(value);
+  const payload = row(item.payload);
+  const cycleId = text(payload.cycleId);
+  const eventName = text(item.event_name);
+  if (!cycleId || !eventName) return null;
+  return {
+    sequence: numberValue(item.sequence),
+    eventId: text(item.event_id) ?? '',
+    eventName,
+    payload,
+    logbookId: text(item.logbook_id),
+  };
+}
+
+function later(a: LifecycleEvent | null, b: LifecycleEvent | null) {
+  return (a?.sequence ?? 0) > (b?.sequence ?? 0);
+}
+
+function completedCognitive(event: LifecycleEvent | null) {
+  return Boolean(event && event.payload.completed === true);
+}
+
+function signalFromObjectKey(payload: Row): UniversalCycleInput['signal'] {
+  const objectKey = text(payload.objectKey) ?? '';
+  const objectHash = text(payload.objectHash) ?? undefined;
+  if (objectKey.startsWith('url:')) {
+    return { kind: 'url', sourceUrl: objectKey.slice(4), objectHash, content: null, extracted: {}, provenance: {} };
+  }
+  const separator = objectKey.indexOf(':');
+  const kind = separator > 0 ? objectKey.slice(0, separator) : 'unknown';
+  const name = separator > 0 ? objectKey.slice(separator + 1) : objectKey || undefined;
+  return { kind, name, objectHash, content: null, extracted: {}, provenance: {} };
+}
+
+async function readTracks() {
+  const db = createServiceSupabaseClient();
+  const result = await db.from('epistemic_events')
+    .select('sequence,event_id,event_name,payload,logbook_id')
+    .in('event_name', [
+      'SFI_UNIVERSAL_CYCLE_RESUMED',
+      SFI_UNIVERSAL_COGNITIVE_CHECKPOINT,
+      'SFI_UNIVERSAL_COGNITIVE_CYCLE_EXECUTED',
+      'SFI_UNIVERSAL_AI_SYNTHESIS_COMPLETED',
+      'SFI_UNIVERSAL_CYCLE_CLOSED',
+    ])
+    .order('sequence', { ascending: false })
+    .limit(EVENT_SCAN_LIMIT);
+  if (result.error) return { ok: false as const, tracks: [] as CycleTrack[], error: result.error.message };
+
+  const map = new Map<string, CycleTrack>();
+  for (const value of result.data ?? []) {
+    const event = eventRow(value);
+    if (!event) continue;
+    let track = map.get(text(event.payload.cycleId)!);
+    if (!track) {
+      track = { cycleId: text(event.payload.cycleId)!, resume: null, checkpoint: null, cognitive: null, synthesis: null, closed: null };
+      map.set(track.cycleId, track);
+    }
+    if (event.eventName === 'SFI_UNIVERSAL_CYCLE_RESUMED' && !track.resume) track.resume = event;
+    else if (event.eventName === SFI_UNIVERSAL_COGNITIVE_CHECKPOINT && !track.checkpoint) track.checkpoint = event;
+    else if (event.eventName === 'SFI_UNIVERSAL_COGNITIVE_CYCLE_EXECUTED' && !track.cognitive) track.cognitive = event;
+    else if (event.eventName === 'SFI_UNIVERSAL_AI_SYNTHESIS_COMPLETED' && !track.synthesis) track.synthesis = event;
+    else if (event.eventName === 'SFI_UNIVERSAL_CYCLE_CLOSED' && !track.closed) track.closed = event;
+  }
+  return { ok: true as const, tracks: [...map.values()], error: null as string | null };
+}
+
+function checkpointContext(event: LifecycleEvent | null): KernelContext | null {
+  if (!event) return null;
+  const context = row(event.payload.context) as unknown as KernelContext;
+  if (!context || typeof context.cycleId !== 'string' || !context.cycleId) return null;
+  return context;
+}
+
+function synthesisInput(context: KernelContext, lineageRefs: string[]) {
+  const metadata = row(context.metadata);
+  return {
+    cycleId: context.cycleId,
+    actorId: SYSTEM_ACTOR,
+    tenantId: text(metadata.tenantId) ?? 'sfi',
+    question: text(metadata.question),
+    objective: text(metadata.objective),
+    caseClass: text(metadata.caseClass),
+    signal: {
+      kind: text(metadata.signalType) ?? 'unknown',
+      name: text(metadata.objectKey),
+      objectHash: text(metadata.objectHash),
+      extracted: {
+        measurements: row(metadata.materialMeasurements),
+        epistemicPartition: row(metadata.materialEpistemicPartition),
+        unresolved: metadata.materialUnresolved ?? null,
+      },
+      provenance: {
+        hydratedFromEventId: text(metadata.hydrationEventId),
+      },
+    },
+    deterministicOutputs: {
+      hypotheses: context.hypotheses,
+      contradictions: context.contradictions,
+      predictions: context.predictions,
+      risks: context.risks,
+      opportunities: context.opportunities,
+      simulations: context.simulations,
+    },
+    runtimeMetadata: context.metadata,
+    lineageRefs,
+  };
+}
+
+async function appendCognitiveCompletion(context: KernelContext, result: Awaited<ReturnType<typeof executeCognitiveCycle>>, lineage: string[]) {
+  return appendEpistemicEvent({
+    eventName: 'SFI_UNIVERSAL_COGNITIVE_CYCLE_EXECUTED',
+    epistemicClass: 'derived',
+    confidence: result.completed ? 1 : 0.5,
+    occurredAt: new Date().toISOString(),
+    source: { sourceId: SYSTEM_ACTOR, sourceType: 'durable_cycle_continuation' },
+    logbookId: context.logbookId,
+    lineage,
+    payload: {
+      cycleId: context.cycleId,
+      taskId: context.taskId ?? null,
+      resumed: true,
+      completed: result.completed,
+      executedAgents: result.executedAgents,
+      missingAgents: result.missingAgents,
+      hypotheses: result.context.hypotheses,
+      contradictions: result.context.contradictions,
+      predictions: result.context.predictions,
+      risks: result.context.risks,
+      opportunities: result.context.opportunities,
+      simulations: result.context.simulations,
+      metadata: result.context.metadata,
+      continuation: 'DURABLE_CHECKPOINT_RESUME',
+    },
+  });
+}
+
+async function synthesizeIfMissing(track: CycleTrack, context: KernelContext, completionEventId: string | null) {
+  const latestCompletion = track.cognitive;
+  const synthesisIsCurrent = latestCompletion && track.synthesis && later(track.synthesis, latestCompletion);
+  if (synthesisIsCurrent) return { status: 'SYNTHESIS_ALREADY_CURRENT' as const, eventId: track.synthesis?.eventId ?? null };
+  const refs = [track.resume?.eventId, track.checkpoint?.eventId, completionEventId].filter((item): item is string => Boolean(item));
+  const synthesis = await synthesizeUniversalCycleWithAi(synthesisInput(context, refs));
+  return { status: synthesis.status, eventId: synthesis.eventId };
+}
+
+async function continueCheckpoint(track: CycleTrack) {
+  const context = checkpointContext(track.checkpoint);
+  if (!context) return { cycleId: track.cycleId, state: 'CHECKPOINT_CONTEXT_INVALID' as const };
+
+  if (track.closed && later(track.closed, track.checkpoint)) {
+    return { cycleId: track.cycleId, state: 'CYCLE_ALREADY_CLOSED' as const };
+  }
+
+  const checkpointCompleted = track.checkpoint?.payload.completed === true;
+  const currentCompletion = track.cognitive && later(track.cognitive, track.checkpoint) && completedCognitive(track.cognitive);
+  let completionEventId = currentCompletion ? track.cognitive?.eventId ?? null : null;
+  let result: Awaited<ReturnType<typeof executeCognitiveCycle>> | null = null;
+
+  if (!currentCompletion) {
+    result = checkpointCompleted
+      ? await executeCognitiveCycle(context, { maxAgentsPerInvocation: 1, continuationSource: SYSTEM_ACTOR })
+      : await executeCognitiveCycle(context, { maxAgentsPerInvocation: 4, continuationSource: SYSTEM_ACTOR });
+    if (result.completed) {
+      const completion = await appendCognitiveCompletion(context, result, [track.resume?.eventId, track.checkpoint?.eventId].filter((item): item is string => Boolean(item)));
+      completionEventId = completion.ok ? String(completion.data.event_id ?? '') || null : null;
+    }
+  }
+
+  const effectiveContext = result?.context ?? context;
+  if (!(result?.completed ?? currentCompletion ?? checkpointCompleted)) {
+    return {
+      cycleId: track.cycleId,
+      state: 'CHECKPOINTED_CONTINUATION' as const,
+      executedAgents: result?.executedAgents ?? [],
+      missingAgents: result?.missingAgents ?? [],
+    };
+  }
+
+  const synthesis = await synthesizeIfMissing(track, effectiveContext, completionEventId);
+  return {
+    cycleId: track.cycleId,
+    state: 'COGNITIVE_RUNTIME_COMPLETED' as const,
+    completionEventId,
+    synthesis,
+    returnPlan: row(effectiveContext.metadata).returnPlan ?? null,
+  };
+}
+
+async function bootstrapLegacyResume(track: CycleTrack) {
+  if (!track.resume) return { cycleId: track.cycleId, state: 'NO_RESUME_EVENT' as const };
+  const payload = track.resume.payload;
+  const tenantId = text(payload.tenantId) ?? 'sfi';
+  const rawInput: UniversalCycleInput = {
+    signal: signalFromObjectKey(payload),
+    question: text(payload.question) ?? undefined,
+    objective: text(payload.objective) ?? undefined,
+    context: {},
+  };
+  const hydration = await hydrateUniversalCycleInput(rawInput, tenantId, { resumeCycleId: track.cycleId });
+  if (!hydration.hydrated) {
+    return { cycleId: track.cycleId, state: 'LEGACY_RESUME_HYDRATION_REQUIRED' as const, hydrationBasis: hydration.basis };
+  }
+  const preparedInput: UniversalCycleInput = {
+    ...hydration.input,
+    context: {
+      ...row(hydration.input.context),
+      observationHydration: {
+        contract: hydration.contract,
+        hydrated: hydration.hydrated,
+        basis: hydration.basis,
+        eventId: hydration.eventId,
+      },
+      durableContinuation: {
+        bootstrapFromResumeEventId: track.resume.eventId,
+        rule: 'Reuse the same cycle and canonical structured result. Do not reload or persist raw dataset rows.',
+      },
+    },
+  };
+
+  const cycle = await runUniversalCognitiveCycle(preparedInput, SYSTEM_ACTOR, tenantId, {
+    resumeCycleId: track.cycleId,
+    resumeReason: 'DURABLE_RUNTIME_CONTINUATION',
+    resumeLineageEventId: track.resume.eventId,
+  });
+
+  return {
+    cycleId: track.cycleId,
+    state: cycle.result.completed ? 'LEGACY_RESUME_COMPLETED' as const : 'LEGACY_RESUME_CHECKPOINTED' as const,
+    completed: cycle.result.completed,
+    executedAgents: cycle.result.executedAgents,
+    missingAgents: cycle.result.missingAgents,
+    checkpointingEnabled: true,
+  };
+}
+
+export async function runUniversalCycleContinuation(input: { limit?: number } = {}) {
+  const scan = await readTracks();
+  if (!scan.ok) return { ok: false as const, processed: 0, results: [], error: scan.error };
+  const limit = Math.max(1, Math.min(5, input.limit ?? 2));
+  const candidates = scan.tracks
+    .filter((track) => {
+      if (track.closed && (!track.resume || later(track.closed, track.resume))) return false;
+      const unfinishedCheckpoint = track.checkpoint && (!track.cognitive || later(track.checkpoint, track.cognitive) || !completedCognitive(track.cognitive));
+      const legacyInterruptedResume = track.resume && (!track.cognitive || later(track.resume, track.cognitive)) && (!track.checkpoint || !later(track.checkpoint, track.resume));
+      const synthesisMissing = track.cognitive && completedCognitive(track.cognitive) && (!track.synthesis || later(track.cognitive, track.synthesis));
+      return Boolean(unfinishedCheckpoint || legacyInterruptedResume || synthesisMissing);
+    })
+    .sort((a, b) => Math.max(b.resume?.sequence ?? 0, b.checkpoint?.sequence ?? 0, b.cognitive?.sequence ?? 0) - Math.max(a.resume?.sequence ?? 0, a.checkpoint?.sequence ?? 0, a.cognitive?.sequence ?? 0))
+    .slice(0, limit);
+
+  const results: unknown[] = [];
+  for (const track of candidates) {
+    try {
+      const checkpointIsUsable = track.checkpoint && (!track.resume || later(track.checkpoint, track.resume));
+      if (checkpointIsUsable) results.push(await continueCheckpoint(track));
+      else if (track.resume && (!track.cognitive || later(track.resume, track.cognitive))) results.push(await bootstrapLegacyResume(track));
+      else if (track.cognitive && completedCognitive(track.cognitive)) {
+        const context = checkpointContext(track.checkpoint);
+        results.push(context
+          ? { cycleId: track.cycleId, state: 'SYNTHESIS_RECOVERY', synthesis: await synthesizeIfMissing(track, context, track.cognitive.eventId) }
+          : { cycleId: track.cycleId, state: 'SYNTHESIS_CONTEXT_UNAVAILABLE' });
+      }
+    } catch (error) {
+      results.push({ cycleId: track.cycleId, state: 'CONTINUATION_FAILED', error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
+  return {
+    ok: results.every((item) => row(item).state !== 'CONTINUATION_FAILED'),
+    processed: results.length,
+    results,
+    rule: 'Only unfinished same-cycle cognitive work is resumed. No new Case, raw source reprocessing, RETURN fabrication, closure or learning promotion is performed.',
+  };
+}

--- a/src/lib/sfi/universalCycleContinuation.ts
+++ b/src/lib/sfi/universalCycleContinuation.ts
@@ -259,6 +259,7 @@ async function bootstrapLegacyResume(track: CycleTrack) {
       },
       durableContinuation: {
         bootstrapFromResumeEventId: track.resume.eventId,
+        maxAgentsPerInvocation: 4,
         rule: 'Reuse the same cycle and canonical structured result. Do not reload or persist raw dataset rows.',
       },
     },


### PR DESCRIPTION
## Problem
Universal signal runs can persist `SFI_UNIVERSAL_CYCLE_RESUMED` and several `SFI_AGENT_EXECUTED` events, then die on the deployment window before the cognitive cycle and synthesis are finalized. The operator becomes the implicit scheduler, while `AWAITING_RETURN` does not declare what observation is required or who is responsible for acquiring it.

## Change
- persist `SFI_UNIVERSAL_COGNITIVE_CHECKPOINT` after agent progress using the existing epistemic event store;
- restore the latest unfinalized checkpoint and skip already processed agents;
- treat partial cognitive-run events (`completed:false`) as resumable rather than final;
- ordinary runs keep their prior agent budget; only the automatic legacy-recovery lane is deliberately bounded;
- persist `SFI_UNIVERSAL_RETURN_PLAN_RECORDED` on completed cognition without manufacturing RETURN;
- reuse the existing hourly OIDC continuity heartbeat to resume unfinished universal cycles;
- bootstrap pre-checkpoint interrupted cycles from same-cycle resume identity + canonical structured-result hydration only;
- explicitly omit raw tabular material/caller-declared extraction payloads from durable checkpoints;
- no new Case, no new table/memory store, no raw source re-upload/reprocessing, no automatic RETURN/CONTRAST/closure/learning promotion.

## SFI PRECHECK
Owner: SFI universal signal runtime + existing continuity heartbeat.
Existing capability inspected: `universalSignalCycle`, `cognitiveCycle`, canonical observation hydrator, governed execution router, epistemic event store, `/api/cron/continuity-heartbeat`, and the existing hourly GitHub OIDC continuity workflow.
Absorb vs create decision: absorb continuation into the existing cognitive runtime and continuity heartbeat; create only one bounded continuation helper because no existing owner reconstructs unfinished universal-cycle execution. No new product/surface/agent/store.
Authoritative writer: existing `appendEpistemicEvent` event-store path; existing universal lifecycle remains authoritative for cycle state.
Persistence/lineage impact: adds derived checkpoint and RETURN-plan events to the same universal-cycle logbook. Checkpoint lineage remains same-cycle; raw dataset rows and caller-declared extraction payloads are omitted.
Front delta: none.
Back delta: durable checkpoint restore, bounded heartbeat continuation, legacy pre-checkpoint bootstrap from canonical hydration, and explicit RETURN-plan derivation.
DB delta: none; no migration, table or alternate persistence owner.
Redundancy removed: removes the need for the operator/GPT caller to act as an implicit retry scheduler after deployment timeouts; reuses the existing heartbeat rather than adding another scheduler.
Execution/ROOT boundary: heartbeat may resume only unfinished internal cognition. It cannot open a new Case/parallel cycle, expand external authority, fabricate RETURN, close cycles, promote learning or write canon. ROOT authority is unchanged.
Rollback: revert this PR; existing universal-cycle events remain readable and prior runtime semantics resume. New derived checkpoint/plan events are non-authoritative and safely ignored by prior code.
Verification: canonical architecture preflight, SFI Verify, MIHM contract validation, External OAuth, typecheck/build, then production same-cycle continuity proof on `ce563b2a-3715-49ce-8806-1cc051f6ad71` with no XLSX re-upload/reprocessing and no fabricated RETURN.

## Target continuity proof
Existing cycle: `ce563b2a-3715-49ce-8806-1cc051f6ad71`.

After production deployment, the hourly continuity lane should reuse the persisted structured analysis result and same cycle, bootstrap durable checkpointing for this pre-fix interruption, finish the runtime across bounded recovery invocations if necessary, synthesize, and expose an explicit RETURN plan. It must not re-upload/reprocess the XLSX or fabricate empirical closure.

## ADR
Adds `ADR-SFI-DURABLE-UNIVERSAL-CYCLE-002.md` as the implementation decision record.