### PR TITLE
feat(sfi): capture observed GenAI telemetry and assurance

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -165,6 +165,9 @@ jobs:
       - name: Verify SFI System and AI Assurance Domain V1
         run: npx tsx scripts/qa-sfi-system-ai-assurance-domain-v1.ts
 
+      - name: Verify GenAI telemetry and assurance
+        run: npx tsx scripts/qa-sfi-genai-telemetry.ts
+
       - name: Typecheck
         id: typecheck
         shell: bash

--- a/scripts/cognitive-spine/qa-root-cognitive-spine-observability.ts
+++ b/scripts/cognitive-spine/qa-root-cognitive-spine-observability.ts
@@ -10,6 +10,7 @@ const route = read('src/app/api/root/cognitive-spine/status/route.ts');
 const scenes = read('src/components/sfi/scenes.ts');
 const liveUi = read('src/components/sfi/SfiConsole.tsx');
 const operatingUi = read('src/components/sfi/SfiOperatingWorkspace.tsx');
+const governanceUi = read('src/components/sfi/SfiGovernanceWorkspace.tsx');
 const scenePage = read('src/app/[scene]/page.tsx');
 const anatomy = read('src/components/root/cognitive-spine/CognitiveSpineAnatomy.tsx');
 const park = read('src/components/sfi/CognitiveSpinePark.tsx');
