### PR TITLE
fix(sfi): make targeted continuity proof reconstruct post-cognitive state

### DIFF
--- a/.github/workflows/sfi-continuity-hourly.yml
+++ b/.github/workflows/sfi-continuity-hourly.yml
@@ -162,7 +162,7 @@ jobs:
               if universal.get('requestedCycleId') != requested:
                   raise SystemExit('targeted cycleId was not acknowledged by the cognitive continuation lane')
               if not isinstance(target, dict) or target.get('ok') is not True or target.get('cycleId') != requested:
-                  raise SystemExit('targeted existing cycle state was not reconstructed successfully')
+                  raise SystemExit('targeted existing cycle was not processed or reconstructed successfully')
               if int(target.get('eventCount') or 0) < 1:
                   raise SystemExit('targeted existing cycle has no reconstructable lifecycle events')
           PY

--- a/.github/workflows/sfi-continuity-hourly.yml
+++ b/.github/workflows/sfi-continuity-hourly.yml
@@ -30,6 +30,43 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Resolve optional existing-cycle proof target
+        id: target
+        shell: bash
+        env:
+          MANUAL_CYCLE_ID: ${{ inputs.cycle_id || '' }}
+          UPSTREAM_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cycle_id="$MANUAL_CYCLE_ID"
+          source="workflow_dispatch"
+
+          if [ -z "$cycle_id" ] && [ "${GITHUB_EVENT_NAME}" = "workflow_run" ] && [ -n "$UPSTREAM_SHA" ]; then
+            source="deployment_commit_marker"
+            commit_file="$RUNNER_TEMP/sfi-deployed-commit.json"
+            curl --fail-with-body --silent --show-error \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${UPSTREAM_SHA}" > "$commit_file"
+            cycle_id="$(python - "$commit_file" <<'PY'
+          import json, re, sys
+          with open(sys.argv[1], encoding='utf-8') as handle:
+              payload = json.load(handle)
+          message = ((payload.get('commit') or {}).get('message') or '')
+          match = re.search(r'\[sfi-cycle-proof:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\]', message)
+          print(match.group(1).lower() if match else '')
+          PY
+            )"
+          fi
+
+          if [ -z "$cycle_id" ]; then
+            source="none"
+          fi
+          echo "cycle_id=$cycle_id" >> "$GITHUB_OUTPUT"
+          echo "source=$source" >> "$GITHUB_OUTPUT"
+          printf '{"cycleId":"%s","source":"%s"}\n' "$cycle_id" "$source"
+
       - name: Request short-lived GitHub OIDC token
         id: oidc
         shell: bash
@@ -48,7 +85,8 @@ jobs:
         env:
           OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
           SFI_CONTINUITY_ENDPOINT: https://system-friction.vercel.app/api/cron/continuity-heartbeat
-          CYCLE_ID: ${{ inputs.cycle_id || '' }}
+          CYCLE_ID: ${{ steps.target.outputs.cycle_id }}
+          TARGET_SOURCE: ${{ steps.target.outputs.source }}
         run: |
           set -euo pipefail
           endpoint="$SFI_CONTINUITY_ENDPOINT"
@@ -67,14 +105,18 @@ jobs:
             -H "X-SFI-Continuity-Trigger: github-actions-oidc" \
             "$endpoint" > "$response_file"
 
-          python - "$response_file" "$CYCLE_ID" <<'PY'
+          python - "$response_file" "$CYCLE_ID" "$TARGET_SOURCE" <<'PY'
           import json, sys
 
-          response_file, requested = sys.argv[1], sys.argv[2].strip()
+          response_file, requested, target_source = sys.argv[1], sys.argv[2].strip(), sys.argv[3].strip()
           with open(response_file, encoding='utf-8') as handle:
               payload = json.load(handle)
 
           universal = payload.get('universalCycleContinuation') or {}
