### PR TITLE
feat(discovery): add governed operational Discovery observation plane

### DIFF
--- a/.github/workflows/sfi-verify.yml
+++ b/.github/workflows/sfi-verify.yml
@@ -76,7 +76,7 @@ jobs:
         run: npx tsx scripts/qa-sfi-temporal-surfaces.ts
 
       - name: Verify canonical discovery object integrity
-        run: npx tsx scripts/qa-sfi-discovery-integrity.ts && node --import tsx --test src/lib/discovery/canonicalObjectRegistry.test.ts
+        run: npx tsx scripts/qa-sfi-discovery-integrity.ts && npx tsx scripts/qa-sfi-discovery-operational.ts && node --import tsx --test src/lib/discovery/canonicalObjectRegistry.test.ts src/lib/discovery/discoveryMesh.test.ts
 
       - name: Verify governed Research Graph projection
         run: node --import tsx --test src/lib/research/researchGraphProjection.test.ts && npm run qa:sfi-research-metadata

--- a/scripts/qa-sfi-discovery-operational.ts
+++ b/scripts/qa-sfi-discovery-operational.ts
@@ -60,6 +60,8 @@ async function main() {
     metricFamilies: 7,
     falseZero: true,
     candidatePromotion: false,
+    canonicalOwnerReused: true,
+    externalIdentityOwnerReused: true,
     duplicateCanonicalOwner: false,
     duplicateIdentityOwner: false,
     rlsForced: true,

--- a/scripts/qa-sfi-discovery-operational.ts
+++ b/scripts/qa-sfi-discovery-operational.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+async function text(path: string) { return readFile(path, 'utf8'); }
+
+async function main() {
+  const mesh = await text('src/lib/discovery/discoveryMesh.ts');
+  const repository = await text('src/lib/discovery/discoveryRepository.ts');
+  const route = await text('src/app/api/discovery/observe/route.ts');
+  const migration = await text('supabase/migrations/20260908004000_create_sfi_discovery_observation_plane.sql');
+  const canonical = await text('src/lib/discovery/canonicalObjectRegistry.ts');
+  const identity = await text('src/lib/public/institutionProfile.ts');
+  const contractLock = await text('docs/program/SFI-CONTRACT-LOCK.md');
+
+  assert(mesh.includes("SFI-DISCOVERY-MESH-1.0"));
+  assert(mesh.includes("SFI-DISCOVERY-OBSERVATION-1.0"));
+  for (const mode of ['query','distinct_intent','open_source']) assert(mesh.includes(`'${mode}'`), `missing discovery mode ${mode}`);
+  for (const state of ['AVAILABLE','DEGRADED','UNAVAILABLE','MISSING','NOT_OBSERVED']) assert(mesh.includes(`'${state}'`), `missing availability ${state}`);
+  for (const metric of ['UDR','EIC','IRD','ACR','ECR','MPD','ERR']) assert(mesh.includes(metric), `missing metric emitter ${metric}`);
+  for (const submetric of ['NAME','DOMAIN','METHOD','ENTITY']) assert(mesh.includes(`${submetric}: collisionMetric('${submetric}')`), `missing ECR-${submetric}`);
+  assert(mesh.includes("candidateClass: 'SOURCE_CANDIDATE'"), 'candidate epistemic class missing');
+  assert(mesh.includes('candidatesAreCanonical: false'), 'candidate must never imply canon');
+  assert(mesh.includes('automaticCanon: false'), 'automatic canon boundary missing');
+  assert(mesh.includes('automaticPublication: false'), 'automatic publication boundary missing');
+  assert(mesh.includes('automaticExecution: false'), 'automatic execution boundary missing');
+  assert(mesh.includes('Numeric zero is emitted only when an eligible observed denominator exists'), 'false-zero contract missing');
+  assert(mesh.includes('publicSemanticProjectionsForCanonicalObjects'), 'Discovery Mesh must project existing canonical objects');
+  assert(mesh.includes('SFI_CANONICAL_IDENTITY_FINGERPRINT'), 'Discovery Mesh must reuse canonical institution identity');
+
+  assert(route.includes('requireAuthenticatedUser'), 'discovery observation writer must require verified session auth');
+  assert(route.includes('persistDiscoveryObservation'), 'discovery route must use repository owner');
+  assert(route.includes('candidatePromotion: false'), 'route must deny candidate promotion authority');
+  assert(route.includes('automaticCanon: false'), 'route must deny automatic canon');
+  assert(repository.includes("from('sfi_discovery_queries')"), 'query persistence owner missing');
+  assert(repository.includes("from('sfi_discovery_query_runs')"), 'run persistence owner missing');
+  assert(repository.includes("from('sfi_entity_collisions')"), 'collision persistence owner missing');
+  assert(repository.includes("run_id: result.observationId"), 'deterministic replay identity missing');
+  assert(repository.includes("code === '23505'"), 'idempotent replay handling missing');
+
+  for (const table of ['sfi_discovery_queries','sfi_discovery_query_runs','sfi_entity_collisions','sfi_external_representations']) {
+    assert(migration.includes(`public.${table}`), `migration missing ${table}`);
+    assert(migration.includes(`alter table public.${table} enable row level security`), `RLS missing ${table}`);
+    assert(migration.includes(`alter table public.${table} force row level security`), `FORCE RLS missing ${table}`);
+    assert(migration.includes(`revoke all on public.${table} from anon, authenticated`), `Data API revoke missing ${table}`);
+  }
+  assert(!migration.includes('create table if not exists public.sfi_canonical_objects'), 'must not create a second canonical object owner');
+  assert(!migration.includes('create table if not exists public.sfi_external_nodes'), 'must not duplicate verified identity owner');
+  assert(canonical.includes('export const SFI_CANONICAL_OBJECT_REGISTRY'), 'existing canonical object owner missing');
+  assert(identity.includes('export const SFI_EXTERNAL_IDENTITY_NODES'), 'existing external identity owner missing');
+  assert(contractLock.includes('UDR — Unbranded Discovery Rate'), 'frozen UDR meaning missing');
+  assert(contractLock.includes('EIC — External Identity Coherence'), 'frozen EIC meaning missing');
+  assert(contractLock.includes('IRD — Independent Reference Density'), 'frozen IRD meaning missing');
+  assert(contractLock.includes('MPD — Multi-Platform Propagation Depth'), 'frozen MPD meaning missing');
+  assert(contractLock.includes('ERR — Entity Reconstruction Rate'), 'frozen ERR meaning missing');
+
+  console.log(JSON.stringify({
+    ok: true,
+    contract: 'SFI-DISCOVERY-INTEGRITY-1.0',
+    modes: 3,
+    metricFamilies: 7,
+    falseZero: true,
+    candidatePromotion: false,
+    duplicateCanonicalOwner: false,
+    duplicateIdentityOwner: false,
+    rlsForced: true,
+    directBrowserDataApi: false,
+    durableQueryRuns: true,
+  }, null, 2));
+}
+
+main().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/src/app/api/discovery/observe/route.ts
+++ b/src/app/api/discovery/observe/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAuthenticatedUser } from '@/lib/system/access/server';
+import { persistDiscoveryObservation, readDiscoveryRun } from '@/lib/discovery/discoveryRepository';
+import { SFI_DISCOVERY_AVAILABILITY, SFI_DISCOVERY_MODES } from '@/lib/discovery/discoveryMesh';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
+const sourceSchema = z.object({
+  sourceId: z.string().trim().min(1).max(500),
+  sourceUrl: z.string().trim().url().max(2000).nullable(),
+  publisher: z.string().trim().max(500).nullable(),
+  platform: z.string().trim().min(1).max(200),
+  providerClass: z.enum(['SEARCH','AI','ACADEMIC','FEED','OTHER']),
+  independent: z.boolean(),
+}).strict();
+const retrievalSchema = z.object({
+  observationId: z.string().trim().min(1).max(500),
+  source: sourceSchema,
+  observedAt: z.string().datetime(),
+  query: z.string().trim().min(1).max(2000),
+  unbranded: z.boolean(),
+  retrieved: z.boolean().nullable(),
+  attributedEntityName: z.string().trim().max(500).nullable().optional(),
+  attributedDomain: z.string().trim().max(2000).nullable().optional(),
+  citedCanonicalUrl: z.string().trim().max(2000).nullable().optional(),
+  reconstructedFields: z.object({
+    name: z.string().trim().max(500).optional(),
+    domain: z.string().trim().max(2000).optional(),
+    entityId: z.string().trim().max(2000).optional(),
+    descriptor: z.string().trim().max(2000).optional(),
+  }).strict().optional(),
+  references: z.array(z.object({ url: z.string().url().max(2000), independent: z.boolean() }).strict()).max(200).optional(),
+  collisions: z.array(z.object({ dimension: z.enum(['NAME','DOMAIN','METHOD','ENTITY']), observed: z.boolean(), value: z.string().max(2000).nullable() }).strict()).max(100).optional(),
+  propagationPlatforms: z.array(z.string().trim().min(1).max(200)).max(100).optional(),
+  status: z.enum(SFI_DISCOVERY_AVAILABILITY).optional(),
+}).strict();
+const feedSchema = z.object({
+  id: z.string().max(500).nullable().optional(),
+  url: z.string().max(2000).nullable().optional(),
+  title: z.string().max(1000).nullable().optional(),
+  summary: z.string().max(5000).nullable().optional(),
+  publisher: z.string().max(500).nullable().optional(),
+  publishedAt: z.string().max(100).nullable().optional(),
+  platform: z.string().trim().min(1).max(200),
+}).strict();
+const observeSchema = z.object({
+  mode: z.enum(SFI_DISCOVERY_MODES),
+  query: z.string().trim().min(1).max(2000),
+  intent: z.string().trim().max(1000).nullable().optional(),
+  retrievalObservations: z.array(retrievalSchema).max(500).optional(),
+  feedItems: z.array(feedSchema).max(500).optional(),
+}).strict();
+
+function fail(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  const status = message.includes('NOT_FOUND') ? 404 : message.includes('REQUIRED') || message.includes('UNSUPPORTED') || error instanceof z.ZodError ? 400 : 500;
+  return NextResponse.json({ ok: false, error: message }, { status });
+}
+
+export async function GET(request: Request) {
+  try {
+    await requireAuthenticatedUser();
+    const runId = new URL(request.url).searchParams.get('runId')?.trim();
+    if (!runId) return NextResponse.json({ ok: false, error: 'runId_required' }, { status: 400 });
+    const data = await readDiscoveryRun(z.string().uuid().parse(runId));
+    return NextResponse.json({ ok: true, contract: 'SFI-DISCOVERY-OBSERVATION-1.0', ...data });
+  } catch (error) {
+    return fail(error);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { user } = await requireAuthenticatedUser();
+    const input = observeSchema.parse(await request.json());
+    const persisted = await persistDiscoveryObservation(input, user.id);
+    return NextResponse.json({
+      ok: true,
+      contract: persisted.result.contract,
+      queryId: persisted.queryId,
+      runId: persisted.runId,
+      replay: persisted.replay,
+      observation: persisted.result,
+      authority: {
+        persistence: 'OBSERVED_DISCOVERY_TEST_ONLY',
+        candidatePromotion: false,
+        automaticCanon: false,
+        externalExecution: false,
+      },
+    }, { status: persisted.replay ? 200 : 201 });
+  } catch (error) {
+    return fail(error);
+  }
+}

