### PR TITLE
fix(db): execute reset genesis adapters as ESM

### DIFF
--- a/scripts/db/package.json
+++ b/scripts/db/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## SFI PRECHECK
Owner: SFI-00 persistence closure; WS-08 assurance.
Observed failure: canonical reset run #34302650388 attempt 2 reached the configured direct PostgreSQL secret and failed before snapshot/destruction because `tsx` compiled `scripts/db/preserve-institutional-integrations.ts` as CommonJS, rejecting top-level await.
Existing capability: both preservation adapters are valid TypeScript modules and use top-level await intentionally; `scripts/db` already contains `.mjs` ESM utilities.
Absorb vs create: ABSORB. Add a directory-local module boundary only.
Delta: add `scripts/db/package.json` with `{"type":"module"}` so `.ts` reset adapters execute as ESM under `node --import tsx`.
Behavioral change: none to reset, preservation, authority, data classification, World retention, OAuth, or Instrument Bank semantics.
Destructive boundary: no database operation in this PR. Reset remains fail-closed and will only execute after this exact head is assured and merged.
Verification: exact-head CI + independent review, then merge and rerun canonical reset on main.