### PR TITLE
fix(closure): preserve persisted RETURN disposition during close

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -174,6 +174,9 @@ jobs:
       - name: Verify runtime read-plane stability
         run: npx tsx scripts/qa-sfi-runtime-readplane-stability.ts
 
+      - name: Verify universal closure RETURN disposition fallback
+        run: node --import tsx --test src/lib/sfi/universalClosure.test.ts
+
       - name: Typecheck
         id: typecheck
         shell: bash

--- a/src/lib/sfi/universalClosure.test.ts
+++ b/src/lib/sfi/universalClosure.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { assessUniversalClosure } from './universalClosure';
+
+function historyWithReturn(outcome: Record<string, unknown>) {
+  return {
+    cycleId: 'ce563b2a-3715-49ce-8806-1cc051f6ad71',
+    events: [],
+    cognitiveRuns: [],
+    structuredResults: [],
+    returnContrasts: [],
+    closures: [],
+    returns: [
+      {
+        event_id: 'return-event-1',
+        event_name: 'SFI_UNIVERSAL_RETURN_RECORDED',
+        payload: { outcome },
+      },
+    ],
+  };
+}
+
+test('closure preserves disposition fields from latest persisted RETURN when close request omits closure body', () => {
+  const assessment = assessUniversalClosure({
+    history: historyWithReturn({
+      conclusion: 'La evidencia ya permite un cierre descriptivo delimitado.',
+      limitations: ['No existe todavía observación longitudinal posterior a la intervención.'],
+      missingEvidence: ['Validación longitudinal 30/60/90 días.'],
+    }),
+  });
+
+  assert.equal(assessment.envelope.conclusion, 'La evidencia ya permite un cierre descriptivo delimitado.');
+  assert.deepEqual(assessment.envelope.limitations, ['No existe todavía observación longitudinal posterior a la intervención.']);
+  assert.deepEqual(assessment.envelope.missingEvidence, ['Validación longitudinal 30/60/90 días.']);
+  assert.equal(assessment.missing.includes('LIMITATIONS_OR_MISSING_EVIDENCE'), false);
+  assert.equal(assessment.missing.includes('CONCLUSION_OR_PRIMARY_HYPOTHESIS'), false);
+  assert.equal(assessment.ready, true);
+});
+
+test('explicit close request has precedence over persisted RETURN disposition', () => {
+  const assessment = assessUniversalClosure({
+    history: historyWithReturn({
+      conclusion: 'RETURN conclusion',
+      limitations: ['RETURN limitation'],
+      missingEvidence: ['RETURN missing evidence'],
+    }),
+    requested: {
+      conclusion: 'Explicit conclusion',
+      limitations: ['Explicit limitation'],
+      missingEvidence: ['Explicit missing evidence'],
+    },
+  });
+
+  assert.equal(assessment.envelope.conclusion, 'Explicit conclusion');
+  assert.deepEqual(assessment.envelope.limitations, ['Explicit limitation']);
+  assert.deepEqual(assessment.envelope.missingEvidence, ['Explicit missing evidence']);
+});
+
+test('closure still reports missing disposition when neither request nor RETURN contains it', () => {
+  const assessment = assessUniversalClosure({
+    history: historyWithReturn({}),
+  });
+
+  assert.equal(assessment.envelope.conclusion, null);
+  assert.deepEqual(assessment.envelope.limitations, []);
+  assert.deepEqual(assessment.envelope.missingEvidence, []);
+  assert.equal(assessment.missing.includes('LIMITATIONS_OR_MISSING_EVIDENCE'), true);
+  assert.equal(assessment.ready, false);
+});

--- a/src/lib/sfi/universalClosure.test.ts
+++ b/src/lib/sfi/universalClosure.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { assessUniversalClosure } from './universalClosure';
 
