### PR TITLE
fix(auth): make session state stable and access contract explicit

### DIFF
--- a/src/app/auth-unavailable/page.tsx
+++ b/src/app/auth-unavailable/page.tsx
@@ -1,0 +1,29 @@
+function safeInternalPath(value: unknown) {
+  if (typeof value !== 'string' || !value.startsWith('/') || value.startsWith('//')) return '/entry';
+  if (value.startsWith('/login') || value.startsWith('/auth-unavailable')) return '/entry';
+  return value;
+}
+
+export default async function AuthUnavailablePage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const next = safeInternalPath(Array.isArray(params.next) ? params.next[0] : params.next);
+
+  return (
+    <main className="login">
+      <section>
+        <div className="sigil">SFI.</div>
+        <h1>Verificación temporalmente indisponible</h1>
+        <p>
+          SFI no ha clasificado tu sesión como cerrada ni tu cuenta como no autorizada. El servicio de verificación no respondió a tiempo.
+        </p>
+        <p>No vuelvas a introducir tu contraseña por este mensaje. Reintenta la superficie cuando el servicio responda.</p>
+        <p><a href={next}>REINTENTAR</a></p>
+        <p><a href="/field">ABRIR FIELD PÚBLICO</a></p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/entry/page.tsx
+++ b/src/app/entry/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from 'next/navigation';
 import { getServerUserContext } from '@/lib/server/productionBackend';
 
+// Single bounded post-login resolver. It decides a destination from verified
+// access context; it does not create, persist or elevate institutional authority.
 function safeInternalPath(value: unknown) {
   if (typeof value !== 'string' || !value.startsWith('/') || value.startsWith('//')) return null;
   if (value.startsWith('/login') || value.startsWith('/entry') || value.startsWith('/auth-unavailable')) return null;

--- a/src/app/entry/page.tsx
+++ b/src/app/entry/page.tsx
@@ -1,0 +1,32 @@
+import { redirect } from 'next/navigation';
+import { getServerUserContext } from '@/lib/server/productionBackend';
+
+function safeInternalPath(value: unknown) {
+  if (typeof value !== 'string' || !value.startsWith('/') || value.startsWith('//')) return null;
+  if (value.startsWith('/login') || value.startsWith('/entry') || value.startsWith('/auth-unavailable')) return null;
+  return value;
+}
+
+export default async function EntryPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const requested = safeInternalPath(Array.isArray(params.next) ? params.next[0] : params.next);
+  const ctx = await getServerUserContext();
+
+  if (ctx.authState === 'unavailable') {
+    const next = requested ?? '/entry';
+    redirect(`/auth-unavailable?next=${encodeURIComponent(next)}`);
+  }
+
+  if (!ctx.user) {
+    const next = requested ? `?next=${encodeURIComponent(requested)}` : '';
+    redirect(`/login${next}`);
+  }
+
+  if (requested) redirect(requested);
+  if (ctx.canObserveRoot) redirect('/root');
+  redirect('/field');
+}

--- a/src/components/sfi/LoginSurface.tsx
+++ b/src/components/sfi/LoginSurface.tsx
@@ -3,25 +3,64 @@
 import { FormEvent, useMemo, useState } from 'react';
 import { createBrowserSupabaseClient } from '@/runtime/supabase/client';
 
-function safeNextPath() {
+function requestedNextPath() {
   const candidate = new URLSearchParams(window.location.search).get('next') || '';
-  return candidate.startsWith('/') && !candidate.startsWith('//') ? candidate : '/root';
+  return candidate.startsWith('/') && !candidate.startsWith('//') ? candidate : '';
+}
+
+function postLoginPath() {
+  const next = requestedNextPath();
+  return next ? `/entry?next=${encodeURIComponent(next)}` : '/entry';
+}
+
+function readableAuthError(message: string) {
+  const normalized = message.toLowerCase();
+  if (
+    normalized.includes('timeout') ||
+    normalized.includes('deadline') ||
+    normalized.includes('temporarily unavailable') ||
+    normalized.includes('failed to fetch') ||
+    normalized.includes('context canceled')
+  ) {
+    return 'El servicio de acceso tardó demasiado. No significa que tu cuenta o contraseña sean incorrectas. Reintenta en unos segundos.';
+  }
+  if (normalized.includes('invalid login credentials')) {
+    return 'El correo o la contraseña no coinciden con una cuenta registrada.';
+  }
+  return message;
 }
 
 export function LoginSurface() {
   const sb = useMemo(() => createBrowserSupabaseClient(), []);
   const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (busy) return;
     if (!sb) return setError('Supabase no configurado');
+
+    setBusy(true);
+    setError('');
     const form = new FormData(event.currentTarget);
-    const { error: signInError } = await sb.auth.signInWithPassword({
-      email: String(form.get('email') || ''),
-      password: String(form.get('password') || ''),
-    });
-    if (signInError) setError(signInError.message);
-    else window.location.href = safeNextPath();
+
+    try {
+      const { error: signInError } = await sb.auth.signInWithPassword({
+        email: String(form.get('email') || ''),
+        password: String(form.get('password') || ''),
+      });
+
+      if (signInError) {
+        setError(readableAuthError(signInError.message));
+        setBusy(false);
+        return;
+      }
+
+      window.location.href = postLoginPath();
+    } catch (cause) {
+      setError(readableAuthError(cause instanceof Error ? cause.message : 'No fue posible verificar el acceso.'));
+      setBusy(false);
+    }
   };
 
   return (
@@ -29,11 +68,15 @@ export function LoginSurface() {
       <form onSubmit={submit}>
         <div className="sigil">SFI.</div>
         <h1>Acceso al instituto</h1>
-        <p>Observación, evidencia, decisión y retorno.</p>
-        <input name="email" type="email" placeholder="correo" required />
-        <input name="password" type="password" placeholder="contraseña" required />
-        <button>ENTRAR</button>
+        <p>Acceso institucional mediante correo y contraseña. Esta superficie no usa Google, Apple ni otro inicio de sesión social.</p>
+        <input name="email" type="email" placeholder="correo" autoComplete="username" required />
+        <input name="password" type="password" placeholder="contraseña" autoComplete="current-password" required />
+        <button disabled={busy}>{busy ? 'VERIFICANDO…' : 'ENTRAR'}</button>
         {error && <small>{error}</small>}
+        <small>
+          Juan Antonio Marín Liera · Founder — acceso ROOT soberano. Edwing Peredo Guadarrama · Director de Dominio — SFI Studio — acceso institucional a Studio y observación ROOT; las acciones soberanas permanecen reservadas al Founder.
+        </small>
+        <small><a href="/field">FIELD es público y no requiere iniciar sesión.</a></small>
       </form>
     </main>
   );

--- a/src/lib/auth/actions.ts
+++ b/src/lib/auth/actions.ts
@@ -10,10 +10,15 @@ function formValue(formData: FormData, key: string) {
 }
 
 function safeInternalRedirect(value: string) {
-  if (!value) return '/field'
-  if (!value.startsWith('/')) return '/field'
-  if (value.startsWith('//')) return '/field'
-  if (value.startsWith('/login') || value.startsWith('/signup') || value.startsWith('/verify')) return '/field'
+  if (!value) return '/entry'
+  if (!value.startsWith('/')) return '/entry'
+  if (value.startsWith('//')) return '/entry'
+  if (
+    value.startsWith('/login') ||
+    value.startsWith('/signup') ||
+    value.startsWith('/verify') ||
+    value.startsWith('/auth-unavailable')
+  ) return '/entry'
   return value
 }
 
@@ -22,7 +27,7 @@ function record(value: unknown): Record<string, unknown> {
 }
 
 async function resolvePostLoginPath(userId: string, requestedNext: string) {
-  if (requestedNext !== '/field') return requestedNext
+  if (requestedNext !== '/entry') return requestedNext
   const service = createServiceSupabaseClient()
   const { data: profile } = await service
     .from('profiles')
@@ -31,8 +36,9 @@ async function resolvePostLoginPath(userId: string, requestedNext: string) {
     .maybeSingle()
   const role = typeof profile?.role === 'string' ? profile.role : null
   const access = record(profile?.module_access)
-  if (role === 'observer' && (access.root === true || access.root_observe === true)) return '/root'
-  return requestedNext
+  const rootObserverRole = role === 'root' || role === 'system' || role === 'observer' || role === 'controller'
+  if (rootObserverRole && (access.root === true || access.root_observe === true || access.full_access === true)) return '/root'
+  return '/field'
 }
 
 export async function registerAction(formData: FormData) {
@@ -45,7 +51,7 @@ export async function registerAction(formData: FormData) {
 
   const supabase = await createServerSupabaseClient()
   if (!supabase) redirect(`/signup?error=supabase_no_configurado&next=${encodeURIComponent(next)}`)
-  const origin = process.env.NEXT_PUBLIC_APP_URL || 'https://systemfriction.org'
+  const origin = process.env.NEXT_PUBLIC_APP_URL || 'https://www.systemfriction.org'
   const { error } = await supabase.auth.signUp({
     email: parsed.data.email,
     password: parsed.data.password,
@@ -77,7 +83,7 @@ export async function forgotPasswordAction(formData: FormData) {
   if (!limit.allowed) redirect('/forgot?error=rate_limit')
   const supabase = await createServerSupabaseClient()
   if (!supabase) redirect('/forgot?error=supabase_no_configurado')
-  const origin = process.env.NEXT_PUBLIC_APP_URL || 'https://systemfriction.org'
+  const origin = process.env.NEXT_PUBLIC_APP_URL || 'https://www.systemfriction.org'
   await supabase.auth.resetPasswordForEmail(email, { redirectTo: `${origin}/reset` })
   redirect('/forgot?state=sent')
 }
@@ -90,7 +96,7 @@ export async function resetPasswordAction(formData: FormData) {
   if (!supabase) redirect('/reset?error=supabase_no_configurado')
   const { error } = await supabase.auth.updateUser({ password })
   if (error) redirect(`/reset?error=${encodeURIComponent(error.message)}`)
-  redirect('/field')
+  redirect('/entry')
 }
 
 export async function logoutAction() {

--- a/src/lib/root/server.ts
+++ b/src/lib/root/server.ts
@@ -59,7 +59,7 @@ export async function requireRootActor(action: string) {
 export async function requireRootObserverPage(pathname: string) {
   const ctx = await getServerUserContext();
   if (ctx.authState === 'unavailable') {
-    redirect(`/login?error=auth_temporarily_unavailable&next=${encodeURIComponent(pathname)}`);
+    redirect(`/auth-unavailable?next=${encodeURIComponent(pathname)}`);
   }
   if (!ctx.user) redirect(`/login?next=${encodeURIComponent(pathname)}`);
   if (!ctx.canObserveRoot) redirect('/unauthorized');
@@ -69,7 +69,7 @@ export async function requireRootObserverPage(pathname: string) {
 export async function requireFounderPage(pathname: string) {
   const ctx = await getServerUserContext();
   if (ctx.authState === 'unavailable') {
-    redirect(`/login?error=auth_temporarily_unavailable&next=${encodeURIComponent(pathname)}`);
+    redirect(`/auth-unavailable?next=${encodeURIComponent(pathname)}`);
   }
   if (!ctx.user) redirect(`/login?next=${encodeURIComponent(pathname)}`);
   if (!ctx.isRoot) redirect('/unauthorized');

--- a/src/lib/system/access/server.ts
+++ b/src/lib/system/access/server.ts
@@ -263,7 +263,7 @@ async function readMemberWorkspaceCounts(supabase: Awaited<ReturnType<typeof cre
 function authFailureRedirect(error: AccessDeniedError, nextPath: string) {
   const encoded = encodeURIComponent(nextPath);
   if (error.status === 401) redirect(`/login?next=${encoded}`);
-  if (error.status === 503) redirect(`/login?error=auth_temporarily_unavailable&next=${encoded}`);
+  if (error.status === 503) redirect(`/auth-unavailable?next=${encoded}`);
 }
 
 export async function requireSfiMemberPage(nextPath = '/member') {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -24,10 +24,25 @@ const ROOT_INTERNAL_FRAME_PREFIXES = [
 ] as const
 
 type ModuleAccess = Record<string, unknown> | null | undefined
+type SessionIdentity = { id: string; email: string | null }
 
-function isRefreshTokenMissing(error: unknown) {
-  const message = error instanceof Error ? error.message : String(error || '')
-  return message.toLowerCase().includes('refresh token not found') || message.toLowerCase().includes('refresh_token_not_found')
+function authErrorText(error: unknown) {
+  if (error instanceof Error) return error.message
+  if (error && typeof error === 'object' && 'message' in error) {
+    return String((error as { message?: unknown }).message ?? '')
+  }
+  return String(error || '')
+}
+
+function isMissingSessionError(error: unknown) {
+  const message = authErrorText(error).toLowerCase()
+  return (
+    message.includes('auth session missing') ||
+    message.includes('session missing') ||
+    message.includes('refresh token not found') ||
+    message.includes('refresh_token_not_found') ||
+    message.includes('invalid refresh token')
+  )
 }
 
 function clearSupabaseAuthCookies(response: NextResponse, request: NextRequest) {
@@ -81,11 +96,21 @@ function isStudioRouteUser(
   return Boolean(email && allowed.includes(email.toLowerCase()))
 }
 
+function requestedPath(request: NextRequest) {
+  return `${request.nextUrl.pathname}${request.nextUrl.search}`
+}
+
 function redirectToLoginWithNext(request: NextRequest, error?: string) {
   const loginUrl = new URL('/login', request.url)
-  loginUrl.searchParams.set('next', `${request.nextUrl.pathname}${request.nextUrl.search}`)
+  loginUrl.searchParams.set('next', requestedPath(request))
   if (error) loginUrl.searchParams.set('error', error)
   return NextResponse.redirect(loginUrl)
+}
+
+function redirectToAuthUnavailable(request: NextRequest) {
+  const unavailableUrl = new URL('/auth-unavailable', request.url)
+  unavailableUrl.searchParams.set('next', requestedPath(request))
+  return NextResponse.redirect(unavailableUrl)
 }
 
 function isLocalStudioBypass(request: NextRequest) {
@@ -149,28 +174,37 @@ export async function proxy(request: NextRequest) {
     },
   })
 
-  let user = null
+  // Do not call /auth/v1/user on every protected navigation. In production that
+  // endpoint has shown intermittent 500/504 responses and long latency. getClaims()
+  // verifies the signed access token (and refreshes only when actually necessary),
+  // reducing both remote verification pressure and false logout transitions.
+  let identity: SessionIdentity | null = null
   let authUnavailable = false
   try {
-    const result = await supabase.auth.getUser()
-    user = result.data.user
-    if (result.error && isRefreshTokenMissing(result.error)) {
+    const result = await supabase.auth.getClaims()
+    const claims = result.data?.claims as Record<string, unknown> | undefined
+    const subject = typeof claims?.sub === 'string' ? claims.sub : null
+    const email = typeof claims?.email === 'string' ? claims.email : null
+
+    if (result.error && isMissingSessionError(result.error)) {
       clearSupabaseAuthCookies(response, request)
-      user = null
     } else if (result.error) {
       authUnavailable = true
+    } else if (subject) {
+      identity = { id: subject, email }
     }
   } catch (error) {
-    if (isRefreshTokenMissing(error)) {
+    if (isMissingSessionError(error)) {
       clearSupabaseAuthCookies(response, request)
-      user = null
     } else {
       authUnavailable = true
     }
   }
 
-  if (authUnavailable) return redirectToLoginWithNext(request, 'auth_temporarily_unavailable')
-  if (!user) return redirectToLoginWithNext(request)
+  // A transport/backend outage is not a logout. Never send the user to the login
+  // form for a 5xx/timeout because that makes a healthy local session look invalid.
+  if (authUnavailable) return redirectToAuthUnavailable(request)
+  if (!identity) return redirectToLoginWithNext(request)
 
   // ROOT authorization intentionally happens only in the server-side ROOT gates
   // (requireRootObserverPage / requireRootViewer / requireRootActor), which use the
@@ -180,13 +214,16 @@ export async function proxy(request: NextRequest) {
   if (pathname.startsWith('/root')) return response
 
   if (pathname.startsWith('/studio')) {
-    const { data: profile } = await supabase
+    const { data: profile, error: profileError } = await supabase
       .from('profiles')
       .select('role,module_access')
-      .eq('user_id', user.id)
+      .eq('user_id', identity.id)
       .maybeSingle()
 
-    if (!isStudioRouteUser(user.id, profile?.role, user.email, profile?.module_access as ModuleAccess)) {
+    const allowedWithoutProfile = isStudioRouteUser(identity.id, null, identity.email, null)
+    if (profileError && !allowedWithoutProfile) return redirectToAuthUnavailable(request)
+
+    if (!isStudioRouteUser(identity.id, profile?.role, identity.email, profile?.module_access as ModuleAccess)) {
       return NextResponse.redirect(new URL('/unauthorized', request.url))
     }
   }


### PR DESCRIPTION
## Problema observado en producción

Después del despliegue de `dd49838c594881ce95c9125291d5e4a06da7983a`, Supabase Auth siguió mostrando intermitencia real: `/user` produjo timeouts/504 y el flujo de refresh/password produjo fallos 500/504 transitorios antes de recuperarse. El frontend y los guards todavía convertían parte de esos fallos transitorios en navegación a `/login`, por lo que una sesión válida podía parecer cerrada durante una navegación protegida.

## SFI PRECHECK

Owner: Auth / Institutional Access boundary; ROOT policy remains owned by the existing ROOT access layer.

Existing capability inspected: `src/proxy.ts`, `src/runtime/supabase/server.ts`, `src/lib/root/server.ts`, `src/lib/system/access/server.ts`, `src/lib/server/productionBackend.ts`, `src/components/sfi/LoginSurface.tsx`, existing Supabase SSR session/cookie flow and institutional member registry.

Absorb vs create decision: absorb authentication semantics into the existing access path. Two minimal pages are added only as bounded UI states: `/entry` is the single post-login resolver and `/auth-unavailable` represents an existing 503 state that was previously misrepresented as `/login`; neither creates a new auth engine or authority plane.

Authoritative writer: unchanged. Supabase Auth remains authoritative for session credentials; `profiles`/institutional registry remain authoritative for SFI access metadata. The new surfaces write no institutional state.

Persistence/lineage impact: none. No new table, memory, event writer, cycle identity, RETURN, CONTRAST, learning or evidence lineage is introduced.

Front delta: explicit email/password login contract, disabled pending submit, deterministic `/entry`, and a separate `/auth-unavailable` UI so a backend outage is not visually represented as logout.

Back delta: protected-navigation identity verification moves from mandatory `auth.getUser()` calls to verified claims; real missing/invalid sessions still clear auth cookies and go to login, while transient verification failures go to an unavailable state. ROOT/access guards adopt the same 401/503 distinction.

DB delta: none.

Redundancy removed: contradictory post-login destinations and three independent `503 -> /login` paths are converged. The proxy no longer forces `/auth/v1/user` verification on every protected navigation.

Execution/ROOT boundary: unchanged. Juan Antonio Marín Liera retains sovereign Founder/ROOT authority. Edwing Peredo Guadarrama remains institutional controller / Director de Dominio — SFI Studio with Studio access and ROOT observation where registered; no sovereign ROOT execution, governance write or canonical promotion is granted by this change.

Rollback: revert PR #357. No persistence migration or data rollback is required.

Verification: SFI canonical preflight, domain-boundary checks, institutional contracts, TypeScript typecheck, Next production build, existing Studio gates, then production deployment and post-deploy Auth/runtime observation.

## Corrección

- El proxy deja de depender de `auth.getUser()` en cada navegación protegida y usa claims verificadas como identidad de sesión, con refresh sólo cuando corresponda.
- `401 / sesión ausente` y `503 / verificación temporalmente indisponible` quedan separados semánticamente.
- Un outage ya no redirige a `/login`; usa `/auth-unavailable` y conserva el significado de la sesión sin conceder acceso mientras no pueda verificarse.
- ROOT y los access guards aplican el mismo contrato.
- Se añade `/entry` como único resolvedor post-login para evitar destinos contradictorios.
- Login queda explícitamente definido como correo + contraseña, con estado pendiente para impedir doble submit y mensajes comprensibles para timeout vs credenciales incorrectas.
- FIELD continúa público.
- El fallback de callbacks de autenticación usa el host canónico `www.systemfriction.org` (la variable de entorno sigue teniendo prioridad).

## Invariantes

- No se modifica la identidad canónica de ciclos, RETURN, CONTRAST ni learning.
- No se concede autoridad por degradación de Auth.
- `auth unavailable != anonymous != unauthorized`.
- Ninguna indisponibilidad de backend se representa como cierre de sesión.
