### PR TITLE
fix(ci): validate DB proof/reset workflows before execution

### DIFF
--- a/.github/workflows/sfi-db-canonical-reset.yml
+++ b/.github/workflows/sfi-db-canonical-reset.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 45
     env:
       DATABASE_URL: ${{ secrets.SFI_DATABASE_URL || secrets.DATABASE_URL || secrets.SUPABASE_DB_URL || secrets.POSTGRES_URL }}
-      SFI_DB_EVIDENCE_DIR: ${{ runner.temp }}/sfi-db-evidence
+      SFI_DB_EVIDENCE_DIR: /tmp/sfi-db-evidence
       SFI_DB_REQUIRE_RESET_CLASSIFICATION: 'YES'
       SFI_DB_SNAPSHOT_MAX_AGE_MINUTES: '180'
     steps:
@@ -83,7 +83,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sfi-db-pre-reset-proof-${{ github.run_id }}
-          path: ${{ runner.temp }}/sfi-db-evidence/
+          path: /tmp/sfi-db-evidence/
           if-no-files-found: error
           retention-days: 90
           compression-level: 0

--- a/.github/workflows/sfi-db-proof-snapshot.yml
+++ b/.github/workflows/sfi-db-proof-snapshot.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     env:
       DATABASE_URL: ${{ secrets.SFI_DATABASE_URL || secrets.DATABASE_URL || secrets.SUPABASE_DB_URL || secrets.POSTGRES_URL }}
-      SFI_DB_EVIDENCE_DIR: ${{ runner.temp }}/sfi-db-evidence
+      SFI_DB_EVIDENCE_DIR: /tmp/sfi-db-evidence
       SFI_DB_REQUIRE_RESET_CLASSIFICATION: 'YES'
       SFI_DB_SNAPSHOT_MAX_AGE_MINUTES: '180'
     steps:
@@ -76,7 +76,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sfi-db-proof-${{ github.run_id }}
-          path: ${{ runner.temp }}/sfi-db-evidence/
+          path: /tmp/sfi-db-evidence/
           if-no-files-found: error
           retention-days: 90
           compression-level: 0

--- a/scripts/qa-sfi-operational-reset.ts
+++ b/scripts/qa-sfi-operational-reset.ts
@@ -127,6 +127,8 @@ assert.match(snapshotWorkflow, /name: SFI DB Proof Snapshot/);
 assert.match(snapshotWorkflow, /workflow_dispatch:/);
 assert.match(snapshotWorkflow, /\.github\/sfi-db-snapshot-trigger/);
 assert.match(snapshotWorkflow, /SFI_DB_SNAPSHOT_REQUEST=ISSUE_430/);
+assert.match(snapshotWorkflow, /SFI_DB_EVIDENCE_DIR: \/tmp\/sfi-db-evidence/);
+assert.doesNotMatch(snapshotWorkflow, /SFI_DB_EVIDENCE_DIR:.*runner\.temp/, 'runner context is unavailable in job-level env and would invalidate the workflow before jobs start');
 assert.match(snapshotWorkflow, /node scripts\/db\/create-db-evidence-snapshot\.mjs/);
 assert.match(snapshotWorkflow, /node scripts\/db\/verify-db-evidence-snapshot\.mjs/);
 assert.match(snapshotWorkflow, /actions\/upload-artifact@v4/);
@@ -138,6 +140,8 @@ assert.doesNotMatch(snapshotWorkflow, /pull_request:/, 'proof workflow must not 
 assert.match(resetWorkflow, /name: SFI DB Canonical Reset/);
 assert.match(resetWorkflow, /SFI_DB_CANONICAL_RESET=ISSUE_430/);
 assert.match(resetWorkflow, /RESET_SFI_CANONICAL/);
+assert.match(resetWorkflow, /SFI_DB_EVIDENCE_DIR: \/tmp\/sfi-db-evidence/);
+assert.doesNotMatch(resetWorkflow, /SFI_DB_EVIDENCE_DIR:.*runner\.temp/, 'runner context is unavailable in job-level env and would invalidate the destructive workflow before its guards can execute');
 assert.match(resetWorkflow, /Upload proof before any destructive statement/);
 assert.match(resetWorkflow, /Execute founder-authorized canonical reset/);
 assert.match(resetWorkflow, /steps\.proof\.outputs\.artifact-id/);
@@ -170,6 +174,7 @@ console.log(JSON.stringify({
     'SNAPSHOT_CONTAINS_HASHED_PUBLIC_TABLE_INVENTORY',
     'EXTERNAL_PROOF_ARTIFACT_REQUIRED_BEFORE_DESTRUCTION',
     'PROOF_ONLY_WORKFLOW_CANNOT_DELETE',
+    'DB_WORKFLOWS_VALIDATE_BEFORE_JOB_EXECUTION',
     'DESTRUCTIVE_WORKFLOW_UPLOADS_PROOF_BEFORE_RESET',
     'UNCLASSIFIED_PUBLIC_TABLE_BLOCKS_RESET',
     'FULL_WORLD_LONGITUDINAL_CORPUS_PRESERVED',


### PR DESCRIPTION
## Scope
Repair the issue #430 DB proof/reset GitHub Actions workflows after the first proof-only trigger demonstrated both workflow definitions were rejected before jobs started.

## Observed defect
Run `34186854693` (`sfi-db-proof-snapshot.yml`) completed FAILURE with zero jobs. The canonical reset workflow was likewise invalid and produced zero jobs. No database command executed.

## Root cause
Both workflows referenced `${{ runner.temp }}` from job-level `env`. The `runner` context is not available while GitHub validates that job definition, so the workflows could not materialize jobs.

## Repair
Use the runner-local literal `/tmp/sfi-db-evidence` for `SFI_DB_EVIDENCE_DIR` and artifact paths. Preserve all existing trigger, proof-before-destruction, classification, target binding and World-preservation guards.

## QA
`qa-sfi-operational-reset.ts` now rejects `runner.temp` in job-level evidence-dir declarations and requires the literal runner-local path in both workflows.

## Safety
No DB schema/data mutation. No reset trigger created. The longitudinal World corpus remains protected by `SFI-CANONICAL-RESET-CLASSIFICATION-1.1` (10 PRESERVE_DATA tables).