### PR TITLE
feat(auth): recover governed ROOT proposal decision plane

### DIFF
--- a/.github/workflows/sfi-root-governance-decision.yml
+++ b/.github/workflows/sfi-root-governance-decision.yml
@@ -1,0 +1,47 @@
+name: SFI ROOT Governance Decision Boundary
+
+on:
+  pull_request:
+    paths:
+      - 'src/lib/sfi/oauthConfig.ts'
+      - 'src/lib/sfi/externalAuth.ts'
+      - 'src/app/api/oauth/authorize/route.ts'
+      - 'src/app/api/external/v1/governance/proposals/**'
+      - 'scripts/qa-sfi-root-governance-decision.ts'
+      - '.github/workflows/sfi-root-governance-decision.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/lib/sfi/oauthConfig.ts'
+      - 'src/lib/sfi/externalAuth.ts'
+      - 'src/app/api/oauth/authorize/route.ts'
+      - 'src/app/api/external/v1/governance/proposals/**'
+      - 'scripts/qa-sfi-root-governance-decision.ts'
+      - '.github/workflows/sfi-root-governance-decision.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  boundary:
+    name: Verify ROOT decision authority boundary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact head
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: SFI-ROOT-GOVERNANCE-DECISION-BOUNDARY-1.0
+        run: npx tsx scripts/qa-sfi-root-governance-decision.ts
+
+      - name: Typecheck authority surface
+        run: npm run typecheck

