### PR TITLE
feat(institution): formalize authority roles and governed account administration

### DIFF
--- a/docs/program/SFI-INSTITUTIONAL-AUTHORITY-ACCESS-2026.md
+++ b/docs/program/SFI-INSTITUTIONAL-AUTHORITY-ACCESS-2026.md
@@ -1,0 +1,82 @@
+# SFI INSTITUTIONAL AUTHORITY + ACCOUNT ADMINISTRATION 2026
+
+**Contract:** `SFI-INSTITUTIONAL-AUTHORITY-ACCESS-1.0`  
+**Corpus authority:** `SFI-CI-007` / `SFI-CI-008`  
+**Status:** PROPOSED IN PR #374  
+**Base inspected:** `main` after PR #373 merge
+
+## Purpose
+
+Make institutional roles executable without converting organizational hierarchy into sovereign or cross-user personal access.
+
+## Role boundary
+
+| Role | Institutional operation | Account administration | ROOT sovereign view | CANON | Cross-user PERSONAL |
+|---|---|---|---|---|---|
+| Founder / ROOT | full | subordinate roles | yes | yes | no by hierarchy |
+| Institutional Director | broad | subordinate roles + Domain Directors | no | no | no |
+| Domain Director | scoped domain | no by default | no | no | no |
+| Operator / Researcher / Steward | assigned scope | no | no | no | no |
+| External collaborator / Observer | assigned read scope | no | no | no | no |
+
+## Identity ownership
+
+- Supabase Auth owns credentials and invitation acceptance.
+- `profiles` owns the durable institutional mandate projection.
+- `sfi_audit_events` owns account-administration lineage.
+- The browser never receives service-role credentials.
+- Administrators never read or assign a user's final password.
+
+## Founder ceiling
+
+The generic account console may appoint an Institutional Director and subordinate roles. It may not create another `founder_root`, mutate the current Founder account, or treat account administration as a constitutional succession mechanism.
+
+## Institutional Director ceiling
+
+The Director may invite users, assign subordinate roles, and appoint Domain Directors. The Director may not:
+
+- view or mutate Founder account metadata through the directory;
+- change its own role or authority;
+- create or edit another Institutional Director;
+- create ROOT;
+- promote CANON;
+- grant sovereign actions;
+- grant ROOT observation;
+- grant cross-user PERSONAL access.
+
+## ROOT / privacy boundary
+
+The current ROOT state aggregates sovereign institutional state with Cognitive Twin and AMV state. Until these readers are partitioned by `PERSONAL` / `INSTITUTIONAL`, ROOT observation remains Founder-only. Director authority is projected through institutional surfaces, not the sovereign ROOT reader.
+
+## External agent boundary
+
+Edwing's human account may hold Institutional Director authority. His external GPT remains `institutional_operator`; human organizational authority is not inherited by an external model or OAuth client.
+
+## Provisioning flow
+
+```text
+ADMINISTRATOR SESSION
+  -> /institution/access
+  -> governed API
+  -> authority ceiling check
+  -> Supabase Auth invitation
+  -> profiles mandate
+  -> sfi_audit_events
+  -> user accepts invitation
+  -> authenticated institutional session
+```
+
+## RETURN
+
+After merge/deployment verify:
+
+1. Founder can open `/institution/access`.
+2. Institutional Director can open it.
+3. Director response contains no Founder account row.
+4. Director cannot assign `founder_root` or `institutional_director`.
+5. Director cannot edit self.
+6. Invitation creates Auth identity, profile mandate, and audit event.
+7. Invited institutional profile satisfies `requireSfiMember` without hardcoded membership.
+8. Edwing cannot observe ROOT.
+9. External OAuth scopes remain unchanged.
+10. Personal owner-scoped data remains inaccessible cross-user.

