### PR TITLE
fix(governance): preserve sovereign ROOT decision authority

### DIFF
--- a/src/app/api/acp/proposals/[id]/approve/route.ts
+++ b/src/app/api/acp/proposals/[id]/approve/route.ts
@@ -15,8 +15,12 @@ async function routeId(ctx: RouteContext) { const params = await Promise.resolve
 export async function POST(req: Request, ctx: RouteContext) {
   const gate = await requireGovernedActor('acp.proposals.approve');
   if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
-  const authority = resolveProposalReviewerAuthority(gate.ctx);
-  if (!authority) return NextResponse.json({ ok: false, error: 'proposal_reviewer_required' }, { status: 403 });
+
+  // Sovereign ROOT is resolved directly at the write boundary. A secondary
+  // reviewer projection must never be able to downgrade an already-verified
+  // ROOT session into proposal_reviewer_required.
+  const authority = gate.ctx.isRoot ? 'root' as const : resolveProposalReviewerAuthority(gate.ctx);
+  if (!authority) return NextResponse.json({ ok: false, error: 'proposal_reviewer_required', authenticated: true, isRoot: gate.ctx.isRoot }, { status: 403 });
 
   const proposalId = await routeId(ctx);
   if (!proposalId) return NextResponse.json({ ok: false, error: 'missing_proposal_id' }, { status: 400 });

--- a/src/app/api/acp/proposals/[id]/reject/route.ts
+++ b/src/app/api/acp/proposals/[id]/reject/route.ts
@@ -13,8 +13,12 @@ async function routeId(ctx: RouteContext) { const params = await Promise.resolve
 export async function POST(req: Request, ctx: RouteContext) {
   const gate = await requireGovernedActor('acp.proposals.reject');
   if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
-  const authority = resolveProposalReviewerAuthority(gate.ctx);
-  if (!authority) return NextResponse.json({ ok: false, error: 'proposal_reviewer_required' }, { status: 403 });
+
+  // Sovereign ROOT is resolved directly at the write boundary. A secondary
+  // reviewer projection must never be able to downgrade an already-verified
+  // ROOT session into proposal_reviewer_required.
+  const authority = gate.ctx.isRoot ? 'root' as const : resolveProposalReviewerAuthority(gate.ctx);
+  if (!authority) return NextResponse.json({ ok: false, error: 'proposal_reviewer_required', authenticated: true, isRoot: gate.ctx.isRoot }, { status: 403 });
 
   const proposalId = await routeId(ctx);
   if (!proposalId) return NextResponse.json({ ok: false, error: 'missing_proposal_id' }, { status: 400 });


### PR DESCRIPTION
Fixes a ROOT authority regression class in proposal ACCEPT/DENY writes.

Observed production session: authenticated founder resolves as isRoot=true, role=root, full_access=true. Proposal decision routes must therefore never downgrade that verified ROOT session through a secondary reviewer projection.

Changes:
- resolve ROOT directly at approve/reject write boundaries;
- preserve controller delegation and root_only fail-closed behavior;
- include explicit auth/root diagnostics if reviewer authority is genuinely absent;
- preserve existing queue + governed dispatch after ACCEPT.

Invariant: verified ROOT authority cannot be silently reduced by proposal reviewer projection. No canonical-promotion or executor authority expansion.