+// Regression boundary: closing a cycle must not require the caller to repeat
+// disposition fields that are already persisted in the latest RETURN outcome.
 function historyWithReturn(outcome: Record<string, unknown>) {
   return {
     cycleId: 'ce563b2a-3715-49ce-8806-1cc051f6ad71',

--- a/src/lib/sfi/universalClosure.ts
+++ b/src/lib/sfi/universalClosure.ts
@@ -165,6 +165,7 @@ export function assessUniversalClosure(input: {
   const persistedSignals = predictionSignals(predictions);
   const lastReturn = latest(input.history.returns);
   const returnPayload = lastReturn ? eventPayload(lastReturn) : {};
+  const returnOutcome = row(returnPayload.outcome);
   const lastContrast = latest(contrastEvents(input.history));
   const lastContrastPayload = lastContrast ? eventPayload(lastContrast) : {};
 
@@ -183,7 +184,9 @@ export function assessUniversalClosure(input: {
     ...list(requested.supportingEvidence).filter((item): item is string => typeof item === 'string'),
   ];
   const counterEvidence = list(requested.counterEvidence).length ? list(requested.counterEvidence) : contradictions;
-  const missingEvidence = list(requested.missingEvidence);
+  const missingEvidence = list(requested.missingEvidence).length
+    ? list(requested.missingEvidence)
+    : list(returnOutcome.missingEvidence);
   const expectedSignals = empirical
     ? persistedSignals.expectedSignals
     : list(requested.expectedSignals).length ? list(requested.expectedSignals) : list(predictionRow.expectedSignals);
@@ -225,8 +228,10 @@ export function assessUniversalClosure(input: {
         }
       : null
     : requested.learningCandidate ?? null;
-  const conclusion = requested.conclusion ?? null;
-  const limitations = list(requested.limitations);
+  const conclusion = text(requested.conclusion) ?? text(returnOutcome.conclusion) ?? null;
+  const limitations = list(requested.limitations).length
+    ? list(requested.limitations)
+    : list(returnOutcome.limitations);
 
   const missing: string[] = [];
   if (klass === 'DESCRIPTIVE_DELIMITED') {


### PR DESCRIPTION
## Root cause
`assessUniversalClosure()` already falls back to the latest persisted RETURN for `observedReturn/outcome`, but it rebuilt `conclusion`, `limitations`, and `missingEvidence` only from the explicit close request. When `/api/external/v1/signal` calls close without `body.closure`, valid disposition fields already persisted in RETURN disappear from the closure envelope and SFI can emit the false gate `LIMITATIONS_OR_MISSING_EVIDENCE`.

## SFI PRECHECK
Owner: Universal Cycle / universal closure lifecycle.
Existing capability inspected: `assessUniversalClosure()` in `src/lib/sfi/universalClosure.ts`, external close adapter, persisted RETURN history and existing SFI Verify workflow.
Absorb vs create decision: absorb the fallback into the existing canonical closure assessor; only a regression test is added, no parallel closure service.
Authoritative writer: unchanged; canonical universal-cycle event writer remains `appendEpistemicEvent` through the existing closure lifecycle.
Persistence/lineage impact: no schema or data migration. Existing persisted RETURN becomes readable as the fallback source; no new evidence or lineage is fabricated.
Front delta: none.
Back delta: preserve explicit close-request precedence and fall back to `latest persisted RETURN.payload.outcome` for `conclusion`, `limitations`, and `missingEvidence`.
DB delta: none.
Redundancy removed: eliminates the need to resend closure disposition fields that already exist in the persisted RETURN.
Execution/ROOT boundary: unchanged. This patch does not approve proposals, relax empirical gates, promote learning, manufacture RETURN, or expand autonomous authority.
Rollback: revert this PR; no database rollback required.
Verification: regression for persisted fallback + explicit override + both-empty gate; full SFI Verify, typecheck and build; production deployment; retry closure on the same Mesa de Ayuda cycle without re-uploading evidence.

## Fix
Precedence: `EXPLICIT_CLOSE_REQUEST > LATEST_PERSISTED_RETURN > EMPTY` for:
- `conclusion`
- `limitations`
- `missingEvidence`

No preregistration, prediction, RETURN evidence, calibration, contrast, confidence, learning, or empirical closure gate is relaxed.

## Regression
Adds an executable regression reproducing Mesa de Ayuda cycle semantics:
1. persisted RETURN contains conclusion/limitations/missingEvidence;
2. close request omits nested closure;
3. closure envelope preserves the persisted fields;
4. `LIMITATIONS_OR_MISSING_EVIDENCE` is not manufactured;
5. explicit close request still overrides RETURN;
6. when both sources are empty the gate remains present.

The regression is wired into `SFI Verify` before typecheck/build.

## SFI traceability
Root-cause event: `01e9678d-de58-4ab1-9ba9-68b380972256`
Governed proposal: `5b4faab0-d2aa-4842-8f93-f50e1461edf2`
Benchmark cycle after production deploy: `ce563b2a-3715-49ce-8806-1cc051f6ad71`

## Boundary
This PR is separate from runtime stabilization #360. It changes closure projection semantics only and does not modify DB schema, auth, OAuth, runtime health, or data-plane load behavior.