+          before = payload.get('returnPlanUpgradeBefore') or {}
+          after = payload.get('returnPlanUpgradeAfter') or {}
+          empirical = payload.get('universalEmpiricalContinuation') or {}
+          target = payload.get('targetCycleState')
           summary = {
               'ok': payload.get('ok'),
               'trigger': payload.get('trigger'),
@@ -82,6 +124,12 @@ jobs:
               'status': payload.get('status'),
               'runId': payload.get('runId'),
               'requestedCycleId': payload.get('requestedCycleId'),
+              'targetSource': target_source,
+              'returnPlanUpgradeBefore': {
+                  'ok': before.get('ok'),
+                  'processed': before.get('processed'),
+                  'results': before.get('results', []),
+              },
               'universal': {
                   'ok': universal.get('ok'),
                   'processed': universal.get('processed'),
@@ -89,15 +137,32 @@ jobs:
                   'schedulingPolicy': universal.get('schedulingPolicy'),
                   'results': universal.get('results', []),
               },
+              'returnPlanUpgradeAfter': {
+                  'ok': after.get('ok'),
+                  'processed': after.get('processed'),
+                  'results': after.get('results', []),
+              },
+              'empirical': {
+                  'ok': empirical.get('ok'),
+                  'processed': empirical.get('processed'),
+                  'results': empirical.get('results', []),
+              },
+              'targetCycleState': target,
           }
           print(json.dumps(summary, ensure_ascii=False, separators=(',', ':')))
 
           if payload.get('ok') is not True:
               raise SystemExit('continuity heartbeat reported ok=false')
-          if universal.get('ok') is False:
-              raise SystemExit('universal cycle continuation reported ok=false')
-          if requested and universal.get('requestedCycleId') != requested:
-              raise SystemExit('targeted cycleId was not acknowledged by the live continuation lane')
-          if requested and int(universal.get('processed') or 0) < 1:
-              raise SystemExit('targeted existing cycle was not processed')
+          for lane_name, lane in [('returnPlanUpgradeBefore', before), ('universal', universal), ('returnPlanUpgradeAfter', after), ('empirical', empirical)]:
+              if lane.get('ok') is False:
+                  raise SystemExit(f'{lane_name} reported ok=false')
+          if requested:
+              if payload.get('requestedCycleId') != requested:
+                  raise SystemExit('targeted cycleId was not acknowledged by the live heartbeat')
+              if universal.get('requestedCycleId') != requested:
+                  raise SystemExit('targeted cycleId was not acknowledged by the cognitive continuation lane')
+              if not isinstance(target, dict) or target.get('ok') is not True or target.get('cycleId') != requested:
+                  raise SystemExit('targeted existing cycle state was not reconstructed successfully')
+              if int(target.get('eventCount') or 0) < 1:
+                  raise SystemExit('targeted existing cycle has no reconstructable lifecycle events')
           PY

--- a/src/app/api/cron/continuity-heartbeat/route.ts
+++ b/src/app/api/cron/continuity-heartbeat/route.ts
@@ -6,11 +6,122 @@ import { runGovernedExecutionRouter } from '@/lib/execution/governedExecutionRou
 import { runUniversalCycleContinuation } from '@/lib/sfi/universalCycleContinuation';
 import { runUniversalEmpiricalContinuation } from '@/lib/sfi/universalEmpiricalContinuation';
 import { runUniversalReturnPlanUpgrade } from '@/lib/sfi/universalReturnPlanUpgrade';
