### PR TITLE
fix(db): pin PostgreSQL 17 client path for canonical reset

### DIFF
--- a/.github/workflows/sfi-db-canonical-reset.yml
+++ b/.github/workflows/sfi-db-canonical-reset.yml
@@ -72,6 +72,9 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo apt-get update -y
           sudo apt-get install -y postgresql-client-17
+          /usr/lib/postgresql/17/bin/pg_dump --version | grep -E '17\.'
+          echo '/usr/lib/postgresql/17/bin' >> "$GITHUB_PATH"
+          export PATH="/usr/lib/postgresql/17/bin:$PATH"
           pg_dump --version | grep -E '17\.'
           npm ci
 


### PR DESCRIPTION
## SFI PRECHECK
Owner: SFI-00 persistence closure; WS-08 assurance.
Observed failure: canonical reset run #34306876050 installed `postgresql-client-17` successfully but failed its version sanity check because the runner's global `pg_dump` remained resolved through the distro wrapper/older client. No connection, snapshot, upload or destructive SQL occurred.
Absorb vs create: ABSORB. Pin the already-installed PostgreSQL 17 client directory in PATH.
Delta: verify `/usr/lib/postgresql/17/bin/pg_dump` directly, append `/usr/lib/postgresql/17/bin` to `GITHUB_PATH`, export it for the current shell, then reverify `pg_dump` resolves to v17. No data/authority/reset contract change.
Destructive boundary: this PR performs no database operation. #430 remains gated by proof-before-destruction.
Verification: exact-head Program Completion, SFI Verify/reset-safety/typecheck/build, Audio, review threads; then merge and retrigger #430.