### PR TITLE
fix(program): make completion receipts durably valid

### DIFF
--- a/docs/program/SFI-COMPLETION-RECEIPTS.json
+++ b/docs/program/SFI-COMPLETION-RECEIPTS.json
@@ -1,4 +1,4 @@
 {
-  "contract": "SFI-PROGRAM-COMPLETION-RECEIPTS-1.1",
+  "contract": "SFI-PROGRAM-COMPLETION-RECEIPTS-1.2",
   "receipts": {}
 }

--- a/scripts/lib/programCompletionReceipts.mjs
+++ b/scripts/lib/programCompletionReceipts.mjs
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 
-export const COMPLETION_RECEIPT_CONTRACT = 'SFI-PROGRAM-COMPLETION-RECEIPTS-1.1';
+export const COMPLETION_RECEIPT_CONTRACT = 'SFI-PROGRAM-COMPLETION-RECEIPTS-1.2';
 
 export function requirementHash(requirement) {
   const source = String(requirement?.source ?? '').trim();
@@ -30,37 +30,28 @@ export function evaluateCompletionReceipt(requirement, ledger, options = {}) {
   if (receipt.status !== 'SATISFIED') return invalid(receipt, 'RECEIPT_STATUS_NOT_SATISFIED', expectedHash);
   if (receipt.requirementHash !== expectedHash) return invalid(receipt, 'REQUIREMENT_HASH_MISMATCH', expectedHash);
   if (typeof options.currentHead !== 'string' || !options.currentHead.trim()) return invalid(receipt, 'CURRENT_HEAD_REQUIRED', expectedHash);
-  if (receipt.head !== options.currentHead) return invalid(receipt, 'RECEIPT_HEAD_MISMATCH', expectedHash);
+  if (typeof receipt.head !== 'string' || !receipt.head.trim()) return invalid(receipt, 'VERIFIED_HEAD_REQUIRED', expectedHash);
+  if (receipt.head !== options.currentHead) {
+    if (typeof options.verifyReceiptHead !== 'function') return invalid(receipt, 'VERIFIED_HEAD_RESOLVER_REQUIRED', expectedHash);
+    let relation;
+    try { relation = options.verifyReceiptHead(receipt.head, options.currentHead, receipt); }
+    catch (error) { relation = { ok: false, error: error instanceof Error ? error.message : String(error) }; }
+    if (relation !== true && relation?.ok !== true) return invalid(receipt, relation?.error || 'RECEIPT_HEAD_NOT_ADMISSIBLE', expectedHash);
+  }
   if (receipt.verifiedBy !== 'SFI-08') return invalid(receipt, 'INDEPENDENT_VERIFIER_REQUIRED', expectedHash);
   if (receipt.returnState !== 'RETURN_PASS') return invalid(receipt, 'RETURN_PASS_REQUIRED', expectedHash);
   if (options.external === true && receipt.externalObserved !== true) return invalid(receipt, 'EXTERNAL_OBSERVATION_REQUIRED', expectedHash);
-
-  if (!Array.isArray(receipt.evidence) || receipt.evidence.length === 0) {
-    return invalid(receipt, 'COMPLETION_EVIDENCE_REQUIRED', expectedHash);
-  }
+  if (!Array.isArray(receipt.evidence) || receipt.evidence.length === 0) return invalid(receipt, 'COMPLETION_EVIDENCE_REQUIRED', expectedHash);
   if (receipt.evidence.some((value) => !value || typeof value !== 'object' || Array.isArray(value) || typeof value.kind !== 'string' || typeof value.ref !== 'string' || !value.ref.trim())) {
     return invalid(receipt, 'STRUCTURED_EVIDENCE_REFERENCE_REQUIRED', expectedHash);
   }
   if (typeof options.verifyEvidence !== 'function') return invalid(receipt, 'EVIDENCE_RESOLVER_REQUIRED', expectedHash);
 
   const evidenceResults = receipt.evidence.map((evidence) => {
-    try {
-      return options.verifyEvidence(evidence, { receipt, requirement, currentHead: options.currentHead });
-    } catch (error) {
-      return { ok: false, error: error instanceof Error ? error.message : String(error) };
-    }
+    try { return options.verifyEvidence(evidence, { receipt, requirement, currentHead: options.currentHead }); }
+    catch (error) { return { ok: false, error: error instanceof Error ? error.message : String(error) }; }
   });
-  if (evidenceResults.some((result) => result !== true && result?.ok !== true)) {
-    return invalid(receipt, 'OBSERVED_EVIDENCE_VERIFICATION_FAILED', expectedHash);
-  }
+  if (evidenceResults.some((result) => result !== true && result?.ok !== true)) return invalid(receipt, 'OBSERVED_EVIDENCE_VERIFICATION_FAILED', expectedHash);
 
-  return {
-    state: 'VALID',
-    satisfied: true,
-    receipt,
-    error: null,
-    expectedHash,
-    evidence: [...receipt.evidence],
-    evidenceResults,
-  };
+  return { state: 'VALID', satisfied: true, receipt, error: null, expectedHash, evidence: [...receipt.evidence], evidenceResults };
 }

--- a/scripts/qa-sfi-program-completion-receipts.mjs
+++ b/scripts/qa-sfi-program-completion-receipts.mjs
@@ -1,81 +1,42 @@
 import assert from 'node:assert/strict';
 import { evaluateCompletionReceipt, requirementHash } from './lib/programCompletionReceipts.mjs';
 
-const requirement = {
-  id: 'QA-REQUIREMENT-001',
-  source: 'QA canonical source',
-  requirement: 'A bounded internal capability must preserve evidence and return proof.',
-};
+const requirement = { id: 'QA-REQUIREMENT-001', source: 'QA canonical source', requirement: 'A bounded internal capability must preserve evidence and return proof.' };
 const hash = requirementHash(requirement);
-const currentHead = 'qa-head-001';
+const verifiedHead = 'qa-code-head-001';
+const ledgerHead = 'qa-ledger-head-002';
 const observedEvidence = [
-  { kind: 'GIT_COMMIT', ref: currentHead },
+  { kind: 'GIT_COMMIT', ref: verifiedHead },
   { kind: 'WORKFLOW_RUN', ref: 'qa-workflow-001' },
   { kind: 'RETURN_RECEIPT', ref: 'artifacts/qa/return.json', sha256: 'sha256:qa' },
 ];
 const verifyEvidence = (evidence) => ({ ok: observedEvidence.some((candidate) => candidate.kind === evidence.kind && candidate.ref === evidence.ref) });
-const options = { currentHead, verifyEvidence };
-
+const verifyLedgerOnlyDescendant = (receiptHead, currentHead) => ({ ok: receiptHead === verifiedHead && currentHead === ledgerHead });
 const valid = {
-  contract: 'SFI-PROGRAM-COMPLETION-RECEIPTS-1.1',
-  receipts: {
-    [requirement.id]: {
-      status: 'SATISFIED',
-      requirementHash: hash,
-      head: currentHead,
-      evidence: observedEvidence,
-      verifiedBy: 'SFI-08',
-      returnState: 'RETURN_PASS',
-    },
-  },
+  contract: 'SFI-PROGRAM-COMPLETION-RECEIPTS-1.2',
+  receipts: { [requirement.id]: { status: 'SATISFIED', requirementHash: hash, head: verifiedHead, evidence: observedEvidence, verifiedBy: 'SFI-08', returnState: 'RETURN_PASS' } },
 };
-assert.equal(evaluateCompletionReceipt(requirement, valid, options).satisfied, true, 'observed exact-head receipt must make SATISFIED reachable');
+assert.equal(evaluateCompletionReceipt(requirement, valid, { currentHead: verifiedHead, verifyEvidence }).satisfied, true, 'exact verified head remains valid');
+assert.equal(evaluateCompletionReceipt(requirement, valid, { currentHead: ledgerHead, verifyReceiptHead: verifyLedgerOnlyDescendant, verifyEvidence }).satisfied, true, 'ledger-only descendant must not self-invalidate durable receipt');
+assert.equal(evaluateCompletionReceipt(requirement, valid, { currentHead: ledgerHead, verifyEvidence }).error, 'VERIFIED_HEAD_RESOLVER_REQUIRED');
+assert.equal(evaluateCompletionReceipt(requirement, valid, { currentHead: 'changed-code-head', verifyReceiptHead: () => ({ ok: false, error: 'RECEIPT_HEAD_INVALIDATED_BY_CODE_CHANGE' }), verifyEvidence }).error, 'RECEIPT_HEAD_INVALIDATED_BY_CODE_CHANGE');
 
-const staleRequirement = structuredClone(valid);
-staleRequirement.receipts[requirement.id].requirementHash = 'sha256:stale';
-assert.equal(evaluateCompletionReceipt(requirement, staleRequirement, options).error, 'REQUIREMENT_HASH_MISMATCH');
-
-const staleHead = structuredClone(valid);
-staleHead.receipts[requirement.id].head = 'old-head';
-assert.equal(evaluateCompletionReceipt(requirement, staleHead, options).error, 'RECEIPT_HEAD_MISMATCH');
-
-const emptyEvidence = structuredClone(valid);
-emptyEvidence.receipts[requirement.id].evidence = [];
-assert.equal(evaluateCompletionReceipt(requirement, emptyEvidence, options).error, 'COMPLETION_EVIDENCE_REQUIRED');
-
-const claimedEvidence = structuredClone(valid);
-claimedEvidence.receipts[requirement.id].evidence = [{ kind: 'WORKFLOW_RUN', ref: 'claimed-but-unobserved' }];
-assert.equal(evaluateCompletionReceipt(requirement, claimedEvidence, options).error, 'OBSERVED_EVIDENCE_VERIFICATION_FAILED');
-
-const unstructuredEvidence = structuredClone(valid);
-unstructuredEvidence.receipts[requirement.id].evidence = ['claimed'];
-assert.equal(evaluateCompletionReceipt(requirement, unstructuredEvidence, options).error, 'STRUCTURED_EVIDENCE_REFERENCE_REQUIRED');
-
-const wrongVerifier = structuredClone(valid);
-wrongVerifier.receipts[requirement.id].verifiedBy = 'self-asserted';
-assert.equal(evaluateCompletionReceipt(requirement, wrongVerifier, options).error, 'INDEPENDENT_VERIFIER_REQUIRED');
-
-assert.equal(evaluateCompletionReceipt(requirement, valid, { currentHead }).error, 'EVIDENCE_RESOLVER_REQUIRED');
-
+const staleRequirement = structuredClone(valid); staleRequirement.receipts[requirement.id].requirementHash = 'sha256:stale';
+assert.equal(evaluateCompletionReceipt(requirement, staleRequirement, { currentHead: verifiedHead, verifyEvidence }).error, 'REQUIREMENT_HASH_MISMATCH');
+const emptyEvidence = structuredClone(valid); emptyEvidence.receipts[requirement.id].evidence = [];
+assert.equal(evaluateCompletionReceipt(requirement, emptyEvidence, { currentHead: verifiedHead, verifyEvidence }).error, 'COMPLETION_EVIDENCE_REQUIRED');
+const claimedEvidence = structuredClone(valid); claimedEvidence.receipts[requirement.id].evidence = [{ kind: 'WORKFLOW_RUN', ref: 'claimed-but-unobserved' }];
+assert.equal(evaluateCompletionReceipt(requirement, claimedEvidence, { currentHead: verifiedHead, verifyEvidence }).error, 'OBSERVED_EVIDENCE_VERIFICATION_FAILED');
+const unstructuredEvidence = structuredClone(valid); unstructuredEvidence.receipts[requirement.id].evidence = ['claimed'];
+assert.equal(evaluateCompletionReceipt(requirement, unstructuredEvidence, { currentHead: verifiedHead, verifyEvidence }).error, 'STRUCTURED_EVIDENCE_REFERENCE_REQUIRED');
+const wrongVerifier = structuredClone(valid); wrongVerifier.receipts[requirement.id].verifiedBy = 'self-asserted';
+assert.equal(evaluateCompletionReceipt(requirement, wrongVerifier, { currentHead: verifiedHead, verifyEvidence }).error, 'INDEPENDENT_VERIFIER_REQUIRED');
+assert.equal(evaluateCompletionReceipt(requirement, valid, { currentHead: verifiedHead }).error, 'EVIDENCE_RESOLVER_REQUIRED');
 const externalWithoutObservation = structuredClone(valid);
-assert.equal(
-  evaluateCompletionReceipt(requirement, externalWithoutObservation, { ...options, external: true }).error,
-  'EXTERNAL_OBSERVATION_REQUIRED',
-  'external action must not be fabricated as satisfied',
-);
+assert.equal(evaluateCompletionReceipt(requirement, externalWithoutObservation, { currentHead: verifiedHead, verifyEvidence, external: true }).error, 'EXTERNAL_OBSERVATION_REQUIRED');
 externalWithoutObservation.receipts[requirement.id].externalObserved = true;
-assert.equal(evaluateCompletionReceipt(requirement, externalWithoutObservation, { ...options, external: true }).satisfied, true);
+assert.equal(evaluateCompletionReceipt(requirement, externalWithoutObservation, { currentHead: verifiedHead, verifyEvidence, external: true }).satisfied, true);
+assert.equal(evaluateCompletionReceipt(requirement, { receipts: {} }, { currentHead: verifiedHead, verifyEvidence }).state, 'ABSENT');
 
-assert.equal(evaluateCompletionReceipt(requirement, { receipts: {} }, options).state, 'ABSENT');
-
-console.log(JSON.stringify({
-  ok: true,
-  contract: 'SFI-PROGRAM-COMPLETION-RECEIPTS-1.1',
-  validObservedReceiptPromotes: true,
-  exactHeadRequired: true,
-  independentVerifierRequired: true,
-  structuredEvidenceRequired: true,
-  observedEvidenceResolverRequired: true,
-  staleReceiptFailsClosed: true,
-  externalObservationRequired: true,
-}));
+console.log(JSON.stringify({ ok: true, contract: 'SFI-PROGRAM-COMPLETION-RECEIPTS-1.2', exactHeadValid: true, ledgerOnlyDescendantValid: true,
+  interveningCodeChangeFailsClosed: true, independentVerifierRequired: true, structuredEvidenceRequired: true, observedEvidenceResolverRequired: true, externalObservationRequired: true }));

--- a/scripts/sfi-program-completion-reconcile.mjs
+++ b/scripts/sfi-program-completion-reconcile.mjs
@@ -9,9 +9,9 @@ const root = process.cwd();
 const artifactPath = path.join(root, 'artifacts/program-completion/completion.json');
 const markdownPath = path.join(root, 'artifacts/program-completion/completion.md');
 const ledgerPath = path.join(root, 'docs/program/SFI-COMPLETION-RECEIPTS.json');
+const LEDGER_REPOSITORY_PATH = 'docs/program/SFI-COMPLETION-RECEIPTS.json';
 
 if (!fs.existsSync(artifactPath)) throw new Error('SFI_PROGRAM_COMPLETION_BASE_ARTIFACT_MISSING');
-
 const report = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
 const ledger = loadCompletionReceiptLedger(ledgerPath);
 const canonicalStatuses = ['SATISFIED','IN_PROGRESS','PARTIAL','MISSING','EXTERNAL_ACTION','SUPERSEDED_BY_AUTHORIZED_DECISION'];
@@ -21,11 +21,7 @@ let promoted = 0;
 function externalRequirement(requirement) {
   return /(external-only|external action|registry submission|directory submission|account ownership|platform acceptance|LinkedIn|Medium|YouTube|Bluesky|Mastodon|Hugging Face|Zenodo|ORCID|ROR|ResearchGate|Postman|OSF)/i.test(`${requirement?.source ?? ''} ${requirement?.requirement ?? ''}`);
 }
-
-function sha256File(filePath) {
-  return `sha256:${createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')}`;
-}
-
+function sha256File(filePath) { return `sha256:${createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')}`; }
 function safeRepositoryPath(value) {
   const candidate = path.resolve(root, String(value || ''));
   const relative = path.relative(root, candidate);
@@ -33,40 +29,40 @@ function safeRepositoryPath(value) {
   return candidate;
 }
 
+function verifyReceiptHead(verifiedHead, currentHead) {
+  try {
+    execFileSync('git', ['cat-file', '-e', `${verifiedHead}^{commit}`], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['merge-base', '--is-ancestor', verifiedHead, currentHead], { cwd: root, stdio: 'ignore' });
+    const changed = execFileSync('git', ['diff', '--name-only', verifiedHead, currentHead], { cwd: root, encoding: 'utf8' })
+      .split('\n').map((value) => value.trim()).filter(Boolean);
+    const disallowed = changed.filter((file) => file !== LEDGER_REPOSITORY_PATH);
+    if (disallowed.length) return { ok: false, error: `RECEIPT_HEAD_INVALIDATED_BY_CODE_CHANGE:${disallowed.join(',')}` };
+    return { ok: true, verifiedHead, currentHead, changed };
+  } catch { return { ok: false, error: 'RECEIPT_VERIFIED_HEAD_NOT_ANCESTOR' }; }
+}
+
 function verifyObservedEvidence(evidence, context) {
   const kind = String(evidence?.kind || '');
   const ref = String(evidence?.ref || '').trim();
   if (!ref) return { ok: false, error: 'EVIDENCE_REF_REQUIRED' };
-
   if (kind === 'GIT_COMMIT') {
-    try {
-      execFileSync('git', ['cat-file', '-e', `${ref}^{commit}`], { cwd: root, stdio: 'ignore' });
-      return { ok: true, observed: `git:${ref}` };
-    } catch {
-      return { ok: false, error: 'GIT_COMMIT_NOT_OBSERVED' };
-    }
+    try { execFileSync('git', ['cat-file', '-e', `${ref}^{commit}`], { cwd: root, stdio: 'ignore' }); return { ok: true, observed: `git:${ref}` }; }
+    catch { return { ok: false, error: 'GIT_COMMIT_NOT_OBSERVED' }; }
   }
-
   if (kind === 'WORKFLOW_RUN') {
     if (!/^\d+$/.test(ref)) return { ok: false, error: 'WORKFLOW_RUN_ID_REQUIRED' };
     try {
       const repository = process.env.GITHUB_REPOSITORY || report.repository || 'Aptymok/system-friction';
       const raw = execFileSync('gh', ['api', `repos/${repository}/actions/runs/${ref}`], {
-        cwd: root,
-        encoding: 'utf8',
-        env: { ...process.env, GH_TOKEN: process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '' },
-        stdio: ['ignore', 'pipe', 'ignore'],
-        timeout: 30_000,
+        cwd: root, encoding: 'utf8', env: { ...process.env, GH_TOKEN: process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '' },
+        stdio: ['ignore', 'pipe', 'ignore'], timeout: 30_000,
       });
       const run = JSON.parse(raw);
       if (run.conclusion !== 'success') return { ok: false, error: 'WORKFLOW_RUN_NOT_SUCCESS' };
-      if (run.head_sha !== context.currentHead) return { ok: false, error: 'WORKFLOW_RUN_HEAD_MISMATCH' };
+      if (run.head_sha !== context.receipt.head) return { ok: false, error: 'WORKFLOW_RUN_VERIFIED_HEAD_MISMATCH' };
       return { ok: true, observed: `workflow:${ref}@${run.head_sha}` };
-    } catch {
-      return { ok: false, error: 'WORKFLOW_RUN_NOT_OBSERVED' };
-    }
+    } catch { return { ok: false, error: 'WORKFLOW_RUN_NOT_OBSERVED' }; }
   }
-
   if (['RETURN_RECEIPT','PRODUCTION_OBSERVATION','EXTERNAL_RECEIPT'].includes(kind)) {
     try {
       const filePath = safeRepositoryPath(ref);
@@ -75,34 +71,19 @@ function verifyObservedEvidence(evidence, context) {
       const observedHash = sha256File(filePath);
       if (observedHash !== evidence.sha256) return { ok: false, error: 'EVIDENCE_FILE_DIGEST_MISMATCH' };
       return { ok: true, observed: `${kind}:${ref}:${observedHash}` };
-    } catch (error) {
-      return { ok: false, error: error instanceof Error ? error.message : String(error) };
-    }
+    } catch (error) { return { ok: false, error: error instanceof Error ? error.message : String(error) }; }
   }
-
   return { ok: false, error: `UNSUPPORTED_EVIDENCE_KIND:${kind}` };
 }
 
 for (const requirement of report.requirements ?? []) {
   const external = externalRequirement(requirement);
   const assessment = evaluateCompletionReceipt(requirement, ledger, {
-    external,
-    currentHead: report.head,
-    verifyEvidence: verifyObservedEvidence,
+    external, currentHead: report.head, verifyReceiptHead, verifyEvidence: verifyObservedEvidence,
   });
-  requirement.completionReceipt = {
-    state: assessment.state,
-    error: assessment.error ?? null,
-    requirementHash: assessment.expectedHash ?? null,
-    externalRequirement: external,
-  };
-
-  if (assessment.state === 'INVALID') {
-    invalidReceipts.push({ requirementId: requirement.id, error: assessment.error, expectedHash: assessment.expectedHash });
-    continue;
-  }
+  requirement.completionReceipt = { state: assessment.state, error: assessment.error ?? null, requirementHash: assessment.expectedHash ?? null, externalRequirement: external };
+  if (assessment.state === 'INVALID') { invalidReceipts.push({ requirementId: requirement.id, error: assessment.error, expectedHash: assessment.expectedHash }); continue; }
   if (!assessment.satisfied) continue;
-
   requirement.status = 'SATISFIED';
   requirement.evidence = [...new Set([...(requirement.evidence ?? []), ...(assessment.evidence ?? []).map((value) => `${value.kind}:${value.ref}`)])];
   requirement.trajectoryRef = `completion-receipt:${requirement.id}`;
@@ -116,84 +97,34 @@ for (const requirement of report.requirements ?? []) {
 
 report.counts = Object.fromEntries(canonicalStatuses.map((status) => [status, (report.requirements ?? []).filter((r) => r.status === status).length]));
 report.counts.UNCLASSIFIED = (report.requirements ?? []).filter((r) => !canonicalStatuses.includes(r.status)).length;
-report.contract = 'SFI-PROGRAM-COMPLETION-CONTROLLER-1.2';
+report.contract = 'SFI-PROGRAM-COMPLETION-CONTROLLER-1.3';
 report.completionReceiptContract = ledger.contract;
 report.completionReceiptState = {
-  ledgerPath: 'docs/program/SFI-COMPLETION-RECEIPTS.json',
-  receiptCount: Object.keys(ledger.receipts ?? {}).length,
-  promotedSatisfiedCount: promoted,
-  invalidReceiptCount: invalidReceipts.length,
-  invalidReceipts,
-  exactHead: report.head,
-  independentVerifier: 'SFI-08',
-  evidenceResolution: 'OBSERVED_REFERENCE_REQUIRED',
+  ledgerPath: LEDGER_REPOSITORY_PATH, receiptCount: Object.keys(ledger.receipts ?? {}).length, promotedSatisfiedCount: promoted,
+  invalidReceiptCount: invalidReceipts.length, invalidReceipts, currentHead: report.head, independentVerifier: 'SFI-08',
+  evidenceResolution: 'OBSERVED_REFERENCE_REQUIRED', verifiedHeadRule: 'EXACT_OR_LEDGER_ONLY_DESCENDANT',
 };
-report.qa = {
-  ...(report.qa ?? {}),
-  satisfiedReachableThroughBoundReceipt: true,
-  completionReceiptsFailClosed: invalidReceipts.length === 0,
-  externalClassificationIndependentOfMutableStatus: true,
-  selfAssertedEvidenceRejected: true,
-};
-
+report.qa = { ...(report.qa ?? {}), satisfiedReachableThroughBoundReceipt: true, completionReceiptsFailClosed: invalidReceipts.length === 0,
+  externalClassificationIndependentOfMutableStatus: true, selfAssertedEvidenceRejected: true, ledgerCommitDoesNotSelfInvalidateReceipt: true };
 for (const invalid of invalidReceipts) {
   report.hardDefects ??= [];
-  report.hardDefects.push({
-    id: `${invalid.requirementId}:invalid-completion-receipt`,
-    rule: 'INVALID_COMPLETION_RECEIPT',
-    requirementId: invalid.requirementId,
-    receiptError: invalid.error,
-    trajectoryRef: '#405',
-  });
+  report.hardDefects.push({ id: `${invalid.requirementId}:invalid-completion-receipt`, rule: 'INVALID_COMPLETION_RECEIPT', requirementId: invalid.requirementId, receiptError: invalid.error, trajectoryRef: '#405' });
 }
-
 const incomplete = (report.requirements ?? []).some((r) => !['SATISFIED','EXTERNAL_ACTION','SUPERSEDED_BY_AUTHORIZED_DECISION'].includes(r.status));
-report.nextProgramAction = invalidReceipts.length
-  ? 'REPAIR_INVALID_COMPLETION_RECEIPTS'
-  : incomplete
-    ? 'EXECUTE_COMPLETION_TRAJECTORIES'
-    : 'RUN_FINAL_ASSURANCE_AND_RETURN_GATE';
-
+report.nextProgramAction = invalidReceipts.length ? 'REPAIR_INVALID_COMPLETION_RECEIPTS' : incomplete ? 'EXECUTE_COMPLETION_TRAJECTORIES' : 'RUN_FINAL_ASSURANCE_AND_RETURN_GATE';
 fs.writeFileSync(artifactPath, `${JSON.stringify(report, null, 2)}\n`);
 const md = [
-  '# SFI · Autonomous Program Completion Controller',
-  '',
-  `**Contract:** ${report.contract}  `,
-  `**HEAD:** ${report.head}  `,
-  `**Generated:** ${report.generatedAt}  `,
-  `**Receipt contract:** ${ledger.contract}  `,
-  '',
-  '## Classification',
-  ...Object.entries(report.counts).map(([key, value]) => `- ${key}: ${value}`),
-  '',
-  '## Completion receipt assurance',
-  `- receipts: ${report.completionReceiptState.receiptCount}`,
-  `- promoted SATISFIED: ${promoted}`,
-  `- invalid receipts: ${invalidReceipts.length}`,
-  `- exact HEAD: ${report.head}`,
-  '- verifier: SFI-08 only',
-  '- rule: code/file presence and green CI alone never promote SATISFIED',
-  '- rule: every evidence reference must resolve to observed immutable state',
-  '- external-only requirements are detected from the requirement itself and require externalObserved=true',
-  '',
-  '## Hard defects',
-  ...((report.hardDefects ?? []).length ? report.hardDefects.map((d) => `- ${d.rule}: ${d.requirementId}`) : ['- none']),
-  '',
-  '## Active completion trajectories',
-  ...(report.requirements ?? []).filter((r) => !['SATISFIED','SUPERSEDED_BY_AUTHORIZED_DECISION'].includes(r.status)).map((r) => `- **${r.id} · ${r.status} · ${r.owner} · ${r.trajectoryRef}** — ${r.requirement} — NEXT: ${r.nextAction}`),
-  '',
-  '## Authority',
-  report.rootGateRule,
+  '# SFI · Autonomous Program Completion Controller','',`**Contract:** ${report.contract}  `,`**HEAD:** ${report.head}  `,`**Generated:** ${report.generatedAt}  `,`**Receipt contract:** ${ledger.contract}  `,'',
+  '## Classification',...Object.entries(report.counts).map(([key,value]) => `- ${key}: ${value}`),'','## Completion receipt assurance',
+  `- receipts: ${report.completionReceiptState.receiptCount}`,`- promoted SATISFIED: ${promoted}`,`- invalid receipts: ${invalidReceipts.length}`,
+  `- current HEAD: ${report.head}`,'- verifier: SFI-08 only','- verified head: exact current HEAD or an ancestor separated only by the completion receipt ledger file',
+  '- rule: any intervening code/runtime/QA change invalidates the receipt','- rule: code/file presence and green CI alone never promote SATISFIED',
+  '- rule: every evidence reference must resolve to observed immutable state','- external-only requirements require externalObserved=true','',
+  '## Hard defects',...((report.hardDefects ?? []).length ? report.hardDefects.map((d) => `- ${d.rule}: ${d.requirementId}`) : ['- none']),'',
+  '## Active completion trajectories',...(report.requirements ?? []).filter((r) => !['SATISFIED','SUPERSEDED_BY_AUTHORIZED_DECISION'].includes(r.status)).map((r) => `- **${r.id} · ${r.status} · ${r.owner} · ${r.trajectoryRef}** — ${r.requirement} — NEXT: ${r.nextAction}`),'',
+  '## Authority',report.rootGateRule,
 ].join('\n');
 fs.writeFileSync(markdownPath, `${md}\n`);
-
-console.log(JSON.stringify({
-  ok: invalidReceipts.length === 0,
-  contract: report.contract,
-  receiptCount: report.completionReceiptState.receiptCount,
-  promotedSatisfiedCount: promoted,
-  invalidReceiptCount: invalidReceipts.length,
-  counts: report.counts,
-  nextProgramAction: report.nextProgramAction,
-}));
+console.log(JSON.stringify({ ok: invalidReceipts.length === 0, contract: report.contract, receiptCount: report.completionReceiptState.receiptCount,
+  promotedSatisfiedCount: promoted, invalidReceiptCount: invalidReceipts.length, counts: report.counts, nextProgramAction: report.nextProgramAction }));
 if (invalidReceipts.length) process.exitCode = 2;


### PR DESCRIPTION
## Trigger
The completion receipt contract required `receipt.head === current HEAD` while the receipt ledger itself is versioned in Git. Persisting a receipt necessarily changes HEAD, making durable SATISFIED promotion structurally self-invalidating.

## SFI PRECHECK
Owner: SFI-00 Completion Controller; WS-08 assurance.
Existing capability inspected: `programCompletionReceipts.mjs`, `sfi-program-completion-reconcile.mjs`, receipt QA, empty canonical ledger.
Absorb vs create decision: ABSORB. Repair the existing receipt verifier; no new ledger, controller, workstream or authority source.
Authoritative writer: `docs/program/SFI-COMPLETION-RECEIPTS.json` remains the sole completion receipt ledger.
Persistence/lineage impact: receipts bind the verified code/evidence HEAD. They remain valid on a descendant only when Git proves the only changed path is the receipt ledger itself. Any intervening code/runtime/QA change invalidates them fail-closed.
Front delta: NONE.
Back delta: verified-head ancestry/ledger-only relation + workflow evidence bound to receipt verified HEAD.
DB delta: NONE.
Redundancy removed: impossible exact-current-HEAD self-reference.
Execution/ROOT boundary: no authority expansion; only SFI-08 + RETURN_PASS + observed structured evidence may promote SATISFIED.
Rollback: revert this PR; existing empty ledger contains no completion claims.
Verification: exact-head receipt valid; ledger-only descendant valid; intervening code change invalid; stale requirement/evidence/verifier/external observation continue to fail closed; full Program Completion + SFI Verify green.

## Cost boundary
No production deployment is requested.