--- a/scripts/qa-sfi-root-governance-decision.ts
+++ b/scripts/qa-sfi-root-governance-decision.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const oauthConfig = readFileSync('src/lib/sfi/oauthConfig.ts', 'utf8');
+const authorize = readFileSync('src/app/api/oauth/authorize/route.ts', 'utf8');
+const externalAuth = readFileSync('src/lib/sfi/externalAuth.ts', 'utf8');
+const decisionRoute = readFileSync('src/app/api/external/v1/governance/proposals/[id]/decision/route.ts', 'utf8');
+
+assert.match(oauthConfig, /SFI_ROOT_SCOPES[\s\S]*'governance:decide'/, 'root scope registry must expose governance:decide');
+const personalBlock = oauthConfig.match(/export const SFI_PERSONAL_SCOPES = \[([\s\S]*?)\] as const;/)?.[1] ?? '';
+assert.equal(personalBlock.includes("'governance:decide'"), false, 'personal OAuth scopes must not include governance:decide');
+
+assert.match(authorize, /const rootDelegate = profileRole === 'root' \|\| profileRole === 'system'/, 'OAuth root delegation must derive from authenticated profile role');
+assert.match(authorize, /rootDelegate\s*\? SFI_ROOT_SCOPES/, 'root scopes must only be selected for rootDelegate principals');
+assert.match(authorize, /const delegatedRole = rootDelegate[\s\S]*'root_delegate'/, 'issued OAuth credential must bind root_delegate role to rootDelegate');
+assert.match(authorize, /const tenantId = personalPrincipal \? `user:\$\{context\.user\.id\}` : 'sfi'/, 'institutional principals must be issued in SFI tenant');
+
+assert.match(externalAuth, /credential\.authMethod === 'oauth'/, 'external auth must preserve OAuth identity metadata');
+assert.match(externalAuth, /scope\.startsWith\('cases:'\)/, 'personal scope routing must remain explicitly bounded');
+assert.equal(externalAuth.includes("scope === 'governance:decide'"), false, 'personal route allowlist must not open governance:decide');
+
+assert.match(decisionRoute, /const REQUIRED_SCOPE = 'governance:decide'/, 'decision endpoint must require governance:decide');
+assert.match(decisionRoute, /credential\.authMethod !== 'oauth'/, 'static tokens must be rejected for sovereign decision');
+assert.match(decisionRoute, /credential\.role !== 'root_delegate'/, 'non-root delegated OAuth credentials must be rejected');
+assert.match(decisionRoute, /credential\.tenantId !== 'sfi'/, 'decision endpoint must require institutional SFI tenant');
+assert.match(decisionRoute, /!credential\.subjectId/, 'decision endpoint must require a bound subject identity');
+assert.match(decisionRoute, /\.from\('profiles'\)[\s\S]*\.eq\('user_id', credential\.subjectId\)/, 'decision endpoint must re-read live profile authority');
+assert.match(decisionRoute, /role === 'root' \|\| role === 'system'/, 'live sovereign profile must remain ROOT or system');
+assert.match(decisionRoute, /access\.full_access === true && access\.root === true/, 'live sovereign profile must retain full_access + root flags');
+assert.match(decisionRoute, /decideActionProposal\(\{[\s\S]*decisionAuthority: 'root'/, 'decision must flow through canonical proposal lifecycle');
+assert.match(decisionRoute, /queueApprovedProposal\(\{[\s\S]*decisionAuthority: 'root'/, 'accepted decision must flow through canonical proposal queue');
+assert.match(decisionRoute, /dispatchQueuedProposal\(proposalId\)/, 'accepted proposal must flow through governed execution router');
+assert.equal(/\.from\('action_proposals'\)[\s\S]{0,500}\.update\(/.test(decisionRoute), false, 'route must not directly mutate action_proposals authority state');
+
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-ROOT-GOVERNANCE-DECISION-BOUNDARY-1.0',
+  guarantees: [
+    'governance:decide is ROOT-only',
+    'scope possession is not sovereign authority',
+    'static tokens cannot decide',
+    'live ROOT profile is revalidated',
+    'decision uses canonical lifecycle and governed execution',
+  ],
+}, null, 2));

--- a/src/app/api/external/v1/governance/proposals/[id]/decision/route.ts
+++ b/src/app/api/external/v1/governance/proposals/[id]/decision/route.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from 'next/server';
+import { dispatchQueuedProposal } from '@/lib/execution/governedExecutionRouter';
+import { decideActionProposal } from '@/lib/governance/proposalLifecycle';
+import { queueApprovedProposal } from '@/lib/governance/proposalQueue';
+import { authorizeExternalRequest, externalAuthError } from '@/lib/sfi/externalAuth';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+export const dynamic = 'force-dynamic';
+
+const REQUIRED_SCOPE = 'governance:decide' as const;
+type RouteContext = { params: Promise<{ id: string }> | { id: string } };
+
+async function routeId(ctx: RouteContext) {
+  const params = await Promise.resolve(ctx.params);
+  return typeof params.id === 'string' && params.id.trim() ? params.id.trim() : null;
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function sovereignRootProfile(profile: Record<string, unknown> | null) {
+  if (!profile) return false;
+  const role = typeof profile.role === 'string' ? profile.role.trim().toLowerCase() : '';
+  const access = record(profile.module_access);
+  return (role === 'root' || role === 'system') && access.full_access === true && access.root === true;
+}
+
+export async function POST(req: Request, ctx: RouteContext) {
+  const auth = authorizeExternalRequest(req, REQUIRED_SCOPE);
+  if (!auth.credential) return NextResponse.json(externalAuthError(auth, REQUIRED_SCOPE), { status: 401 });
+
+  const credential = auth.credential;
+  if (credential.authMethod !== 'oauth' || !credential.subjectId || credential.role !== 'root_delegate' || credential.tenantId !== 'sfi') {
+    return NextResponse.json({
+      ok: false,
+      error: 'sovereign_root_oauth_required',
+      scopeAllowed: auth.scopeAllowed,
+      authMethod: credential.authMethod ?? null,
+      role: credential.role ?? null,
+      tenantId: credential.tenantId ?? null,
+    }, { status: 403 });
+  }
+
+  const proposalId = await routeId(ctx);
+  if (!proposalId) return NextResponse.json({ ok: false, error: 'missing_proposal_id' }, { status: 400 });
+
+  const body = await req.json().catch(() => ({})) as Record<string, unknown>;
+  const decision = body.decision === 'accept' || body.decision === 'deny' ? body.decision : null;
+  if (!decision) return NextResponse.json({ ok: false, error: 'decision_must_be_accept_or_deny' }, { status: 400 });
+  const note = typeof body.note === 'string' && body.note.trim() ? body.note.trim() : decision === 'deny' ? 'external_root_denied' : null;
+
+  const service = createServiceSupabaseClient();
+  const profileRead = await service
+    .from('profiles')
+    .select('user_id,email,role,module_access')
+    .eq('user_id', credential.subjectId)
+    .maybeSingle();
+  if (profileRead.error) {
+    return NextResponse.json({ ok: false, error: 'root_profile_read_failed', details: profileRead.error.message }, { status: 503 });
+  }
+  if (!sovereignRootProfile(profileRead.data as Record<string, unknown> | null)) {
+    return NextResponse.json({ ok: false, error: 'sovereign_root_authority_required' }, { status: 403 });
+  }
+
+  const current = await service.from('action_proposals').select('*').eq('id', proposalId).single();
+  if (current.error || !current.data) {
+    return NextResponse.json({ ok: false, error: current.error?.message ?? 'proposal_not_found' }, { status: 404 });
+  }
+
+  const actorId = credential.subjectId;
+  const actorLabel = typeof profileRead.data?.email === 'string' ? profileRead.data.email : credential.actorId ?? null;
+  const decided = await decideActionProposal({
+    proposalId,
+    actorId,
+    actorLabel,
+    decision,
+    decisionAuthority: 'root',
+    note,
+    currentRow: current.data,
+  });
+  if (!decided.ok) return NextResponse.json(decided, { status: 409 });
+
+  if (decision === 'deny') {
+    return NextResponse.json({
+      ok: true,
+      data: decided.data,
+      decision: { decision, authority: 'root', actorId, actorLabel, scope: REQUIRED_SCOPE },
+    });
+  }
+
+  const queued = await queueApprovedProposal({
+    proposalId,
+    actorId,
+    actorLabel,
+    decisionAuthority: 'root',
+    currentRow: decided.data as Record<string, unknown>,
+    note,
+  });
+  if (!queued.ok) {
+    return NextResponse.json({
+      ok: false,
+      error: 'proposal_approved_but_queue_transition_failed',
+      decisionRecorded: true,
+      decision: decided.data,
+      queueError: queued,
+    }, { status: 409 });
+  }
+
+  const execution = await dispatchQueuedProposal(proposalId).catch((error) => ({
+    ok: false as const,
+    state: 'DISPATCH_FAILED',
+    proposalId,
+    error: error instanceof Error ? error.message : String(error),
+  }));
+
+  return NextResponse.json({
+    ok: true,
+    data: queued.data,
+    decision: { decision, authority: 'root', actorId, actorLabel, scope: REQUIRED_SCOPE },
+    execution,
+  });
+}

--- a/src/lib/sfi/oauthConfig.ts
+++ b/src/lib/sfi/oauthConfig.ts
@@ -4,6 +4,7 @@ export const SFI_ROOT_SCOPES = [
   'observe',
   'propose',
   'execute',
+  'governance:decide',
   'cases:read',
   'cases:write',
   'lab:read',


### PR DESCRIPTION
## SFI PRECHECK
Owner: SFI-00 / authority recovery
Existing capability inspected: OAuth central scope registry; externalAuth; OAuth authorize; governance proposal lifecycle; proposal queue; governed execution router; final-convergence branch.
Absorb vs create decision: selectively absorb only the valid `governance:decide` ROOT scope and governed decision endpoint from `full-remake/final-convergence`; do not absorb partial Discovery Mesh.
Authoritative writer: existing proposalLifecycle + proposalQueue + governedExecutionRouter remain authoritative; this route does not become a direct proposal writer.
Persistence/lineage impact: reuses existing `action_proposals` persistence and decision/queue/execution lineage; no new canonical store.
Front delta: NONE.
Back delta: ROOT-only OAuth decision surface plus boundary QA.
DB delta: NONE.
Redundancy removed: recovers the only valid authority delta remaining in `full-remake/final-convergence` while leaving partial Discovery to WS-03.
Execution/ROOT boundary: scope possession is insufficient; requires OAuth, `root_delegate`, institutional tenant, subject identity, and live sovereign ROOT profile revalidation before any decision. ADD/PROMOTE authority remains ROOT.
Rollback: revert this PR; no irreversible schema/data mutation.
Verification: exact-head QA must prove ROOT scope is excluded from personal scopes; static tokens cannot use the route; non-ROOT OAuth cannot use the route; sovereign profile is re-read from DB; route delegates decision→queue→governed execution; full SFI Verify/typecheck/build pass.