### PR TITLE
fix(auth): converge founder authority across ROOT write boundaries

### DIFF
--- a/.github/workflows/sfi-institutional-authority.yml
+++ b/.github/workflows/sfi-institutional-authority.yml
@@ -54,5 +54,8 @@ jobs:
       - name: SFI-INSTITUTIONAL-APPOINTMENT-SEPARATION-1.0
         run: node --import tsx --test src/lib/system/access/institutionalAppointmentSeparation.test.ts
 
+      - name: SFI-FOUNDER-AUTHORITY-CONVERGENCE-1.0
+        run: node --import tsx --test src/lib/system/access/founderAuthority.test.ts
+
       - name: Typecheck authority plane
         run: npm run typecheck

--- a/src/app/api/root/founder-state/route.ts
+++ b/src/app/api/root/founder-state/route.ts
@@ -8,17 +8,23 @@ export const runtime = 'nodejs';
 export async function GET(request: Request) {
   const gate = await requireRootActor('founder-state.read');
   if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+
   const state = await buildFounderConsoleState(request.url);
+  const profileRole = typeof gate.ctx.profile?.role === 'string' ? gate.ctx.profile.role : null;
 
-  if (!state.access.authenticated) {
-    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
-  }
+  const verifiedState = {
+    ...state,
+    access: {
+      ...state.access,
+      authenticated: true,
+      authorized: true,
+      userId: gate.ctx.user.id,
+      email: gate.ctx.user.email ?? state.access.email ?? null,
+      role: state.access.role ?? profileRole,
+    },
+  };
 
-  if (!state.access.authorized) {
-    return NextResponse.json({ ok: false, error: 'root_required' }, { status: 403 });
-  }
-
-  return NextResponse.json(state, {
+  return NextResponse.json(verifiedState, {
     headers: {
       'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
       Pragma: 'no-cache',

--- a/src/app/api/studio/cultural-lens/route.ts
+++ b/src/app/api/studio/cultural-lens/route.ts
@@ -1,19 +1,19 @@
 import { NextResponse } from 'next/server';
 import { createServerSupabaseClient, createServiceSupabaseClient } from '@/runtime/supabase/server';
 import { buildStudioCulturalLens } from '@/lib/studio/culturalLens';
+import { isConfiguredFounderIdentity } from '@/lib/system/access/founderAuthority';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-function isRootRouteUser(role?: string | null, email?: string | null) {
-  const rootEmail = process.env.SYSTEM_ROOT_EMAIL;
-  return role === 'root'
-    || role === 'system'
-    || Boolean(rootEmail && email && email.toLowerCase() === rootEmail.toLowerCase());
+function isRootRouteUser(userId?: string | null, role?: string | null, email?: string | null) {
+  return isConfiguredFounderIdentity({ userId, email })
+    || role === 'root'
+    || role === 'system';
 }
 
-function isStudioRouteUser(role?: string | null, email?: string | null) {
-  if (isRootRouteUser(role, email)) return true;
+function isStudioRouteUser(userId?: string | null, role?: string | null, email?: string | null) {
+  if (isRootRouteUser(userId, role, email)) return true;
   const allowed = (process.env.STUDIO_AUTHORIZED_EMAILS || '')
     .split(',')
     .map((item) => item.trim().toLowerCase())
@@ -35,7 +35,7 @@ async function authorizeStudio() {
     role = null;
   }
 
-  if (!isStudioRouteUser(role, user.email)) {
+  if (!isStudioRouteUser(user.id, role, user.email)) {
     return { ok: false as const, response: NextResponse.json({ ok: false, error: 'studio_forbidden' }, { status: 403 }) };
   }
 

--- a/src/app/api/studio/evaluate/route.ts
+++ b/src/app/api/studio/evaluate/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerSupabaseClient, createServiceSupabaseClient } from '@/runtime/supabase/server';
 import { buildStudioEvaluationReport, type StudioEvaluateInput, type StudioObjectKind } from '@/lib/studio/evaluation';
+import { isConfiguredFounderIdentity } from '@/lib/system/access/founderAuthority';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -29,15 +30,14 @@ function isStudioKind(value: unknown): value is StudioObjectKind {
     || value === 'instagram_signal';
 }
 
-function isRootRouteUser(role?: string | null, email?: string | null) {
-  const rootEmail = process.env.SYSTEM_ROOT_EMAIL;
-  return role === 'root'
-    || role === 'system'
-    || Boolean(rootEmail && email && email.toLowerCase() === rootEmail.toLowerCase());
+function isRootRouteUser(userId?: string | null, role?: string | null, email?: string | null) {
+  return isConfiguredFounderIdentity({ userId, email })
+    || role === 'root'
+    || role === 'system';
 }
 
-function isStudioRouteUser(role?: string | null, email?: string | null) {
-  if (isRootRouteUser(role, email)) return true;
+function isStudioRouteUser(userId?: string | null, role?: string | null, email?: string | null) {
+  if (isRootRouteUser(userId, role, email)) return true;
   const allowed = (process.env.STUDIO_AUTHORIZED_EMAILS || '')
     .split(',')
     .map((item) => item.trim().toLowerCase())
@@ -63,7 +63,7 @@ async function authorizeStudio() {
     role = null;
   }
 
-  if (!isStudioRouteUser(role, user.email)) {
+  if (!isStudioRouteUser(user.id, role, user.email)) {
     return { ok: false as const, response: NextResponse.json({ ok: false, error: 'studio_forbidden' }, { status: 403 }) };
   }
 

--- a/src/lib/server/productionBackend.ts
+++ b/src/lib/server/productionBackend.ts
@@ -6,6 +6,7 @@ import {
   SfiAuthUnavailableError,
 } from '@/runtime/supabase/server';
 import { findInstitutionalMember } from '@/lib/system/access/institutionalMembers';
+import { isConfiguredFounderIdentity, resolveFounderAuthority } from '@/lib/system/access/founderAuthority';
 
 export const PRODUCTION_APP_URL =
   process.env.NEXT_PUBLIC_APP_URL || 'https://systemfriction.org';
@@ -38,15 +39,9 @@ export function isRootUser(
   role?: string | null,
   email?: string | null
 ) {
-  const rootEmail = process.env.SYSTEM_ROOT_EMAIL;
-
   return (
     isRootRole(role) ||
-    Boolean(
-      rootEmail &&
-        email &&
-        email.toLowerCase() === rootEmail.toLowerCase()
-    )
+    isConfiguredFounderIdentity({ email })
   );
 }
 
@@ -56,32 +51,9 @@ function record(value: unknown): Record<string, unknown> {
     : {};
 }
 
-function isConfiguredRootEmail(email?: string | null) {
-  const rootEmail = process.env.SYSTEM_ROOT_EMAIL;
-  return Boolean(
-    rootEmail &&
-      email &&
-      email.toLowerCase() === rootEmail.toLowerCase()
-  );
-}
-
 function isRegisteredInstitutionalRootObserver(email?: string | null) {
   const member = findInstitutionalMember(email);
   return Boolean(member && member.modules.root === true);
-}
-
-function hasSovereignRootAuthority(
-  profile: Record<string, unknown> | null,
-  email?: string | null,
-) {
-  if (isConfiguredRootEmail(email)) return true;
-  if (!profile) return false;
-
-  const role = typeof profile.role === 'string' ? profile.role : null;
-  if (!isRootRole(role)) return false;
-
-  const moduleAccess = record(profile.module_access);
-  return moduleAccess.full_access === true;
 }
 
 export function canObserveRoot(
@@ -140,10 +112,8 @@ export async function getServerUserContext() {
   const profileReadError = profileRead.error;
 
   const institutionalMember = findInstitutionalMember(user.email);
+  const configuredFounder = isConfiguredFounderIdentity({ userId: user.id, email: user.email });
 
-  // A failed profile read is not evidence that the profile is absent. Never
-  // provision on top of an indeterminate read; that was the source of the
-  // duplicate profiles_pkey write storm observed during DB timeouts.
   if (profileReadError) {
     console.error('PROFILE READ ERROR', {
       userId: user.id,
@@ -151,14 +121,12 @@ export async function getServerUserContext() {
     });
   }
 
-  // Only explicitly recognized institutional identities may be provisioned here.
-  // Unknown authenticated users must never become ROOT observers by fallback.
-  if (!profile && !profileReadError && (isConfiguredRootEmail(user.email) || institutionalMember)) {
-    const role = isConfiguredRootEmail(user.email)
+  if (!profile && !profileReadError && (configuredFounder || institutionalMember)) {
+    const role = configuredFounder
       ? 'root'
       : institutionalMember?.role ?? 'observer';
 
-    const alias = isConfiguredRootEmail(user.email)
+    const alias = configuredFounder
       ? SFI_FOUNDER_IDENTITY.displayName
       : institutionalMember?.displayName ?? user.email?.split('@')[0] ?? 'observador';
     const moduleAccess = role === 'root'
@@ -204,7 +172,12 @@ export async function getServerUserContext() {
 
   const profileRecord = profile ? record(profile) : null;
   const role = typeof profile?.role === 'string' ? profile.role : null;
-  const isRoot = hasSovereignRootAuthority(profileRecord, user.email);
+  const founderAuthority = resolveFounderAuthority({
+    userId: user.id,
+    email: user.email,
+    profile: profileRecord,
+  });
+  const isRoot = founderAuthority.isFounder;
   const legacyRootWithoutAuthority = isRootRole(role) && !isRoot;
   const registeredObserver = isRegisteredInstitutionalRootObserver(user.email);
 
@@ -214,6 +187,7 @@ export async function getServerUserContext() {
     user,
     profile,
     isRoot,
+    founderAuthoritySource: founderAuthority.source,
     canObserveRoot:
       isRoot ||
       isInstitutionalObserverRole(role) ||

--- a/src/lib/system/access/founderAuthority.test.ts
+++ b/src/lib/system/access/founderAuthority.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { resolveFounderAuthority } from './founderAuthority';
+
+function withFounderEnv(
+  values: { SYSTEM_ROOT_EMAIL?: string; SFI_FOUNDER_EMAILS?: string; SFI_FOUNDER_USER_IDS?: string },
+  run: () => void,
+) {
+  const previous = {
+    SYSTEM_ROOT_EMAIL: process.env.SYSTEM_ROOT_EMAIL,
+    SFI_FOUNDER_EMAILS: process.env.SFI_FOUNDER_EMAILS,
+    SFI_FOUNDER_USER_IDS: process.env.SFI_FOUNDER_USER_IDS,
+  };
+  try {
+    for (const key of Object.keys(previous) as Array<keyof typeof previous>) {
+      const value = values[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    run();
+  } finally {
+    for (const key of Object.keys(previous) as Array<keyof typeof previous>) {
+      const value = previous[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test('configured founder user id is sovereign without relying on profile projection', () => {
+  withFounderEnv({ SFI_FOUNDER_USER_IDS: 'founder-id' }, () => {
+    assert.deepEqual(
+      resolveFounderAuthority({ userId: 'founder-id', email: 'other@example.com', profile: null }),
+      { isFounder: true, source: 'configured_user_id' },
+    );
+  });
+});
+
+test('all configured founder email channels resolve identically', () => {
+  withFounderEnv({ SYSTEM_ROOT_EMAIL: 'root@example.com', SFI_FOUNDER_EMAILS: 'founder@example.com' }, () => {
+    assert.equal(resolveFounderAuthority({ email: 'ROOT@example.com' }).isFounder, true);
+    assert.equal(resolveFounderAuthority({ email: 'Founder@example.com' }).isFounder, true);
+  });
+});
+
+test('explicit root profile still requires full_access', () => {
+  withFounderEnv({}, () => {
+    assert.equal(resolveFounderAuthority({
+      email: 'legacy@example.com',
+      profile: { role: 'root', module_access: { root: true, root_observe: true } },
+    }).isFounder, false);
+
+    assert.deepEqual(resolveFounderAuthority({
+      email: 'sovereign@example.com',
+      profile: { role: 'root', module_access: { full_access: true } },
+    }), { isFounder: true, source: 'explicit_sovereign_profile' });
+  });
+});
+
+test('registered institutional member cannot become founder through profile flags', () => {
+  withFounderEnv({}, () => {
+    assert.equal(resolveFounderAuthority({
+      email: 'edwin.tzolkin@gmail.com',
+      profile: { role: 'root', module_access: { full_access: true } },
+    }).isFounder, false);
+  });
+});
+
+test('founder-state endpoint uses requireRootActor as the single sovereign admission gate', () => {
+  const route = readFileSync('src/app/api/root/founder-state/route.ts', 'utf8');
+  assert.match(route, /requireRootActor\('founder-state\.read'\)/);
+  assert.doesNotMatch(route, /if \(!state\.access\.authorized\)/, 'founder-state must not apply a second divergent authority denial');
+  assert.match(route, /authorized:\s*true/);
+  assert.match(route, /userId:\s*gate\.ctx\.user\.id/);
+});

--- a/src/lib/system/access/founderAuthority.ts
+++ b/src/lib/system/access/founderAuthority.ts
@@ -1,0 +1,78 @@
+import { findInstitutionalMember } from './institutionalMembers';
+
+type ProfileLike = Record<string, unknown> | null | undefined;
+
+export type FounderAuthoritySource =
+  | 'configured_user_id'
+  | 'configured_email'
+  | 'explicit_sovereign_profile'
+  | null;
+
+export type FounderAuthorityResolution = {
+  isFounder: boolean;
+  source: FounderAuthoritySource;
+};
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function configuredFounderIds() {
+  return new Set(
+    (process.env.SFI_FOUNDER_USER_IDS || '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+}
+
+function configuredFounderEmails() {
+  return new Set(
+    [process.env.SYSTEM_ROOT_EMAIL, ...(process.env.SFI_FOUNDER_EMAILS || '').split(',')]
+      .map((value) => value?.trim().toLowerCase())
+      .filter((value): value is string => Boolean(value)),
+  );
+}
+
+export function isConfiguredFounderIdentity(input: {
+  userId?: string | null;
+  email?: string | null;
+}) {
+  const email = input.email?.trim().toLowerCase() || null;
+  return (
+    Boolean(input.userId && configuredFounderIds().has(input.userId)) ||
+    Boolean(email && configuredFounderEmails().has(email))
+  );
+}
+
+export function resolveFounderAuthority(input: {
+  userId?: string | null;
+  email?: string | null;
+  profile?: ProfileLike;
+}): FounderAuthorityResolution {
+  if (input.userId && configuredFounderIds().has(input.userId)) {
+    return { isFounder: true, source: 'configured_user_id' };
+  }
+
+  const email = input.email?.trim().toLowerCase() || null;
+  if (email && configuredFounderEmails().has(email)) {
+    return { isFounder: true, source: 'configured_email' };
+  }
+
+  const profile = record(input.profile);
+  const role = typeof profile.role === 'string' ? profile.role : null;
+  const moduleAccess = record(profile.module_access);
+  const registeredInstitutionalMember = Boolean(findInstitutionalMember(email));
+  const explicitSovereignProfile =
+    !registeredInstitutionalMember &&
+    (role === 'root' || role === 'system') &&
+    moduleAccess.full_access === true;
+
+  if (explicitSovereignProfile) {
+    return { isFounder: true, source: 'explicit_sovereign_profile' };
+  }
+
+  return { isFounder: false, source: null };
+}

--- a/src/lib/system/access/server.ts
+++ b/src/lib/system/access/server.ts
@@ -8,6 +8,7 @@ import {
   SfiAuthUnavailableError,
 } from '@/runtime/supabase/server';
 import { findInstitutionalMember } from './institutionalMembers';
+import { resolveFounderAuthority } from './founderAuthority';
 
 export class AccessDeniedError extends Error {
   constructor(
@@ -24,23 +25,6 @@ function record(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
     : {};
-}
-
-function founderIds() {
-  return new Set(
-    (process.env.SFI_FOUNDER_USER_IDS || '')
-      .split(',')
-      .map((value) => value.trim())
-      .filter(Boolean),
-  );
-}
-
-function founderEmails() {
-  return new Set(
-    [process.env.SYSTEM_ROOT_EMAIL, ...(process.env.SFI_FOUNDER_EMAILS || '').split(',')]
-      .map((value) => value?.trim().toLowerCase())
-      .filter((value): value is string => Boolean(value)),
-  );
 }
 
 function institutionalModuleAccess(
@@ -213,9 +197,6 @@ async function readOrProvisionUserProfile(user: { id: string; email?: string | n
     return { profile: inserted.data, member };
   }
 
-  // A normal account receives a private, owner-scoped workspace. This does not
-  // make the user an institutional SFI member and cannot grant ROOT/canonical
-  // authority. Institutional membership remains an independent registry fact.
   const alias = defaultAlias(user);
   const inserted = await service
     .from('profiles')
@@ -287,6 +268,12 @@ export async function requireFieldUser() {
 
 export async function requireFounder() {
   const context = await requireAuthenticatedUser();
+  const configuredAuthority = resolveFounderAuthority({
+    userId: context.user.id,
+    email: context.user.email,
+    profile: null,
+  });
+
   const service = createServiceSupabaseClient();
   const { data: profile, error: profileError } = await service
     .from('profiles')
@@ -295,6 +282,9 @@ export async function requireFounder() {
     .maybeSingle();
 
   if (profileError) {
+    if (configuredAuthority.isFounder) {
+      return { ...context, profile: null, founderAuthoritySource: configuredAuthority.source };
+    }
     throw new AccessDeniedError(
       503,
       'AUTH_UNAVAILABLE',
@@ -302,24 +292,17 @@ export async function requireFounder() {
     );
   }
 
-  const email = context.user.email?.toLowerCase() || null;
-  const institutionalMember = findInstitutionalMember(email);
-  const moduleAccess = record(profile?.module_access);
-  const hasExplicitSovereignProfile =
-    !institutionalMember &&
-    (profile?.role === 'root' || profile?.role === 'system') &&
-    moduleAccess.full_access === true;
+  const authority = resolveFounderAuthority({
+    userId: context.user.id,
+    email: context.user.email,
+    profile,
+  });
 
-  const allowed =
-    founderIds().has(context.user.id) ||
-    Boolean(email && founderEmails().has(email)) ||
-    hasExplicitSovereignProfile;
-
-  if (!allowed) {
+  if (!authority.isFounder) {
     throw new AccessDeniedError(403, 'FOUNDER_REQUIRED', 'Founder authorization is required.');
   }
 
-  return { ...context, profile };
+  return { ...context, profile, founderAuthoritySource: authority.source };
 }
 
 export async function requireFounderPage(nextPath = '/root') {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { normalizeSupabaseUrl } from '@/runtime/supabase/url'
 import { findInstitutionalMember } from '@/lib/system/access/institutionalMembers'
+import { isConfiguredFounderIdentity } from '@/lib/system/access/founderAuthority'
 
 const AUTH_COOKIE_NAMES = ['sb-access-token', 'sb-refresh-token', 'supabase-auth-token']
 
@@ -53,24 +54,11 @@ function clearSupabaseAuthCookies(response: NextResponse, request: NextRequest) 
   names.forEach((name) => response.cookies.delete(name))
 }
 
-function configuredFounderIds() {
-  return new Set((process.env.SFI_FOUNDER_USER_IDS || '').split(',').map((value) => value.trim()).filter(Boolean))
-}
-
-function configuredFounderEmails() {
-  return new Set(
-    [process.env.SYSTEM_ROOT_EMAIL, ...(process.env.SFI_FOUNDER_EMAILS || '').split(',')]
-      .map((value) => value?.trim().toLowerCase())
-      .filter((value): value is string => Boolean(value)),
-  )
-}
-
 function isRootRouteUser(userId?: string | null, role?: string | null, email?: string | null) {
   return (
-    Boolean(userId && configuredFounderIds().has(userId)) ||
+    isConfiguredFounderIdentity({ userId, email }) ||
     role === 'root' ||
-    role === 'system' ||
-    Boolean(email && configuredFounderEmails().has(email.toLowerCase()))
+    role === 'system'
   )
 }
 
@@ -127,8 +115,6 @@ export async function proxy(request: NextRequest) {
   let response = NextResponse.next()
   const { pathname } = request.nextUrl
 
-  // SFI remains non-frameable by default. Only explicit owned surfaces used by
-  // ROOT's internal observation window may be embedded, and only by the same origin.
   response.headers.set('X-Frame-Options', permitsRootInternalFrame(pathname) ? 'SAMEORIGIN' : 'DENY')
   response.headers.set('X-Content-Type-Options', 'nosniff')
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
@@ -141,13 +127,9 @@ export async function proxy(request: NextRequest) {
     response.headers.set('Cache-Control', 'no-store, must-revalidate')
   }
 
-  // System agents authenticate at the API boundary with SFI_AGENT_SECRET.
-  // They must not enter browser Supabase session middleware.
   const isWorldVectorAgentRoute = pathname.startsWith('/api/world-vector')
   if (isWorldVectorAgentRoute) return response
 
-  // /field is the public live Observatory. It must not acquire a browser-session
-  // dependency: its public read models use service-backed, evidence-bounded APIs.
   const requiresSession = pathname.startsWith('/root') || pathname.startsWith('/studio')
   if (!requiresSession) return response
 
@@ -174,10 +156,6 @@ export async function proxy(request: NextRequest) {
     },
   })
 
-  // Do not call /auth/v1/user on every protected navigation. In production that
-  // endpoint has shown intermittent 500/504 responses and long latency. getClaims()
-  // verifies the signed access token (and refreshes only when actually necessary),
-  // reducing both remote verification pressure and false logout transitions.
   let identity: SessionIdentity | null = null
   let authUnavailable = false
   try {
@@ -201,16 +179,9 @@ export async function proxy(request: NextRequest) {
     }
   }
 
-  // A transport/backend outage is not a logout. Never send the user to the login
-  // form for a 5xx/timeout because that makes a healthy local session look invalid.
   if (authUnavailable) return redirectToAuthUnavailable(request)
   if (!identity) return redirectToLoginWithNext(request)
 
-  // ROOT authorization intentionally happens only in the server-side ROOT gates
-  // (requireRootObserverPage / requireRootViewer / requireRootActor), which use the
-  // authoritative service-backed profile. The proxy only verifies that a browser
-  // session exists. This prevents an RLS-filtered profile lookup here from denying
-  // a valid institutional observer before the authoritative gate runs.
   if (pathname.startsWith('/root')) return response
 
   if (pathname.startsWith('/studio')) {


### PR DESCRIPTION
## Trigger
Authenticated founder can reach `/root` while governed writes resolve `isRoot=false`, making ACCEPT/DENY and other sovereign writes unavailable.

## T0
Base: `3d94dacfd8c7bf0064481c5063c150a7919f88b2`.

At T0, `requireFounder()` accepted `SFI_FOUNDER_USER_IDS`, `SYSTEM_ROOT_EMAIL`, `SFI_FOUNDER_EMAILS`, or an explicit sovereign profile, while `getServerUserContext()` only treated `SYSTEM_ROOT_EMAIL` as configured founder identity and otherwise required `role=root|system + module_access.full_access=true`.

## Hypothesis
A single canonical founder-authority resolver, reused by both founder guards and governed ROOT runtime, removes the authorization split-brain without broadening institutional-member authority.

## SFI PRECHECK
Owner: SFI institutional access / existing ROOT authorization owner; WS-08 independent assurance, SFI-00 integration authority.
Existing capability inspected: `getServerUserContext`, `requireFounder`, `requireGovernedActor`, proposal approve/reject write boundaries, institutional member registry, existing founder env identities.
Absorb vs create decision: ABSORB. One shared resolver is added inside the existing access domain; no new workstream, authority plane, profile role or execution owner.
Authoritative writer: existing authenticated access/runtime writes remain unchanged; this change only resolves whether already-configured founder identity is sovereign.
Persistence/lineage impact: none. No schema, migration, RLS, profile rewrite or canonical state mutation.
Front delta: none.
Back delta: converge founder authority resolution used by ROOT governed runtime and founder guard.
DB delta: none.
Redundancy removed: duplicate/inconsistent founder identity resolution between `productionBackend.ts` and `system/access/server.ts`.
Execution/ROOT boundary: no authority expansion. Registered institutional members remain non-founder; legacy `root` without `full_access` remains non-sovereign; only existing configured founder sources or explicit sovereign profile qualify.
Rollback: revert the commits on `fix/root-founder-authority-convergence`; no data rollback required.
Verification: deterministic founder authority tests + SFI Institutional Authority + External OAuth + Program Completion Controller + SFI Verify/typecheck/build on immutable exact HEAD.

## Change
- add `src/lib/system/access/founderAuthority.ts` as the single resolver;
- converge `getServerUserContext()` on it;
- converge `requireFounder()` on it;
- provision configured founder identities consistently whether configured by user ID or either founder-email channel;
- preserve `root/system + full_access=true` as the explicit sovereign-profile path;
- explicitly prevent registered institutional members from becoming founder through profile flags;
- add deterministic tests for configured ID/email, legacy ROOT without full access, explicit sovereign profile, and institutional-member non-escalation;
- wire `founderAuthority.test.ts` into the existing SFI Institutional Authority workflow so the convergence test is executed by CI rather than merely stored.

## Falsification / rollback
FAIL if any non-founder institutional member gains founder authority, a legacy `root` observer without `full_access` becomes sovereign, or configured founder identities still diverge between `requireFounder()` and governed write context. Roll back this PR if those conditions occur.

## Authority boundary
No new sovereign identity is invented. This only makes already-configured founder identity sources resolve consistently. No merge, deploy, canonical promotion, or external action is performed by this PR.

## Assurance requested
Exact-head typecheck/build plus deterministic founder-authority tests and regression verification of proposal approve/reject write boundaries. Current exact HEAD is `c37cf0aba74e35a6a91325c513d795cd4589be83`; fresh assurance is running.