### PR TITLE
fix(world): use native WebSocket runtime for observer smoke

### DIFF
--- a/.github/workflows/sfi-world-signal-observer.yml
+++ b/.github/workflows/sfi-world-signal-observer.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Validate controlled trigger and World persistence identity
         shell: bash
@@ -46,14 +46,19 @@ jobs:
             grep -Fx 'SFI_WORLD_SIGNAL_OBSERVER_REQUEST=ISSUE_154' .github/sfi-world-signal-observer-trigger
           fi
 
-      - name: Install dependencies
+      - name: Install dependencies and direct-server marker
+        shell: bash
         run: |
           set -euo pipefail
           npm ci
-          # `server-only` is a framework marker resolved by Next during bundled execution.
-          # This smoke invokes the same server module directly through tsx, so install the
-          # exact marker version transiently without changing the application lockfile.
-          npm install --no-save --package-lock=false server-only@0.0.1
+          # Next resolves `server-only` during bundled execution. The assurance runner
+          # imports the same server module directly, so materialize only this exact marker
+          # without asking npm to reconcile the installed application dependency graph.
+          SERVER_ONLY_ARCHIVE="$(npm pack server-only@0.0.1 --silent)"
+          mkdir -p node_modules/server-only
+          tar -xzf "$SERVER_ONLY_ARCHIVE" -C node_modules/server-only --strip-components=1
+          rm -f "$SERVER_ONLY_ARCHIVE"
+          test -f node_modules/server-only/package.json
 
       - name: Execute WorldSignalObserverAgent
         id: execute

--- a/scripts/qa-sfi-discovery-operational.ts
+++ b/scripts/qa-sfi-discovery-operational.ts
@@ -61,8 +61,6 @@ async function main() {
   assert(contractLock.includes('MPD — Multi-Platform Propagation Depth'), 'frozen MPD meaning missing');
   assert(contractLock.includes('ERR — Entity Reconstruction Rate'), 'frozen ERR meaning missing');
 
-  // #154: WorldSignalObserverAgent is a governed World/Discovery domain agent, not a second
-  // cognitive agent and not a second persistence owner. It must reuse the longitudinal World writer.
   assert(worldCaseContract.includes('### WorldSignalObserverAgent'), 'canonical WorldSignalObserverAgent requirement missing');
   for (const token of [
     "SFI-WORLD-SIGNAL-OBSERVER-1.0",
@@ -106,7 +104,6 @@ async function main() {
   assert(worldReobserve.includes('runWorldHypothesisCycle'), 'human reobserve hypothesis owner must remain explicit and separate');
   assert(worldReobserve.includes('runWorldCalibrationCycle'), 'human reobserve calibration owner must remain explicit and separate');
 
-  // Controlled executable proof: main-only explicit observation smoke, no hypothesis/case/canon writer.
   for (const token of [
     'executeWorldSignalObserverAgent',
     "SFI-WORLD-SIGNAL-OBSERVER-EXECUTION-1.1",
@@ -128,7 +125,9 @@ async function main() {
     ".github/sfi-world-signal-observer-trigger",
     'SFI_WORLD_SIGNAL_OBSERVER_REQUEST=ISSUE_154',
     'SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}',
-    'npm install --no-save --package-lock=false server-only@0.0.1',
+    'node-version: 22',
+    'npm pack server-only@0.0.1 --silent',
+    'node_modules/server-only/package.json',
     'id: execute',
     'npx tsx scripts/run-world-signal-observer-agent.ts',
     'if: ${{ always() }}',
@@ -137,13 +136,14 @@ async function main() {
     'Authority: `OBSERVE`',
     'Hypothesis promotion: **NOT PERFORMED BY THIS AGENT**',
   ]) assert(worldSignalWorkflow.includes(token), `world_signal_observer_workflow_missing:${token}`);
+  assert(!worldSignalWorkflow.includes('npm install --no-save'), 'WorldSignalObserverAgent smoke must not reconcile the installed application dependency graph');
   assert(!worldSignalWorkflow.includes('schedule:'), 'WorldSignalObserverAgent proof must not introduce a new autonomous timer');
   assert(!worldSignalWorkflow.includes('pull_request:'), 'WorldSignalObserverAgent proof must not write live World data from PRs');
   assert(!worldSignalWorkflow.includes('runWorldHypothesisCycle'), 'WorldSignalObserverAgent proof workflow must not own hypothesis generation');
 
   console.log(JSON.stringify({
     ok: true,
-    contract: 'SFI-DISCOVERY-INTEGRITY-1.4',
+    contract: 'SFI-DISCOVERY-INTEGRITY-1.5',
     modes: 3,
     metricFamilies: 7,
     falseZero: true,
@@ -163,7 +163,8 @@ async function main() {
       controlledExecutionReceipt: true,
       immutableCommitBinding: true,
       failureReceiptPreserved: true,
-      directTsxServerOnlyMarkerPinned: true,
+      nativeWebSocketRuntime: true,
+      isolatedServerOnlyMarker: true,
       automaticHypothesisPromotion: false,
       automaticCaseQualification: false,
       automaticPublication: false,


### PR DESCRIPTION
## Scope
Repair the second live `WorldSignalObserverAgent` smoke failure using the observed receipt from run 34194310474.

## SFI PRECHECK
Owner: SFI-00 · World / Discovery assurance
Existing capability inspected: run 34194310474, artifact 10043326670, `SFI World Signal Observer` workflow, Supabase client runtime.
Absorb vs create decision: ABSORB existing smoke; change only its Node/test-marker environment.
Authoritative writer: `src/lib/world-observatory/worldCycle.ts::runWorldObservationCycle` remains unchanged.
Persistence/lineage impact: none; receipt remains immutable and tied to `GITHUB_SHA`.
Front delta: none.
Back delta: smoke runtime Node 20 -> Node 22; replace `npm install --no-save` with isolated `npm pack server-only@0.0.1` extraction.
DB delta: zero DDL, migration, reset or deletion.
Redundancy removed: avoids npm reconciliation of the application dependency graph solely to provide one framework marker.
Execution/ROOT boundary: remains `OBSERVE`; no ROOT or promotion authority.
Rollback: revert this PR; World writer/data unchanged.
Verification: SFI Verify + Completion Controller + Audio exact-head; third controlled main smoke must emit immutable receipt and is the only evidence accepted for EXECUTED/PERSISTED.

## Observed defect
Run `34194310474` reached the agent but failed before World persistence with: `Node.js 20 detected without native WebSocket support`. The failure receipt was preserved as artifact `10043326670`, digest `sha256:8065f577bfa9fc4e81471a350b261e10e1d4929cdc2b5dc0a72db5a102fd825d`.

## Safety
No production deploy. No history rewrite. No schema or collector change.