### PR TITLE
fix(db): route canonical reset through Supavisor IPv4 session mode

### DIFF
--- a/.github/workflows/sfi-db-canonical-reset.yml
+++ b/.github/workflows/sfi-db-canonical-reset.yml
@@ -26,6 +26,7 @@ jobs:
     timeout-minutes: 45
     env:
       DATABASE_URL: ${{ secrets.SFI_DATABASE_URL || secrets.DATABASE_URL || secrets.SUPABASE_DB_URL || secrets.POSTGRES_URL }}
+      SFI_SUPABASE_REGION: us-west-1
       SFI_DB_EVIDENCE_DIR: /tmp/sfi-db-evidence
       SFI_DB_REQUIRE_RESET_CLASSIFICATION: 'YES'
       SFI_DB_SNAPSHOT_MAX_AGE_MINUTES: '180'
@@ -47,7 +48,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "${DATABASE_URL:-}" ]]; then
-            echo 'No direct PostgreSQL secret is configured for canonical reset.' >&2
+            echo 'No PostgreSQL secret is configured for canonical reset.' >&2
             exit 1
           fi
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
@@ -57,13 +58,28 @@ jobs:
             grep -Fx 'SFI_DB_CANONICAL_RESET=ISSUE_430' .github/sfi-db-canonical-reset-trigger
           fi
 
-      - name: Install reset dependencies
+      - name: Install PostgreSQL 17 reset dependencies
         shell: bash
         run: |
           set -euo pipefail
           sudo apt-get update -y
-          sudo apt-get install -y postgresql-client zip unzip
+          sudo apt-get install -y ca-certificates curl gnupg zip unzip
+          sudo install -d -m 0755 /usr/share/postgresql-common/pgdg
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | sudo gpg --dearmor --yes -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg
+          . /etc/os-release
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.gpg] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
+          sudo apt-get update -y
+          sudo apt-get install -y postgresql-client-17
+          pg_dump --version | grep -E '17\.'
           npm ci
+
+      - name: Resolve IPv4 session pooler and verify PostgreSQL connectivity
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/db/resolve-reset-database-url.mjs
 
       - name: Export and validate canonical genesis configuration
         shell: bash
@@ -144,6 +160,7 @@ jobs:
             echo "- Pre-reset proof artifact: \`${{ steps.proof.outputs.artifact-id }}\`"
             echo "- Pre-reset proof digest: \`${{ steps.proof.outputs.artifact-digest }}\`"
             echo "- Post-reset genesis artifact: \`${{ steps.genesis.outputs.artifact-id }}\`"
+            echo '- Database route: **Supavisor session mode / IPv4 / SSL required**'
             echo '- Legacy preservation: **full longitudinal World corpus**'
             echo '- Protected World plane: source observations, friction readings, hypotheses, outcomes, learning events, WorldSpect snapshots, World Vector cycles/observations/reports/alerts'
             echo '- Registered institutional identities/OAuth configuration: **reseeded from canonical registry; no authority expansion; no usage history restored**'

