### PR TITLE
feat(mcp): add public read-only adapter foundation

### DIFF
--- a/.github/workflows/sfi-public-mcp-readonly.yml
+++ b/.github/workflows/sfi-public-mcp-readonly.yml
@@ -1,0 +1,48 @@
+name: SFI Public MCP Readonly
+
+on:
+  pull_request:
+    paths:
+      - 'src/lib/mcp/**'
+      - 'src/app/api/mcp/public/**'
+      - 'scripts/qa-sfi-public-mcp-readonly.ts'
+      - 'docs/program/workstreams/WS-04-PUBLIC-MCP-R3.md'
+      - '.github/workflows/sfi-public-mcp-readonly.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  public-mcp-readonly:
+    name: SFI-PUBLIC-MCP-READONLY-1.0
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if npm install --no-audit --no-fund; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Dependency installation failed after ${attempt} attempts."
+              exit 1
+            fi
+            rm -rf node_modules/ffmpeg-static
+            sleep $((attempt * 10))
+          done
+
+      - name: Verify public MCP read-only boundary
+        run: npx tsx scripts/qa-sfi-public-mcp-readonly.ts

--- a/docs/program/workstreams/WS-04-PUBLIC-MCP-R3.md
+++ b/docs/program/workstreams/WS-04-PUBLIC-MCP-R3.md
@@ -1,0 +1,131 @@
+# WS-04 · R3 PUBLIC MCP READ-ONLY ADAPTER
+
+**Original baseline:** `0b97fdb277eb4af0a537a60837ceb76658199c20`  
+**Refresh baseline:** `4c463f9359a3a1f36c8c2e4d7e4a93039a714182`  
+**Owner:** SFI-04 · MACHINE INTERFACES  
+**Integration authority:** SFI-00 · CONTROL ROOM  
+**Self-merge:** FORBIDDEN  
+**Server ID:** `org.systemfriction/public`  
+**Endpoint:** `/api/mcp/public`  
+**Protocol revision:** `2026-07-28`  
+**Authority:** `PUBLIC_READ_ONLY`
+
+## Slice
+
+This bounded R3 slice adds a stateless public MCP adapter over existing authoritative public readers. It does not create another application backend, OAuth implementation, canonical object registry, Evidence Capsule contract, event store, persistence owner, model router, Capability Broker, or authority plane.
+
+The branch was refreshed after SFI-00 integrated PR #383. The obsolete disposition `PUBLIC_EVIDENCE_CAPSULE_OWNER_NOT_AVAILABLE_AT_BASELINE` is removed. `get_public_evidence` now consumes the integrated WS-03 owner `SFI-EVIDENCE-CAPSULE-1.0` directly and does not reproduce its publicability or epistemic rules.
+
+## Reused owners
+
+- canonical institution projection: `src/lib/public/institutionProfile.ts`;
+- canonical public object/publicability owner: `src/lib/discovery/canonicalObjectRegistry.ts`;
+- Evidence Capsule/public semantic owner: `src/lib/discovery/publicSemanticProjection.ts`;
+- governed public research projection: `src/lib/research/researchGraphProjection.ts`;
+- governed public world-state reader: `src/lib/observatory/public/readGovernedPublicObservatoryState.ts`.
+
+The authenticated external gateway remains unchanged and is not callable through this public adapter.
+
+## Available tools
+
+```text
+get_institution
+search_concepts
+get_concept
+search_methods
+get_method
+search_instruments
+get_public_evidence
+get_public_return
+get_public_research
+get_epistemic_contract
+get_public_world_state
+```
+
+Canonical search/read tools consume only objects admitted by `SFI-CANONICAL-OBJECT-1.0`. An authoritative valid empty registry is represented as available with zero results; it is not represented as unavailable.
+
+`get_public_evidence` accepts a canonical public-object identifier plus the Evidence Capsule request coordinates required by the WS-03 contract. The MCP adapter first refuses to reveal non-public canonical records, then delegates capsule disposition and construction to `evidenceCapsuleDisposition()` and `evidenceCapsuleForCanonicalObject()`. A WS-03 `BLOCK` is reflected as `BLOCK` with no capsule. The adapter never promotes, repairs, or reclassifies that result.
+
+## Explicitly unavailable tools
+
+```text
+get_public_capabilities  UNAVAILABLE · NO_AUTHORITATIVE_PUBLIC_CAPABILITY_PROJECTION
+```
+
+Current main still has no authoritative public capability projection. Capability Broker and Cognitive Passport remain internal governed runtime owners and are not substitutes for a public capability contract.
+
+## Resources
+
+```text
+sfi://institution
+sfi://epistemic-contract
+sfi://canonical/objects
+sfi://research
+sfi://world-state
+sfi://mcp/status
+```
+
+`sfi://mcp/status` exposes the public server identity, authority ceiling, available tool names, the integrated Evidence Capsule contract identifier, and explicit unavailable-tool reasons without exposing internal runtime topology.
+
+## Epistemic and privacy boundary
+
+- machine output remains an external representation;
+- `MODEL OUTPUT != OBSERVATION`;
+- `SIMULATION != OBSERVATION`;
+- `MISSING != EVIDENCE`;
+- `UNAVAILABLE != ZERO`;
+- `PRIVATE != PUBLIC`;
+- private/review-required canonical objects cannot enter MCP projections;
+- Evidence Capsule four-axis publicability, rights, governance, evidence identity, epistemic state and RETURN reality boundary remain owned by WS-03;
+- public world state is read through the existing governed publication gate;
+- no private Twin, private case, ROOT state, governance internals, or internal capability/passport metadata is exposed.
+
+## Authority and execution boundary
+
+The adapter exports only `POST` for MCP JSON-RPC transport. Its catalog contains no mutation or institutional-action capability. It does not import the authenticated external gateway, OAuth, `externalAuth`, Capability Broker, Cognitive Passport registry, or service-role client.
+
+Unknown or deferred tool names fail closed. The adapter never maps a model/tool name to authority.
+
+## Persistence
+
+`NONE`.
+
+The MCP core remains stateless. This refresh adds no session store, migration, table, RLS policy, evidence store, or event persistence.
+
+## Contract delta
+
+No new cross-workstream contract is created by WS-04.
+
+Consumed upstream contract:
+
+```text
+SFI-EVIDENCE-CAPSULE-1.0 · WS-03 · integrated by PR #383
+```
+
+`SFI-PUBLIC-MCP-READONLY-1.0` remains the Machine Interfaces gate. `org.systemfriction/public` remains the reserved public server identity.
+
+## QA
+
+Dedicated deterministic gate:
+
+```text
+SFI-PUBLIC-MCP-READONLY-1.0
+```
+
+Implementation:
+
+```text
+scripts/qa-sfi-public-mcp-readonly.ts
+.github/workflows/sfi-public-mcp-readonly.yml
+```
+
+The gate verifies direct reuse of the WS-03 Evidence Capsule owner, no duplicate owner/contract, non-public/private filtering, owner BLOCK propagation, SIMULATED/DERIVED not becoming observed evidence, MISSING not becoming evidence, authoritative empty result not becoming UNAVAILABLE, header/body routing agreement, public-capability UNAVAILABLE disposition, absence of action-capable tools, absence of ROOT/Twin/private runtime dependencies, no service-role path, no persistence mutations, and reuse of canonical owners.
+
+## Deferred by scope
+
+- authenticated MCP execution;
+- external OAuth expansion;
+- Official MCP Registry submission;
+- ChatGPT/Codex directory listing;
+- public capability projection until a dedicated authoritative public owner exists;
+- audio MCP.

