### PR TITLE
fix(release): require explicit production deploy trigger

### DIFF
--- a/.github/workflows/sfi-vercel-prebuilt-production.yml
+++ b/.github/workflows/sfi-vercel-prebuilt-production.yml
@@ -5,17 +5,12 @@ on:
     branches:
       - main
     paths:
-      - .github/workflows/sfi-vercel-prebuilt-production.yml
-      - package.json
-      - package-lock.json
-      - next.config.*
-      - tsconfig.json
-      - vercel.json
-      - 'public/**'
-      - 'src/**'
-      - 'scripts/merge-openapi-*.mjs'
+      - .github/sfi-production-deploy-trigger
   workflow_dispatch:
 
+# Production deploy is deliberately decoupled from ordinary implementation merges.
+# A release is started only by explicit workflow dispatch or by changing the
+# dedicated deploy-trigger marker after SFI-00 has an exact clean canonical HEAD.
 permissions:
   contents: read
 


### PR DESCRIPTION
## SFI PRECHECK

Owner: SFI-00 · CONTROL ROOM

Existing capability inspected:
- `.github/workflows/sfi-vercel-prebuilt-production.yml`
- post-merge production run 34147576559 on canonical main `b6cbf152d286f797e286c521f7290b4177cb1246`
- `scripts/qa-sfi-agent-api-hardening.ts` deployment assertions

Absorb vs create decision:
- Preserve the existing prebuilt Vercel production lane.
- Remove ordinary implementation paths (`src/**`, public/package/config changes) as automatic production-deploy triggers.
- Reuse `workflow_dispatch` and retain a push lane only for a dedicated explicit marker `.github/sfi-production-deploy-trigger`.

Authoritative writer:
- GitHub Actions remains the deployment orchestrator; Vercel remains the production deployment provider.
- This PR does not introduce a second deployment writer.

Persistence/lineage impact:
- No DB or application persistence mutation.
- GitHub workflow run remains the deployment evidence lane.

Front delta:
- NONE.

Back delta:
- Production deployment trigger policy only.

DB delta:
- NONE.

Redundancy removed:
- Removes automatic deployment coupling from routine source/config merges while preserving one canonical deployment workflow.

Execution/ROOT boundary:
- Routine release-control repair under accepted #405 convergence authority; no institutional ADD/PROMOTE, identity, scope, or authority expansion.

Rollback:
- Revert this PR to restore the prior path-triggered deployment behavior.

Verification:
- SFI Verify must pass on exact immutable HEAD.
- Workflow must still target canonical `main`, perform prebuilt production deployment, and remain manually dispatchable.
- Ordinary `src/**` merges must no longer satisfy the production workflow path filter.

Context: the FULL REMAKE requires a single controlled production deploy only after an exact clean canonical HEAD. The previous workflow automatically deployed routine `src/**` merges and already consumed one unintended post-#410 production run. This repair prevents additional deployment waste while convergence continues.