--- a/scripts/db/resolve-reset-database-url.mjs
+++ b/scripts/db/resolve-reset-database-url.mjs
@@ -1,0 +1,70 @@
+import { appendFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+
+const raw = process.env.DATABASE_URL;
+const githubEnv = process.env.GITHUB_ENV;
+const region = process.env.SFI_SUPABASE_REGION || 'us-west-1';
+
+if (!raw) throw new Error('SFI_RESET_DATABASE_URL_REQUIRED');
+if (!githubEnv) throw new Error('SFI_RESET_GITHUB_ENV_REQUIRED');
+
+function testConnection(url) {
+  const result = spawnSync(
+    'psql',
+    ['--no-psqlrc', '--set', 'ON_ERROR_STOP=1', '--dbname', url, '--tuples-only', '--no-align', '--command', 'select 1;'],
+    { encoding: 'utf8', stdio: ['ignore', 'ignore', 'pipe'], timeout: 15_000 },
+  );
+  return { ok: !result.error && result.status === 0, detail: String(result.stderr || '').trim() };
+}
+
+const input = new URL(raw);
+if (!/^postgres(?:ql)?:$/.test(input.protocol)) throw new Error('SFI_RESET_DATABASE_URL_PROTOCOL_INVALID');
+
+const direct = input.hostname.match(/^db\.([a-z0-9]+)\.supabase\.co$/i);
+const isPooler = /\.pooler\.supabase\.com$/i.test(input.hostname);
+const candidates = [];
+
+if (direct) {
+  const projectRef = direct[1];
+  for (const shard of [0, 1]) {
+    const candidate = new URL(input.toString());
+    candidate.hostname = `aws-${shard}-${region}.pooler.supabase.com`;
+    candidate.port = '5432';
+    candidate.username = `postgres.${projectRef}`;
+    candidate.searchParams.set('sslmode', 'require');
+    candidates.push(candidate);
+  }
+} else if (isPooler) {
+  const candidate = new URL(input.toString());
+  candidate.port = '5432';
+  candidate.searchParams.set('sslmode', 'require');
+  candidates.push(candidate);
+} else {
+  throw new Error(`SFI_RESET_DATABASE_HOST_NOT_APPROVED:${input.hostname}`);
+}
+
+let selected = null;
+const failures = [];
+for (const candidate of candidates) {
+  const tested = testConnection(candidate.toString());
+  if (tested.ok) {
+    selected = candidate;
+    break;
+  }
+  failures.push(`${candidate.hostname}:${tested.detail.replaceAll(raw, '[REDACTED]').slice(0, 240)}`);
+}
+
+if (!selected) throw new Error(`SFI_RESET_IPV4_SESSION_POOLER_UNREACHABLE:${failures.join(' | ')}`);
+
+const resolved = selected.toString();
+console.log(`::add-mask::${resolved}`);
+await appendFile(githubEnv, `DATABASE_URL=${resolved}\n`, 'utf8');
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-RESET-DATABASE-ROUTING-1.0',
+  connectionMode: 'SUPAVISOR_SESSION_IPV4',
+  host: selected.hostname,
+  port: selected.port,
+  sslmode: selected.searchParams.get('sslmode'),
+  secretLogged: false,
+}));


### PR DESCRIPTION
## SFI PRECHECK
Owner: SFI-00 persistence closure; WS-08 assurance.
Observed failure: canonical reset run #34305567694 on main `7be9eeab...` passed secret validation and ESM execution but failed pre-snapshot because the direct Supabase host resolved IPv6 and GitHub Actions had no IPv6 route.
External platform contract: current Supabase guidance identifies GitHub Actions as IPv4-only, direct DB connections as IPv6 by default, and Shared Pooler/Supavisor session mode on port 5432 as the IPv4 alternative for persistent/native Postgres clients and backup/restore.
Absorb vs create: ABSORB. Preserve the same `SFI_DATABASE_URL` secret and derive an ephemeral session-pooler URL at runtime; no new credential and no paid IPv4 add-on.
Delta: add fail-closed resolver that accepts only Supabase direct/pooler hosts, derives project ref, tests `aws-0`/`aws-1` regional session-pooler candidates without logging credentials, masks the selected URI, and exports it through `GITHUB_ENV`. Install PostgreSQL client 17 because the target database is PostgreSQL 17 and the V2 snapshot uses `pg_dump`.
Region: canonical Supabase project region `us-west-1`.
Authority/data semantics: unchanged. No DB write in this PR. World preservation, founder genesis, institutional non-sovereignty, OAuth reconstruction, Instrument Bank reconstruction and proof-before-destruction remain unchanged.
Failure boundary: connectivity must pass before genesis export; snapshot must verify and upload before any destructive statement.
Verification: exact-head Program Completion + SFI Verify/build/typecheck + Audio + independent review. After merge, trigger #430 again and require full pre/post artifacts plus independent Supabase readback.