--- a/scripts/qa-sfi-public-mcp-readonly.ts
+++ b/scripts/qa-sfi-public-mcp-readonly.ts
@@ -1,0 +1,373 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  SFI_CANONICAL_OBJECT_CONTRACT,
+  canonicalObjectKey,
+  canonicalUrlFor,
+  type SfiCanonicalObjectRecord,
+  type SfiCanonicalObjectType,
+} from '../src/lib/discovery/canonicalObjectRegistry';
+import { SFI_EVIDENCE_CAPSULE_CONTRACT } from '../src/lib/discovery/publicSemanticProjection';
+import { SFI_PUBLIC_PROFILE } from '../src/lib/public/institutionProfile';
+import {
+  SFI_PUBLIC_MCP_AUTHORITY,
+  SFI_PUBLIC_MCP_DEFERRED_TOOLS,
+  SFI_PUBLIC_MCP_GATE,
+  SFI_PUBLIC_MCP_PROTOCOL_VERSION,
+  SFI_PUBLIC_MCP_RESOURCES,
+  SFI_PUBLIC_MCP_SERVER_ID,
+  SFI_PUBLIC_MCP_TOOLS,
+  dispatchPublicMcpRequest,
+  getPublicCanonicalObject,
+  publicCanonicalObjectProjections,
+  publicEvidenceForCanonicalObjects,
+  searchPublicCanonicalObjects,
+  validatePublicMcpHttpEnvelope,
+} from '../src/lib/mcp/publicMcpServer';
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(path.join(root, relative), 'utf8');
+const routeSource = read('src/app/api/mcp/public/route.ts');
+const serverSource = read('src/lib/mcp/publicMcpServer.ts');
+const evidenceOwnerSource = read('src/lib/discovery/publicSemanticProjection.ts');
+
+function fixture(objectType: SfiCanonicalObjectType, suffix: string): SfiCanonicalObjectRecord {
+  const slug = `mcp-${suffix}`;
+  const sourceRef = `source:mcp:${suffix}`;
+  return {
+    contract: SFI_CANONICAL_OBJECT_CONTRACT,
+    id: `sfi-mcp-${suffix}`,
+    objectKey: canonicalObjectKey(objectType, slug),
+    objectType,
+    slug,
+    canonicalUrl: canonicalUrlFor(objectType, slug),
+    title: `MCP ${objectType} ${suffix}`,
+    summary: `Deterministic ${objectType} public MCP fixture ${suffix}.`,
+    bodyRef: null,
+    epistemicState: objectType === 'RETURN' || objectType === 'OBSERVATION' ? 'OBSERVED' : 'DECLARED',
+    version: '1.0.0',
+    language: 'en',
+    authors: ['System Friction Institute'],
+    methods: [],
+    relatedObjects: [],
+    sourceRefs: [sourceRef],
+    publicState: 'PUBLIC',
+    license: 'CC BY 4.0',
+    createdAt: '2026-09-06T00:00:00.000Z',
+    updatedAt: '2026-09-06T00:00:00.000Z',
+    entity: {
+      entityId: SFI_PUBLIC_PROFILE.institution.entityId,
+      relation: objectType === 'RETURN' || objectType === 'OBSERVATION' ? 'OBSERVED_BY' : 'PUBLISHED_BY',
+    },
+    publication: { state: 'PUBLISHED', explicit: true },
+    eligibility: { privacyClass: 'PUBLIC', publicEligible: true, securityEligible: true },
+    rights: { state: 'OPEN' },
+    evidenceIdentity: { state: 'VALID', refs: [sourceRef] },
+    limitations: [],
+    missing: [],
+  };
+}
+
+function evidenceArgs(record: SfiCanonicalObjectRecord, overrides: Record<string, unknown> = {}) {
+  const observed = record.epistemicState === 'OBSERVED';
+  return {
+    identifier: record.id,
+    capsuleId: `capsule:${record.id}`,
+    claim: `Public evidence claim for ${record.id}`,
+    evidenceRefs: [...record.evidenceIdentity.refs],
+    origin: observed ? 'OBSERVATION' : 'DECLARED',
+    ...(observed ? { observedAt: '2026-09-06T00:01:00.000Z' } : { producedAt: '2026-09-06T00:01:00.000Z' }),
+    ...overrides,
+  };
+}
+
+function request(method: string, params: Record<string, unknown> = {}) {
+  return {
+    jsonrpc: '2.0' as const,
+    id: `qa-${method}`,
+    method,
+    params: {
+      ...params,
+      _meta: {
+        'io.modelcontextprotocol/protocolVersion': SFI_PUBLIC_MCP_PROTOCOL_VERSION,
+        'io.modelcontextprotocol/clientInfo': { name: 'sfi-qa', version: '1.0.0' },
+        'io.modelcontextprotocol/clientCapabilities': {},
+      },
+    },
+  };
+}
+
+async function main() {
+  assert.equal(SFI_PUBLIC_MCP_GATE, 'SFI-PUBLIC-MCP-READONLY-1.0', 'readonly_gate_id_drift');
+  assert.equal(SFI_PUBLIC_MCP_SERVER_ID, 'org.systemfriction/public', 'server_id_drift');
+  assert.equal(SFI_PUBLIC_MCP_PROTOCOL_VERSION, '2026-07-28', 'protocol_version_drift');
+  assert.equal(SFI_PUBLIC_MCP_AUTHORITY, 'PUBLIC_READ_ONLY', 'public_authority_drift');
+  assert.equal(SFI_EVIDENCE_CAPSULE_CONTRACT, 'SFI-EVIDENCE-CAPSULE-1.0', 'upstream_evidence_contract_drift');
+
+  const toolNames = SFI_PUBLIC_MCP_TOOLS.map((tool) => tool.name);
+  assert.deepEqual(toolNames, [
+    'get_institution',
+    'search_concepts',
+    'get_concept',
+    'search_methods',
+    'get_method',
+    'search_instruments',
+    'get_public_evidence',
+    'get_public_return',
+    'get_public_research',
+    'get_epistemic_contract',
+    'get_public_world_state',
+  ], 'available_tool_contract_drift');
+
+  const forbiddenCapabilityPattern = /(?:^|[_-])(write|propose|execute|root|twin|private|governance)(?:$|[_-])/i;
+  for (const tool of SFI_PUBLIC_MCP_TOOLS) {
+    assert.equal(forbiddenCapabilityPattern.test(tool.name), false, `forbidden_public_tool:${tool.name}`);
+  }
+
+  assert.deepEqual(SFI_PUBLIC_MCP_DEFERRED_TOOLS.map((tool) => tool.name), [
+    'get_public_capabilities',
+  ], 'deferred_tool_contract_drift');
+  assert.ok(SFI_PUBLIC_MCP_DEFERRED_TOOLS.every((tool) => tool.state === 'UNAVAILABLE'), 'deferred_tools_must_be_unavailable');
+  assert.equal(toolNames.includes('get_public_capabilities' as never), false, 'unavailable_capability_tool_must_not_be_listed');
+  assert.ok(toolNames.includes('get_public_evidence'), 'integrated_evidence_tool_must_be_listed');
+
+  const publicConcept = fixture('CONCEPT', 'public-concept');
+  const privateConcept = fixture('CONCEPT', 'private-concept');
+  privateConcept.publicState = 'PRIVATE';
+  privateConcept.publication.state = 'DRAFT';
+  privateConcept.eligibility.privacyClass = 'PRIVATE';
+  privateConcept.eligibility.publicEligible = false;
+  privateConcept.eligibility.securityEligible = false;
+
+  const projections = publicCanonicalObjectProjections([publicConcept, privateConcept]);
+  assert.deepEqual(projections.map((item) => item.id), [publicConcept.id], 'private_canonical_object_leaked');
+  assert.deepEqual(searchPublicCanonicalObjects('CONCEPT', '', [publicConcept, privateConcept]).map((item) => item.id), [publicConcept.id], 'private_search_leak');
+  assert.equal(getPublicCanonicalObject('CONCEPT', privateConcept.id, [publicConcept, privateConcept]), null, 'private_get_leak');
+
+  const publicReport = fixture('REPORT', 'evidence-public');
+  const acceptedEvidence = publicEvidenceForCanonicalObjects(evidenceArgs(publicReport), [publicReport]);
+  assert.ok(acceptedEvidence, 'evidence_owner_adapter_return_missing');
+  assert.equal(acceptedEvidence?.sourceContract, SFI_EVIDENCE_CAPSULE_CONTRACT, 'evidence_owner_contract_not_projected');
+  assert.equal(acceptedEvidence?.disposition, 'PUBLISH', 'valid_owner_disposition_not_preserved');
+  assert.equal((acceptedEvidence?.capsule as { contract?: string } | null)?.contract, SFI_EVIDENCE_CAPSULE_CONTRACT, 'capsule_not_created_by_ws03_contract');
+
+  const blockedEvidence = publicEvidenceForCanonicalObjects(evidenceArgs(publicReport, {
+    evidenceRefs: ['source:mcp:not-validated'],
+  }), [publicReport]);
+  assert.equal(blockedEvidence?.state, 'BLOCK', 'owner_block_not_reflected');
+  assert.equal(blockedEvidence?.capsule, null, 'blocked_capsule_leaked');
+  assert.ok((blockedEvidence?.reasons as string[]).includes('EVIDENCE_REF_NOT_VALIDATED'), 'owner_block_reason_not_preserved');
+
+  for (const epistemicState of ['SIMULATED', 'DERIVED'] as const) {
+    const modeled = fixture('REPORT', `modeled-${epistemicState.toLowerCase()}`);
+    modeled.epistemicState = epistemicState;
+    const modeledEvidence = publicEvidenceForCanonicalObjects(evidenceArgs(modeled, {
+      origin: 'OBSERVATION',
+      observedAt: '2026-09-06T00:02:00.000Z',
+      producedAt: undefined,
+    }), [modeled]);
+    assert.equal(modeledEvidence?.state, 'BLOCK', `${epistemicState.toLowerCase()}_became_observed_evidence`);
+    assert.ok((modeledEvidence?.reasons as string[]).includes('OBSERVATION_ORIGIN_REQUIRES_OBSERVED_STATE'), `${epistemicState.toLowerCase()}_origin_state_congruence_not_owned`);
+    assert.equal(modeledEvidence?.capsule, null, `${epistemicState.toLowerCase()}_capsule_leaked`);
+  }
+
+  const missingReport = fixture('REPORT', 'missing-report');
+  missingReport.epistemicState = 'MISSING';
+  missingReport.sourceRefs = ['source:mcp:missing-evidence', 'source:mcp:missing-required-field'];
+  missingReport.evidenceIdentity = { state: 'VALID', refs: ['source:mcp:missing-evidence'] };
+  missingReport.missing = [{
+    field: 'sample_size',
+    reason: 'The public source does not disclose sample size.',
+    sourceRef: 'source:mcp:missing-required-field',
+  }];
+  const missingProjection = publicCanonicalObjectProjections([missingReport])[0];
+  assert.equal(missingProjection.epistemicState, 'MISSING', 'missing_state_rewritten');
+  assert.deepEqual(missingProjection.missing, missingReport.missing, 'missing_lineage_rewritten');
+  const missingEvidence = publicEvidenceForCanonicalObjects(evidenceArgs(missingReport), [missingReport]);
+  assert.equal(missingEvidence?.state, 'BLOCK', 'missing_became_evidence');
+  assert.ok((missingEvidence?.reasons as string[]).includes('MISSING_STATE_CANNOT_BE_EVIDENCE_CAPSULE'), 'missing_owner_block_reason_missing');
+  assert.equal(missingEvidence?.capsule, null, 'missing_capsule_leaked');
+
+  const privateEvidence = publicEvidenceForCanonicalObjects(evidenceArgs(privateConcept), [privateConcept]);
+  assert.equal(privateEvidence?.state, 'AVAILABLE', 'private_lookup_must_not_be_recast_as_unavailable');
+  assert.equal(privateEvidence?.found, false, 'private_object_existence_leaked');
+  assert.equal(privateEvidence?.capsule, null, 'private_capsule_leaked');
+
+  const emptyEvidence = publicEvidenceForCanonicalObjects({
+    identifier: 'sfi-object-not-present',
+    capsuleId: 'capsule:empty',
+    claim: 'No matching public object.',
+    evidenceRefs: ['source:none'],
+    origin: 'DECLARED',
+    producedAt: '2026-09-06T00:03:00.000Z',
+  }, []);
+  assert.equal(emptyEvidence?.state, 'AVAILABLE', 'empty_authoritative_evidence_source_must_not_be_unavailable');
+  assert.equal(emptyEvidence?.found, false, 'empty_authoritative_evidence_source_false_positive');
+  assert.equal(JSON.stringify(emptyEvidence).includes('UNAVAILABLE'), false, 'empty_authoritative_evidence_source_recast_unavailable');
+
+  assert.deepEqual(searchPublicCanonicalObjects('CONCEPT'), [], 'empty_authoritative_registry_must_be_available_empty');
+
+  const validEnvelope = request('tools/call', { name: 'search_concepts', arguments: { q: 'test' } });
+  assert.deepEqual(validatePublicMcpHttpEnvelope({
+    protocolVersion: SFI_PUBLIC_MCP_PROTOCOL_VERSION,
+    method: 'tools/call',
+    name: 'search_concepts',
+  }, validEnvelope), [], 'valid_modern_mcp_envelope_rejected');
+  assert.ok(validatePublicMcpHttpEnvelope({
+    protocolVersion: SFI_PUBLIC_MCP_PROTOCOL_VERSION,
+    method: 'tools/call',
+    name: 'different_tool',
+  }, validEnvelope).includes('NAME_HEADER_MISMATCH'), 'header_body_name_mismatch_not_blocked');
+
+  const dependencies = {
+    readPublicWorldState: async () => ({ state: 'unused' }),
+  };
+
+  const discover = await dispatchPublicMcpRequest(request('server/discover'), dependencies);
+  const discoverText = JSON.stringify(discover);
+  assert.ok(discoverText.includes(SFI_PUBLIC_MCP_SERVER_ID), 'discover_server_identity_missing');
+  assert.ok(discoverText.includes(SFI_PUBLIC_MCP_PROTOCOL_VERSION), 'discover_protocol_missing');
+  assert.equal(/execute|propose|ROOT|Twin/.test(discoverText), false, 'discover_metadata_expands_authority');
+
+  const listedTools = await dispatchPublicMcpRequest(request('tools/list'), dependencies);
+  const listedToolsText = JSON.stringify(listedTools);
+  for (const name of toolNames) assert.ok(listedToolsText.includes(name), `listed_tool_missing:${name}`);
+  for (const deferred of SFI_PUBLIC_MCP_DEFERRED_TOOLS) assert.equal(listedToolsText.includes(deferred.name), false, `deferred_tool_listed:${deferred.name}`);
+
+  const emptyEvidenceViaMcp = await dispatchPublicMcpRequest(request('tools/call', {
+    name: 'get_public_evidence',
+    arguments: {
+      identifier: 'sfi-object-not-present',
+      capsuleId: 'capsule:empty-mcp',
+      claim: 'No matching canonical public object.',
+      evidenceRefs: ['source:none'],
+      origin: 'DECLARED',
+      producedAt: '2026-09-06T00:04:00.000Z',
+    },
+  }), dependencies);
+  const emptyEvidenceViaMcpText = JSON.stringify(emptyEvidenceViaMcp);
+  assert.ok(emptyEvidenceViaMcpText.includes('"state":"AVAILABLE"'), 'mcp_empty_evidence_not_available');
+  assert.ok(emptyEvidenceViaMcpText.includes('"found":false'), 'mcp_empty_evidence_found_drift');
+  assert.equal(emptyEvidenceViaMcpText.includes('UNAVAILABLE'), false, 'mcp_empty_evidence_false_unavailable');
+
+  const deferredCapabilities = await dispatchPublicMcpRequest(request('tools/call', {
+    name: 'get_public_capabilities',
+    arguments: {},
+  }), dependencies);
+  const deferredCapabilitiesText = JSON.stringify(deferredCapabilities);
+  assert.ok(deferredCapabilitiesText.includes('UNAVAILABLE'), 'public_capability_projection_must_remain_unavailable');
+  assert.ok(deferredCapabilitiesText.includes('NO_AUTHORITATIVE_PUBLIC_CAPABILITY_PROJECTION'), 'public_capability_unavailable_reason_drift');
+  assert.equal(deferredCapabilitiesText.includes('"count":0'), false, 'unavailable_capability_projection_must_not_be_false_zero');
+
+  const blockedExecution = await dispatchPublicMcpRequest(request('tools/call', {
+    name: 'execute',
+    arguments: {},
+  }), dependencies);
+  assert.ok(JSON.stringify(blockedExecution).includes('TOOL_NOT_AVAILABLE'), 'execution_name_not_blocked');
+
+  for (const forbiddenName of ['write', 'propose', 'execute', 'root', 'private_twin']) {
+    const blocked = await dispatchPublicMcpRequest(request('tools/call', {
+      name: forbiddenName,
+      arguments: {},
+    }), dependencies);
+    assert.ok(JSON.stringify(blocked).includes('TOOL_NOT_AVAILABLE'), `forbidden_tool_not_blocked:${forbiddenName}`);
+  }
+
+  const unavailableWorld = await dispatchPublicMcpRequest(request('tools/call', {
+    name: 'get_public_world_state',
+    arguments: {},
+  }), {
+    readPublicWorldState: async () => { throw new Error('synthetic unavailable'); },
+  });
+  const unavailableWorldText = JSON.stringify(unavailableWorld);
+  assert.ok(unavailableWorldText.includes('"state":"UNAVAILABLE"'), 'world_unavailable_state_missing');
+  assert.equal(unavailableWorldText.includes('"worldState":0'), false, 'unavailable_world_must_not_be_zero');
+
+  const statusResource = await dispatchPublicMcpRequest(request('resources/read', {
+    uri: 'sfi://mcp/status',
+  }), dependencies);
+  const statusText = JSON.stringify(statusResource);
+  for (const deferred of SFI_PUBLIC_MCP_DEFERRED_TOOLS) assert.ok(statusText.includes(deferred.name), `deferred_status_missing:${deferred.name}`);
+  assert.ok(statusText.includes('PUBLIC_READ_ONLY'), 'status_authority_boundary_missing');
+  assert.ok(statusText.includes(SFI_EVIDENCE_CAPSULE_CONTRACT), 'status_evidence_owner_contract_missing');
+
+  assert.deepEqual(SFI_PUBLIC_MCP_RESOURCES.map((resource) => resource.uri), [
+    'sfi://institution',
+    'sfi://epistemic-contract',
+    'sfi://canonical/objects',
+    'sfi://research',
+    'sfi://world-state',
+    'sfi://mcp/status',
+  ], 'resource_contract_drift');
+
+  // The route is a POST-only adapter. It owns no credentials, persistence, authority, or parallel backend.
+  assert.ok(routeSource.includes("from '@/lib/mcp/publicMcpServer'"), 'route_must_delegate_to_public_mcp_core');
+  assert.ok(routeSource.includes('readGovernedPublicObservatoryState'), 'route_must_reuse_governed_public_world_reader');
+  assert.equal(/export\s+(?:async\s+)?function\s+(GET|PUT|PATCH|DELETE)\b/.test(routeSource), false, 'non_post_route_surface_detected');
+
+  const implementationSource = `${serverSource}\n${routeSource}`;
+  for (const forbidden of [
+    'capabilityBroker',
+    'cognitivePassportRegistry',
+    'externalAuth',
+    '/api/external/v1/execute',
+    '/api/external/v1/propose',
+    "from('epistemic_events')",
+    'createServiceSupabaseClient',
+    'service_role',
+    '.insert(',
+    '.update(',
+    '.delete(',
+  ]) assert.equal(implementationSource.includes(forbidden), false, `forbidden_public_mcp_dependency:${forbidden}`);
+
+  assert.ok(serverSource.includes("from '../discovery/canonicalObjectRegistry'"), 'canonical_object_owner_not_reused');
+  assert.ok(serverSource.includes("from '../discovery/publicSemanticProjection'"), 'ws03_evidence_capsule_owner_not_reused');
+  assert.ok(serverSource.includes('evidenceCapsuleDisposition(record, request)'), 'ws03_evidence_disposition_not_delegated');
+  assert.ok(serverSource.includes('evidenceCapsuleForCanonicalObject(record, request)'), 'ws03_evidence_materialization_not_delegated');
+  assert.ok(evidenceOwnerSource.includes("SFI_EVIDENCE_CAPSULE_CONTRACT = 'SFI-EVIDENCE-CAPSULE-1.0'"), 'ws03_evidence_contract_owner_missing');
+  assert.equal(serverSource.includes('export const SFI_EVIDENCE_CAPSULE_CONTRACT'), false, 'evidence_capsule_contract_duplicated');
+  assert.equal(serverSource.includes('function evidenceCapsuleDisposition('), false, 'evidence_capsule_disposition_duplicated');
+  assert.equal(serverSource.includes('function evidenceCapsuleForCanonicalObject('), false, 'evidence_capsule_materializer_duplicated');
+  for (const ws03OwnedRule of [
+    'PUBLICABILITY_RIGHTS_NOT_CLEARED',
+    'PUBLICABILITY_GOVERNANCE_NOT_PUBLICABLE',
+    'MISSING_STATE_CANNOT_BE_EVIDENCE_CAPSULE',
+    'RETURN_REQUIRES_REALITY_OBSERVATION',
+    'MODEL_OUTPUT_CANNOT_BE_OBSERVATION',
+  ]) assert.equal(serverSource.includes(ws03OwnedRule), false, `ws03_epistemic_rule_duplicated:${ws03OwnedRule}`);
+
+  assert.ok(serverSource.includes("from '../public/institutionProfile'"), 'institution_profile_owner_not_reused');
+  assert.ok(serverSource.includes("from '../research/researchGraphProjection'"), 'research_projection_owner_not_reused');
+  assert.equal(serverSource.includes('export const SFI_CANONICAL_OBJECT_REGISTRY ='), false, 'canonical_registry_duplicated');
+  assert.equal(serverSource.includes('export const SFI_PUBLIC_PROFILE ='), false, 'institution_profile_duplicated');
+
+  console.log(JSON.stringify({
+    contract: SFI_PUBLIC_MCP_GATE,
+    serverId: SFI_PUBLIC_MCP_SERVER_ID,
+    protocolVersion: SFI_PUBLIC_MCP_PROTOCOL_VERSION,
+    authority: SFI_PUBLIC_MCP_AUTHORITY,
+    availableTools: toolNames,
+    unavailableTools: SFI_PUBLIC_MCP_DEFERRED_TOOLS,
+    evidenceCapsuleContract: SFI_EVIDENCE_CAPSULE_CONTRACT,
+    resources: SFI_PUBLIC_MCP_RESOURCES.map((resource) => resource.uri),
+    evidenceOwnerConsumption: 'PASS',
+    duplicateEvidenceOwner: 'PASS',
+    canonicalRegistryEmptyIsAvailable: true,
+    privateLeakage: 'PASS',
+    missingEvidenceBoundary: 'PASS',
+    modeledObservationBoundary: 'PASS',
+    unavailableNotZero: 'PASS',
+    writeProposeExecuteAbsence: 'PASS',
+    publicCapabilityProjection: 'UNAVAILABLE',
+    rootTwinBoundary: 'PASS',
+    persistenceDelta: 'NONE',
+    authorityDelta: 'NONE',
+    status: 'PASS',
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/app/api/mcp/public/route.ts
+++ b/src/app/api/mcp/public/route.ts
@@ -1,0 +1,77 @@
+import {
+  SFI_PUBLIC_MCP_PROTOCOL_VERSION,
+  SFI_PUBLIC_MCP_SERVER_ID,
+  dispatchPublicMcpRequest,
+  isPublicMcpRequest,
+  validatePublicMcpHttpEnvelope,
+} from '@/lib/mcp/publicMcpServer';
+import { readGovernedPublicObservatoryState } from '@/lib/observatory/public/readGovernedPublicObservatoryState';
+
+export const dynamic = 'force-dynamic';
+
+function requestId(value: unknown): string | number | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const id = (value as Record<string, unknown>).id;
+  return typeof id === 'string' || typeof id === 'number' || id === null ? id : null;
+}
+
+function errorResponse(
+  id: string | number | null,
+  code: number,
+  message: string,
+  data: Record<string, unknown>,
+  status: number,
+) {
+  return Response.json({
+    jsonrpc: '2.0',
+    id,
+    error: { code, message, data },
+  }, {
+    status,
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-SFI-MCP-Server': SFI_PUBLIC_MCP_SERVER_ID,
+      'X-SFI-MCP-Protocol': SFI_PUBLIC_MCP_PROTOCOL_VERSION,
+    },
+  });
+}
+
+export async function POST(request: Request) {
+  if (!request.headers.get('content-type')?.toLowerCase().includes('application/json')) {
+    return errorResponse(null, -32600, 'Invalid Request', { reason: 'APPLICATION_JSON_REQUIRED' }, 415);
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return errorResponse(null, -32700, 'Parse error', { reason: 'INVALID_JSON' }, 400);
+  }
+
+  if (!isPublicMcpRequest(payload)) {
+    return errorResponse(requestId(payload), -32600, 'Invalid Request', { reason: 'INVALID_JSON_RPC_REQUEST' }, 400);
+  }
+
+  const envelopeErrors = validatePublicMcpHttpEnvelope({
+    protocolVersion: request.headers.get('mcp-protocol-version'),
+    method: request.headers.get('mcp-method'),
+    name: request.headers.get('mcp-name'),
+  }, payload);
+
+  if (envelopeErrors.length > 0) {
+    return errorResponse(requestId(payload), -32020, 'HeaderMismatch', { errors: envelopeErrors }, 400);
+  }
+
+  const response = await dispatchPublicMcpRequest(payload, {
+    readPublicWorldState: readGovernedPublicObservatoryState,
+  });
+
+  return Response.json(response, {
+    status: 200,
+    headers: {
+      'Cache-Control': 'no-store',
+      'X-SFI-MCP-Server': SFI_PUBLIC_MCP_SERVER_ID,
+      'X-SFI-MCP-Protocol': SFI_PUBLIC_MCP_PROTOCOL_VERSION,
+    },
+  });
+}

--- a/src/lib/mcp/publicMcpServer.ts
+++ b/src/lib/mcp/publicMcpServer.ts
@@ -1,0 +1,701 @@
+import {
+  SFI_CANONICAL_OBJECT_CONTRACT,
+  SFI_CANONICAL_OBJECT_REGISTRY,
+  publicProjectionForCanonicalObject,
+  validateCanonicalObjectRegistry,
+  type SfiCanonicalObjectRecord,
+  type SfiCanonicalObjectType,
+  type SfiCanonicalPublicProjection,
+} from '../discovery/canonicalObjectRegistry';
+import {
+  SFI_EVIDENCE_CAPSULE_CONTRACT,
+  evidenceCapsuleDisposition,
+  evidenceCapsuleForCanonicalObject,
+  type SfiEvidenceCapsuleOrigin,
+  type SfiEvidenceCapsuleRequest,
+} from '../discovery/publicSemanticProjection';
+import { SFI_PUBLIC_PROFILE } from '../public/institutionProfile';
+import {
+  researchGraphProjectionForCanonicalObjects,
+  type SfiResearchProjectableObjectType,
+} from '../research/researchGraphProjection';
+
+export const SFI_PUBLIC_MCP_GATE = 'SFI-PUBLIC-MCP-READONLY-1.0' as const;
+export const SFI_PUBLIC_MCP_SERVER_ID = 'org.systemfriction/public' as const;
+export const SFI_PUBLIC_MCP_SERVER_VERSION = '1.0.0' as const;
+export const SFI_PUBLIC_MCP_PROTOCOL_VERSION = '2026-07-28' as const;
+export const SFI_PUBLIC_MCP_AUTHORITY = 'PUBLIC_READ_ONLY' as const;
+export const SFI_PUBLIC_MCP_ENDPOINT = '/api/mcp/public' as const;
+
+const PUBLIC_CACHE_TTL_MS = 300_000;
+const DYNAMIC_CACHE_TTL_MS = 30_000;
+const EVIDENCE_ORIGINS = ['OBSERVATION', 'DECLARED', 'DERIVED', 'MODEL_OUTPUT'] as const satisfies readonly SfiEvidenceCapsuleOrigin[];
+
+type JsonRpcId = string | number | null;
+type JsonObject = Record<string, unknown>;
+type JsonRpcRequest = {
+  jsonrpc: '2.0';
+  id?: JsonRpcId;
+  method: string;
+  params?: JsonObject;
+};
+
+export type SfiPublicMcpDependencies = Readonly<{
+  readPublicWorldState: () => Promise<unknown>;
+}>;
+
+export type SfiPublicMcpHttpHeaders = Readonly<{
+  protocolVersion: string | null;
+  method: string | null;
+  name: string | null;
+}>;
+
+export type SfiPublicMcpDeferredTool = Readonly<{
+  name: 'get_public_capabilities';
+  state: 'UNAVAILABLE';
+  reason: string;
+}>;
+
+export const SFI_PUBLIC_MCP_DEFERRED_TOOLS: readonly SfiPublicMcpDeferredTool[] = Object.freeze([
+  {
+    name: 'get_public_capabilities',
+    state: 'UNAVAILABLE',
+    reason: 'NO_AUTHORITATIVE_PUBLIC_CAPABILITY_PROJECTION',
+  },
+]);
+
+const EMPTY_INPUT_SCHEMA = Object.freeze({
+  type: 'object',
+  properties: {},
+  additionalProperties: false,
+} as const);
+
+const SEARCH_INPUT_SCHEMA = Object.freeze({
+  type: 'object',
+  properties: {
+    q: { type: 'string', description: 'Optional case-insensitive query over the canonical public title, summary, id, key, or slug.' },
+    limit: { type: 'integer', minimum: 1, maximum: 100, default: 25 },
+  },
+  additionalProperties: false,
+} as const);
+
+const GET_INPUT_SCHEMA = Object.freeze({
+  type: 'object',
+  properties: {
+    identifier: { type: 'string', minLength: 1, description: 'Canonical object id, object key, slug, or canonical URL.' },
+  },
+  required: ['identifier'],
+  additionalProperties: false,
+} as const);
+
+const EVIDENCE_INPUT_SCHEMA = Object.freeze({
+  type: 'object',
+  properties: {
+    identifier: { type: 'string', minLength: 1, description: 'Canonical public-object id, object key, slug, or canonical URL.' },
+    capsuleId: { type: 'string', minLength: 1, description: 'Evidence Capsule identifier supplied to the WS-03 owner.' },
+    claim: { type: 'string', minLength: 1, description: 'Claim supplied unchanged to the WS-03 Evidence Capsule owner.' },
+    evidenceRefs: {
+      type: 'array',
+      minItems: 1,
+      items: { type: 'string', minLength: 1 },
+      description: 'Validated evidence references; WS-03 decides whether each ref is admissible.',
+    },
+    observedAt: { type: 'string', description: 'Observation timestamp when origin is observational. Exactly-one temporal semantics remain WS-03-owned.' },
+    producedAt: { type: 'string', description: 'Production timestamp for non-observational capsule origins. Exactly-one temporal semantics remain WS-03-owned.' },
+    origin: { type: 'string', enum: EVIDENCE_ORIGINS },
+  },
+  required: ['identifier', 'capsuleId', 'claim', 'evidenceRefs', 'origin'],
+  additionalProperties: false,
+} as const);
+
+export const SFI_PUBLIC_MCP_TOOLS = Object.freeze([
+  {
+    name: 'get_institution',
+    description: 'Read the canonical public System Friction Institute profile projection.',
+    inputSchema: EMPTY_INPUT_SCHEMA,
+  },
+  {
+    name: 'search_concepts',
+    description: 'Search explicitly public canonical CONCEPT objects.',
+    inputSchema: SEARCH_INPUT_SCHEMA,
+  },
+  {
+    name: 'get_concept',
+    description: 'Read one explicitly public canonical CONCEPT object.',
+    inputSchema: GET_INPUT_SCHEMA,
+  },
+  {
+    name: 'search_methods',
+    description: 'Search explicitly public canonical METHOD objects.',
+    inputSchema: SEARCH_INPUT_SCHEMA,
+  },
+  {
+    name: 'get_method',
+    description: 'Read one explicitly public canonical METHOD object.',
+    inputSchema: GET_INPUT_SCHEMA,
+  },
+  {
+    name: 'search_instruments',
+    description: 'Search explicitly public canonical INSTRUMENT objects.',
+    inputSchema: SEARCH_INPUT_SCHEMA,
+  },
+  {
+    name: 'get_public_evidence',
+    description: 'Read a WS-03-governed Evidence Capsule projection for an explicitly public canonical object.',
+    inputSchema: EVIDENCE_INPUT_SCHEMA,
+  },
+  {
+    name: 'get_public_return',
+    description: 'Read one explicitly public canonical RETURN object.',
+    inputSchema: GET_INPUT_SCHEMA,
+  },
+  {
+    name: 'get_public_research',
+    description: 'Read the governed public Research Graph projection over canonical public objects.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        q: { type: 'string' },
+        type: {
+          type: 'string',
+          enum: ['METHOD', 'INSTRUMENT', 'DATASET', 'REPORT', 'PAPER', 'SOFTWARE', 'RELEASE', 'RETURN', 'PUBLICATION'],
+        },
+        limit: { type: 'integer', minimum: 1, maximum: 100, default: 25 },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'get_epistemic_contract',
+    description: 'Read the public epistemic classes, lifecycle, and invariant projection.',
+    inputSchema: EMPTY_INPUT_SCHEMA,
+  },
+  {
+    name: 'get_public_world_state',
+    description: 'Read the existing governed public Observatory world-state projection.',
+    inputSchema: EMPTY_INPUT_SCHEMA,
+  },
+] as const);
+
+export type SfiPublicMcpToolName = (typeof SFI_PUBLIC_MCP_TOOLS)[number]['name'];
+
+export const SFI_PUBLIC_MCP_RESOURCES = Object.freeze([
+  {
+    uri: 'sfi://institution',
+    name: 'System Friction Institute public profile',
+    mimeType: 'application/json',
+    description: 'Canonical public institution profile projection.',
+  },
+  {
+    uri: 'sfi://epistemic-contract',
+    name: 'SFI public epistemic contract',
+    mimeType: 'application/json',
+    description: 'Public epistemic classes, lifecycle, and invariants.',
+  },
+  {
+    uri: 'sfi://canonical/objects',
+    name: 'SFI public canonical objects',
+    mimeType: 'application/json',
+    description: 'Only explicitly public canonical object projections.',
+  },
+  {
+    uri: 'sfi://research',
+    name: 'SFI public Research Graph',
+    mimeType: 'application/json',
+    description: 'Governed research projection over canonical public objects.',
+  },
+  {
+    uri: 'sfi://world-state',
+    name: 'SFI governed public world state',
+    mimeType: 'application/json',
+    description: 'Current governed public Observatory state; absence remains unavailable rather than zero.',
+  },
+  {
+    uri: 'sfi://mcp/status',
+    name: 'SFI public MCP status',
+    mimeType: 'application/json',
+    description: 'Server identity, authority boundary, available tools, upstream Evidence Capsule contract, and explicit unavailable tools.',
+  },
+] as const);
+
+const TOOL_NAMES = new Set<string>(SFI_PUBLIC_MCP_TOOLS.map((tool) => tool.name));
+const RESOURCE_URIS = new Set<string>(SFI_PUBLIC_MCP_RESOURCES.map((resource) => resource.uri));
+const DEFERRED_BY_NAME = new Map<string, SfiPublicMcpDeferredTool>(SFI_PUBLIC_MCP_DEFERRED_TOOLS.map((tool) => [tool.name, tool]));
+
+function row(value: unknown): JsonObject {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonObject : {};
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function boundedLimit(value: unknown, fallback = 25): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(1, Math.min(100, Math.trunc(parsed)));
+}
+
+function publicInstitutionProjection() {
+  return {
+    contract: SFI_PUBLIC_PROFILE.contract,
+    institution: SFI_PUBLIC_PROFILE.institution,
+    operatingPrinciple: SFI_PUBLIC_PROFILE.operatingPrinciple,
+    instruments: SFI_PUBLIC_PROFILE.instruments,
+    lifecycle: SFI_PUBLIC_PROFILE.lifecycle,
+    epistemicClasses: SFI_PUBLIC_PROFILE.epistemicClasses,
+    invariants: SFI_PUBLIC_PROFILE.invariants,
+    publicSurfaces: SFI_PUBLIC_PROFILE.publicSurfaces,
+  };
+}
+
+function publicEpistemicProjection() {
+  return {
+    sourceContract: SFI_PUBLIC_PROFILE.contract,
+    lifecycle: SFI_PUBLIC_PROFILE.lifecycle,
+    epistemicClasses: SFI_PUBLIC_PROFILE.epistemicClasses,
+    invariants: SFI_PUBLIC_PROFILE.invariants,
+    boundary: {
+      modelOutputIsObservation: false,
+      simulationIsObservation: false,
+      missingIsEvidence: false,
+      missingRemainsMissing: true,
+      externalRepresentationIsCanon: false,
+    },
+  };
+}
+
+export function publicCanonicalObjectProjections(
+  records: readonly SfiCanonicalObjectRecord[] = SFI_CANONICAL_OBJECT_REGISTRY,
+): SfiCanonicalPublicProjection[] {
+  const errors = validateCanonicalObjectRegistry(records);
+  if (errors.length > 0) throw new Error(`INVALID_CANONICAL_OBJECT_SOURCE:${errors.join('|')}`);
+
+  return records
+    .map((record) => publicProjectionForCanonicalObject(record))
+    .filter((projection): projection is SfiCanonicalPublicProjection => projection !== null)
+    .sort((left, right) => left.objectKey.localeCompare(right.objectKey));
+}
+
+export function searchPublicCanonicalObjects(
+  objectType: SfiCanonicalObjectType,
+  query = '',
+  records: readonly SfiCanonicalObjectRecord[] = SFI_CANONICAL_OBJECT_REGISTRY,
+  limit = 25,
+): SfiCanonicalPublicProjection[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  const bounded = boundedLimit(limit);
+
+  return records
+    .filter((record) => record.objectType === objectType)
+    .map((record) => ({ record, projection: publicProjectionForCanonicalObject(record) }))
+    .filter((entry): entry is { record: SfiCanonicalObjectRecord; projection: SfiCanonicalPublicProjection } => entry.projection !== null)
+    .filter(({ record, projection }) => {
+      if (!normalizedQuery) return true;
+      return [
+        record.id,
+        record.objectKey,
+        record.slug,
+        record.canonicalUrl,
+        projection.title,
+        projection.summary,
+      ].some((value) => value.toLowerCase().includes(normalizedQuery));
+    })
+    .sort((left, right) => left.record.objectKey.localeCompare(right.record.objectKey))
+    .slice(0, bounded)
+    .map(({ projection }) => projection);
+}
+
+export function getPublicCanonicalObject(
+  objectType: SfiCanonicalObjectType,
+  identifier: string,
+  records: readonly SfiCanonicalObjectRecord[] = SFI_CANONICAL_OBJECT_REGISTRY,
+): SfiCanonicalPublicProjection | null {
+  const normalized = identifier.trim();
+  if (!normalized) return null;
+
+  const record = records.find((candidate) => candidate.objectType === objectType && [
+    candidate.id,
+    candidate.objectKey,
+    candidate.slug,
+    candidate.canonicalUrl,
+  ].includes(normalized));
+  return record ? publicProjectionForCanonicalObject(record) : null;
+}
+
+function evidenceRequestFromArgs(args: JsonObject): SfiEvidenceCapsuleRequest | null {
+  const origin = text(args.origin) as SfiEvidenceCapsuleOrigin;
+  if (!(EVIDENCE_ORIGINS as readonly string[]).includes(origin)) return null;
+
+  return {
+    id: text(args.capsuleId),
+    claim: text(args.claim),
+    evidenceRefs: Array.isArray(args.evidenceRefs)
+      ? args.evidenceRefs.filter((value): value is string => typeof value === 'string')
+      : [],
+    observedAt: typeof args.observedAt === 'string' ? args.observedAt : null,
+    producedAt: typeof args.producedAt === 'string' ? args.producedAt : null,
+    origin,
+  };
+}
+
+export function publicEvidenceForCanonicalObjects(
+  args: JsonObject,
+  records: readonly SfiCanonicalObjectRecord[] = SFI_CANONICAL_OBJECT_REGISTRY,
+): JsonObject | null {
+  const identifier = text(args.identifier);
+  if (!identifier) return null;
+
+  const record = records.find((candidate) => [
+    candidate.id,
+    candidate.objectKey,
+    candidate.slug,
+    candidate.canonicalUrl,
+  ].includes(identifier));
+
+  if (!record || publicProjectionForCanonicalObject(record) === null) {
+    return {
+      available: true,
+      state: 'AVAILABLE',
+      sourceContract: SFI_EVIDENCE_CAPSULE_CONTRACT,
+      found: false,
+      capsule: null,
+    };
+  }
+
+  const request = evidenceRequestFromArgs(args);
+  if (!request) return null;
+
+  const ownerDisposition = evidenceCapsuleDisposition(record, request);
+  if (ownerDisposition.disposition === 'BLOCK') {
+    return {
+      available: true,
+      state: 'BLOCK',
+      sourceContract: SFI_EVIDENCE_CAPSULE_CONTRACT,
+      found: true,
+      disposition: ownerDisposition.disposition,
+      reasons: ownerDisposition.reasons,
+      capsule: null,
+    };
+  }
+
+  const capsule = evidenceCapsuleForCanonicalObject(record, request);
+  if (!capsule) {
+    return {
+      available: false,
+      state: 'UNAVAILABLE',
+      sourceContract: SFI_EVIDENCE_CAPSULE_CONTRACT,
+      reason: 'EVIDENCE_CAPSULE_OWNER_RETURNED_NULL_AFTER_PUBLISH',
+    };
+  }
+
+  return {
+    available: true,
+    state: 'AVAILABLE',
+    sourceContract: SFI_EVIDENCE_CAPSULE_CONTRACT,
+    found: true,
+    disposition: ownerDisposition.disposition,
+    capsule,
+  };
+}
+
+function publicMcpStatus(records: readonly SfiCanonicalObjectRecord[] = SFI_CANONICAL_OBJECT_REGISTRY) {
+  return {
+    serverId: SFI_PUBLIC_MCP_SERVER_ID,
+    serverVersion: SFI_PUBLIC_MCP_SERVER_VERSION,
+    protocolVersion: SFI_PUBLIC_MCP_PROTOCOL_VERSION,
+    endpoint: SFI_PUBLIC_MCP_ENDPOINT,
+    authority: SFI_PUBLIC_MCP_AUTHORITY,
+    sourceContract: SFI_CANONICAL_OBJECT_CONTRACT,
+    evidenceCapsuleContract: SFI_EVIDENCE_CAPSULE_CONTRACT,
+    canonicalRegistry: {
+      available: validateCanonicalObjectRegistry(records).length === 0,
+      publicObjectCount: publicCanonicalObjectProjections(records).length,
+    },
+    availableTools: SFI_PUBLIC_MCP_TOOLS.map((tool) => tool.name),
+    unavailableTools: SFI_PUBLIC_MCP_DEFERRED_TOOLS,
+    restrictions: [
+      'PUBLIC_CANONICAL_READS_ONLY',
+      'NO_PRIVATE_STATE',
+      'NO_AUTHORITY_INHERITANCE',
+      'NO_CANON_MUTATION',
+      'EVIDENCE_CAPSULE_DISPOSITION_OWNED_BY_WS03',
+    ],
+  };
+}
+
+function completeResult<T extends JsonObject>(payload: T) {
+  return {
+    resultType: 'complete',
+    ...payload,
+  } as const;
+}
+
+function toolResult(payload: JsonObject) {
+  return completeResult({
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    structuredContent: payload,
+    isError: false,
+  });
+}
+
+function jsonRpcResult(id: JsonRpcId, result: JsonObject) {
+  return { jsonrpc: '2.0' as const, id, result };
+}
+
+function jsonRpcError(id: JsonRpcId, code: number, message: string, data?: JsonObject) {
+  return {
+    jsonrpc: '2.0' as const,
+    id,
+    error: {
+      code,
+      message,
+      ...(data ? { data } : {}),
+    },
+  };
+}
+
+function requestId(request: JsonRpcRequest): JsonRpcId {
+  return typeof request.id === 'string' || typeof request.id === 'number' || request.id === null ? request.id : null;
+}
+
+function searchResult(type: SfiCanonicalObjectType, args: JsonObject) {
+  const q = text(args.q);
+  const limit = boundedLimit(args.limit);
+  const items = searchPublicCanonicalObjects(type, q, SFI_CANONICAL_OBJECT_REGISTRY, limit);
+  return {
+    available: true,
+    sourceContract: SFI_CANONICAL_OBJECT_CONTRACT,
+    objectType: type,
+    query: q || null,
+    count: items.length,
+    items,
+  };
+}
+
+function getResult(type: SfiCanonicalObjectType, args: JsonObject) {
+  const identifier = text(args.identifier);
+  if (!identifier) return null;
+  const object = getPublicCanonicalObject(type, identifier);
+  return {
+    available: true,
+    sourceContract: SFI_CANONICAL_OBJECT_CONTRACT,
+    objectType: type,
+    identifier,
+    found: object !== null,
+    object,
+  };
+}
+
+function publicResearch(args: JsonObject) {
+  const graph = researchGraphProjectionForCanonicalObjects();
+  const q = text(args.q).toLowerCase();
+  const requestedType = text(args.type) as SfiResearchProjectableObjectType | '';
+  const limit = boundedLimit(args.limit);
+  const items = graph.nodes
+    .filter((node) => !requestedType || node.objectType === requestedType)
+    .filter((node) => !q || [node.canonicalObjectId, node.canonicalObjectKey, node.canonicalUrl, node.title, node.summary]
+      .some((value) => value.toLowerCase().includes(q)))
+    .slice(0, limit);
+  const selectedIds = new Set(items.map((node) => node.canonicalObjectId));
+  const relationships = graph.relationships.filter((edge) => selectedIds.has(edge.fromCanonicalObjectId) && selectedIds.has(edge.toCanonicalObjectId));
+
+  return {
+    available: true,
+    contract: graph.contract,
+    sourceContract: graph.sourceContract,
+    count: items.length,
+    items,
+    relationships,
+  };
+}
+
+async function callTool(
+  name: string,
+  args: JsonObject,
+  dependencies: SfiPublicMcpDependencies,
+): Promise<JsonObject | null> {
+  switch (name as SfiPublicMcpToolName) {
+    case 'get_institution':
+      return toolResult({ available: true, institution: publicInstitutionProjection() });
+    case 'search_concepts':
+      return toolResult(searchResult('CONCEPT', args));
+    case 'get_concept': {
+      const result = getResult('CONCEPT', args);
+      return result ? toolResult(result) : null;
+    }
+    case 'search_methods':
+      return toolResult(searchResult('METHOD', args));
+    case 'get_method': {
+      const result = getResult('METHOD', args);
+      return result ? toolResult(result) : null;
+    }
+    case 'search_instruments':
+      return toolResult(searchResult('INSTRUMENT', args));
+    case 'get_public_evidence': {
+      const result = publicEvidenceForCanonicalObjects(args);
+      return result ? toolResult(result) : null;
+    }
+    case 'get_public_return': {
+      const result = getResult('RETURN', args);
+      return result ? toolResult(result) : null;
+    }
+    case 'get_public_research':
+      return toolResult(publicResearch(args));
+    case 'get_epistemic_contract':
+      return toolResult({ available: true, epistemicContract: publicEpistemicProjection() });
+    case 'get_public_world_state': {
+      try {
+        const worldState = await dependencies.readPublicWorldState();
+        return toolResult({ available: true, state: 'AVAILABLE', worldState });
+      } catch {
+        return toolResult({
+          available: false,
+          state: 'UNAVAILABLE',
+          reason: 'PUBLIC_WORLD_STATE_UNAVAILABLE',
+        });
+      }
+    }
+    default:
+      return null;
+  }
+}
+
+async function resourcePayload(uri: string, dependencies: SfiPublicMcpDependencies): Promise<JsonObject | null> {
+  switch (uri) {
+    case 'sfi://institution':
+      return { available: true, institution: publicInstitutionProjection() };
+    case 'sfi://epistemic-contract':
+      return { available: true, epistemicContract: publicEpistemicProjection() };
+    case 'sfi://canonical/objects': {
+      const objects = publicCanonicalObjectProjections();
+      return {
+        available: true,
+        sourceContract: SFI_CANONICAL_OBJECT_CONTRACT,
+        count: objects.length,
+        objects,
+      };
+    }
+    case 'sfi://research':
+      return publicResearch({});
+    case 'sfi://world-state':
+      try {
+        return { available: true, state: 'AVAILABLE', worldState: await dependencies.readPublicWorldState() };
+      } catch {
+        return { available: false, state: 'UNAVAILABLE', reason: 'PUBLIC_WORLD_STATE_UNAVAILABLE' };
+      }
+    case 'sfi://mcp/status':
+      return publicMcpStatus();
+    default:
+      return null;
+  }
+}
+
+function subjectForRequest(request: JsonRpcRequest): string | null {
+  const params = row(request.params);
+  if (request.method === 'tools/call') return text(params.name) || null;
+  if (request.method === 'resources/read') return text(params.uri) || null;
+  return null;
+}
+
+export function validatePublicMcpHttpEnvelope(
+  headers: SfiPublicMcpHttpHeaders,
+  request: JsonRpcRequest,
+): string[] {
+  const errors: string[] = [];
+  if (headers.protocolVersion !== SFI_PUBLIC_MCP_PROTOCOL_VERSION) errors.push('PROTOCOL_VERSION_MISMATCH');
+  if (headers.method !== request.method) errors.push('METHOD_HEADER_MISMATCH');
+
+  const subject = subjectForRequest(request);
+  if (subject !== null) {
+    if (headers.name !== subject) errors.push('NAME_HEADER_MISMATCH');
+  } else if (headers.name) {
+    errors.push('UNEXPECTED_NAME_HEADER');
+  }
+
+  const meta = row(row(request.params)._meta);
+  if (text(meta['io.modelcontextprotocol/protocolVersion']) !== SFI_PUBLIC_MCP_PROTOCOL_VERSION) {
+    errors.push('META_PROTOCOL_VERSION_MISMATCH');
+  }
+  return errors;
+}
+
+export function isPublicMcpRequest(value: unknown): value is JsonRpcRequest {
+  const candidate = row(value);
+  return candidate.jsonrpc === '2.0'
+    && typeof candidate.method === 'string'
+    && candidate.method.trim().length > 0
+    && (typeof candidate.id === 'undefined' || candidate.id === null || typeof candidate.id === 'string' || typeof candidate.id === 'number')
+    && (typeof candidate.params === 'undefined' || (candidate.params !== null && typeof candidate.params === 'object' && !Array.isArray(candidate.params)));
+}
+
+export async function dispatchPublicMcpRequest(
+  request: JsonRpcRequest,
+  dependencies: SfiPublicMcpDependencies,
+) {
+  const id = requestId(request);
+  const params = row(request.params);
+
+  switch (request.method) {
+    case 'server/discover':
+      return jsonRpcResult(id, completeResult({
+        supportedVersions: [SFI_PUBLIC_MCP_PROTOCOL_VERSION],
+        capabilities: { tools: {}, resources: {} },
+        serverInfo: { name: SFI_PUBLIC_MCP_SERVER_ID, version: SFI_PUBLIC_MCP_SERVER_VERSION },
+        instructions: 'Public authoritative reads only. Missing and unavailable states remain explicit. The server does not mutate institutional state.',
+        ttlMs: PUBLIC_CACHE_TTL_MS,
+        cacheScope: 'public',
+      }));
+
+    case 'tools/list':
+      return jsonRpcResult(id, completeResult({
+        tools: SFI_PUBLIC_MCP_TOOLS,
+        ttlMs: PUBLIC_CACHE_TTL_MS,
+        cacheScope: 'public',
+      }));
+
+    case 'tools/call': {
+      const name = text(params.name);
+      const args = row(params.arguments);
+      const deferred = DEFERRED_BY_NAME.get(name);
+      if (deferred) {
+        return jsonRpcResult(id, toolResult({
+          available: false,
+          state: deferred.state,
+          reason: deferred.reason,
+          tool: deferred.name,
+        }));
+      }
+      if (!TOOL_NAMES.has(name)) return jsonRpcError(id, -32602, 'Invalid params', { reason: 'TOOL_NOT_AVAILABLE' });
+      const result = await callTool(name, args, dependencies);
+      if (!result) return jsonRpcError(id, -32602, 'Invalid params', { reason: 'REQUIRED_TOOL_ARGUMENT_MISSING' });
+      return jsonRpcResult(id, result);
+    }
+
+    case 'resources/list':
+      return jsonRpcResult(id, completeResult({
+        resources: SFI_PUBLIC_MCP_RESOURCES,
+        ttlMs: PUBLIC_CACHE_TTL_MS,
+        cacheScope: 'public',
+      }));
+
+    case 'resources/read': {
+      const uri = text(params.uri);
+      if (!RESOURCE_URIS.has(uri)) return jsonRpcError(id, -32602, 'Invalid params', { reason: 'RESOURCE_NOT_AVAILABLE' });
+      const payload = await resourcePayload(uri, dependencies);
+      if (!payload) return jsonRpcError(id, -32602, 'Invalid params', { reason: 'RESOURCE_NOT_AVAILABLE' });
+      return jsonRpcResult(id, completeResult({
+        contents: [{
+          uri,
+          mimeType: 'application/json',
+          text: JSON.stringify(payload),
+        }],
+        ttlMs: uri === 'sfi://world-state' ? DYNAMIC_CACHE_TTL_MS : PUBLIC_CACHE_TTL_MS,
+        cacheScope: 'public',
+      }));
+    }
+
+    default:
+      return jsonRpcError(id, -32601, 'Method not found');
+  }
+}


### PR DESCRIPTION
## SFI-04 · R3 · Public MCP Read-Only Adapter

Original baseline: `0b97fdb277eb4af0a537a60837ceb76658199c20`
Refresh baseline after SFI-00 integration of #383: `4c463f9359a3a1f36c8c2e4d7e4a93039a714182`

Implements one bounded Machine Interfaces slice for reserved server `org.systemfriction/public`.

### SFI PRECHECK

Owner: `SFI-04 · MACHINE INTERFACES`

Existing capability inspected: existing `/api/external/v1/manifest`, external gateway/OAuth scopes, `SFI-CANONICAL-OBJECT-1.0`, `SFI_PUBLIC_PROFILE`, governed Research Graph projection, governed public Observatory reader, integrated WS-03 `SFI-EVIDENCE-CAPSULE-1.0` owner, Capability Broker/Cognitive Passport internals, CI, and current machine-readable resources.

Absorb vs create decision: CREATE only the public MCP transport/adapter because no MCP implementation exists; ABSORB institution/canonical/publicability/research/world-state reads from existing owners and now ABSORB Evidence Capsule disposition/materialization directly from `src/lib/discovery/publicSemanticProjection.ts`. No second backend, Evidence Capsule contract, publicability implementation, evidence store, or canonical source is created.

Authoritative writer: NONE. This slice is PUBLIC READ ONLY. Existing upstream owners remain authoritative for their data, publication disposition, evidence identity and Evidence Capsule disposition.

Persistence/lineage impact: NONE. No table, migration, evidence store, event store, session store, lineage writer, or mutation path is introduced. Existing canonical sourceRefs/evidenceIdentity/publication lineage is preserved.

Front delta: NONE. No UI surface is added.

Back delta: one stateless MCP `2026-07-28` adapter at `/api/mcp/public`, pure public MCP core, deterministic QA gate, dedicated CI workflow, and WS-04 slice receipt. Refresh delta is limited to consuming the now-integrated WS-03 Evidence Capsule owner for `get_public_evidence`.

DB delta: NONE.

Redundancy removed: obsolete `PUBLIC_EVIDENCE_CAPSULE_OWNER_NOT_AVAILABLE_AT_BASELINE` disposition. `get_public_evidence` delegates to `evidenceCapsuleDisposition()` and `evidenceCapsuleForCanonicalObject()` instead of reproducing WS-03 rules.

Execution/ROOT boundary: public catalog has no write/propose/execute/ROOT/private Twin/private case/governance-internal capability; no OAuth/externalAuth/Capability Broker/Cognitive Passport execution routing is imported. Unknown/deferred tools fail closed.

Rollback: revert the five files introduced by this PR. No persistence rollback or data migration is required.

Verification: `SFI-PUBLIC-MCP-READONLY-1.0` dedicated workflow plus repository `SFI Verify` on the exact immutable PR HEAD; SFI-08 performs independent exact-head assurance before SFI-00 integration.

### Refresh after #383

`get_public_evidence` is now AVAILABLE as a read-only adapter over `SFI-EVIDENCE-CAPSULE-1.0`.

The adapter:
- exposes only canonical objects already admitted to public projection;
- passes Evidence Capsule request coordinates to the WS-03 owner;
- reflects WS-03 `BLOCK` without emitting a capsule;
- does not reinterpret `epistemicState`, origin/state congruence, RETURN reality boundary, four-axis publicability, rights, governance or evidence identity;
- preserves `MODEL OUTPUT != OBSERVATION`, `SIMULATION != OBSERVATION`, `MISSING != EVIDENCE`, `UNAVAILABLE != ZERO`, and `PRIVATE != PUBLIC`.

`get_public_capabilities` remains explicitly `UNAVAILABLE · NO_AUTHORITATIVE_PUBLIC_CAPABILITY_PROJECTION`. No public capability owner was fabricated.

### Boundaries
- no authenticated MCP;
- no OAuth expansion;
- no external gateway execution routing;
- no ROOT/private Twin/private case/governance internals;
- no Capability Broker or Cognitive Passport exposure;
- no persistence/migration/RLS delta;
- no service-role browser path;
- no canonical-object duplication;
- no Evidence Capsule owner duplication;
- no external registry submission or listing claim.

### QA
Dedicated workflow: `SFI Public MCP Readonly` / job `SFI-PUBLIC-MCP-READONLY-1.0`.
Existing `SFI Verify` remains independently required.

NO MERGE by SFI-04. SFI-08 exact-head assurance required before SFI-00 integration.