+import { readUniversalCycleHistory } from '@/lib/sfi/universalSignalCycle';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 type AuthorizedTrigger = 'vercel_cron' | 'github_actions_oidc' | 'development';
+type Row = Record<string, unknown>;
+
+function row(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown, max = 1200) {
+  return typeof value === 'string' && value.trim() ? value.trim().slice(0, max) : null;
+}
+
+function strings(value: unknown, max = 6) {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+      .map((item) => item.trim().slice(0, 600))
+      .slice(0, max)
+    : [];
+}
+
+function latestNamed(events: unknown[], eventName: string) {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = row(events[index]);
+    if (text(event.event_name) === eventName) return event;
+  }
+  return null;
+}
+
+function summarizeReturnPlan(event: Row | null) {
+  if (!event) return null;
+  const payload = row(event.payload);
+  const plan = row(payload.plan);
+  const capability = row(plan.capabilityResolution);
+  return {
+    eventId: text(event.event_id),
+    occurredAt: text(event.occurred_at),
+    contract: text(plan.contract),
+    status: text(plan.status),
+    acquisitionState: text(plan.acquisitionState),
+    responsibility: text(plan.responsibility),
+    humanInputRequired: plan.humanInputRequired === true,
+    requiredHumanInput: strings(plan.requiredHumanInput),
+    expectedSignals: strings(plan.expectedSignals),
+    contradictionSignals: strings(plan.contradictionSignals),
+    next: text(plan.next),
+    capabilityResolution: Object.keys(capability).length ? {
+      contract: text(capability.contract),
+      decision: text(capability.decision) ?? text(capability.state),
+      capabilityId: text(capability.capabilityId),
+      sourceClass: text(capability.sourceClass),
+      humanInputRequired: capability.humanInputRequired === true,
+      requiredHumanInput: strings(capability.requiredHumanInput),
+      reason: text(capability.reason),
+      provider: text(capability.provider),
+      model: text(capability.model),
+    } : null,
+  };
+}
+
+async function readTargetCycleProof(cycleId: string | undefined) {
+  if (!cycleId) return null;
+  const history = await readUniversalCycleHistory(cycleId);
+  if (!history.ok) {
+    return { ok: false as const, cycleId, state: history.state ?? null, error: history.error ?? 'cycle_history_unavailable' };
+  }
+  const events = Array.isArray(history.events) ? history.events : [];
+  const latestEvent = events.length ? row(events[events.length - 1]) : null;
+  const cognitive = latestNamed(events, 'SFI_UNIVERSAL_COGNITIVE_CYCLE_EXECUTED');
+  const synthesis = latestNamed(events, 'SFI_UNIVERSAL_AI_SYNTHESIS_COMPLETED');
+  const returnPlan = latestNamed(events, 'SFI_UNIVERSAL_RETURN_PLAN_RECORDED');
+  const returnEvent = latestNamed(events, 'SFI_UNIVERSAL_RETURN_RECORDED');
+  const contrast = latestNamed(events, 'SFI_UNIVERSAL_RETURN_CONTRASTED');
+  const closure = latestNamed(events, 'SFI_UNIVERSAL_CYCLE_CLOSED');
+  const cognitivePayload = row(cognitive?.payload);
+  const synthesisPayload = row(synthesis?.payload);
+  const synthesisBody = row(synthesisPayload.synthesis);
+
+  return {
+    ok: true as const,
+    cycleId,
+    state: history.state ?? null,
+    eventCount: events.length,
+    latestEvent: latestEvent ? {
+      eventId: text(latestEvent.event_id),
+      eventName: text(latestEvent.event_name),
+      epistemicClass: text(latestEvent.epistemic_class),
+      occurredAt: text(latestEvent.occurred_at),
+    } : null,
+    cognition: {
+      completed: cognitivePayload.completed === true,
+      eventId: text(cognitive?.event_id),
+      occurredAt: text(cognitive?.occurred_at),
+      executedAgentCount: Array.isArray(cognitivePayload.executedAgents) ? cognitivePayload.executedAgents.length : 0,
+      missingAgentCount: Array.isArray(cognitivePayload.missingAgents) ? cognitivePayload.missingAgents.length : 0,
+    },
+    synthesis: synthesis ? {
+      eventId: text(synthesis.event_id),
+      occurredAt: text(synthesis.occurred_at),
+      status: text(synthesisBody.status) ?? text(synthesisPayload.status),
+      provider: text(synthesisBody.provider) ?? text(synthesisPayload.provider),
+      model: text(synthesisBody.model) ?? text(synthesisPayload.model),
+    } : null,
+    returnPlan: summarizeReturnPlan(returnPlan),
+    returnRecorded: Boolean(returnEvent),
+    returnEventId: text(returnEvent?.event_id),
+    contrastRecorded: Boolean(contrast),
+    contrastEventId: text(contrast?.event_id),
+    closed: Boolean(closure),
+    closureEventId: text(closure?.event_id),
+    boundary: 'Read-only bounded proof derived from the existing universal-cycle ledger. It exposes lifecycle state and RETURN requirements only; it does not create evidence, RETURN, CONTRAST, closure, learning, or raw material.',
+  };
+}
 
 function bearer(request: NextRequest) {
   const match = (request.headers.get('authorization') ?? '').match(/^Bearer\s+(.+)$/i);
@@ -121,12 +232,22 @@ export async function GET(request: NextRequest) {
           error: error instanceof Error ? error.message : String(error),
         }));
 
+    const targetCycleState = requestedCycleId
+      ? await readTargetCycleProof(requestedCycleId).catch((error) => ({
+          ok: false as const,
+          cycleId: requestedCycleId,
+          state: null,
+          error: error instanceof Error ? error.message : String(error),
+        }))
+      : null;
+
     const laneFailure = transitionWatchdog.ok === false
       || governedExecution.ok === false
       || universalCycleContinuation.ok === false
       || returnPlanUpgradeBefore.ok === false
       || returnPlanUpgradeAfter.ok === false
       || universalEmpiricalContinuation.ok === false