@@ -33,12 +34,13 @@ assert.ok(route.includes("requireRootViewer('root.cognitive-spine.status')"), 'r
 assert.ok(route.includes("'Cache-Control': 'no-store'"), 'root_ct_status_endpoint_cache_boundary_missing');
 
 // ROOT stays on the canonical live-scene runtime. Method Lab is not an owner of this projection.
-// Follow the current capability owners rather than a retired pre-convergence component location.
+// Governance capabilities are delegated to SfiGovernanceWorkspace rather than duplicated in the operating shell.
 assert.ok(scenes.includes("root:{key:'root'"), 'root_live_scene_missing');
 assert.ok(scenes.includes("title:'Observatorio de Fricción'"), 'root_live_scene_semantics_missing');
 assert.ok(liveUi.includes('COGNITIVE TWIN'), 'root_live_scene_twin_observability_missing');
-assert.ok(operatingUi.includes("jsonFetch('/api/acp/proposals')") && operatingUi.includes('setProposals'), 'root_operating_workspace_proposal_feed_missing');
-assert.ok(operatingUi.includes('ACEPTAR') && operatingUi.includes('DENEGAR') && operatingUi.includes('PEDIR EVIDENCIA'), 'root_operating_workspace_governance_controls_missing');
+assert.ok(operatingUi.includes('SfiGovernanceWorkspace'), 'root_operating_workspace_governance_delegate_missing');
+assert.ok(governanceUi.includes("jsonFetch('/api/acp/proposals')") && governanceUi.includes('setProposals'), 'root_governance_workspace_proposal_feed_missing');
+assert.ok(governanceUi.includes('ACEPTAR') && governanceUi.includes('DENEGAR') && governanceUi.includes('PEDIR EVIDENCIA'), 'root_governance_workspace_controls_missing');
 assert.ok(scenePage.includes('SCENE_KEYS.includes'), 'dynamic_scene_gate_missing');
 assert.ok(scenePage.includes('<SfiConsole') && scenePage.includes('scene={scene as SceneKey}'), 'dynamic_scene_runtime_missing');
 

--- a/scripts/qa-sfi-genai-telemetry.ts
+++ b/scripts/qa-sfi-genai-telemetry.ts
@@ -140,7 +140,7 @@ assert.equal(assuranceWithoutFalsePositive.contractVersion, SFI_GENAI_ASSURANCE_
 assert.equal(assuranceWithoutFalsePositive.telemetryCoverage.provider.value, 1);
 assert.equal(assuranceWithoutFalsePositive.telemetryCoverage.inputTokens.value, 1);
 assert.equal(assuranceWithoutFalsePositive.quality.structuredInferenceCompletionRate.value, 1);
-assert.equal(assuranceWithoutFalsePositive.evidenceSufficiency.partial, 1);
+assert.equal(assuranceWithoutFalsePositive.evidenceSufficiency.insufficient, 1);
 assert.equal(assuranceWithoutFalsePositive.returnCalibration.calibratedContrasts, 1);
 assert.equal(assuranceWithoutFalsePositive.returnCalibration.contradicted, 1);
 assert.equal(assuranceWithoutFalsePositive.falsePositive.rate.observation, 'NOT_OBSERVED', 'CONTRADICTED must never be silently converted into a false positive');

--- a/scripts/qa-sfi-genai-telemetry.ts
+++ b/scripts/qa-sfi-genai-telemetry.ts
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import {
+  SFI_GENAI_TELEMETRY_CONTRACT,
+  compactObservedGenAiTelemetry,
+  mapGenAiTelemetryToOpenTelemetry,
+  normalizeObservedGenAiTelemetry,
+} from '../src/lib/sfi/cognitive-runtime/genAiTelemetry';
+import {
+  SFI_GENAI_ASSURANCE_CONTRACT,
+  deriveGenAiAssuranceMetrics,
+} from '../src/lib/sfi/cognitive-runtime/genAiAssurance';
+import { projectExecutionRecordFromEvent } from '../src/lib/sfi/cognitive-runtime/executionRecords';
+
+const openai = normalizeObservedGenAiTelemetry({
+  ok: true,
+  provider: 'openai',
+  model: 'gpt-observed',
+  usage: { prompt_tokens: 120, completion_tokens: 30, total_cost_usd: 0.0042 },
+  latencyMs: 840,
+});
+assert.equal(openai.contractVersion, SFI_GENAI_TELEMETRY_CONTRACT);
+assert.deepEqual(openai.provider, { value: 'openai', observation: 'OBSERVED' });
+assert.deepEqual(openai.inputTokens, { value: 120, observation: 'OBSERVED' });
+assert.deepEqual(openai.outputTokens, { value: 30, observation: 'OBSERVED' });
+assert.deepEqual(openai.providerCost, { value: 0.0042, observation: 'OBSERVED' });
+assert.equal(openai.providerCostCurrency.observation, 'NOT_OBSERVED', 'currency must not be invented from a *_usd field');
+assert.deepEqual(openai.latencyMs, { value: 840, observation: 'OBSERVED' });
+
+const anthropic = normalizeObservedGenAiTelemetry({
+  ok: true,
+  provider: 'anthropic',
+  model: 'claude-observed',
+  usage: { input_tokens: 91, output_tokens: 17 },
+  latencyMs: 510,
+});
+assert.equal(anthropic.inputTokens.value, 91);
+assert.equal(anthropic.outputTokens.value, 17);
+assert.equal(anthropic.providerCost.observation, 'NOT_OBSERVED');
+
+const gemini = normalizeObservedGenAiTelemetry({
+  ok: true,
+  provider: 'gemini',
+  model: 'gemini-observed',
+  usage: { promptTokenCount: 88, candidatesTokenCount: 19 },
+  latencyMs: 440,
+});
+assert.equal(gemini.inputTokens.value, 88);
+assert.equal(gemini.outputTokens.value, 19);
+
+const ollama = normalizeObservedGenAiTelemetry({
+  ok: true,
+  provider: 'ollama',
+  model: 'llama-observed',
+  usage: { prompt_eval_count: 64, eval_count: 22 },
+  latencyMs: 1200,
+});
+assert.equal(ollama.inputTokens.value, 64);
+assert.equal(ollama.outputTokens.value, 22);
+
+const unavailable = normalizeObservedGenAiTelemetry({
+  ok: false,
+  provider: 'degraded',
+  model: 'unavailable',
+  usage: { prompt_tokens: 999, completion_tokens: 999, cost: 999 },
+  latencyMs: 5,
+});
+assert.equal(unavailable.provider.observation, 'NOT_OBSERVED');
+assert.equal(unavailable.model.observation, 'NOT_OBSERVED');
+assert.equal(unavailable.inputTokens.observation, 'NOT_OBSERVED');
+assert.equal(unavailable.providerCost.observation, 'NOT_OBSERVED');
+assert.equal(unavailable.latencyMs.observation, 'NOT_OBSERVED', 'failed routing duration must not masquerade as observed provider latency');
+
+const compact = compactObservedGenAiTelemetry(openai);
+assert.equal(compact.telemetryContractVersion, SFI_GENAI_TELEMETRY_CONTRACT);
+assert.equal(compact.observedInputTokens, 120);
+assert.equal(compact.observedProviderCost, 0.0042);
+
+const otel = mapGenAiTelemetryToOpenTelemetry(openai);
+assert.equal(otel.mappingAuthority, 'INTEROPERABILITY_ONLY');
+assert.equal(otel.contentCaptured, false);
+assert.equal(otel.attributes['gen_ai.provider.name'], 'openai');
+assert.equal(otel.attributes['gen_ai.response.model'], 'gpt-observed');
+assert.equal(otel.attributes['gen_ai.usage.input_tokens'], 120);
+assert.equal(otel.attributes['gen_ai.usage.output_tokens'], 30);
+assert.deepEqual(otel.metrics['gen_ai.client.operation.duration'], { value: 0.84, unit: 's' });
+assert.ok(!Object.keys(otel.attributes).some((key) => /prompt|input\.messages|output\.messages|content/i.test(key)), 'OTel interoperability mapping must not emit prompt/output content');
+
+const execution = projectExecutionRecordFromEvent({
+  event_id: 'evt-m5-observed',
+  event_name: 'SFI_AGENT_EXECUTED',
+  occurred_at: '2026-09-03T01:00:00.000Z',
+  source: { sourceId: 'risk_agent', sourceType: 'runtime' },
+  payload: {
+    executionId: 'RUN-M5-OBSERVED',
+    llmProvider: 'openai',
+    llmModel: 'gpt-observed',
+    aiGovernance: { disposition: 'ALLOW_ANALYSIS_ONLY', risk: 'LOW', reasons: [] },
+    metadata: {
+      agentInsight: {
+        epistemicClass: 'INFERENCE',
+        status: 'COMPLETE',
+        summary: 'Bounded observed telemetry test.',
+        observations: [], hypotheses: [], contradictions: [], missingEvidence: ['external outcome pending'], recommendations: [],
+        confidence: 0.6,
+        generatedAt: '2026-09-03T01:00:01.000Z',
+      },
+      llmRuntime: {
+        telemetryContractVersion: SFI_GENAI_TELEMETRY_CONTRACT,
+        observedProvider: 'openai',
+        observedModel: 'gpt-observed',
+        observedInputTokens: 120,
+        observedOutputTokens: 30,
+        observedProviderCost: 0.0042,
+        observedLatencyMs: 840,
+      },
+    },
+  },
+});
+assert.ok(execution);
+assert.equal(execution.telemetry.inputTokens.observation, 'OBSERVED');
+assert.equal(execution.telemetry.inputTokens.value, 120);
+assert.equal(execution.telemetry.outputTokens.value, 30);
+assert.equal(execution.telemetry.providerCost.value, 0.0042);
+assert.equal(execution.telemetry.latencyMs.value, 840);
+
+const contrast = {
+  event_id: 'evt-return-contrast-m5',
+  event_name: 'SFI_UNIVERSAL_RETURN_CONTRASTED',
+  epistemic_class: 'derived',
+  payload: {
+    calibrationStatus: 'CONTRAST_RECORDED',
+    classification: 'CONTRADICTED',
+    classificationConfidence: 0.81,
+    returnTraceability: 'VERIFIED_EVIDENCE_LINKED',
+  },
+};
+const assuranceWithoutFalsePositive = deriveGenAiAssuranceMetrics([execution], [contrast], { agentId: 'risk_agent' });
+assert.equal(assuranceWithoutFalsePositive.contractVersion, SFI_GENAI_ASSURANCE_CONTRACT);
+assert.equal(assuranceWithoutFalsePositive.telemetryCoverage.provider.value, 1);
+assert.equal(assuranceWithoutFalsePositive.telemetryCoverage.inputTokens.value, 1);
+assert.equal(assuranceWithoutFalsePositive.quality.structuredInferenceCompletionRate.value, 1);
+assert.equal(assuranceWithoutFalsePositive.evidenceSufficiency.partial, 1);
+assert.equal(assuranceWithoutFalsePositive.returnCalibration.calibratedContrasts, 1);
+assert.equal(assuranceWithoutFalsePositive.returnCalibration.contradicted, 1);
+assert.equal(assuranceWithoutFalsePositive.falsePositive.rate.observation, 'NOT_OBSERVED', 'CONTRADICTED must never be silently converted into a false positive');
+assert.equal(assuranceWithoutFalsePositive.boundaries.returnCalibrationAutomaticallyAttributedToAgent, false);
+
+const assuranceWithExplicitFalsePositive = deriveGenAiAssuranceMetrics([execution], [
+  contrast,
+  { event_name: 'SFI_EXPLICIT_QUALITY_OBSERVATION', epistemic_class: 'observed', payload: { falsePositive: true } },
+  { event_name: 'SFI_EXPLICIT_QUALITY_OBSERVATION', epistemic_class: 'observed', payload: { falsePositive: false } },
+]);
+assert.equal(assuranceWithExplicitFalsePositive.falsePositive.rate.observation, 'OBSERVED');
+assert.equal(assuranceWithExplicitFalsePositive.falsePositive.rate.value, 0.5);
+assert.equal(assuranceWithExplicitFalsePositive.falsePositive.observations, 2);
+
+const telemetrySource = readFileSync('src/lib/sfi/cognitive-runtime/genAiTelemetry.ts', 'utf8');
+const assuranceSource = readFileSync('src/lib/sfi/cognitive-runtime/genAiAssurance.ts', 'utf8');
+const agentClient = readFileSync('src/infrastructure/ai/agentLlmClient.ts', 'utf8');
+const runtimeWriter = readFileSync('src/lib/sfi/cognitive-runtime/runtimeAgentExecutor.ts', 'utf8');
+const recordsRoute = readFileSync('src/app/api/root/cognitive-runtime/records/route.ts', 'utf8');
+
+assert.match(agentClient, /normalizeObservedGenAiTelemetry/);
+assert.match(agentClient, /result\.usage/);
+assert.match(agentClient, /result\.latency_ms/);
+assert.doesNotMatch(agentClient, /observedInputTokens:\s*null/);
+assert.doesNotMatch(agentClient, /observedOutputTokens:\s*null/);
+assert.doesNotMatch(agentClient, /observedProviderCost:\s*null/);
+assert.match(runtimeWriter, /recordAgentExecutionEvent/);
+assert.match(runtimeWriter, /llmRuntime:\s*metadata\.llmRuntime/);
+assert.match(recordsRoute, /readGenAiAssuranceMetrics/);
+assert.match(recordsRoute, /telemetryIsEvidence:\s*false/);
+assert.match(recordsRoute, /openTelemetryIsTruthAuthority:\s*false/);
+assert.doesNotMatch(telemetrySource + assuranceSource, /create table|usage_ledger|appendEpistemicEvent|recordAgentExecutionEvent/i, 'M5 must not create a second telemetry ledger or writer');
+
+console.log(JSON.stringify({
+  ok: true,
+  telemetryContract: SFI_GENAI_TELEMETRY_CONTRACT,
+  assuranceContract: SFI_GENAI_ASSURANCE_CONTRACT,
+  observedTokensNormalized: true,
+  providerCostEstimated: false,
+  failedRouteLatencyPromotedToProviderLatency: false,
+  openTelemetryAuthority: 'INTEROPERABILITY_ONLY',
+  promptOutputContentCaptured: false,
+  falsePositiveWithoutExplicitObservation: 'NOT_OBSERVED',
+  returnCalibrationDerivedFromObservedContrast: true,
+  duplicateTelemetryLedgerCreated: false,
+}, null, 2));

--- a/src/app/api/root/cognitive-runtime/records/route.ts
+++ b/src/app/api/root/cognitive-runtime/records/route.ts
@@ -9,6 +9,7 @@ import {
   readAgentExecutionStates,
   readExecutionRecords,
 } from '@/lib/sfi/cognitive-runtime/executionRecords';
+import { readGenAiAssuranceMetrics } from '@/lib/sfi/cognitive-runtime/genAiAssurance';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -57,9 +58,10 @@ export async function GET(request: Request) {
   const contract = executionContractForAgent(agentId);
   if (!contract) return NextResponse.json({ ok: false, error: 'execution_contract_not_found' }, { status: 409 });
 
-  const [stateRead, history] = await Promise.all([
+  const [stateRead, history, assurance] = await Promise.all([
     readAgentExecutionStates(),
     readExecutionRecords({ agentId, executionId: executionId ?? undefined, limit }),
+    readGenAiAssuranceMetrics({ agentId, limit }),
   ]);
   const state = stateRead.states.find((item) => item.agentId === agentId) ?? null;
 
@@ -76,12 +78,22 @@ export async function GET(request: Request) {
       exhaustive: history.exhaustive,
       warnings: history.warnings,
     },
+    assurance: assurance.metrics,
+    assuranceRead: {
+      generatedAt: assurance.generatedAt,
+      source: assurance.source,
+      readLimit: assurance.readLimit,
+      exhaustive: assurance.exhaustive,
+      warnings: assurance.warnings,
+    },
     boundary: {
       auditUnit: 'EXECUTION',
       contextIsEvidence: false,
       inferenceIsObservation: false,
       authorityExpandedByModel: false,
       historyAbsenceMeansNonExistence: false,
+      telemetryIsEvidence: false,
+      openTelemetryIsTruthAuthority: false,
     } satisfies Row,
   }, { headers: { 'Cache-Control': 'no-store' } });
 }

--- a/src/infrastructure/ai/agentLlmClient.ts
+++ b/src/infrastructure/ai/agentLlmClient.ts
@@ -6,6 +6,11 @@ import type { StudioTwinContext } from '@/core/cognitive-twin/studioContext';
 import { readStudioTwinContext } from '@/core/cognitive-twin/studioContext';
 import { SFI_CONVERGED_COGNITIVE_AGENT_REGISTRY } from '@/lib/sfi/cognitive-runtime/convergedRegistry';
 import { executionContractForAgent } from '@/lib/sfi/cognitive-runtime/executionContracts';
+import {
+  compactObservedGenAiTelemetry,
+  mapGenAiTelemetryToOpenTelemetry,
+  normalizeObservedGenAiTelemetry,
+} from '@/lib/sfi/cognitive-runtime/genAiTelemetry';
 import type { KernelContext } from '@/lib/sfi/cognitive-runtime/kernelContext';
 
 type AgentInsight = {
@@ -280,6 +285,14 @@ export async function augmentAgentWithLlm(agentId: string, context: KernelContex
     requirements,
     maxTokens: MAX_AGENT_OUTPUT_TOKENS,
   });
+  const telemetry = normalizeObservedGenAiTelemetry({
+    ok: result.ok,
+    provider: result.provider,
+    model: result.model,
+    usage: result.usage,
+    latencyMs: result.latency_ms,
+  });
+  const telemetryOpenTelemetry = mapGenAiTelemetryToOpenTelemetry(telemetry);
   const parsed = result.ok ? parseInsight(result.result) : null;
   const generatedAt = new Date().toISOString();
   const insight: AgentInsight = parsed
@@ -347,9 +360,8 @@ export async function augmentAgentWithLlm(agentId: string, context: KernelContex
       promptProjection: `AGENT_SPECIFIC:${agentId}`,
       maxPromptCharacters: MAX_PROMPT_CHARS,
       maxOutputTokens: MAX_AGENT_OUTPUT_TOKENS,
-      observedInputTokens: null,
-      observedOutputTokens: null,
-      observedProviderCost: null,
+      ...compactObservedGenAiTelemetry(telemetry),
+      telemetryOpenTelemetry,
       updatedAt: generatedAt,
     },
   };

--- a/src/lib/sfi/cognitive-runtime/genAiAssurance.ts
+++ b/src/lib/sfi/cognitive-runtime/genAiAssurance.ts
@@ -1,0 +1,189 @@
+import {
+  deriveExecutionEpistemicState,
+  readExecutionRecords,
+  type SfiExecutionRecord,
+} from './executionRecords';
+
+export const SFI_GENAI_ASSURANCE_CONTRACT = 'SFI-GENAI-ASSURANCE-1.0' as const;
+
+type Row = Record<string, unknown>;
+type Observation<T> = { value: T | null; observation: 'OBSERVED' | 'NOT_OBSERVED' };
+
+type RatioMetric = Observation<number> & {
+  numerator: number;
+  denominator: number;
+};
+
+function row(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown, max = 160): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim().slice(0, max) : null;
+}
+
+function ratio(numerator: number, denominator: number): RatioMetric {
+  return denominator > 0
+    ? { value: numerator / denominator, observation: 'OBSERVED', numerator, denominator }
+    : { value: null, observation: 'NOT_OBSERVED', numerator, denominator };
+}
+
+function observedNumber(value: number | null): Observation<number> {
+  return value === null ? { value: null, observation: 'NOT_OBSERVED' } : { value, observation: 'OBSERVED' };
+}
+
+function eventName(value: unknown) {
+  const source = row(value);
+  return text(source.event_name ?? source.eventName, 160);
+}
+
+function eventPayload(value: unknown) {
+  return row(row(value).payload);
+}
+
+function isGenAiExecution(record: SfiExecutionRecord) {
+  return record.telemetry.provider.observation === 'OBSERVED'
+    || record.interpretation.epistemicClass === 'INFERENCE'
+    || Boolean(record.errors.llm);
+}
+
+function telemetryCoverage(records: SfiExecutionRecord[]) {
+  const eligible = records.filter(isGenAiExecution);
+  const countObserved = (selector: (record: SfiExecutionRecord) => { observation: 'OBSERVED' | 'NOT_OBSERVED' }) =>
+    eligible.filter((record) => selector(record).observation === 'OBSERVED').length;
+  return {
+    eligibleExecutions: eligible.length,
+    provider: ratio(countObserved((record) => record.telemetry.provider), eligible.length),
+    model: ratio(countObserved((record) => record.telemetry.model), eligible.length),
+    inputTokens: ratio(countObserved((record) => record.telemetry.inputTokens), eligible.length),
+    outputTokens: ratio(countObserved((record) => record.telemetry.outputTokens), eligible.length),
+    providerCost: ratio(countObserved((record) => record.telemetry.providerCost), eligible.length),
+    latencyMs: ratio(countObserved((record) => record.telemetry.latencyMs), eligible.length),
+  };
+}
+
+function structuredInferenceQuality(records: SfiExecutionRecord[]) {
+  const observed = records.filter((record) => record.interpretation.epistemicClass === 'INFERENCE');
+  const complete = observed.filter((record) => record.interpretation.status === 'COMPLETE').length;
+  const failedOrDegraded = observed.filter((record) => ['FAILED', 'DEGRADED'].includes(record.interpretation.status ?? '')).length;
+  return {
+    observedInferenceExecutions: observed.length,
+    complete,
+    failedOrDegraded,
+    structuredInferenceCompletionRate: ratio(complete, observed.length),
+    boundary: 'RUNTIME_SCHEMA_COMPLETION_NOT_SEMANTIC_TRUTH_OR_MODEL_ACCURACY' as const,
+  };
+}
+
+function evidenceSufficiency(records: SfiExecutionRecord[]) {
+  const inferenceRecords = records.filter((record) => record.interpretation.epistemicClass === 'INFERENCE');
+  const states = inferenceRecords.map(deriveExecutionEpistemicState);
+  const sufficient = states.filter((state) => state === 'SUFFICIENT').length;
+  const partial = states.filter((state) => state === 'PARTIAL').length;
+  const insufficient = states.filter((state) => state === 'INSUFFICIENT').length;
+  const contradicted = states.filter((state) => state === 'CONTRADICTED').length;
+  const notObserved = states.filter((state) => state === 'NOT_OBSERVED').length;
+  const epistemicallyObserved = sufficient + partial + insufficient + contradicted;
+  return {
+    inferenceExecutions: inferenceRecords.length,
+    sufficient,
+    partial,
+    insufficient,
+    contradicted,
+    notObserved,
+    sufficientRate: ratio(sufficient, epistemicallyObserved),
+    boundedOrMissingEvidenceRate: ratio(partial + insufficient, epistemicallyObserved),
+    boundary: 'SUFFICIENCY_IS_DERIVED_ONLY_WHEN_THE_EXECUTION_RECORD_SUPPORTS_IT_NOT_FROM_MODEL_CONFIDENCE' as const,
+  };
+}
+
+function returnCalibration(events: unknown[]) {
+  const contrasts = events.filter((event) => eventName(event) === 'SFI_UNIVERSAL_RETURN_CONTRASTED');
+  const calibrated = contrasts.filter((event) => text(eventPayload(event).calibrationStatus, 80) === 'CONTRAST_RECORDED');
+  const classifications = calibrated.map((event) => text(eventPayload(event).classification, 80)).filter(Boolean);
+  const count = (classification: string) => classifications.filter((value) => value === classification).length;
+  return {
+    observedContrasts: contrasts.length,
+    calibratedContrasts: calibrated.length,
+    calibrationCompletionRate: ratio(calibrated.length, contrasts.length),
+    confirmed: count('CONFIRMED'),
+    partial: count('PARTIAL'),
+    contradicted: count('CONTRADICTED'),
+    inconclusive: count('INCONCLUSIVE'),
+    classificationConfidenceMean: observedNumber((() => {
+      const values = calibrated
+        .map((event) => Number(eventPayload(event).classificationConfidence))
+        .filter((value) => Number.isFinite(value) && value >= 0 && value <= 1);
+      return values.length ? values.reduce((sum, value) => sum + value, 0) / values.length : null;
+    })()),
+    attribution: 'GLOBAL_UNATTRIBUTED_UNLESS_EXPLICIT_EXECUTION_LINEAGE_EXISTS' as const,
+    boundary: 'RETURN_CONTRAST_IS_CALIBRATION_AGAINST_VERIFIED_OBSERVED_RETURN_NOT_CANON_OR_TRUTH_PROBABILITY' as const,
+  };
+}
+
+function falsePositiveMetric(events: unknown[]) {
+  const explicit = events.flatMap((event) => {
+    const payload = eventPayload(event);
+    return typeof payload.falsePositive === 'boolean' ? [payload.falsePositive] : [];
+  });
+  if (!explicit.length) {
+    return {
+      observations: 0,
+      falsePositives: 0,
+      rate: ratio(0, 0),
+      boundary: 'FALSE_POSITIVE_REMAINS_NOT_OBSERVED_WITHOUT_AN_EXPLICIT_PERSISTED_BOOLEAN' as const,
+    };
+  }
+  const falsePositives = explicit.filter(Boolean).length;
+  return {
+    observations: explicit.length,
+    falsePositives,
+    rate: ratio(falsePositives, explicit.length),
+    boundary: 'FALSE_POSITIVE_IS_NEVER_INFERRED_FROM_CONTRADICTED_OR_FAILED_EXECUTIONS' as const,
+  };
+}
+
+export function deriveGenAiAssuranceMetrics(records: SfiExecutionRecord[], events: unknown[], input?: { agentId?: string | null }) {
+  return {
+    contractVersion: SFI_GENAI_ASSURANCE_CONTRACT,
+    scope: {
+      agentId: input?.agentId ?? null,
+      executionRecords: records.length,
+      eventWindow: events.length,
+      exhaustive: false,
+    },
+    telemetryCoverage: telemetryCoverage(records),
+    quality: structuredInferenceQuality(records),
+    evidenceSufficiency: evidenceSufficiency(records),
+    returnCalibration: returnCalibration(events),
+    falsePositive: falsePositiveMetric(events),
+    boundaries: {
+      boundedReadAbsenceMeansNonExistence: false,
+      telemetryIsEvidence: false,
+      modelConfidenceIsTruthProbability: false,
+      returnCalibrationAutomaticallyAttributedToAgent: false,
+      openTelemetryIsTruthAuthority: false,
+    },
+  };
+}
+
+export async function readGenAiAssuranceMetrics(input?: { agentId?: string; limit?: number }) {
+  const { streamRecentEpistemicEvents } = await import('@/lib/events/eventStore');
+  const limit = Math.max(1, Math.min(500, input?.limit ?? 200));
+  const [executionRead, eventRead] = await Promise.all([
+    readExecutionRecords({ agentId: input?.agentId, limit }),
+    streamRecentEpistemicEvents(limit),
+  ]);
+  return {
+    generatedAt: new Date().toISOString(),
+    source: 'epistemic_events',
+    readLimit: limit,
+    exhaustive: false as const,
+    warnings: [
+      ...executionRead.warnings,
+      ...('warnings' in eventRead && Array.isArray(eventRead.warnings) ? eventRead.warnings.map(String) : []),
+      'Assurance metrics are bounded projections over canonical observed records; absence outside the window is not proof of non-existence.',
+    ],
+    metrics: deriveGenAiAssuranceMetrics(executionRead.records, eventRead.data ?? [], { agentId: input?.agentId ?? null }),
+  };
+}