--- a/src/app/api/institution/access/route.ts
+++ b/src/app/api/institution/access/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import {
+  inviteInstitutionalAccount,
+  listInstitutionalAccounts,
+  updateInstitutionalAccount,
+} from '@/lib/system/access/accountAdmin';
+import { AccessDeniedError, requireInstitutionalAccountAdmin } from '@/lib/system/access/server';
+
+export const dynamic = 'force-dynamic';
+
+function errorResponse(error: unknown) {
+  if (error instanceof AccessDeniedError) {
+    return NextResponse.json({ ok: false, error: error.code, message: error.message }, { status: error.status });
+  }
+  const message = error instanceof Error ? error.message : 'Institutional account operation failed.';
+  return NextResponse.json({ ok: false, error: 'ACCOUNT_OPERATION_FAILED', message }, { status: 400 });
+}
+
+export async function GET() {
+  try {
+    const context = await requireInstitutionalAccountAdmin();
+    const state = await listInstitutionalAccounts(context);
+    return NextResponse.json({ ok: true, ...state });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const context = await requireInstitutionalAccountAdmin();
+    const body = await request.json();
+    const result = await inviteInstitutionalAccount(context, body);
+    return NextResponse.json({ ok: true, ...result }, { status: 201 });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}
+
+export async function PATCH(request: Request) {
+  try {
+    const context = await requireInstitutionalAccountAdmin();
+    const body = await request.json();
+    const result = await updateInstitutionalAccount(context, body);
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/institution/access/page.tsx
+++ b/src/app/institution/access/page.tsx
@@ -1,0 +1,17 @@
+import InstitutionAccessConsole from '@/components/sfi/InstitutionAccessConsole';
+import { listInstitutionalAccounts } from '@/lib/system/access/accountAdmin';
+import { requireInstitutionalAccountAdminPage } from '@/lib/system/access/server';
+
+export const dynamic = 'force-dynamic';
+
+export default async function InstitutionAccessPage() {
+  const context = await requireInstitutionalAccountAdminPage('/institution/access');
+  const state = await listInstitutionalAccounts(context);
+  return (
+    <InstitutionAccessConsole
+      initialAccounts={state.accounts}
+      authority={state.authority}
+      assignableRoles={state.assignableRoles}
+    />
+  );
+}

--- a/src/components/sfi/InstitutionAccessConsole.tsx
+++ b/src/components/sfi/InstitutionAccessConsole.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type CSSProperties } from 'react';
 import Link from 'next/link';
 import {
   SFI_INSTITUTIONAL_DOMAIN_LABELS,
@@ -9,7 +9,20 @@ import {
   type SfiInstitutionalDomain,
   type SfiInstitutionalRoleKey,
 } from '@/lib/system/access/institutionalRoles';
-import type { InstitutionalAccountView } from '@/lib/system/access/accountAdmin';
+
+type InstitutionalAccountView = {
+  userId: string;
+  email: string | null;
+  alias: string;
+  displayTitle: string;
+  institutionalRole: SfiInstitutionalRoleKey;
+  domain: SfiInstitutionalDomain;
+  technicalRole: string;
+  status: 'ACTIVE' | 'INVITED' | 'SUSPENDED';
+  createdAt: string | null;
+  lastSignInAt: string | null;
+  editable: boolean;
+};
 
 type Props = {
   initialAccounts: InstitutionalAccountView[];
@@ -187,7 +200,7 @@ export default function InstitutionAccessConsole({ initialAccounts, authority, a
   );
 }
 
-const inputStyle: React.CSSProperties = {
+const inputStyle: CSSProperties = {
   width: '100%',
   boxSizing: 'border-box',
   background: '#0d0d0a',
@@ -198,7 +211,7 @@ const inputStyle: React.CSSProperties = {
   fontSize: 12,
 };
 
-const buttonStyle: React.CSSProperties = {
+const buttonStyle: CSSProperties = {
   background: '#15110d',
   color: '#e7c98b',
   border: '1px solid rgba(197,33,43,.65)',

--- a/src/components/sfi/InstitutionAccessConsole.tsx
+++ b/src/components/sfi/InstitutionAccessConsole.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import {
+  SFI_INSTITUTIONAL_DOMAIN_LABELS,
+  SFI_INSTITUTIONAL_ROLE_LABELS,
+  type SfiAccountAdminAuthority,
+  type SfiInstitutionalDomain,
+  type SfiInstitutionalRoleKey,
+} from '@/lib/system/access/institutionalRoles';
+import type { InstitutionalAccountView } from '@/lib/system/access/accountAdmin';
+
+type Props = {
+  initialAccounts: InstitutionalAccountView[];
+  authority: SfiAccountAdminAuthority;
+  assignableRoles: readonly SfiInstitutionalRoleKey[];
+};
+
+type Draft = {
+  alias: string;
+  institutionalRole: SfiInstitutionalRoleKey;
+  domain: SfiInstitutionalDomain;
+};
+
+const DOMAIN_ENTRIES = Object.entries(SFI_INSTITUTIONAL_DOMAIN_LABELS) as [SfiInstitutionalDomain, string][];
+
+function roleDomain(role: SfiInstitutionalRoleKey, domain: SfiInstitutionalDomain) {
+  return role === 'institutional_director' ? 'institution' : domain;
+}
+
+export default function InstitutionAccessConsole({ initialAccounts, authority, assignableRoles }: Props) {
+  const [accounts, setAccounts] = useState(initialAccounts);
+  const [email, setEmail] = useState('');
+  const [alias, setAlias] = useState('');
+  const [role, setRole] = useState<SfiInstitutionalRoleKey>(assignableRoles.includes('institutional_operator') ? 'institutional_operator' : assignableRoles[0]);
+  const [domain, setDomain] = useState<SfiInstitutionalDomain>('institution');
+  const [drafts, setDrafts] = useState<Record<string, Draft>>({});
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const roleOptions = useMemo(() => assignableRoles.map((value) => ({ value, label: SFI_INSTITUTIONAL_ROLE_LABELS[value] })), [assignableRoles]);
+
+  async function reload() {
+    const response = await fetch('/api/institution/access', { cache: 'no-store' });
+    const payload = await response.json();
+    if (!response.ok || !payload.ok) throw new Error(payload.message || 'No se pudo actualizar el directorio.');
+    setAccounts(payload.accounts);
+  }
+
+  async function invite() {
+    setBusy(true);
+    setNotice(null);
+    try {
+      const response = await fetch('/api/institution/access', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email, alias, institutionalRole: role, domain: roleDomain(role, domain) }),
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.ok) throw new Error(payload.message || 'No se pudo crear la invitación.');
+      setEmail('');
+      setAlias('');
+      setNotice('Invitación institucional creada. La persona define su propia credencial al aceptar.');
+      await reload();
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : 'La invitación falló.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function draftFor(account: InstitutionalAccountView): Draft {
+    return drafts[account.userId] ?? {
+      alias: account.alias,
+      institutionalRole: account.institutionalRole,
+      domain: account.domain,
+    };
+  }
+
+  function patchDraft(userId: string, current: Draft, patch: Partial<Draft>) {
+    setDrafts((previous) => ({ ...previous, [userId]: { ...current, ...patch } }));
+  }
+
+  async function save(account: InstitutionalAccountView) {
+    const draft = draftFor(account);
+    setBusy(true);
+    setNotice(null);
+    try {
+      const response = await fetch('/api/institution/access', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          userId: account.userId,
+          alias: draft.alias,
+          institutionalRole: draft.institutionalRole,
+          domain: roleDomain(draft.institutionalRole, draft.domain),
+        }),
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.ok) throw new Error(payload.message || 'No se pudo actualizar la cuenta.');
+      setDrafts((previous) => {
+        const next = { ...previous };
+        delete next[account.userId];
+        return next;
+      });
+      setNotice('Mandato institucional actualizado y auditado.');
+      await reload();
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : 'La actualización falló.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main style={{ minHeight: '100vh', background: '#070705', color: '#e6dcc6', padding: '38px 24px 80px', fontFamily: 'Georgia, serif' }}>
+      <div style={{ maxWidth: 1180, margin: '0 auto' }}>
+        <header style={{ borderBottom: '1px solid rgba(190,32,38,.55)', paddingBottom: 24, display: 'flex', justifyContent: 'space-between', gap: 24, alignItems: 'flex-end', flexWrap: 'wrap' }}>
+          <div>
+            <small style={{ letterSpacing: '.24em', color: '#b6a98e' }}>SYSTEM FRICTION INSTITUTE · IDENTITY / AUTHORITY</small>
+            <h1 style={{ margin: '10px 0 6px', fontSize: 'clamp(34px,5vw,64px)', fontWeight: 400 }}>ACCESO INSTITUCIONAL</h1>
+            <p style={{ margin: 0, maxWidth: 800, color: '#a99d86', lineHeight: 1.6 }}>Cuentas, mandatos y límites. La administración de identidad no concede CANON, soberanía ni acceso a espacios personales ajenos.</p>
+          </div>
+          <div style={{ display: 'flex', gap: 14 }}>
+            <Link href="/institution" style={{ color: '#d1b47b', textDecoration: 'none' }}>INSTITUCIÓN</Link>
+            <Link href="/field" style={{ color: '#d1b47b', textDecoration: 'none' }}>FIELD</Link>
+          </div>
+        </header>
+
+        <section style={{ marginTop: 28, border: '1px solid rgba(209,180,123,.22)', padding: 20 }}>
+          <small style={{ color: '#d4a246', letterSpacing: '.18em' }}>TU CEILING</small>
+          <p style={{ marginBottom: 0, lineHeight: 1.65 }}>
+            {authority === 'founder'
+              ? 'FOUNDER / ROOT · Puede nombrar Dirección Institucional y roles subordinados. ROOT no se crea desde esta consola.'
+              : 'DIRECCIÓN INSTITUCIONAL · Puede crear y administrar roles subordinados, incluidos Directores de Dominio. No puede editar ROOT, otro Director Institucional ni su propia autoridad.'}
+          </p>
+        </section>
+
+        <section style={{ marginTop: 28 }}>
+          <small style={{ color: '#d4a246', letterSpacing: '.18em' }}>NUEVA CUENTA / INVITACIÓN</small>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(190px,1fr))', gap: 10, marginTop: 12 }}>
+            <input aria-label="Nombre" placeholder="Nombre institucional" value={alias} onChange={(event) => setAlias(event.target.value)} style={inputStyle} />
+            <input aria-label="Correo" placeholder="correo@dominio" value={email} onChange={(event) => setEmail(event.target.value)} style={inputStyle} />
+            <select aria-label="Rol" value={role} onChange={(event) => setRole(event.target.value as SfiInstitutionalRoleKey)} style={inputStyle}>
+              {roleOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+            <select aria-label="Dominio" value={roleDomain(role, domain)} disabled={role === 'institutional_director'} onChange={(event) => setDomain(event.target.value as SfiInstitutionalDomain)} style={inputStyle}>
+              {DOMAIN_ENTRIES.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+            </select>
+            <button disabled={busy || !email || !alias} onClick={invite} style={buttonStyle}>INVITAR</button>
+          </div>
+          <p style={{ color: '#8f8676', fontSize: 12, lineHeight: 1.55 }}>SFI envía una invitación. Ningún administrador conoce ni establece la contraseña final del usuario.</p>
+          {notice && <p role="status" style={{ borderLeft: '2px solid #c5212b', paddingLeft: 12, color: '#d8c7a5' }}>{notice}</p>}
+        </section>
+
+        <section style={{ marginTop: 42 }}>
+          <small style={{ color: '#d4a246', letterSpacing: '.18em' }}>DIRECTORIO INSTITUCIONAL</small>
+          <div style={{ marginTop: 12, display: 'grid', gap: 10 }}>
+            {accounts.map((account) => {
+              const draft = draftFor(account);
+              return (
+                <article key={account.userId} style={{ borderTop: '1px solid rgba(209,180,123,.22)', padding: '18px 0', display: 'grid', gridTemplateColumns: 'minmax(190px,1.2fr) minmax(180px,1fr) minmax(170px,1fr) minmax(150px,.8fr) auto', gap: 10, alignItems: 'center' }}>
+                  <div>
+                    <input disabled={!account.editable} value={draft.alias} onChange={(event) => patchDraft(account.userId, draft, { alias: event.target.value })} style={inputStyle} />
+                    <small style={{ display: 'block', marginTop: 6, color: '#827a6c' }}>{account.email ?? 'correo reservado'} · {account.status}</small>
+                  </div>
+                  <select disabled={!account.editable} value={draft.institutionalRole} onChange={(event) => patchDraft(account.userId, draft, { institutionalRole: event.target.value as SfiInstitutionalRoleKey })} style={inputStyle}>
+                    {account.editable ? roleOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>) : <option value={account.institutionalRole}>{SFI_INSTITUTIONAL_ROLE_LABELS[account.institutionalRole]}</option>}
+                  </select>
+                  <select disabled={!account.editable || draft.institutionalRole === 'institutional_director'} value={roleDomain(draft.institutionalRole, draft.domain)} onChange={(event) => patchDraft(account.userId, draft, { domain: event.target.value as SfiInstitutionalDomain })} style={inputStyle}>
+                    {DOMAIN_ENTRIES.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+                  </select>
+                  <div><small style={{ color: '#877b65' }}>{account.displayTitle}</small></div>
+                  <button disabled={busy || !account.editable} onClick={() => save(account)} style={buttonStyle}>{account.editable ? 'GUARDAR' : 'SELLADO'}</button>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <footer style={{ marginTop: 46, borderTop: '1px solid rgba(209,180,123,.18)', paddingTop: 18, color: '#776f63', fontSize: 12, lineHeight: 1.6 }}>
+          PERSONAL no hereda autoridad de INSTITUTIONAL. SHARED_LAB exige promoción deliberada. Todas las altas y modificaciones de mandato se registran en <code>sfi_audit_events</code>.
+        </footer>
+      </div>
+    </main>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  boxSizing: 'border-box',
+  background: '#0d0d0a',
+  color: '#e6dcc6',
+  border: '1px solid rgba(209,180,123,.28)',
+  padding: '11px 12px',
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  fontSize: 12,
+};
+
+const buttonStyle: React.CSSProperties = {
+  background: '#15110d',
+  color: '#e7c98b',
+  border: '1px solid rgba(197,33,43,.65)',
+  padding: '11px 14px',
+  cursor: 'pointer',
+  letterSpacing: '.1em',
+  fontSize: 11,
+};

--- a/src/lib/system/access/accountAdmin.ts
+++ b/src/lib/system/access/accountAdmin.ts
@@ -1,0 +1,268 @@
+import 'server-only';
+
+import type { User } from '@supabase/supabase-js';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import type { requireInstitutionalAccountAdmin } from './server';
+import {
+  assignableInstitutionalRoles,
+  canAssignInstitutionalRole,
+  institutionalModuleAccessForRole,
+  institutionalTitle,
+  isInstitutionalDomain,
+  isInstitutionalRole,
+  technicalRoleForInstitutionalRole,
+  type SfiAccountAdminAuthority,
+  type SfiInstitutionalDomain,
+  type SfiInstitutionalRoleKey,
+} from './institutionalRoles';
+
+export type InstitutionalAccountAdminContext = Awaited<ReturnType<typeof requireInstitutionalAccountAdmin>>;
+
+export type InstitutionalAccountView = {
+  userId: string;
+  email: string | null;
+  alias: string;
+  displayTitle: string;
+  institutionalRole: SfiInstitutionalRoleKey;
+  domain: SfiInstitutionalDomain;
+  technicalRole: string;
+  status: 'ACTIVE' | 'INVITED' | 'SUSPENDED';
+  createdAt: string | null;
+  lastSignInAt: string | null;
+  editable: boolean;
+};
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function institutionalRoleFromProfile(profile: { role?: unknown; module_access?: unknown }): SfiInstitutionalRoleKey | null {
+  const access = record(profile.module_access);
+  const explicit = access.institutional_role;
+  if (isInstitutionalRole(explicit)) return explicit;
+  if (profile.role === 'root' || profile.role === 'system') return 'founder_root';
+  return null;
+}
+
+function domainFromProfile(profile: { module_access?: unknown }): SfiInstitutionalDomain {
+  const access = record(profile.module_access);
+  return isInstitutionalDomain(access.institutional_domain) ? access.institutional_domain : 'institution';
+}
+
+function isFounderTarget(profile: { role?: unknown; module_access?: unknown }) {
+  return institutionalRoleFromProfile(profile) === 'founder_root' || profile.role === 'root' || profile.role === 'system';
+}
+
+function statusForUser(user: User): InstitutionalAccountView['status'] {
+  if (user.banned_until && new Date(user.banned_until).getTime() > Date.now()) return 'SUSPENDED';
+  if (!user.last_sign_in_at) return 'INVITED';
+  return 'ACTIVE';
+}
+
+async function allAuthUsers() {
+  const service = createServiceSupabaseClient();
+  const users: User[] = [];
+  for (let page = 1; page <= 20; page += 1) {
+    const result = await service.auth.admin.listUsers({ page, perPage: 200 });
+    if (result.error) throw result.error;
+    users.push(...result.data.users);
+    if (result.data.users.length < 200) break;
+  }
+  return users;
+}
+
+function canEditTarget(
+  authority: SfiAccountAdminAuthority,
+  actorId: string,
+  target: { user_id: string; role: unknown; module_access: unknown },
+) {
+  if (isFounderTarget(target)) return false; // ROOT changes are constitutional, never generic account administration.
+  if (authority === 'institutional_director' && target.user_id === actorId) return false; // No self-elevation/self-rewrite.
+  const targetRole = institutionalRoleFromProfile(target);
+  if (!targetRole) return false;
+  if (authority === 'institutional_director' && targetRole === 'institutional_director') return false;
+  return true;
+}
+
+export async function listInstitutionalAccounts(context: InstitutionalAccountAdminContext) {
+  const service = createServiceSupabaseClient();
+  const [users, profilesResult] = await Promise.all([
+    allAuthUsers(),
+    service
+      .from('profiles')
+      .select('user_id,alias,email,role,module_access,subscription_tier')
+      .order('alias', { ascending: true }),
+  ]);
+  if (profilesResult.error) throw profilesResult.error;
+
+  const userById = new Map(users.map((user) => [user.id, user]));
+  const accounts: InstitutionalAccountView[] = [];
+
+  for (const profile of profilesResult.data ?? []) {
+    const institutionalRole = institutionalRoleFromProfile(profile);
+    if (!institutionalRole) continue;
+    if (context.accountAuthority === 'institutional_director' && institutionalRole === 'founder_root') continue;
+
+    const user = userById.get(profile.user_id);
+    const access = record(profile.module_access);
+    const domain = domainFromProfile(profile);
+    accounts.push({
+      userId: profile.user_id,
+      email: user?.email ?? profile.email ?? null,
+      alias: String(profile.alias || user?.email?.split('@')[0] || 'member'),
+      displayTitle: String(access.display_title || institutionalTitle(institutionalRole, domain)),
+      institutionalRole,
+      domain,
+      technicalRole: String(profile.role || ''),
+      status: user ? statusForUser(user) : 'INVITED',
+      createdAt: user?.created_at ?? null,
+      lastSignInAt: user?.last_sign_in_at ?? null,
+      editable: canEditTarget(context.accountAuthority, context.user.id, profile),
+    });
+  }
+
+  return {
+    accounts,
+    authority: context.accountAuthority,
+    assignableRoles: assignableInstitutionalRoles(context.accountAuthority),
+  };
+}
+
+function normalizeInvitationInput(input: {
+  email?: unknown;
+  alias?: unknown;
+  institutionalRole?: unknown;
+  domain?: unknown;
+}) {
+  const email = String(input.email || '').trim().toLowerCase();
+  const alias = String(input.alias || '').trim();
+  if (!email || !email.includes('@')) throw new Error('A valid email is required.');
+  if (!alias) throw new Error('Display name is required.');
+  if (!isInstitutionalRole(input.institutionalRole)) throw new Error('A valid institutional role is required.');
+  if (!isInstitutionalDomain(input.domain)) throw new Error('A valid institutional domain is required.');
+  const role = input.institutionalRole;
+  const domain = role === 'institutional_director' ? 'institution' : input.domain;
+  if (role === 'domain_director' && domain === 'institution') {
+    throw new Error('A Domain Director requires a specific domain.');
+  }
+  return { email, alias, role, domain } as const;
+}
+
+export async function inviteInstitutionalAccount(
+  context: InstitutionalAccountAdminContext,
+  input: { email?: unknown; alias?: unknown; institutionalRole?: unknown; domain?: unknown },
+) {
+  const service = createServiceSupabaseClient();
+  const normalized = normalizeInvitationInput(input);
+  if (!canAssignInstitutionalRole(context.accountAuthority, normalized.role)) {
+    throw new Error('This authority cannot assign the requested institutional role.');
+  }
+
+  const invited = await service.auth.admin.inviteUserByEmail(normalized.email, {
+    data: {
+      display_name: normalized.alias,
+      sfi_institutional_role: normalized.role,
+      sfi_institutional_domain: normalized.domain,
+    },
+  });
+  if (invited.error || !invited.data.user) {
+    throw invited.error ?? new Error('Supabase did not return an invited user.');
+  }
+
+  const user = invited.data.user;
+  const moduleAccess = institutionalModuleAccessForRole(normalized.role, normalized.domain);
+  const profileWrite = await service.from('profiles').upsert({
+    user_id: user.id,
+    alias: normalized.alias,
+    email: normalized.email,
+    role: technicalRoleForInstitutionalRole(normalized.role),
+    subscription_tier: 'enterprise',
+    module_access: moduleAccess,
+    last_seen_at: new Date().toISOString(),
+  }, { onConflict: 'user_id' });
+  if (profileWrite.error) throw profileWrite.error;
+
+  const audit = await service.from('sfi_audit_events').insert({
+    actor_id: context.user.id,
+    action: 'SFI_INSTITUTIONAL_ACCOUNT_INVITED',
+    target_type: 'auth_user',
+    target_id: user.id,
+    before_state: null,
+    after_state: {
+      email: normalized.email,
+      alias: normalized.alias,
+      institutional_role: normalized.role,
+      institutional_domain: normalized.domain,
+    },
+    context: { account_authority: context.accountAuthority, source: '/institution/access' },
+  });
+  if (audit.error) throw audit.error;
+
+  return { userId: user.id };
+}
+
+export async function updateInstitutionalAccount(
+  context: InstitutionalAccountAdminContext,
+  input: { userId?: unknown; alias?: unknown; institutionalRole?: unknown; domain?: unknown },
+) {
+  const service = createServiceSupabaseClient();
+  const userId = String(input.userId || '').trim();
+  const alias = String(input.alias || '').trim();
+  if (!userId || !alias) throw new Error('Account id and display name are required.');
+  if (!isInstitutionalRole(input.institutionalRole)) throw new Error('A valid institutional role is required.');
+  if (!isInstitutionalDomain(input.domain)) throw new Error('A valid institutional domain is required.');
+  const role = input.institutionalRole;
+  const domain = role === 'institutional_director' ? 'institution' : input.domain;
+  if (role === 'domain_director' && domain === 'institution') throw new Error('A Domain Director requires a specific domain.');
+  if (!canAssignInstitutionalRole(context.accountAuthority, role)) {
+    throw new Error('This authority cannot assign the requested institutional role.');
+  }
+
+  const existing = await service
+    .from('profiles')
+    .select('user_id,alias,email,role,module_access,subscription_tier')
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (existing.error) throw existing.error;
+  if (!existing.data) throw new Error('Institutional account profile not found.');
+  if (!canEditTarget(context.accountAuthority, context.user.id, existing.data)) {
+    throw new Error('This account is outside the caller account-management ceiling.');
+  }
+
+  const beforeRole = institutionalRoleFromProfile(existing.data);
+  const beforeDomain = domainFromProfile(existing.data);
+  const nextAccess = institutionalModuleAccessForRole(role, domain, record(existing.data.module_access));
+  const updated = await service.from('profiles').update({
+    alias,
+    role: technicalRoleForInstitutionalRole(role),
+    subscription_tier: 'enterprise',
+    module_access: nextAccess,
+    last_seen_at: new Date().toISOString(),
+  }).eq('user_id', userId);
+  if (updated.error) throw updated.error;
+
+  const audit = await service.from('sfi_audit_events').insert({
+    actor_id: context.user.id,
+    action: 'SFI_INSTITUTIONAL_ACCOUNT_UPDATED',
+    target_type: 'profile',
+    target_id: userId,
+    before_state: {
+      alias: existing.data.alias,
+      institutional_role: beforeRole,
+      institutional_domain: beforeDomain,
+      technical_role: existing.data.role,
+    },
+    after_state: {
+      alias,
+      institutional_role: role,
+      institutional_domain: domain,
+      technical_role: technicalRoleForInstitutionalRole(role),
+    },
+    context: { account_authority: context.accountAuthority, source: '/institution/access' },
+  });
+  if (audit.error) throw audit.error;
+
+  return { userId };
+}

--- a/src/lib/system/access/institutionalMembers.ts
+++ b/src/lib/system/access/institutionalMembers.ts
@@ -1,3 +1,5 @@
+import type { SfiInstitutionalDomain, SfiInstitutionalRoleKey } from './institutionalRoles';
+
 export type SfiExternalScope =
   | 'observe'
   | 'propose'
@@ -16,6 +18,8 @@ export type SfiInstitutionalMember = {
   displayName: string;
   title: string;
   role: 'operator' | 'controller' | 'observer';
+  institutionalRole: SfiInstitutionalRoleKey;
+  institutionalDomain: SfiInstitutionalDomain;
   decisionAuthority?: 'controller';
   workspace: '/member' | '/root';
   modules: {
@@ -35,8 +39,10 @@ const MEMBERS: SfiInstitutionalMember[] = [
   {
     email: 'edwin.tzolkin@gmail.com',
     displayName: 'Edwing Peredo Guadarrama',
-    title: 'Director de Dominio — SFI Studio',
+    title: 'Director Institucional — System Friction Institute',
     role: 'controller',
+    institutionalRole: 'institutional_director',
+    institutionalDomain: 'institution',
     decisionAuthority: 'controller',
     workspace: '/root',
     modules: {
@@ -47,6 +53,8 @@ const MEMBERS: SfiInstitutionalMember[] = [
       root: true,
     },
     external: {
+      // External GPT authority deliberately remains an institutional operator.
+      // Human directorship does not delegate identity administration or sovereignty to an agent.
       role: 'institutional_operator',
       scopes: [
         'observe',

--- a/src/lib/system/access/institutionalMembers.ts
+++ b/src/lib/system/access/institutionalMembers.ts
@@ -44,13 +44,15 @@ const MEMBERS: SfiInstitutionalMember[] = [
     institutionalRole: 'institutional_director',
     institutionalDomain: 'institution',
     decisionAuthority: 'controller',
-    workspace: '/root',
+    // Director authority is institutional, not sovereign. ROOT currently mixes
+    // institutional state with Founder Cognitive Twin / AMV state.
+    workspace: '/member',
     modules: {
       field: true,
       studio: true,
       observatory: true,
       worldField: true,
-      root: true,
+      root: false,
     },
     external: {
       // External GPT authority deliberately remains an institutional operator.

--- a/src/lib/system/access/institutionalRoles.ts
+++ b/src/lib/system/access/institutionalRoles.ts
@@ -146,8 +146,10 @@ export function institutionalModuleAccessForRole(
     planner: flags.field,
     simulator: flags.studio,
     social: flags.world_field,
-    root: founder || director,
-    root_observe: founder || director,
+    // ROOT currently aggregates sovereign + Cognitive Twin/AMV state. Until
+    // readers are partitioned by PERSONAL/INSTITUTIONAL, only Founder may see it.
+    root: founder,
+    root_observe: founder,
     full_access: founder,
     executor: false,
     root_execution: founder,
@@ -169,6 +171,8 @@ export function institutionalModuleAccessForRole(
 
   // No non-Founder role may inherit sovereign authority from older profile state.
   if (!founder) {
+    next.root = false;
+    next.root_observe = false;
     next.full_access = false;
     next.root_execution = false;
     next.governance_write = false;

--- a/src/lib/system/access/institutionalRoles.ts
+++ b/src/lib/system/access/institutionalRoles.ts
@@ -1,0 +1,181 @@
+export type SfiInstitutionalRoleKey =
+  | 'founder_root'
+  | 'institutional_director'
+  | 'domain_director'
+  | 'institutional_operator'
+  | 'researcher_maker'
+  | 'data_steward'
+  | 'observer'
+  | 'external_collaborator';
+
+export type SfiInstitutionalDomain =
+  | 'institution'
+  | 'field'
+  | 'studio'
+  | 'observatory'
+  | 'world_field'
+  | 'method_lab'
+  | 'governance'
+  | 'library'
+  | 'research_graph'
+  | 'machine_interfaces';
+
+export type SfiTechnicalProfileRole = 'observer' | 'operator' | 'controller' | 'root' | 'system';
+export type SfiAccountAdminAuthority = 'founder' | 'institutional_director';
+
+export const SFI_INSTITUTIONAL_ROLE_LABELS: Record<SfiInstitutionalRoleKey, string> = {
+  founder_root: 'Founder / ROOT',
+  institutional_director: 'Director Institucional',
+  domain_director: 'Director de Dominio',
+  institutional_operator: 'Operador Institucional',
+  researcher_maker: 'Investigador / Maker',
+  data_steward: 'Data Steward',
+  observer: 'Observador / Auditor',
+  external_collaborator: 'Colaborador Externo',
+};
+
+export const SFI_INSTITUTIONAL_DOMAIN_LABELS: Record<SfiInstitutionalDomain, string> = {
+  institution: 'Institución',
+  field: 'Field',
+  studio: 'Studio',
+  observatory: 'Observatory',
+  world_field: 'World Field',
+  method_lab: 'Method Lab',
+  governance: 'Governance',
+  library: 'Library / Archive',
+  research_graph: 'Research Graph',
+  machine_interfaces: 'Machine Interfaces',
+};
+
+const TECHNICAL_ROLE: Record<SfiInstitutionalRoleKey, SfiTechnicalProfileRole> = {
+  founder_root: 'root',
+  institutional_director: 'controller',
+  domain_director: 'controller',
+  institutional_operator: 'operator',
+  researcher_maker: 'operator',
+  data_steward: 'operator',
+  observer: 'observer',
+  external_collaborator: 'observer',
+};
+
+const DIRECTOR_ASSIGNABLE: readonly SfiInstitutionalRoleKey[] = [
+  'domain_director',
+  'institutional_operator',
+  'researcher_maker',
+  'data_steward',
+  'observer',
+  'external_collaborator',
+];
+
+const FOUNDER_ASSIGNABLE: readonly SfiInstitutionalRoleKey[] = [
+  'institutional_director',
+  ...DIRECTOR_ASSIGNABLE,
+];
+
+export function isInstitutionalRole(value: unknown): value is SfiInstitutionalRoleKey {
+  return typeof value === 'string' && value in SFI_INSTITUTIONAL_ROLE_LABELS;
+}
+
+export function isInstitutionalDomain(value: unknown): value is SfiInstitutionalDomain {
+  return typeof value === 'string' && value in SFI_INSTITUTIONAL_DOMAIN_LABELS;
+}
+
+export function assignableInstitutionalRoles(authority: SfiAccountAdminAuthority) {
+  return authority === 'founder' ? FOUNDER_ASSIGNABLE : DIRECTOR_ASSIGNABLE;
+}
+
+export function canAssignInstitutionalRole(
+  authority: SfiAccountAdminAuthority,
+  role: SfiInstitutionalRoleKey,
+) {
+  return assignableInstitutionalRoles(authority).includes(role);
+}
+
+export function technicalRoleForInstitutionalRole(role: SfiInstitutionalRoleKey) {
+  return TECHNICAL_ROLE[role];
+}
+
+export function institutionalTitle(role: SfiInstitutionalRoleKey, domain: SfiInstitutionalDomain) {
+  if (role === 'founder_root') return 'Founder — System Friction Institute';
+  if (role === 'institutional_director') return 'Director Institucional — System Friction Institute';
+  if (role === 'domain_director') return `Director de Dominio — SFI ${SFI_INSTITUTIONAL_DOMAIN_LABELS[domain]}`;
+  return `${SFI_INSTITUTIONAL_ROLE_LABELS[role]} — SFI ${SFI_INSTITUTIONAL_DOMAIN_LABELS[domain]}`;
+}
+
+function domainFlags(domain: SfiInstitutionalDomain) {
+  return {
+    field: domain === 'institution' || domain === 'field',
+    studio: domain === 'institution' || domain === 'studio',
+    observatory: domain === 'institution' || domain === 'observatory',
+    world_field: domain === 'institution' || domain === 'world_field',
+    method_lab: domain === 'institution' || domain === 'method_lab',
+    governance: domain === 'institution' || domain === 'governance',
+    library: domain === 'institution' || domain === 'library',
+    research_graph: domain === 'institution' || domain === 'research_graph',
+    machine_interfaces: domain === 'institution' || domain === 'machine_interfaces',
+  };
+}
+
+export function institutionalModuleAccessForRole(
+  role: SfiInstitutionalRoleKey,
+  domain: SfiInstitutionalDomain,
+  current?: Record<string, unknown>,
+) {
+  const director = role === 'institutional_director';
+  const founder = role === 'founder_root';
+  const flags = domainFlags(founder || director ? 'institution' : domain);
+  const write = founder || director || role === 'domain_director' || role === 'institutional_operator' || role === 'researcher_maker' || role === 'data_steward';
+  const execute = founder || director || role === 'domain_director' || role === 'institutional_operator';
+  const evidenceReview = founder || director || role === 'domain_director' || role === 'data_steward';
+
+  const next: Record<string, unknown> = {
+    ...(current ?? {}),
+    institutional_member: true,
+    institutional_role: role,
+    institutional_domain: founder || director ? 'institution' : domain,
+    display_title: institutionalTitle(role, founder || director ? 'institution' : domain),
+    institutional_read: true,
+    institutional_write: write,
+    institutional_execute: execute,
+    evidence_review: evidenceReview,
+    account_provision: founder || director,
+    account_manage: founder || director,
+    domain_role_assign: founder || director,
+    personal_cross_user: false,
+    ...flags,
+    planner: flags.field,
+    simulator: flags.studio,
+    social: flags.world_field,
+    root: founder || director,
+    root_observe: founder || director,
+    full_access: founder,
+    executor: false,
+    root_execution: founder,
+    governance_write: founder,
+    sovereign_actions: founder,
+    canonical_promotion: founder,
+  };
+
+  // Experimental delegation metadata must never survive promotion to a durable role.
+  for (const key of [
+    'experiment_id',
+    'experiment_end',
+    'experiment_role',
+    'experiment_start',
+    'experiment_scopes',
+    'experiment_observer',
+    'experiment_observability',
+  ]) delete next[key];
+
+  // No non-Founder role may inherit sovereign authority from older profile state.
+  if (!founder) {
+    next.full_access = false;
+    next.root_execution = false;
+    next.governance_write = false;
+    next.sovereign_actions = false;
+    next.canonical_promotion = false;
+    next.personal_cross_user = false;
+  }
+
+  return next;
+}

--- a/src/lib/system/access/server.ts
+++ b/src/lib/system/access/server.ts
@@ -8,11 +8,12 @@ import {
   SfiAuthUnavailableError,
 } from '@/runtime/supabase/server';
 import { findInstitutionalMember } from './institutionalMembers';
+import { institutionalModuleAccessForRole, type SfiAccountAdminAuthority } from './institutionalRoles';
 
 export class AccessDeniedError extends Error {
   constructor(
     public readonly status: 401 | 403 | 404 | 503,
-    public readonly code: 'AUTH_REQUIRED' | 'AUTH_UNAVAILABLE' | 'FOUNDER_REQUIRED' | 'FIELD_USER_REQUIRED' | 'SFI_MEMBER_REQUIRED' | 'OWNER_REQUIRED' | 'NOT_FOUND',
+    public readonly code: 'AUTH_REQUIRED' | 'AUTH_UNAVAILABLE' | 'FOUNDER_REQUIRED' | 'FIELD_USER_REQUIRED' | 'SFI_MEMBER_REQUIRED' | 'ACCOUNT_ADMIN_REQUIRED' | 'OWNER_REQUIRED' | 'NOT_FOUND',
     message: string,
   ) {
     super(message);
@@ -20,7 +21,7 @@ export class AccessDeniedError extends Error {
   }
 }
 
-function record(value: unknown): Record<string, unknown> {
+export function accessRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
     : {};
@@ -47,35 +48,22 @@ function institutionalModuleAccess(
   member: NonNullable<ReturnType<typeof findInstitutionalMember>>,
   current?: unknown,
 ) {
-  return {
-    ...record(current),
-    display_title: member.title,
-    observatory: member.modules.observatory,
-    planner: member.modules.field,
-    simulator: member.modules.studio,
-    social: member.modules.worldField,
-    field: member.modules.field,
-    studio: member.modules.studio,
-    world_field: member.modules.worldField,
-    root: member.modules.root,
-    root_observe: member.modules.root,
-    full_access: false,
-    executor: false,
-    root_execution: false,
-    governance_write: false,
-    sovereign_actions: false,
-    canonical_promotion: false,
-  };
+  return institutionalModuleAccessForRole(
+    member.institutionalRole,
+    member.institutionalDomain,
+    accessRecord(current),
+  );
 }
 
 function personalModuleAccess(current?: unknown) {
   return {
-    ...record(current),
+    ...accessRecord(current),
     field: true,
     studio: true,
     personal_lab: true,
     personal_cognitive: true,
     external_agent: true,
+    institutional_member: false,
     root: false,
     root_observe: false,
     full_access: false,
@@ -84,6 +72,9 @@ function personalModuleAccess(current?: unknown) {
     governance_write: false,
     sovereign_actions: false,
     canonical_promotion: false,
+    account_provision: false,
+    account_manage: false,
+    personal_cross_user: false,
   };
 }
 
@@ -150,10 +141,13 @@ async function readOrProvisionUserProfile(user: { id: string; email?: string | n
 
   if (existing.data && member) {
     const desiredAccess = institutionalModuleAccess(member, existing.data.module_access);
-    const currentAccess = record(existing.data.module_access);
+    const currentAccess = accessRecord(existing.data.module_access);
     const accessKeys = [
-      'display_title','observatory','planner','simulator','social','field','studio','world_field','root','root_observe',
-      'full_access','executor','root_execution','governance_write','sovereign_actions','canonical_promotion',
+      'display_title','institutional_member','institutional_role','institutional_domain',
+      'institutional_read','institutional_write','institutional_execute','evidence_review',
+      'account_provision','account_manage','domain_role_assign','personal_cross_user',
+      'observatory','planner','simulator','social','field','studio','world_field','method_lab','governance','library','research_graph','machine_interfaces',
+      'root','root_observe','full_access','executor','root_execution','governance_write','sovereign_actions','canonical_promotion',
     ] as const;
     const requiresReconcile =
       existing.data.alias !== member.displayName ||
@@ -241,10 +235,29 @@ export async function requireUserProfile() {
   return { ...context, profile: resolved.profile, member: resolved.member };
 }
 
+function hasFounderAuthority(context: {
+  user: { id: string; email?: string | null };
+  profile: { role?: unknown; module_access?: unknown } | null | undefined;
+  member?: ReturnType<typeof findInstitutionalMember>;
+}) {
+  const email = context.user.email?.toLowerCase() || null;
+  const moduleAccess = accessRecord(context.profile?.module_access);
+  const institutionalMember = context.member ?? findInstitutionalMember(email);
+  const hasExplicitSovereignProfile =
+    !institutionalMember &&
+    (context.profile?.role === 'root' || context.profile?.role === 'system') &&
+    moduleAccess.full_access === true;
+
+  return founderIds().has(context.user.id) ||
+    Boolean(email && founderEmails().has(email)) ||
+    hasExplicitSovereignProfile;
+}
+
 export async function requireSfiMember() {
   const context = await requireUserProfile();
   const role = String(context.profile.role || '').toLowerCase();
-  const institutional = Boolean(context.member) || role === 'root' || role === 'system';
+  const moduleAccess = accessRecord(context.profile.module_access);
+  const institutional = Boolean(context.member) || moduleAccess.institutional_member === true || role === 'root' || role === 'system';
   if (!institutional) {
     throw new AccessDeniedError(403, 'SFI_MEMBER_REQUIRED', 'An active SFI institutional membership is required.');
   }
@@ -302,29 +315,45 @@ export async function requireFounder() {
     );
   }
 
-  const email = context.user.email?.toLowerCase() || null;
-  const institutionalMember = findInstitutionalMember(email);
-  const moduleAccess = record(profile?.module_access);
-  const hasExplicitSovereignProfile =
-    !institutionalMember &&
-    (profile?.role === 'root' || profile?.role === 'system') &&
-    moduleAccess.full_access === true;
-
-  const allowed =
-    founderIds().has(context.user.id) ||
-    Boolean(email && founderEmails().has(email)) ||
-    hasExplicitSovereignProfile;
-
-  if (!allowed) {
+  if (!hasFounderAuthority({ user: context.user, profile })) {
     throw new AccessDeniedError(403, 'FOUNDER_REQUIRED', 'Founder authorization is required.');
   }
 
   return { ...context, profile };
 }
 
+export async function requireInstitutionalAccountAdmin(): Promise<Awaited<ReturnType<typeof requireUserProfile>> & { accountAuthority: SfiAccountAdminAuthority }> {
+  const context = await requireUserProfile();
+  if (hasFounderAuthority(context)) return { ...context, accountAuthority: 'founder' };
+
+  const moduleAccess = accessRecord(context.profile.module_access);
+  const institutionalRole = String(moduleAccess.institutional_role || '');
+  if (
+    institutionalRole === 'institutional_director' &&
+    moduleAccess.institutional_member === true &&
+    moduleAccess.account_provision === true &&
+    moduleAccess.account_manage === true &&
+    moduleAccess.canonical_promotion !== true &&
+    moduleAccess.sovereign_actions !== true
+  ) {
+    return { ...context, accountAuthority: 'institutional_director' };
+  }
+
+  throw new AccessDeniedError(403, 'ACCOUNT_ADMIN_REQUIRED', 'Institutional account administration authority is required.');
+}
+
 export async function requireFounderPage(nextPath = '/root') {
   try {
     return await requireFounder();
+  } catch (error) {
+    if (error instanceof AccessDeniedError) authFailureRedirect(error, nextPath);
+    redirect('/unauthorized');
+  }
+}
+
+export async function requireInstitutionalAccountAdminPage(nextPath = '/institution/access') {
+  try {
+    return await requireInstitutionalAccountAdmin();
   } catch (error) {
     if (error instanceof AccessDeniedError) authFailureRedirect(error, nextPath);
     redirect('/unauthorized');

--- a/src/lib/system/access/server.ts
+++ b/src/lib/system/access/server.ts
@@ -8,7 +8,7 @@ import {
   SfiAuthUnavailableError,
 } from '@/runtime/supabase/server';
 import { findInstitutionalMember } from './institutionalMembers';
-import { institutionalModuleAccessForRole, type SfiAccountAdminAuthority } from './institutionalRoles';
+import { institutionalModuleAccessForRole, isInstitutionalRole, type SfiAccountAdminAuthority } from './institutionalRoles';
 
 export class AccessDeniedError extends Error {
   constructor(
@@ -140,8 +140,19 @@ async function readOrProvisionUserProfile(user: { id: string; email?: string | n
   if (existing.error) throw existing.error;
 
   if (existing.data && member) {
-    const desiredAccess = institutionalModuleAccess(member, existing.data.module_access);
     const currentAccess = accessRecord(existing.data.module_access);
+    const durableMandate = currentAccess.institutional_member === true && isInstitutionalRole(currentAccess.institutional_role);
+
+    // The hardcoded member registry bootstraps known principals and their external
+    // agent scopes. Once a durable institutional mandate exists in profiles,
+    // account administration becomes authoritative and login must not silently
+    // overwrite a later Founder-approved role change.
+    if (durableMandate) {
+      await ensureFieldProfile(user, String(existing.data.alias || member.displayName));
+      return { profile: existing.data, member };
+    }
+
+    const desiredAccess = institutionalModuleAccess(member, existing.data.module_access);
     const accessKeys = [
       'display_title','institutional_member','institutional_role','institutional_domain',
       'institutional_read','institutional_write','institutional_execute','evidence_review',

--- a/supabase/migrations/20260905073500_reconcile_institutional_authority_roles.sql
+++ b/supabase/migrations/20260905073500_reconcile_institutional_authority_roles.sql
@@ -1,0 +1,103 @@
+-- SFI institutional authority reconciliation.
+-- This migration does not create new sovereign authority classes in profiles.role.
+-- It preserves the existing coarse role constraint and records institutional mandate in module_access.
+
+update public.profiles
+set
+  role = 'root',
+  subscription_tier = 'founder',
+  module_access = (
+    coalesce(module_access, '{}'::jsonb)
+    - array[
+      'experiment_id','experiment_end','experiment_role','experiment_start',
+      'experiment_scopes','experiment_observer','experiment_observability'
+    ]
+  ) || jsonb_build_object(
+    'institutional_member', true,
+    'institutional_role', 'founder_root',
+    'institutional_domain', 'institution',
+    'display_title', 'Founder — System Friction Institute',
+    'institutional_read', true,
+    'institutional_write', true,
+    'institutional_execute', true,
+    'evidence_review', true,
+    'account_provision', true,
+    'account_manage', true,
+    'domain_role_assign', true,
+    'personal_cross_user', false,
+    'canonical_promotion', true,
+    'sovereign_actions', true,
+    'root_execution', true,
+    'full_access', true
+  )
+where lower(email) = 'aptymok@gmail.com';
+
+update public.profiles
+set
+  alias = 'Edwing Peredo Guadarrama',
+  role = 'controller',
+  subscription_tier = 'enterprise',
+  module_access = (
+    coalesce(module_access, '{}'::jsonb)
+    - array[
+      'experiment_id','experiment_end','experiment_role','experiment_start',
+      'experiment_scopes','experiment_observer','experiment_observability'
+    ]
+  ) || jsonb_build_object(
+    'institutional_member', true,
+    'institutional_role', 'institutional_director',
+    'institutional_domain', 'institution',
+    'display_title', 'Director Institucional — System Friction Institute',
+    'institutional_read', true,
+    'institutional_write', true,
+    'institutional_execute', true,
+    'evidence_review', true,
+    'account_provision', true,
+    'account_manage', true,
+    'domain_role_assign', true,
+    'personal_cross_user', false,
+    'field', true,
+    'studio', true,
+    'observatory', true,
+    'world_field', true,
+    'method_lab', true,
+    'governance', true,
+    'library', true,
+    'research_graph', true,
+    'machine_interfaces', true,
+    'planner', true,
+    'simulator', true,
+    'social', true,
+    'root', true,
+    'root_observe', true,
+    'full_access', false,
+    'executor', false,
+    'root_execution', false,
+    'governance_write', false,
+    'sovereign_actions', false,
+    'canonical_promotion', false
+  )
+where lower(email) = 'edwin.tzolkin@gmail.com';
+
+insert into public.sfi_audit_events (
+  actor_id, action, target_type, target_id, before_state, after_state, context
+)
+select
+  null,
+  'SFI_INSTITUTIONAL_AUTHORITY_RECONCILED',
+  'migration',
+  '20260905073500_reconcile_institutional_authority_roles',
+  null,
+  jsonb_build_object(
+    'founder_role', 'founder_root',
+    'director_role', 'institutional_director',
+    'canon_reserved_to_founder', true,
+    'personal_cross_user', false
+  ),
+  jsonb_build_object('source', 'repository_migration', 'authority', 'SFI-CI-008')
+where not exists (
+  select 1
+  from public.sfi_audit_events
+  where action = 'SFI_INSTITUTIONAL_AUTHORITY_RECONCILED'
+    and target_id = '20260905073500_reconcile_institutional_authority_roles'
+);

--- a/supabase/migrations/20260905073500_reconcile_institutional_authority_roles.sql
+++ b/supabase/migrations/20260905073500_reconcile_institutional_authority_roles.sql
@@ -68,8 +68,10 @@ set
     'planner', true,
     'simulator', true,
     'social', true,
-    'root', true,
-    'root_observe', true,
+    -- ROOT readers currently combine institutional state with Founder-private
+    -- Cognitive Twin/AMV state. Director access stays outside this plane.
+    'root', false,
+    'root_observe', false,
     'full_access', false,
     'executor', false,
     'root_execution', false,
@@ -92,6 +94,7 @@ select
     'founder_role', 'founder_root',
     'director_role', 'institutional_director',
     'canon_reserved_to_founder', true,
+    'director_root_observe', false,
     'personal_cross_user', false
   ),
   jsonb_build_object('source', 'repository_migration', 'authority', 'SFI-CI-008')


### PR DESCRIPTION
## Objective
Formalize the SFI-CI-008 authority model in runtime identity administration without expanding CANON or cross-user personal access.

## Authority model
- Founder / ROOT: constitutional authority; can provision institutional roles, including Institutional Director; generic account console cannot create/demote ROOT.
- Institutional Director: broad institutional operating authority; may invite/manage subordinate institutional accounts and appoint Domain Directors.
- Domain Director: scoped domain authority; no institution-wide account administration by default.
- No non-Founder role receives CANON, sovereign actions, root execution, ROOT observation, or cross-user PERSONAL access.
- Edwing's external GPT remains `institutional_operator`; account administration is human-session-only.

## SFI PRECHECK
Owner: Institutional identity / authority; existing owner is `src/lib/system/access/**` with Supabase Auth as credential owner and `profiles` as durable mandate/profile owner.

Existing capability inspected: `institutionalMembers.ts`, `src/lib/system/access/server.ts`, `src/runtime/supabase/server.ts`, Supabase `profiles`, `auth.users`, `sfi_audit_events`, ROOT viewer/actor split, current OAuth member scopes, and open concurrent PR state.

Absorb vs create decision: ABSORB existing access/profile/Auth owners. Create only the missing role-template module, governed account-admin adapter/API, and `/institution/access` surface; no duplicate identity store or password owner.

Authoritative writer: Supabase Auth Admin remains authoritative for identities/invitations; `profiles` remains authoritative for institutional mandate; `sfi_audit_events` remains authoritative audit lineage. Browser code is never a writer to Auth or raw tables.

Persistence/lineage impact: profile `module_access` receives durable `institutional_role` / domain / ceilings. Invitations and role mutations append `sfi_audit_events`. No personal content is copied or promoted.

Front delta: new authenticated `/institution/access` console. It exposes institutional account metadata only and compiles roles into governed capabilities instead of exposing raw service-role/database controls.

Back delta: new account-admin guard plus server-only list/invite/update adapter and API. Known hardcoded members become bootstrap principals; once a durable mandate exists, login does not silently overwrite later Founder-approved role changes.

DB delta: data reconciliation only in existing `profiles` and `sfi_audit_events`; no new table, trigger, enum/check change, or RLS policy change.

Redundancy removed: expired Edwing experimental delegation metadata is removed when durable Director mandate is applied; Director no longer inherits ROOT observer access from the former Studio controller bootstrap.

Execution/ROOT boundary: ROOT remains Founder-only because current ROOT state aggregates Cognitive Twin/AMV and sovereign state. Director can execute institutional operations and manage subordinate accounts but cannot observe ROOT, CANON, self-elevate, edit Founder, edit another Institutional Director, or grant cross-user PERSONAL access.

Rollback: revert this PR and its profile reconciliation; existing Auth users remain intact. No destructive user deletion or credential rewrite is introduced.

Verification: canonical preflight, typecheck/build, existing external OAuth gate, Founder/Director account-admin ceiling tests, invitation/profile/audit integration review, and production verification after merge.

## Changes
- add explicit durable institutional role/domain model and assignment ceilings;
- promote Edwing's human principal from `Director de Dominio — SFI Studio` to `Director Institucional — System Friction Institute`;
- remove Director from sovereign ROOT observer plane because ROOT currently includes Founder Cognitive Twin/AMV state;
- add Founder and Director account-admin guard;
- recognize provisioned institutional members without requiring hardcoded email membership;
- add `/institution/access` account console;
- add `/api/institution/access` GET/POST/PATCH;
- invitations use Supabase Admin server-side only; administrators never see/set user passwords;
- audit invitations and role changes in `sfi_audit_events`;
- add migration that removes expired experimental delegation metadata and reconciles Founder/Director durable authority.

## Privacy / security invariants
- PERSONAL != INSTITUTIONAL != SHARED_LAB.
- Founder account is omitted from Director's account directory and cannot be edited through generic account administration.
- Director cannot modify self, another Institutional Director, ROOT, CANON, or sovereignty.
- service-role credentials remain server-only.

## Concurrent development preflight
Branch cut from `main` `40abf032145679a12346897cca7742dc4f5b2021` after #372 merged. #373 then merged to `main` as `a5a431a7d20b61e87c10b1c6345c56e5794c511a`; its changed files are confined to WS-01 Cognitive Fabric and `.github/workflows/sfi-verify.yml`, with no overlap in the Auth/access files changed here. GitHub reports this PR mergeable.
