### PR TITLE
fix(runtime): remove PostgREST pool pressure from ROOT reads

### DIFF
--- a/src/app/api/cases/route.ts
+++ b/src/app/api/cases/route.ts
@@ -52,6 +52,32 @@ function normalizedProjectKey(value: string) {
   return value.trim().toLowerCase().replace(/[^a-z0-9:_-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 100);
 }
 
+function transientPoolPressure(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  return [
+    'Timed out acquiring connection from connection pool',
+    'statement timeout',
+    'request_timeout',
+    'context deadline exceeded',
+    'PGRST003',
+  ].some((marker) => message.includes(marker));
+}
+
+async function withTransientReadRetry<T>(read: () => Promise<T>) {
+  const delays = [0, 120, 300];
+  let lastError: unknown = null;
+  for (const delay of delays) {
+    if (delay) await new Promise((resolve) => setTimeout(resolve, delay));
+    try {
+      return await read();
+    } catch (error) {
+      lastError = error;
+      if (!transientPoolPressure(error)) throw error;
+    }
+  }
+  throw lastError;
+}
+
 async function writableTenant(userId: string, tenantId: string) {
   const db = createServiceSupabaseClient();
   const membership = await db.from('sfi_tenant_members')
@@ -68,10 +94,8 @@ async function writableTenant(userId: string, tenantId: string) {
 export async function GET() {
   try {
     const { user } = await requireAuthenticatedUser();
-    const [cases, tenants] = await Promise.all([
-      listOperationalCases(user.id),
-      listOperationalTenants(user.id),
-    ]);
+    const cases = await withTransientReadRetry(() => listOperationalCases(user.id));
+    const tenants = await withTransientReadRetry(() => listOperationalTenants(user.id));
     const db = createServiceSupabaseClient();
     const tenantIds = tenants.map((tenant) => tenant.id);
     const caseIds = cases.map((item) => item.id);

--- a/src/lib/sfi/cognitive-runtime/observedRuntime.ts
+++ b/src/lib/sfi/cognitive-runtime/observedRuntime.ts
@@ -1,7 +1,6 @@
 import 'server-only';
 
 import { createServiceSupabaseClient } from '@/runtime/supabase/server';
-import { streamRecentEpistemicEvents } from '@/lib/events/eventStore';
 import { SFI_COGNITIVE_RUNTIME_MODES, SFI_LAYER_QUESTIONS } from './registry';
 import { SFI_CONVERGED_COGNITIVE_AGENT_REGISTRY, SFI_CONVERGED_RUNTIME_SOURCE_TABLES } from './convergedRegistry';
 import { SFI_AGENT_EXECUTION_MAP } from './agentExecutionMap';
@@ -15,6 +14,8 @@ import type {
 
 const freshnessHours = Math.max(1, Number(process.env.SFI_AGENT_EXECUTION_FRESHNESS_HOURS ?? 24));
 const freshnessMs = freshnessHours * 60 * 60 * 1000;
+const TABLE_PROBE_CONCURRENCY = 4;
+const RUNTIME_EVENT_SELECT = 'event_id,event_name,epistemic_class,confidence,occurred_at,created_at,source';
 
 function contractEventName(value: unknown) {
   if (typeof value === 'string') return value;
@@ -46,15 +47,44 @@ function isFresh(value: string | null) {
 
 async function probeTables() {
   const db = createServiceSupabaseClient();
-  const entries = await Promise.all(SFI_CONVERGED_RUNTIME_SOURCE_TABLES.map(async (table) => {
-    const result = await db.from(table).select('*', { count: 'exact', head: true });
-    return [table, {
-      available: !result.error,
-      count: result.error ? null : result.count ?? 0,
-      error: result.error?.message ?? null,
-    }] as const;
-  }));
+  const entries: Array<readonly [string, { available: boolean; count: number | null; error: string | null }]> = [];
+
+  for (let index = 0; index < SFI_CONVERGED_RUNTIME_SOURCE_TABLES.length; index += TABLE_PROBE_CONCURRENCY) {
+    const batch = SFI_CONVERGED_RUNTIME_SOURCE_TABLES.slice(index, index + TABLE_PROBE_CONCURRENCY);
+    const batchEntries = await Promise.all(batch.map(async (table) => {
+      const result = await db.from(table).select('*', { head: true }).limit(1);
+      return [table, {
+        available: !result.error,
+        count: null,
+        error: result.error?.message ?? null,
+      }] as const;
+    }));
+    entries.push(...batchEntries);
+  }
+
   return new Map(entries);
+}
+
+async function readRuntimeEvents() {
+  const db = createServiceSupabaseClient();
+  const executionLimit = Math.max(100, SFI_CONVERGED_COGNITIVE_AGENT_REGISTRY.length * 12);
+  const [recentResult, executionResult] = await Promise.all([
+    db.from('epistemic_events')
+      .select(RUNTIME_EVENT_SELECT)
+      .order('sequence', { ascending: false })
+      .limit(100),
+    db.from('epistemic_events')
+      .select(RUNTIME_EVENT_SELECT)
+      .eq('event_name', 'SFI_AGENT_EXECUTED')
+      .order('occurred_at', { ascending: false })
+      .limit(executionLimit),
+  ]);
+
+  return {
+    recentRows: (recentResult.data ?? []) as Array<Record<string, unknown>>,
+    executionRows: (executionResult.data ?? []) as Array<Record<string, unknown>>,
+    warnings: [recentResult.error?.message, executionResult.error?.message].filter(Boolean) as string[],
+  };
 }
 
 function memoryAccess(memory: string, mode: 'read' | 'write', tableState: Map<string, { available: boolean; count: number | null; error: string | null }>): SfiMemoryAccess {
@@ -75,11 +105,11 @@ function aggregateStatus(statuses: SfiCognitiveRuntimeStatus[]): SfiCognitiveRun
 export async function readObservedSfiCognitiveRuntime(): Promise<SfiCognitiveRuntimeSnapshot> {
   const [tableState, eventStream] = await Promise.all([
     probeTables(),
-    streamRecentEpistemicEvents(500),
+    readRuntimeEvents(),
   ]);
 
-  const eventRows = (eventStream.data ?? []) as Array<Record<string, unknown>>;
-  const executionEvents = eventRows.filter((row) => String(row.event_name ?? '') === 'SFI_AGENT_EXECUTED');
+  const eventRows = eventStream.recentRows;
+  const executionEvents = eventStream.executionRows;
 
   const agents: SfiCognitiveAgentState[] = SFI_CONVERGED_COGNITIVE_AGENT_REGISTRY.map((agent) => {
     const sourceStates = agent.sourceTables.map((table) => [table, tableState.get(table)] as const);
@@ -152,7 +182,7 @@ export async function readObservedSfiCognitiveRuntime(): Promise<SfiCognitiveRun
     };
   });
 
-  const recentEvents = eventRows.slice(0, 100).map((row) => ({
+  const recentEvents = eventRows.map((row) => ({
     eventId: String(row.event_id ?? row.id ?? ''),
     eventName: String(row.event_name ?? 'epistemic.event'),
     epistemicClass: String(row.epistemic_class ?? 'missing'),
@@ -169,7 +199,7 @@ export async function readObservedSfiCognitiveRuntime(): Promise<SfiCognitiveRun
     ? (degradedAgents || missingAgents ? 'degraded' : 'operational')
     : gatedAgents ? 'gated' : 'missing';
 
-  const eventWarnings = 'warnings' in eventStream && Array.isArray(eventStream.warnings) ? eventStream.warnings : [];
+  const eventWarnings = eventStream.warnings;
 
   return {
     generatedAt: new Date().toISOString(),

--- a/supabase/migrations/20260903140000_runtime_read_pressure_indexes.sql
+++ b/supabase/migrations/20260903140000_runtime_read_pressure_indexes.sql
@@ -1,0 +1,9 @@
+-- Reduce PostgREST pool pressure from ROOT/runtime observation reads.
+-- No persistence semantics change: indexes only.
+
+create index if not exists epistemic_events_sequence_desc_idx
+  on public.epistemic_events (sequence desc);
+
+create index if not exists sfi_amv_memory_module_memory_key_created_idx
+  on public.sfi_amv_memory (module, created_at desc)
+  where ((memory_delta -> 'raw' ->> 'memoryKey') is not null);


### PR DESCRIPTION
## Problema observado en producción

A las 2026-09-03 13:54–13:55Z, Supabase Postgres registró una ráfaga sostenida de `canceling statement due to statement timeout` y el frontend expuso `SFI_TENANT_MEMBERSHIP_READ_FAILED:Timed out acquiring connection from connection pool`.

La membresía no estaba ausente: las lecturas de `sfi_tenant_members` para el usuario Founder también devolvieron HTTP 200 durante la misma ventana. La falla es de disponibilidad del pool bajo presión, no de identidad ni autorización.

La traza mostró dos amplificadores concretos:

1. `readObservedSfiCognitiveRuntime()` disparaba un `HEAD count=exact` por cada tabla fuente del runtime en paralelo y además pedía 500 filas completas de `epistemic_events`.
2. `/api/cases` ejecutaba en paralelo `listOperationalCases()` y `listOperationalTenants()`, aunque la primera ya hace una lectura de membresía, generando lecturas duplicadas simultáneas.
3. `epistemic_events ORDER BY sequence DESC LIMIT 500` no tenía índice global por `sequence`, por lo que Postgres hacía Parallel Seq Scan + Sort sobre una tabla de ~216 MB.
4. La lectura canónica de `sfi_amv_memory` filtrada por `module + memoryKey` no tenía un índice parcial que cubriera ese filtro.

## SFI PRECHECK

Owner: Runtime observability / SFI Case Platform read path. Persistencia canónica y autoridad ROOT no cambian.

Existing capability inspected: `src/lib/sfi/cognitive-runtime/observedRuntime.ts`, `src/lib/events/eventStore.ts`, `src/app/api/cases/route.ts`, `src/lib/sfi/case-platform/repository.ts`, `epistemic_events`, `sfi_amv_memory`, `sfi_tenant_members`, índices actuales y logs Postgres/PostgREST.

Absorb vs create decision: absorber la corrección en los readers existentes. No se crea nueva superficie, motor, writer ni plano de autoridad.

Authoritative writer: sin cambios. Los writers canónicos de eventos, memoria, Cases y memberships permanecen intactos.

Persistence/lineage impact: ninguno. Se añaden únicamente índices de lectura; no se modifica contenido, identidad, lineage, RETURN, CONTRAST ni learning.

Front delta: ninguno intencional; el usuario deja de recibir errores espurios de membership provocados por agotamiento temporal del pool.

Back delta: el runtime limita el fan-out de probes a 4, elimina `count=exact` de probes de disponibilidad y reemplaza la lectura de 500 eventos completos por dos lecturas estrechas: 100 headers recientes + ejecuciones `SFI_AGENT_EXECUTED` necesarias. `/api/cases` serializa las dos lecturas de tenant/cases y reintenta sólo errores transitorios de pool/timeout con backoff corto.

DB delta: dos índices de lectura: `epistemic_events_sequence_desc_idx` y `sfi_amv_memory_module_memory_key_created_idx`. La migración ya fue aplicada al proyecto de producción mediante el canal de migraciones de Supabase y se conserva aquí como canon reproducible.

Redundancy removed: se elimina el pico simultáneo de membership reads en `/api/cases` y el fan-out ilimitado de probes del runtime.

Execution/ROOT boundary: sin cambios. La corrección sólo reduce presión de lectura; no concede acceso, autoridad o capacidad de mutación adicional a ningún actor.

Rollback: revertir este PR. Los índices pueden permanecer sin alterar semántica; si se requiere rollback DB explícito, pueden eliminarse por una migración posterior.

Verification: canonical preflight, institutional contracts, typecheck, build, Studio gates; verificar plan de consulta por índice y observar logs Postgres/PostgREST post-deploy para confirmar desaparición de `statement timeout` y pool-acquisition failures.

## Invariantes

- `pool unavailable != membership missing`.
- No se degrada autorización para esconder el error.
- No se omite verificación de membership.
- No se cambia la autoridad soberana ROOT.
- No se altera identidad canónica de ciclos, eventos, memoria o evidencia.