--- a/src/lib/discovery/discoveryMesh.test.ts
+++ b/src/lib/discovery/discoveryMesh.test.ts
@@ -24,13 +24,12 @@ const aiSource = {
   independent: true,
 };
 
-test('query mode ranks public canonical objects but never promotes candidates to canon', () => {
+test('query mode does not fabricate canonical candidates while the public registry is empty', () => {
   const observed = observeDiscovery({ mode: 'query', query: 'friction evidence governed inference' });
   assert.equal(observed.contract, 'SFI-DISCOVERY-OBSERVATION-1.0');
-  assert(observed.candidates.length > 0);
-  assert(observed.candidates.every((candidate) => candidate.canonical === false));
-  assert(observed.externalRepresentations.length > 0);
-  assert(observed.externalRepresentations.every((representation) => representation.representationClass === 'EXTERNAL_REPRESENTATION'));
+  assert.equal(observed.candidates.length, 0);
+  assert.equal(observed.externalRepresentations.length, 0);
+  assert.equal(observed.epistemicBoundary.candidatesAreCanonical, false);
   assert.equal(observed.epistemicBoundary.automaticCanon, false);
   assert.equal(observed.epistemicBoundary.automaticPublication, false);
   assert.equal(observed.epistemicBoundary.automaticExecution, false);

--- a/src/lib/discovery/discoveryMesh.test.ts
+++ b/src/lib/discovery/discoveryMesh.test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  discoveryMetrics,
+  normalizeOpenSourceFeedItem,
+  observeDiscovery,
+} from './discoveryMesh';
+
+const canonicalSource = {
+  sourceId: 'search:test',
+  sourceUrl: 'https://search.example/result',
+  publisher: 'Example Search',
+  platform: 'example-search',
+  providerClass: 'SEARCH' as const,
+  independent: true,
+};
+
+const aiSource = {
+  sourceId: 'ai:test',
+  sourceUrl: 'https://ai.example/answer',
+  publisher: 'Example AI',
+  platform: 'example-ai',
+  providerClass: 'AI' as const,
+  independent: true,
+};
+
+test('query mode ranks public canonical objects but never promotes candidates to canon', () => {
+  const observed = observeDiscovery({ mode: 'query', query: 'friction evidence governed inference' });
+  assert.equal(observed.contract, 'SFI-DISCOVERY-OBSERVATION-1.0');
+  assert(observed.candidates.length > 0);
+  assert(observed.candidates.every((candidate) => candidate.canonical === false));
+  assert(observed.externalRepresentations.length > 0);
+  assert(observed.externalRepresentations.every((representation) => representation.representationClass === 'EXTERNAL_REPRESENTATION'));
+  assert.equal(observed.epistemicBoundary.automaticCanon, false);
+  assert.equal(observed.epistemicBoundary.automaticPublication, false);
+  assert.equal(observed.epistemicBoundary.automaticExecution, false);
+});
+
+test('distinct_intent requires explicit intent rather than guessing it', () => {
+  assert.throws(() => observeDiscovery({ mode: 'distinct_intent', query: 'complex system' }), /DISTINCT_INTENT_REQUIRED/);
+  const observed = observeDiscovery({ mode: 'distinct_intent', query: 'complex system', intent: 'measure structural friction' });
+  assert.equal(observed.intent, 'measure structural friction');
+});
+
+test('malformed optional feed metadata degrades the candidate instead of destroying source identity', () => {
+  const candidate = normalizeOpenSourceFeedItem({ platform: 'feed:test', title: 'Signal', url: 'not-a-url' });
+  assert.equal(candidate.availability, 'DEGRADED');
+  assert.equal(candidate.source.platform, 'feed:test');
+  assert(candidate.provenance.length === 1);
+  assert(candidate.degradationReasons.includes('SOURCE_URL_MISSING_OR_INVALID'));
+  assert(candidate.degradationReasons.includes('SUMMARY_MISSING'));
+});
+
+test('all discovery metrics preserve NOT_OBSERVED separately from numeric zero', () => {
+  const metrics = discoveryMetrics([]);
+  assert.equal(metrics.UDR.availability, 'NOT_OBSERVED');
+  assert.equal(metrics.UDR.value, null);
+  assert.equal(metrics.EIC.value, null);
+  assert.equal(metrics.IRD.value, null);
+  assert.equal(metrics.ACR.R.value, null);
+  assert.equal(metrics.ACR.A.value, null);
+  assert.equal(metrics.ACR.C.value, null);
+  assert.equal(metrics.ECR.NAME.value, null);
+  assert.equal(metrics.ECR.DOMAIN.value, null);
+  assert.equal(metrics.ECR.METHOD.value, null);
+  assert.equal(metrics.ECR.ENTITY.value, null);
+  assert.equal(metrics.MPD.value, null);
+  assert.equal(metrics.ERR.value, null);
+});
+
+test('AVAILABLE + observed failure may emit real zero without converting unavailable to zero', () => {
+  const metrics = discoveryMetrics([{
+    observationId: 'obs-zero',
+    source: canonicalSource,
+    observedAt: '2026-09-08T00:00:00Z',
+    query: 'unbranded systemic observation problem',
+    unbranded: true,
+    retrieved: false,
+    status: 'AVAILABLE',
+  }]);
+  assert.equal(metrics.UDR.availability, 'AVAILABLE');
+  assert.equal(metrics.UDR.value, 0);
+  assert.equal(metrics.UDR.denominator, 1);
+  assert.equal(metrics.EIC.value, null);
+});
+
+test('UDR EIC IRD ACR ECR MPD ERR are derived only from eligible observed retrieval tests', () => {
+  const metrics = discoveryMetrics([
+    {
+      observationId: 'obs-search',
+      source: canonicalSource,
+      observedAt: '2026-09-08T00:00:00Z',
+      query: 'evidence governed complex systems institute',
+      unbranded: true,
+      retrieved: true,
+      reconstructedFields: {
+        name: 'System Friction Institute',
+        domain: 'https://systemfriction.org',
+        entityId: 'https://systemfriction.org/#sfi',
+      },
+      references: [
+        { url: 'https://independent.example/reference', independent: true },
+        { url: 'https://systemfriction.org/institution', independent: false },
+      ],
+      collisions: [
+        { dimension: 'NAME', observed: false, value: null },
+        { dimension: 'DOMAIN', observed: false, value: null },
+        { dimension: 'METHOD', observed: true, value: 'ambiguous acronym' },
+        { dimension: 'ENTITY', observed: false, value: null },
+      ],
+      propagationPlatforms: ['search', 'academic'],
+    },
+    {
+      observationId: 'obs-ai',
+      source: aiSource,
+      observedAt: '2026-09-08T00:01:00Z',
+      query: 'evidence governed complex systems institute',
+      unbranded: true,
+      retrieved: true,
+      attributedEntityName: 'System Friction Institute',
+      citedCanonicalUrl: 'https://systemfriction.org/concepts/system-friction',
+      reconstructedFields: {
+        name: 'System Friction Institute',
+        domain: 'https://systemfriction.org',
+        entityId: 'https://systemfriction.org/#sfi',
+      },
+      propagationPlatforms: ['ai', 'search'],
+    },
+    {
+      observationId: 'obs-unavailable',
+      source: canonicalSource,
+      observedAt: '2026-09-08T00:02:00Z',
+      query: 'ignored',
+      unbranded: true,
+      retrieved: false,
+      status: 'UNAVAILABLE',
+    },
+  ]);
+  assert.equal(metrics.UDR.value, 1);
+  assert.equal(metrics.EIC.value, 1);
+  assert.equal(metrics.IRD.value, 0.5);
+  assert.equal(metrics.ACR.R.value, 1);
+  assert.equal(metrics.ACR.A.value, 1);
+  assert.equal(metrics.ACR.C.value, 1);
+  assert.equal(metrics.ECR.NAME.value, 0);
+  assert.equal(metrics.ECR.METHOD.value, 1);
+  assert.equal(metrics.MPD.value, 3);
+  assert.equal(metrics.ERR.value, 1);
+});
+
+test('open_source mode retains feed provenance and degradation alongside canonical candidates', () => {
+  const observed = observeDiscovery({
+    mode: 'open_source',
+    query: 'governed observation',
+    feedItems: [
+      { id: 'feed-1', platform: 'rss:test', url: 'https://example.org/item', title: 'Governed observation in systems', summary: 'External candidate.', publisher: 'Independent publisher', publishedAt: '2026-09-07T00:00:00Z' },
+      { id: 'feed-2', platform: 'rss:test', title: 'Malformed but retained' },
+    ],
+  });
+  const external = observed.candidates.filter((candidate) => candidate.candidateClass === 'OPEN_SOURCE_CANDIDATE');
+  assert.equal(external.length, 2);
+  assert.equal(external[0]?.canonical, false);
+  assert(external.some((candidate) => candidate.availability === 'DEGRADED'));
+  assert.equal(observed.state, 'DEGRADED');
+});

--- a/src/lib/discovery/discoveryMesh.ts
+++ b/src/lib/discovery/discoveryMesh.ts
@@ -1,0 +1,357 @@
+import { createHash } from 'node:crypto';
+import { SFI_CANONICAL_IDENTITY_FINGERPRINT } from '@/lib/public/institutionProfile';
+import {
+  publicSemanticProjectionsForCanonicalObjects,
+  type SfiPublicSemanticProjection,
+} from './publicSemanticProjection';
+
+export const SFI_DISCOVERY_MESH_CONTRACT = 'SFI-DISCOVERY-MESH-1.0' as const;
+export const SFI_DISCOVERY_OBSERVATION_CONTRACT = 'SFI-DISCOVERY-OBSERVATION-1.0' as const;
+export const SFI_DISCOVERY_CITATION_PACKET_CONTRACT = 'SFI-CITATION-PACKET-1.0' as const;
+export const SFI_DISCOVERY_METADATA_PACKET_CONTRACT = 'SFI-DISCOVERY-METADATA-PACKET-1.0' as const;
+
+export const SFI_DISCOVERY_MODES = ['query', 'distinct_intent', 'open_source'] as const;
+export type SfiDiscoveryMode = (typeof SFI_DISCOVERY_MODES)[number];
+export const SFI_DISCOVERY_AVAILABILITY = ['AVAILABLE', 'DEGRADED', 'UNAVAILABLE', 'MISSING', 'NOT_OBSERVED'] as const;
+export type SfiDiscoveryAvailability = (typeof SFI_DISCOVERY_AVAILABILITY)[number];
+export type SfiDiscoveryProviderClass = 'SEARCH' | 'AI' | 'ACADEMIC' | 'FEED' | 'OTHER';
+export type SfiCollisionDimension = 'NAME' | 'DOMAIN' | 'METHOD' | 'ENTITY';
+
+export interface SfiDiscoverySourceIdentity {
+  sourceId: string;
+  sourceUrl: string | null;
+  publisher: string | null;
+  platform: string;
+  providerClass: SfiDiscoveryProviderClass;
+  independent: boolean;
+}
+
+export interface SfiDiscoveryRetrievalObservation {
+  observationId: string;
+  source: SfiDiscoverySourceIdentity;
+  observedAt: string;
+  query: string;
+  unbranded: boolean;
+  retrieved: boolean | null;
+  attributedEntityName?: string | null;
+  attributedDomain?: string | null;
+  citedCanonicalUrl?: string | null;
+  reconstructedFields?: Partial<{
+    name: string;
+    domain: string;
+    entityId: string;
+    descriptor: string;
+  }>;
+  references?: Array<{ url: string; independent: boolean }>;
+  collisions?: Array<{ dimension: SfiCollisionDimension; observed: boolean; value: string | null }>;
+  propagationPlatforms?: string[];
+  status?: SfiDiscoveryAvailability;
+}
+
+export interface SfiOpenSourceFeedItem {
+  id?: string | null;
+  url?: string | null;
+  title?: string | null;
+  summary?: string | null;
+  publisher?: string | null;
+  publishedAt?: string | null;
+  platform: string;
+}
+
+export interface SfiDiscoveryMetricValue {
+  availability: SfiDiscoveryAvailability;
+  value: number | null;
+  numerator: number | null;
+  denominator: number | null;
+  basis: string;
+  missing: string[];
+}
+
+export interface SfiDiscoveryMetrics {
+  UDR: SfiDiscoveryMetricValue;
+  EIC: SfiDiscoveryMetricValue;
+  IRD: SfiDiscoveryMetricValue;
+  ACR: {
+    R: SfiDiscoveryMetricValue;
+    A: SfiDiscoveryMetricValue;
+    C: SfiDiscoveryMetricValue;
+  };
+  ECR: Record<SfiCollisionDimension, SfiDiscoveryMetricValue>;
+  MPD: SfiDiscoveryMetricValue;
+  ERR: SfiDiscoveryMetricValue;
+}
+
+export interface SfiDiscoveryCandidate {
+  candidateId: string;
+  candidateClass: 'CANONICAL_PUBLIC_OBJECT' | 'OPEN_SOURCE_CANDIDATE';
+  canonical: false;
+  score: number;
+  title: string;
+  summary: string;
+  canonicalObjectKey: string | null;
+  canonicalUrl: string | null;
+  source: SfiDiscoverySourceIdentity;
+  provenance: string[];
+  availability: SfiDiscoveryAvailability;
+  degradationReasons: string[];
+}
+
+export interface SfiDiscoveryExternalRepresentation {
+  representationClass: 'EXTERNAL_REPRESENTATION';
+  canonicalObjectKey: string;
+  canonicalUrl: string;
+  metadataPacket: {
+    contract: typeof SFI_DISCOVERY_METADATA_PACKET_CONTRACT;
+    title: string;
+    description: string;
+    canonical: string;
+    entityId: string;
+    objectType: string;
+    version: string;
+    language: string;
+  };
+  jsonLd: SfiPublicSemanticProjection['jsonLd'];
+  citationPacket: {
+    contract: typeof SFI_DISCOVERY_CITATION_PACKET_CONTRACT;
+    title: string;
+    canonicalUrl: string;
+    entityId: string;
+    authors: string[];
+    version: string;
+    sourceRefs: string[];
+    epistemicState: string;
+    limitations: string[];
+  };
+}
+
+export interface SfiDiscoveryObservationInput {
+  mode: SfiDiscoveryMode;
+  query: string;
+  intent?: string | null;
+  retrievalObservations?: SfiDiscoveryRetrievalObservation[];
+  feedItems?: SfiOpenSourceFeedItem[];
+}
+
+function clean(value: string | null | undefined) { return typeof value === 'string' ? value.trim() : ''; }
+function normalizedText(value: string) { return value.toLowerCase().normalize('NFKD').replace(/[^a-z0-9\s-]/g, ' ').replace(/\s+/g, ' ').trim(); }
+function tokens(value: string) { return [...new Set(normalizedText(value).split(' ').filter((item) => item.length >= 3))]; }
+function sha(value: unknown) { return createHash('sha256').update(JSON.stringify(value)).digest('hex'); }
+function ratio(numerator: number, denominator: number, basis: string): SfiDiscoveryMetricValue {
+  return denominator > 0
+    ? { availability: 'AVAILABLE', value: numerator / denominator, numerator, denominator, basis, missing: [] }
+    : { availability: 'NOT_OBSERVED', value: null, numerator: null, denominator: null, basis, missing: ['NO_ELIGIBLE_OBSERVATIONS'] };
+}
+function unavailable(basis: string, reason: string, availability: SfiDiscoveryAvailability = 'NOT_OBSERVED'): SfiDiscoveryMetricValue {
+  return { availability, value: null, numerator: null, denominator: null, basis, missing: [reason] };
+}
+function eligible(observation: SfiDiscoveryRetrievalObservation) {
+  return (observation.status ?? 'AVAILABLE') === 'AVAILABLE';
+}
+function validHttpUrl(value: string | null | undefined) {
+  try { const url = new URL(clean(value)); return ['http:', 'https:'].includes(url.protocol); } catch { return false; }
+}
+function sameDomain(value: string | null | undefined) {
+  try { return new URL(clean(value)).hostname.replace(/^www\./, '') === new URL(SFI_CANONICAL_IDENTITY_FINGERPRINT.canonicalUrl).hostname; }
+  catch { return false; }
+}
+
+export function normalizeOpenSourceFeedItem(item: SfiOpenSourceFeedItem): SfiDiscoveryCandidate {
+  const degradationReasons: string[] = [];
+  if (!clean(item.title)) degradationReasons.push('TITLE_MISSING');
+  if (!clean(item.summary)) degradationReasons.push('SUMMARY_MISSING');
+  if (!clean(item.publisher)) degradationReasons.push('PUBLISHER_MISSING');
+  if (!validHttpUrl(item.url)) degradationReasons.push('SOURCE_URL_MISSING_OR_INVALID');
+  if (item.publishedAt && !Number.isFinite(Date.parse(item.publishedAt))) degradationReasons.push('PUBLISHED_AT_INVALID');
+  const id = clean(item.id) || sha({ platform: item.platform, url: item.url, title: item.title }).slice(0, 24);
+  return {
+    candidateId: `open-source:${id}`,
+    candidateClass: 'OPEN_SOURCE_CANDIDATE',
+    canonical: false,
+    score: 0,
+    title: clean(item.title) || 'MISSING',
+    summary: clean(item.summary) || 'MISSING',
+    canonicalObjectKey: null,
+    canonicalUrl: null,
+    source: {
+      sourceId: id,
+      sourceUrl: validHttpUrl(item.url) ? clean(item.url) : null,
+      publisher: clean(item.publisher) || null,
+      platform: clean(item.platform) || 'UNKNOWN',
+      providerClass: 'FEED',
+      independent: true,
+    },
+    provenance: [validHttpUrl(item.url) ? clean(item.url) : `feed:${clean(item.platform) || 'unknown'}:${id}`],
+    availability: degradationReasons.length ? 'DEGRADED' : 'AVAILABLE',
+    degradationReasons,
+  };
+}
+
+function scoreProjection(query: string, intent: string, projection: SfiPublicSemanticProjection) {
+  const haystack = normalizedText([
+    projection.object.title,
+    projection.object.summary,
+    projection.object.objectType,
+    projection.object.methods.join(' '),
+    projection.object.relatedObjects.join(' '),
+  ].join(' '));
+  const queryTokens = tokens(`${query} ${intent}`);
+  const matches = queryTokens.filter((token) => haystack.includes(token)).length;
+  return queryTokens.length ? matches / queryTokens.length : 0;
+}
+
+export function canonicalDiscoveryCandidates(query: string, intent = ''): SfiDiscoveryCandidate[] {
+  const projections = publicSemanticProjectionsForCanonicalObjects();
+  return projections
+    .map((projection) => ({ projection, score: scoreProjection(query, intent, projection) }))
+    .filter((row) => row.score > 0)
+    .sort((a, b) => b.score - a.score || a.projection.object.canonicalUrl.localeCompare(b.projection.object.canonicalUrl))
+    .map(({ projection, score }) => ({
+      candidateId: `canonical-candidate:${projection.object.objectKey}`,
+      candidateClass: 'CANONICAL_PUBLIC_OBJECT' as const,
+      canonical: false as const,
+      score,
+      title: projection.object.title,
+      summary: projection.object.summary,
+      canonicalObjectKey: projection.object.objectKey,
+      canonicalUrl: projection.object.canonicalUrl,
+      source: {
+        sourceId: projection.object.id,
+        sourceUrl: projection.object.canonicalUrl,
+        publisher: SFI_CANONICAL_IDENTITY_FINGERPRINT.name,
+        platform: 'systemfriction.org',
+        providerClass: 'OTHER' as const,
+        independent: false,
+      },
+      provenance: [projection.object.canonicalUrl, ...projection.object.sourceRefs],
+      availability: 'AVAILABLE' as const,
+      degradationReasons: [],
+    }));
+}
+
+export function externalRepresentationsForCandidates(candidates: readonly SfiDiscoveryCandidate[]): SfiDiscoveryExternalRepresentation[] {
+  const byKey = new Map(publicSemanticProjectionsForCanonicalObjects().map((projection) => [projection.object.objectKey, projection]));
+  return candidates.flatMap((candidate) => {
+    if (!candidate.canonicalObjectKey) return [];
+    const projection = byKey.get(candidate.canonicalObjectKey);
+    if (!projection) return [];
+    return [{
+      representationClass: 'EXTERNAL_REPRESENTATION' as const,
+      canonicalObjectKey: projection.object.objectKey,
+      canonicalUrl: projection.object.canonicalUrl,
+      metadataPacket: {
+        contract: SFI_DISCOVERY_METADATA_PACKET_CONTRACT,
+        title: projection.object.title,
+        description: projection.object.summary,
+        canonical: projection.object.canonicalUrl,
+        entityId: projection.object.entityId,
+        objectType: projection.object.objectType,
+        version: projection.object.version,
+        language: projection.object.language,
+      },
+      jsonLd: projection.jsonLd,
+      citationPacket: {
+        contract: SFI_DISCOVERY_CITATION_PACKET_CONTRACT,
+        title: projection.object.title,
+        canonicalUrl: projection.object.canonicalUrl,
+        entityId: projection.object.entityId,
+        authors: [...projection.object.authors],
+        version: projection.object.version,
+        sourceRefs: [...projection.object.sourceRefs],
+        epistemicState: projection.object.epistemicState,
+        limitations: [...projection.object.limitations],
+      },
+    }];
+  });
+}
+
+export function discoveryMetrics(observations: readonly SfiDiscoveryRetrievalObservation[]): SfiDiscoveryMetrics {
+  const available = observations.filter(eligible);
+  const unbranded = available.filter((item) => item.unbranded && item.retrieved !== null);
+  const ai = available.filter((item) => item.source.providerClass === 'AI' && item.retrieved !== null);
+  const identity = available.filter((item) => item.reconstructedFields && Object.keys(item.reconstructedFields).length > 0);
+  const referenceObservations = available.filter((item) => Array.isArray(item.references));
+  const propagation = available.filter((item) => Array.isArray(item.propagationPlatforms));
+
+  const identityChecks: boolean[] = [];
+  for (const item of identity) {
+    const fields = item.reconstructedFields ?? {};
+    if (typeof fields.name === 'string') identityChecks.push(normalizedText(fields.name) === normalizedText(SFI_CANONICAL_IDENTITY_FINGERPRINT.name));
+    if (typeof fields.domain === 'string') identityChecks.push(sameDomain(fields.domain));
+    if (typeof fields.entityId === 'string') identityChecks.push(clean(fields.entityId) === SFI_CANONICAL_IDENTITY_FINGERPRINT.entityId);
+  }
+
+  const independentRefs = referenceObservations.flatMap((item) => item.references ?? []).filter((ref) => ref.independent && validHttpUrl(ref.url));
+  const allRefs = referenceObservations.flatMap((item) => item.references ?? []).filter((ref) => validHttpUrl(ref.url));
+
+  const collisionMetric = (dimension: SfiCollisionDimension): SfiDiscoveryMetricValue => {
+    const rows = available.flatMap((item) => item.collisions ?? []).filter((item) => item.dimension === dimension);
+    return rows.length ? ratio(rows.filter((row) => row.observed).length, rows.length, `Observed ${dimension.toLowerCase()} collision rate`) : unavailable(`Observed ${dimension.toLowerCase()} collision rate`, 'NO_COLLISION_TESTS');
+  };
+
+  const reconstructedRequired = identity.length * 3;
+  let reconstructedCorrect = 0;
+  for (const item of identity) {
+    const fields = item.reconstructedFields ?? {};
+    if (normalizedText(fields.name ?? '') === normalizedText(SFI_CANONICAL_IDENTITY_FINGERPRINT.name)) reconstructedCorrect += 1;
+    if (sameDomain(fields.domain)) reconstructedCorrect += 1;
+    if (clean(fields.entityId) === SFI_CANONICAL_IDENTITY_FINGERPRINT.entityId) reconstructedCorrect += 1;
+  }
+
+  const platformSet = new Set(propagation.flatMap((item) => item.propagationPlatforms ?? []).map(clean).filter(Boolean));
+  const mpd = propagation.length
+    ? { availability: 'AVAILABLE' as const, value: platformSet.size, numerator: platformSet.size, denominator: propagation.length, basis: 'Unique observed propagation platforms across eligible observations', missing: [] }
+    : unavailable('Unique observed propagation platforms across eligible observations', 'NO_PROPAGATION_OBSERVATIONS');
+
+  return {
+    UDR: unbranded.length ? ratio(unbranded.filter((item) => item.retrieved === true).length, unbranded.length, 'Unbranded Discovery Rate') : unavailable('Unbranded Discovery Rate', 'NO_UNBRANDED_RETRIEVAL_OBSERVATIONS'),
+    EIC: identityChecks.length ? ratio(identityChecks.filter(Boolean).length, identityChecks.length, 'External Identity Coherence across observed identity fields') : unavailable('External Identity Coherence across observed identity fields', 'NO_IDENTITY_OBSERVATIONS'),
+    IRD: allRefs.length ? ratio(independentRefs.length, allRefs.length, 'Independent Reference Density') : unavailable('Independent Reference Density', 'NO_REFERENCE_OBSERVATIONS'),
+    ACR: {
+      R: ai.length ? ratio(ai.filter((item) => item.retrieved === true).length, ai.length, 'AI retrieval rate') : unavailable('AI retrieval rate', 'NO_AI_RETRIEVAL_OBSERVATIONS'),
+      A: ai.length ? ratio(ai.filter((item) => normalizedText(item.attributedEntityName ?? '') === normalizedText(SFI_CANONICAL_IDENTITY_FINGERPRINT.name)).length, ai.length, 'AI correct attribution rate') : unavailable('AI correct attribution rate', 'NO_AI_RETRIEVAL_OBSERVATIONS'),
+      C: ai.length ? ratio(ai.filter((item) => sameDomain(item.citedCanonicalUrl)).length, ai.length, 'AI canonical citation rate') : unavailable('AI canonical citation rate', 'NO_AI_RETRIEVAL_OBSERVATIONS'),
+    },
+    ECR: {
+      NAME: collisionMetric('NAME'),
+      DOMAIN: collisionMetric('DOMAIN'),
+      METHOD: collisionMetric('METHOD'),
+      ENTITY: collisionMetric('ENTITY'),
+    },
+    MPD: mpd,
+    ERR: reconstructedRequired ? ratio(reconstructedCorrect, reconstructedRequired, 'Entity Reconstruction Rate across canonical name/domain/entityId') : unavailable('Entity Reconstruction Rate across canonical name/domain/entityId', 'NO_RECONSTRUCTION_OBSERVATIONS'),
+  };
+}
+
+export function observeDiscovery(input: SfiDiscoveryObservationInput) {
+  const query = clean(input.query);
+  if (!query) throw new Error('SFI_DISCOVERY_QUERY_REQUIRED');
+  if (!SFI_DISCOVERY_MODES.includes(input.mode)) throw new Error('SFI_DISCOVERY_MODE_UNSUPPORTED');
+  const intent = input.mode === 'distinct_intent' ? clean(input.intent) : '';
+  if (input.mode === 'distinct_intent' && !intent) throw new Error('SFI_DISCOVERY_DISTINCT_INTENT_REQUIRED');
+  const canonical = canonicalDiscoveryCandidates(query, intent);
+  const openSource = input.mode === 'open_source' ? (input.feedItems ?? []).map(normalizeOpenSourceFeedItem) : [];
+  const candidates = [...canonical, ...openSource].sort((a, b) => b.score - a.score || a.candidateId.localeCompare(b.candidateId));
+  const metrics = discoveryMetrics(input.retrievalObservations ?? []);
+  return {
+    contract: SFI_DISCOVERY_OBSERVATION_CONTRACT,
+    meshContract: SFI_DISCOVERY_MESH_CONTRACT,
+    observationId: `discovery:${sha({ mode: input.mode, query, intent, observations: input.retrievalObservations ?? [], feeds: input.feedItems ?? [] }).slice(0, 32)}`,
+    mode: input.mode,
+    query,
+    intent: intent || null,
+    state: candidates.some((item) => item.availability === 'DEGRADED') ? 'DEGRADED' as const : 'AVAILABLE' as const,
+    candidates,
+    externalRepresentations: externalRepresentationsForCandidates(candidates),
+    metrics,
+    epistemicBoundary: {
+      candidateClass: 'SOURCE_CANDIDATE',
+      candidatesAreCanonical: false,
+      automaticCanon: false,
+      automaticPublication: false,
+      automaticExecution: false,
+      automaticAuthorityExpansion: false,
+      metricMeaning: 'Observed retrieval-test measurements only; no universal ranking claim.',
+      falseZero: 'Numeric zero is emitted only when an eligible observed denominator exists and the measured numerator is actually zero.',
+    },
+  };
+}

--- a/src/lib/discovery/discoveryRepository.ts
+++ b/src/lib/discovery/discoveryRepository.ts
@@ -1,0 +1,98 @@
+import 'server-only';
+
+import { createHash } from 'node:crypto';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import type { SfiDiscoveryObservationInput, SfiDiscoveryRetrievalObservation } from './discoveryMesh';
+import { observeDiscovery } from './discoveryMesh';
+
+function normalize(value: string) {
+  return value.toLowerCase().normalize('NFKD').replace(/[^a-z0-9\s-]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function sha256(value: string) {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+
+function provenance(observations: readonly SfiDiscoveryRetrievalObservation[]) {
+  return observations.map((item) => ({
+    observationId: item.observationId,
+    observedAt: item.observedAt,
+    source: item.source,
+    status: item.status ?? 'AVAILABLE',
+  }));
+}
+
+export async function persistDiscoveryObservation(input: SfiDiscoveryObservationInput, actorId: string) {
+  const result = observeDiscovery(input);
+  const service = createServiceSupabaseClient();
+  const normalizedQuery = normalize(result.query);
+  const intent = result.intent?.trim() || null;
+  const queryHash = sha256(JSON.stringify({ mode: result.mode, query: normalizedQuery, intent }));
+  const retrievalObservations = input.retrievalObservations ?? [];
+  const unbranded = retrievalObservations.length
+    ? retrievalObservations.every((item) => item.unbranded)
+    : !/\b(system friction institute|systemfriction|\bsfi\b)/i.test(result.query);
+
+  const queryRow = await service.from('sfi_discovery_queries').upsert({
+    query_hash: queryHash,
+    query_text: result.query,
+    normalized_query: normalizedQuery,
+    mode: result.mode,
+    intent,
+    unbranded,
+    created_by: actorId,
+  }, { onConflict: 'query_hash', ignoreDuplicates: false }).select('id').single();
+  if (queryRow.error || !queryRow.data?.id) throw new Error(`SFI_DISCOVERY_QUERY_PERSIST_FAILED:${queryRow.error?.message ?? 'unknown'}`);
+
+  const observedAt = retrievalObservations
+    .map((item) => Date.parse(item.observedAt))
+    .filter(Number.isFinite)
+    .sort((a, b) => b - a)[0];
+  const observedAtIso = typeof observedAt === 'number' ? new Date(observedAt).toISOString() : new Date().toISOString();
+
+  const runRow = await service.from('sfi_discovery_query_runs').insert({
+    run_id: result.observationId,
+    query_id: queryRow.data.id,
+    actor_id: actorId,
+    observation_contract: result.contract,
+    availability: result.state,
+    candidates: result.candidates,
+    external_representations: result.externalRepresentations,
+    metrics: result.metrics,
+    provenance: provenance(retrievalObservations),
+    epistemic_boundary: result.epistemicBoundary,
+    observed_at: observedAtIso,
+  }).select('id').single();
+  if (runRow.error || !runRow.data?.id) {
+    if (runRow.error?.code === '23505') {
+      const existing = await service.from('sfi_discovery_query_runs').select('id').eq('run_id', result.observationId).maybeSingle();
+      if (!existing.error && existing.data?.id) return { result, queryId: String(queryRow.data.id), runId: String(existing.data.id), replay: true };
+    }
+    throw new Error(`SFI_DISCOVERY_RUN_PERSIST_FAILED:${runRow.error?.message ?? 'unknown'}`);
+  }
+
+  const collisionRows = retrievalObservations.flatMap((observation) => (observation.collisions ?? []).map((collision) => ({
+    run_id: runRow.data.id,
+    dimension: collision.dimension,
+    collision_observed: collision.observed,
+    observed_value: collision.value,
+    source_identity: observation.source,
+    observed_at: observation.observedAt,
+  })));
+  if (collisionRows.length) {
+    const inserted = await service.from('sfi_entity_collisions').insert(collisionRows);
+    if (inserted.error) throw new Error(`SFI_DISCOVERY_COLLISION_PERSIST_FAILED:${inserted.error.message}`);
+  }
+
+  return { result, queryId: String(queryRow.data.id), runId: String(runRow.data.id), replay: false };
+}
+
+export async function readDiscoveryRun(runId: string) {
+  const service = createServiceSupabaseClient();
+  const run = await service.from('sfi_discovery_query_runs').select('*,sfi_discovery_queries(*)').eq('id', runId).maybeSingle();
+  if (run.error) throw new Error(`SFI_DISCOVERY_RUN_READ_FAILED:${run.error.message}`);
+  if (!run.data) throw new Error('SFI_DISCOVERY_RUN_NOT_FOUND');
+  const collisions = await service.from('sfi_entity_collisions').select('*').eq('run_id', runId).order('created_at', { ascending: true });
+  if (collisions.error) throw new Error(`SFI_DISCOVERY_COLLISION_READ_FAILED:${collisions.error.message}`);
+  return { run: run.data, collisions: collisions.data ?? [] };
+}

--- a/supabase/migrations/20260908004000_create_sfi_discovery_observation_plane.sql
+++ b/supabase/migrations/20260908004000_create_sfi_discovery_observation_plane.sql
@@ -1,0 +1,96 @@
+-- SFI-DISCOVERY-MESH-1.0
+-- WS-03 durable observation plane.
+-- Canonical objects remain owned by src/lib/discovery/canonicalObjectRegistry.ts.
+-- Verified institution identity remains owned by src/lib/public/institutionProfile.ts.
+-- These tables persist query definitions, observed retrieval runs, collisions and external representation receipts only.
+
+create table if not exists public.sfi_discovery_queries (
+  id uuid primary key default gen_random_uuid(),
+  query_hash text not null unique check (query_hash ~ '^sha256:[0-9a-f]{64}$'),
+  query_text text not null check (length(btrim(query_text)) > 0),
+  normalized_query text not null check (length(btrim(normalized_query)) > 0),
+  mode text not null check (mode in ('query','distinct_intent','open_source')),
+  intent text,
+  unbranded boolean not null,
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  constraint sfi_discovery_queries_intent_truth check ((mode = 'distinct_intent' and intent is not null and length(btrim(intent)) > 0) or mode <> 'distinct_intent')
+);
+
+comment on table public.sfi_discovery_queries is
+  'WS-03 durable query-corpus owner. A row declares a retrieval test query; it is not a ranking or discovery success claim.';
+
+create table if not exists public.sfi_discovery_query_runs (
+  id uuid primary key default gen_random_uuid(),
+  run_id text not null unique,
+  query_id uuid not null references public.sfi_discovery_queries(id) on delete restrict,
+  actor_id uuid references auth.users(id) on delete set null,
+  observation_contract text not null check (observation_contract = 'SFI-DISCOVERY-OBSERVATION-1.0'),
+  availability text not null check (availability in ('AVAILABLE','DEGRADED','UNAVAILABLE','MISSING','NOT_OBSERVED')),
+  candidates jsonb not null default '[]'::jsonb,
+  external_representations jsonb not null default '[]'::jsonb,
+  metrics jsonb not null,
+  provenance jsonb not null default '[]'::jsonb,
+  epistemic_boundary jsonb not null,
+  observed_at timestamptz not null,
+  created_at timestamptz not null default now()
+);
+
+comment on table public.sfi_discovery_query_runs is
+  'Observed retrieval-test run owner. Metrics retain availability separate from numeric value; NOT_OBSERVED/UNAVAILABLE are never persisted as numeric zero.';
+
+create index if not exists sfi_discovery_query_runs_query_observed_idx
+  on public.sfi_discovery_query_runs(query_id, observed_at desc);
+
+create table if not exists public.sfi_entity_collisions (
+  id uuid primary key default gen_random_uuid(),
+  run_id uuid not null references public.sfi_discovery_query_runs(id) on delete restrict,
+  dimension text not null check (dimension in ('NAME','DOMAIN','METHOD','ENTITY')),
+  collision_observed boolean not null,
+  observed_value text,
+  source_identity jsonb not null,
+  observed_at timestamptz not null,
+  created_at timestamptz not null default now()
+);
+
+comment on table public.sfi_entity_collisions is
+  'Observed entity/name/domain/method collision tests. A false value is an observed no-collision result, distinct from absence of a test.';
+
+create index if not exists sfi_entity_collisions_run_dimension_idx
+  on public.sfi_entity_collisions(run_id, dimension);
+
+create table if not exists public.sfi_external_representations (
+  id uuid primary key default gen_random_uuid(),
+  canonical_object_key text not null,
+  representation_kind text not null,
+  state text not null check (state in ('DRAFT','READY','PUBLISHED','FAILED','SUPERSEDED','REMOVED')),
+  external_url text,
+  content_hash text check (content_hash is null or content_hash ~ '^sha256:[0-9a-f]{64}$'),
+  receipt jsonb not null default '{}'::jsonb,
+  lineage jsonb not null default '[]'::jsonb,
+  observed_at timestamptz,
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  constraint sfi_external_representation_published_truth check (state <> 'PUBLISHED' or (external_url is not null and observed_at is not null))
+);
+
+comment on table public.sfi_external_representations is
+  'External representation/distribution receipt owner. It points to a canonical object key and never redefines the canonical object.';
+
+create index if not exists sfi_external_representations_object_state_idx
+  on public.sfi_external_representations(canonical_object_key, state, created_at desc);
+
+alter table public.sfi_discovery_queries enable row level security;
+alter table public.sfi_discovery_queries force row level security;
+alter table public.sfi_discovery_query_runs enable row level security;
+alter table public.sfi_discovery_query_runs force row level security;
+alter table public.sfi_entity_collisions enable row level security;
+alter table public.sfi_entity_collisions force row level security;
+alter table public.sfi_external_representations enable row level security;
+alter table public.sfi_external_representations force row level security;
+
+-- These are institutional control-plane owners. No direct browser/Data API access.
+revoke all on public.sfi_discovery_queries from anon, authenticated;
+revoke all on public.sfi_discovery_query_runs from anon, authenticated;
+revoke all on public.sfi_entity_collisions from anon, authenticated;
+revoke all on public.sfi_external_representations from anon, authenticated;


### PR DESCRIPTION
## SFI PRECHECK
Owner: SFI-03 · Discovery Mesh; integration authority SFI-00.
Parent: #408 / #389 / #405.

Existing capability inspected: `SFI-CANONICAL-OBJECT-1.0`, public semantic projection/Evidence Capsule foundation, current empty canonical registry, Research Graph/public boundaries, existing Supabase server owner, Contract Lock reserved UDR/EIC/IRD/ACR/ECR/MPD/ERR semantics.

Absorb vs create decision: reuse canonical-object/public projection owners and create only the missing Discovery observation/run/collision/representation receipt plane. No second canon, external-node owner, evidence store, identity store or publication authority.

Authoritative writer: canonical object state remains owned by `src/lib/discovery/canonicalObjectRegistry.ts`; Discovery observation/run/collision/representation receipts are written only through `src/lib/discovery/discoveryRepository.ts` on the server. No canonical promotion writer is introduced.

Persistence/lineage impact: adds the reserved Discovery observation-plane tables for query/run/collision/external-representation receipts. Candidate provenance/source identity and representation lineage are retained; candidates remain non-canonical. No raw source warehouse and no duplicate canonical-object table.

Front delta: NONE in this slice; `/root/discovery` remains residual work.

Back delta: adds operational `query / distinct_intent / open_source` Discovery modes, UDR/EIC/IRD/ACR/ECR/MPD/ERR bounded outputs, authenticated `/api/discovery/observe`, conservative source normalization and server-side receipt persistence.

DB delta: one Discovery-owned migration `20260908004000_create_sfi_discovery_observation_plane.sql`; FORCE RLS and no direct anon/authenticated CRUD. No `sfi_canonical_objects` and no `sfi_external_nodes` duplicate owners.

Redundancy removed: explicitly reuses Canonical Object Registry, public semantic projection/Evidence Capsule and existing identity/publicability owners instead of creating second canon/external-node/publication stores.

Execution/ROOT boundary: observation, reconstruction, query and external candidate collection only. Discovery does not promote canon, publish externally, mint authority or turn SOURCE_CANDIDATE into evidence/canon. `MISSING/NOT_OBSERVED/UNAVAILABLE` remain explicit.

Rollback: revert this PR before migration rollout. After authorized rollout, preserve required receipts if needed and drop only the four WS-03 observation-plane tables in a dedicated rollback migration; canonical/public owners remain intact.

Verification: exact-head Discovery operational QA, SFI Verify/typecheck/build, Program Completion/Audio regressions, and security/RLS review before live migration.

Truth boundary:
- empty canonical registry → zero canonical candidates and zero canonical public representations;
- Discovery must not manufacture objects to satisfy QA;
- `open_source` may surface non-canonical SOURCE_CANDIDATE entries with explicit provenance/degradation;
- external representation does not promote a candidate into canon.

Not claimed: populated public canon, crawler/feed/IndexNow publication, external registry publication, full #154 completion, or WS-03 RETURN_PASS.