+      || targetCycleState?.ok === false
       || studioAutonomy.status === 'DEGRADED';
 
     return NextResponse.json({
@@ -141,9 +262,10 @@ export async function GET(request: NextRequest) {
       universalCycleContinuation,
       returnPlanUpgradeAfter,
       universalEmpiricalContinuation,
+      targetCycleState,
       executionRule: emergencyHalt
         ? 'EMERGENCY_HALT suppresses transition writes, governed execution dispatch, universal cognitive continuation, empirical continuation and learning writes. Continuity probes may record the halted heartbeat only.'
-        : 'One heartbeat owns the complete governed continuation path: legacy RETURN plans are upgraded to AI-governed capability routing, interrupted cognition resumes from durable checkpoints using a sealed Cognitive Twin context, real evidence-linked RETURNs advance through AI-assisted CONTRAST and existing empirical closure rules, and calibrated learning becomes adaptive non-canonical Twin context. Missing evidence remains missing; no RETURN, canon mutation or irreversible external authority is fabricated.',
+        : 'One heartbeat owns the complete governed continuation path: legacy RETURN plans are upgraded to AI-governed capability routing, interrupted cognition resumes from durable checkpoints using a sealed Cognitive Twin context, real evidence-linked RETURNs advance through AI-assisted CONTRAST and existing empirical closure rules, and calibrated learning becomes adaptive non-canonical Twin context. A requested cycle also returns bounded read-only lifecycle proof even when no cognitive work is eligible. Missing evidence remains missing; no RETURN, canon mutation or irreversible external authority is fabricated.',
     });
   } catch (error) {
     return NextResponse.json({ ok: false, error: 'continuity_heartbeat_failed', details: error instanceof Error ? error.message : String(error) }, { status: 500 });


### PR DESCRIPTION
## Objetivo
Hacer verificable un ciclo universal existente aunque ya no tenga trabajo cognitivo elegible, sin crear otro ciclo/Case ni tocar material crudo. El heartbeat canónico podrá reconstruir de forma acotada el estado post-cognitivo y dirigir una prueba post-deploy mediante un marcador auditable del commit desplegado.

## SFI PRECHECK

Existing capability inspected: existing `SFI Continuity Hourly`, GitHub Actions OIDC policy restricted to `main`, `runUniversalCycleContinuation`, `runUniversalReturnPlanUpgrade`, `runUniversalEmpiricalContinuation`, and existing `readUniversalCycleHistory` ledger reconstruction.

Absorb vs create decision: ABSORB into the existing continuity heartbeat and workflow. No new scheduler, endpoint, Case, cycle, persistence surface, table, memory store, evidence store, or authority plane.

Authoritative writer: unchanged. Existing universal-cycle writers remain authoritative for lifecycle events. `targetCycleState` is read-only reconstruction and writes nothing.

Persistence/lineage impact: NONE. No schema change and no new persisted event. Target proof reads only the existing `universal-cycle:<cycleId>` / `structured-result:<cycleId>` ledger through `readUniversalCycleHistory`.

Front delta: NONE. No new UI or public surface.

Back delta: requested heartbeats return a bounded `targetCycleState` containing lifecycle state, latest event, cognition/synthesis status, bounded RETURN-plan requirements, and RETURN/CONTRAST/closure booleans. The canonical GitHub workflow also surfaces all universal continuation lanes. A `[sfi-cycle-proof:<uuid>]` marker in the actually deployed commit may target only the post-deploy `workflow_run`; ordinary scheduled heartbeats remain untargeted.

DB delta: NONE. No migration, SQL, table, view, RPC, raw-row store, or new persistence.

Redundancy removed: removes the need to infer a target cycle's state from whether the cognitive continuation lane happened to process it. A correctly post-cognitive `AWAITING_RETURN` cycle is now observable without pretending it still needs cognition.

Execution/ROOT boundary: proof targeting can request an existing cycle only. It cannot open a cycle, fabricate RETURN/evidence/CONTRAST, change canon, grant access, expand authority, or perform irreversible external work. Missing evidence remains missing.

Verification: canonical architecture preflight; SFI operational-next QA; OAuth/OIDC; Cognitive Spine; CT institutional integration; MIHM; typecheck/build; Vercel preview; merge with one proof marker for `ce563b2a-3715-49ce-8806-1cc051f6ad71`; production deploy; then inspect the post-deploy continuity log for that same cycle and all four continuation lanes.

Rollback: revert this PR. There is no schema rollback and no data migration.

## Production proof target
Existing cycle only: `ce563b2a-3715-49ce-8806-1cc051f6ad71`.

The merge commit used for this one proof will include `[sfi-cycle-proof:ce563b2a-3715-49ce-8806-1cc051f6ad71]`. The marker does not persist targeting into scheduled runs; it is read only from the upstream commit of a successful production deployment.