--- a/src/lib/sfi/cognitive-runtime/genAiTelemetry.ts
+++ b/src/lib/sfi/cognitive-runtime/genAiTelemetry.ts
@@ -1,0 +1,169 @@
+export const SFI_GENAI_TELEMETRY_CONTRACT = 'SFI-GENAI-TELEMETRY-1.0' as const;
+
+export type SfiGenAiProvider = 'openai' | 'anthropic' | 'gemini' | 'groq' | 'ollama' | 'huggingface';
+export type SfiObservedValue<T> = { value: T | null; observation: 'OBSERVED' | 'NOT_OBSERVED' };
+
+type Row = Record<string, unknown>;
+
+export type SfiGenAiTelemetry = {
+  contractVersion: typeof SFI_GENAI_TELEMETRY_CONTRACT;
+  provider: SfiObservedValue<SfiGenAiProvider>;
+  model: SfiObservedValue<string>;
+  inputTokens: SfiObservedValue<number>;
+  outputTokens: SfiObservedValue<number>;
+  providerCost: SfiObservedValue<number>;
+  providerCostCurrency: SfiObservedValue<string>;
+  latencyMs: SfiObservedValue<number>;
+  usageSourceFields: string[];
+  boundary: 'PROVIDER_OR_RUNTIME_OBSERVATION_ONLY_NO_ESTIMATION';
+};
+
+export type SfiGenAiOtelInterop = {
+  contractVersion: typeof SFI_GENAI_TELEMETRY_CONTRACT;
+  mappingAuthority: 'INTEROPERABILITY_ONLY';
+  attributes: Record<string, string | number>;
+  metrics: {
+    'gen_ai.client.operation.duration'?: { value: number; unit: 's' };
+  };
+  contentCaptured: false;
+  boundary: 'OTEL_MAPPING_IS_NOT_SFI_EVIDENCE_OR_TRUTH_AUTHORITY';
+};
+
+function row(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function finiteNonNegative(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function positiveInteger(value: unknown): number | null {
+  const parsed = finiteNonNegative(value);
+  return parsed !== null && Number.isInteger(parsed) ? parsed : null;
+}
+
+function text(value: unknown, max = 120): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim().slice(0, max) : null;
+}
+
+function observed<T>(value: T | null): SfiObservedValue<T> {
+  return value === null ? { value: null, observation: 'NOT_OBSERVED' } : { value, observation: 'OBSERVED' };
+}
+
+function firstNumber(source: Row, keys: string[], sourceFields: Set<string>, integer = false) {
+  for (const key of keys) {
+    const parsed = integer ? positiveInteger(source[key]) : finiteNonNegative(source[key]);
+    if (parsed !== null) {
+      sourceFields.add(key);
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function providerUsageTokens(provider: SfiGenAiProvider, usage: Row, sourceFields: Set<string>) {
+  if (provider === 'gemini') {
+    return {
+      input: firstNumber(usage, ['promptTokenCount'], sourceFields, true),
+      output: firstNumber(usage, ['candidatesTokenCount'], sourceFields, true),
+    };
+  }
+  if (provider === 'ollama') {
+    return {
+      input: firstNumber(usage, ['prompt_eval_count'], sourceFields, true),
+      output: firstNumber(usage, ['eval_count'], sourceFields, true),
+    };
+  }
+  if (provider === 'anthropic') {
+    return {
+      input: firstNumber(usage, ['input_tokens'], sourceFields, true),
+      output: firstNumber(usage, ['output_tokens'], sourceFields, true),
+    };
+  }
+  return {
+    input: firstNumber(usage, ['prompt_tokens', 'input_tokens'], sourceFields, true),
+    output: firstNumber(usage, ['completion_tokens', 'output_tokens'], sourceFields, true),
+  };
+}
+
+function providerCost(usage: Row, sourceFields: Set<string>) {
+  return firstNumber(usage, ['cost', 'total_cost', 'cost_usd', 'total_cost_usd'], sourceFields, false);
+}
+
+function providerCurrency(usage: Row, sourceFields: Set<string>) {
+  const direct = text(usage.currency, 16) ?? text(usage.cost_currency, 16);
+  if (direct) {
+    sourceFields.add(text(usage.currency, 16) ? 'currency' : 'cost_currency');
+    return direct.toUpperCase();
+  }
+  return null;
+}
+
+export function normalizeObservedGenAiTelemetry(input: {
+  ok: boolean;
+  provider: string;
+  model: string;
+  usage: unknown;
+  latencyMs: unknown;
+}): SfiGenAiTelemetry {
+  const provider = input.ok && ['openai', 'anthropic', 'gemini', 'groq', 'ollama', 'huggingface'].includes(input.provider)
+    ? input.provider as SfiGenAiProvider
+    : null;
+  const model = input.ok ? text(input.model, 500) : null;
+  const usage = input.ok ? row(input.usage) : {};
+  const sourceFields = new Set<string>();
+  const tokens = provider ? providerUsageTokens(provider, usage, sourceFields) : { input: null, output: null };
+  const cost = provider ? providerCost(usage, sourceFields) : null;
+  const currency = cost !== null ? providerCurrency(usage, sourceFields) : null;
+  const latency = input.ok ? finiteNonNegative(input.latencyMs) : null;
+
+  return {
+    contractVersion: SFI_GENAI_TELEMETRY_CONTRACT,
+    provider: observed(provider),
+    model: observed(model),
+    inputTokens: observed(tokens.input),
+    outputTokens: observed(tokens.output),
+    providerCost: observed(cost),
+    providerCostCurrency: observed(currency),
+    latencyMs: observed(latency),
+    usageSourceFields: [...sourceFields],
+    boundary: 'PROVIDER_OR_RUNTIME_OBSERVATION_ONLY_NO_ESTIMATION',
+  };
+}
+
+export function compactObservedGenAiTelemetry(telemetry: SfiGenAiTelemetry) {
+  return {
+    telemetryContractVersion: telemetry.contractVersion,
+    observedProvider: telemetry.provider.value,
+    observedModel: telemetry.model.value,
+    observedInputTokens: telemetry.inputTokens.value,
+    observedOutputTokens: telemetry.outputTokens.value,
+    observedProviderCost: telemetry.providerCost.value,
+    observedProviderCostCurrency: telemetry.providerCostCurrency.value,
+    observedLatencyMs: telemetry.latencyMs.value,
+    usageSourceFields: telemetry.usageSourceFields,
+    telemetryBoundary: telemetry.boundary,
+  };
+}
+
+export function mapGenAiTelemetryToOpenTelemetry(telemetry: SfiGenAiTelemetry): SfiGenAiOtelInterop {
+  const attributes: Record<string, string | number> = {};
+  if (telemetry.provider.observation === 'OBSERVED' && telemetry.provider.value) attributes['gen_ai.provider.name'] = telemetry.provider.value;
+  if (telemetry.model.observation === 'OBSERVED' && telemetry.model.value) attributes['gen_ai.response.model'] = telemetry.model.value;
+  if (telemetry.inputTokens.observation === 'OBSERVED' && telemetry.inputTokens.value !== null) attributes['gen_ai.usage.input_tokens'] = telemetry.inputTokens.value;
+  if (telemetry.outputTokens.observation === 'OBSERVED' && telemetry.outputTokens.value !== null) attributes['gen_ai.usage.output_tokens'] = telemetry.outputTokens.value;
+  const metrics: SfiGenAiOtelInterop['metrics'] = {};
+  if (telemetry.latencyMs.observation === 'OBSERVED' && telemetry.latencyMs.value !== null) {
+    metrics['gen_ai.client.operation.duration'] = { value: telemetry.latencyMs.value / 1000, unit: 's' };
+  }
+  return {
+    contractVersion: telemetry.contractVersion,
+    mappingAuthority: 'INTEROPERABILITY_ONLY',
+    attributes,
+    metrics,
+    contentCaptured: false,
+    boundary: 'OTEL_MAPPING_IS_NOT_SFI_EVIDENCE_OR_TRUTH_AUTHORITY',
+  };
+}


### PR DESCRIPTION
## M5 — GenAI telemetry + assurance

### SFI PRECHECK
Owner: existing `src/lib/ai/providerRouter.ts` provider result plus the canonical cognitive-runtime execution-record projection and existing universal RETURN contrast plane.

Existing capability: the provider router already returns the actually selected provider/model, raw provider `usage` and measured runtime latency; the execution record already contains observed telemetry slots; `SFI_UNIVERSAL_RETURN_CONTRASTED` already carries evidence-verified calibration.

Existing capability inspected: `src/lib/ai/providerRouter.ts`, `src/infrastructure/ai/agentLlmClient.ts`, `src/lib/sfi/cognitive-runtime/executionRecords.ts`, `src/lib/sfi/cognitive-runtime/runtimeAgentExecutor.ts`, the existing Root execution-record route, and `src/lib/sfi/universalEmpiricalContinuation.ts`.

Absorb vs create decision: normalize those existing observations into the current execution metadata/read plane. No second telemetry ledger, provider router, execution table, event writer, dashboard or truth store is created.

Authoritative writer: unchanged — `recordAgentExecutionEvent → persistSFIEvent → appendEpistemicEvent → epistemic_events`; the existing universal RETURN/contrast writer is also unchanged.

Persistence/lineage impact: compact normalized telemetry is added only when the runtime/provider actually observed it. Existing events are not rewritten. Provider cost is accepted only when explicitly returned; token counts and cost are never estimated.

Front delta: NONE. Existing Root execution dossier receives the bounded assurance projection through its current read route; no new surface is introduced.

Back delta: stable internal `SFI-GENAI-TELEMETRY-1.0` normalization, provider-specific usage mapping, an OpenTelemetry interoperability adapter, and bounded assurance metrics for runtime quality, evidence sufficiency, explicit false-positive observations and RETURN calibration.

DB delta: NONE.

Redundancy removed: the agent LLM client no longer discards already-observed provider usage/latency and no longer hardcodes token/cost telemetry to null when the provider did report it. The existing router and event plane remain owners.

Epistemic boundary: provider/model/tokens/latency/cost become `OBSERVED` only from an actual successful runtime/provider result. Missing values remain `NOT_OBSERVED`. `CONTRADICTED` is never silently converted into a false positive. OpenTelemetry mapping is interoperability only, emits no prompt/output content, and is not SFI evidence or truth authority.

Execution/ROOT boundary: telemetry and assurance add observability only. They create no execution, intervention, RETURN, learning, canon or external-action authority.

Rollback: revert this PR; the canonical execution writer, event history, RETURN calibration events and provider router remain intact.

Verification: `scripts/qa-sfi-genai-telemetry.ts` plus full SFI Verify, typecheck, build and Studio audio gates must pass before merge.

### Cleanliness gate
M6 is blocked until this PR is merged into `main`, post-merge SFI Verify is green, `SFI Main-Only Convergence` deletes the M5 branch, branch inventory is exactly `[main]`, and there are zero open PRs.

Implements M5 of #347.