### PR TITLE
feat(method-lab): add governed preregistration export

### DIFF
--- a/.github/workflows/sfi-method-lab-preregistration-export.yml
+++ b/.github/workflows/sfi-method-lab-preregistration-export.yml
@@ -1,0 +1,40 @@
+name: SFI Method Lab Preregistration Export
+
+on:
+  pull_request:
+    paths:
+      - 'src/lib/method-lab/preregistrationExport.ts'
+      - 'src/lib/method-lab/preregistrationExport.test.ts'
+      - 'src/lib/method-lab/experimentPersistence.ts'
+      - 'src/app/api/interface/method-lab/route.ts'
+      - '.github/workflows/sfi-method-lab-preregistration-export.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/lib/method-lab/preregistrationExport.ts'
+      - 'src/lib/method-lab/preregistrationExport.test.ts'
+      - 'src/lib/method-lab/experimentPersistence.ts'
+      - 'src/app/api/interface/method-lab/route.ts'
+      - '.github/workflows/sfi-method-lab-preregistration-export.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+      - name: Verify deterministic preregistration export
+        run: node --import tsx --test src/lib/method-lab/preregistrationExport.test.ts
+      - name: Verify Method Lab convergence
+        run: npx tsx scripts/qa-sfi-method-lab-convergence.ts && npx tsx scripts/qa-sfi-method-lab-ui-r4b.ts
+      - name: Typecheck
+        run: npm run typecheck

--- a/scripts/qa-sfi-method-lab-ui-r4b.ts
+++ b/scripts/qa-sfi-method-lab-ui-r4b.ts
@@ -12,6 +12,7 @@ const projection = read('src/lib/method-lab/uiProjection.ts');
 const execution = read('src/lib/method-lab/uiExecution.ts');
 const experimentPersistence = read('src/lib/method-lab/experimentPersistence.ts');
 const experimentContract = read('src/lib/method-lab/experimentContract.ts');
+const preregistrationExport = read('src/lib/method-lab/preregistrationExport.ts');
 const reentry = read('src/lib/method-lab/reentryEngine.ts');
 const personalWorkspace = read('src/lib/sfi/personal/cognitiveWorkspace.ts');
 const twinContract = read('src/core/cognitive-twin/contract.ts');
@@ -24,7 +25,7 @@ assert.match(page, /requireRootObserverPage\('\/method-lab'\)/, 'Institutional M
 assert.match(page, /MethodLabExperimentWorkbench/, 'Slice E must mount on the existing canonical /method-lab route.');
 assert.doesNotMatch(page, /createServiceSupabaseClient|\.from\(/, 'Page rendering must not bypass server-owned persistence boundaries.');
 assert.match(route, /requireUserProfile\(\)/, 'Method Lab UI API must authenticate every read/write.');
-assert.match(route, /allowed: \['preregister', 'execute_simulation'\]/, 'UI API operation surface must stay explicitly bounded.');
+assert.match(route, /allowed: \['preregister', 'export_preregistration', 'execute_simulation'\]/, 'UI API operation surface must stay explicitly bounded.');
 assert.doesNotMatch(route, /requireRootActor|auditRootAction/, 'Owner-scoped UI API must not acquire ROOT mutation authority.');
 assert.match(route, /canonicalPromotion: false/, 'UI route must expose the no-canonical-promotion boundary.');
 
@@ -81,11 +82,15 @@ assert.match(ui, /lineageRefs/);
 assert.match(reentry, /REENTRY_NEVER_INHERITS_OBSERVED/);
 assert.match(reentry, /authorityCeiling: 'RECOMMEND'/);
 
-// Slice F metadata is visible but no external preregistration claim is fabricated.
+// Slice F export is a bounded representation of persisted preregistration, never an external registration claim.
 assert.match(ui, /SLICE F PREREGISTRATION METADATA PREVIEW/);
 assert.match(ui, /externalRegistrationClaim: false/);
 assert.match(projection, /externalRegistrationClaim: false/);
-assert.doesNotMatch(projection, /osf\.io|OSF registration exists|externalRegistrationClaim: true/i);
+assert.match(route, /operation === 'export_preregistration'/);
+assert.match(route, /readOwnedMethodLabExperimentPreregistration/);
+assert.match(preregistrationExport, /NOT_REGISTERED_EXTERNALLY/);
+assert.match(preregistrationExport, /privateTwinPayloadIncluded: false/);
+assert.doesNotMatch(`${projection}\n${route}\n${preregistrationExport}`, /osf\.io|OSF registration exists|externalRegistrationClaim: true/i);
 
 // No OBSERVED inheritance, CANON promotion, or Twin authority expansion.
 assert.match(experimentContract, /METHOD_LAB_EXPERIMENT_SIMULATION_CANNOT_BECOME_OBSERVED/);
@@ -95,15 +100,16 @@ assert.match(twinStatePersistence, /canonicalMutation: false/);
 assert.ok(twinContract.includes('authority') || twinContract.includes('Authority'), 'Canonical Cognitive Twin authority contract must remain present.');
 assert.match(twinContract, /founderReservedActions/);
 assert.match(twinContract, /'mutate_canon'/);
-for (const source of [route, projection, execution, ui]) {
-  assert.doesNotMatch(source, /canonicalMutation:\s*true|promotionAllowed:\s*true|EXECUTE_EXTERNAL|IRREVERSIBLE|\bCANON\b\s*:/, 'Slice E cannot expand canonical/external authority.');
+for (const source of [route, projection, execution, ui, preregistrationExport]) {
+  assert.doesNotMatch(source, /canonicalMutation:\s*true|promotionAllowed:\s*true|EXECUTE_EXTERNAL|IRREVERSIBLE|\bCANON\b\s*:/, 'Method Lab UI/export cannot expand canonical/external authority.');
 }
 
-// Persistence owner remains converged; no schema/migration ownership is introduced by Slice E.
+// Persistence owner remains converged; no schema/migration ownership is introduced by Slice E/F.
 assert.match(experimentPersistence, /\.from\('sfi_lab_analyses'\)/);
 assert.match(execution, /\.from\('sfi_lab_analyses'\)/);
 assert.match(projection, /\.from\('sfi_lab_analyses'\)/);
 assert.doesNotMatch(projection, /create table|alter table|migration/i);
 assert.doesNotMatch(execution, /create table|alter table|migration/i);
+assert.doesNotMatch(preregistrationExport, /createServiceSupabaseClient|\.from\(|create table|alter table|migration/i);
 
 console.log('SFI-METHOD-LAB-UI-R4B PASS');

--- a/src/app/api/interface/method-lab/route.ts
+++ b/src/app/api/interface/method-lab/route.ts
@@ -7,6 +7,8 @@ import {
 } from '@/lib/method-lab/uiProjection';
 import { executeMethodLabUiSimulation, type MethodLabUiSimulationProtocol } from '@/lib/method-lab/uiExecution';
 import { METHOD_LAB_EXPERIMENT_TYPES, type MethodLabExperimentType } from '@/lib/method-lab/experimentContract';
+import { readOwnedMethodLabExperimentPreregistration } from '@/lib/method-lab/experimentPersistence';
+import { buildMethodLabPreregistrationExport } from '@/lib/method-lab/preregistrationExport';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -80,6 +82,31 @@ export async function POST(request: Request) {
     const body = await request.json().catch(() => ({})) as Row;
     const operation = requiredText(body.operation);
 
+    if (operation === 'export_preregistration') {
+      const persisted = await readOwnedMethodLabExperimentPreregistration({
+        ownerId: context.user.id,
+        experimentId: requiredText(body.experimentId),
+      });
+      const exportArtifact = buildMethodLabPreregistrationExport({
+        preregistration: persisted.preregistration,
+        definitionHash: persisted.definitionHash,
+      });
+      return NextResponse.json({
+        ok: true,
+        operation,
+        preregistrationRef: persisted.preregistrationRef,
+        export: exportArtifact,
+        boundaries: {
+          ownerScoped: true,
+          externalRegistrationClaim: false,
+          externalExecution: false,
+          canonicalPromotion: false,
+          privateTwinPayloadIncluded: false,
+          observationInheritance: false,
+        },
+      }, { status: 200 });
+    }
+
     if (operation === 'execute_simulation') {
       const protocolId = simulationProtocol(body.protocolId);
       if (!protocolId) return NextResponse.json({ ok: false, error: 'METHOD_LAB_UI_SIMULATION_PROTOCOL_INVALID' }, { status: 400 });
@@ -104,8 +131,8 @@ export async function POST(request: Request) {
       return NextResponse.json({
         ok: false,
         error: 'METHOD_LAB_UI_OPERATION_NOT_ALLOWED',
-        allowed: ['preregister', 'execute_simulation'],
-        boundary: 'Execution remains owned by existing simulation runtime owners; this API does not create another experiment engine.',
+        allowed: ['preregister', 'export_preregistration', 'execute_simulation'],
+        boundary: 'Execution remains owned by existing simulation runtime owners; export is a representation of persisted preregistration and is not external registration.',
       }, { status: 400 });
     }
 

--- a/src/lib/method-lab/experimentPersistence.ts
+++ b/src/lib/method-lab/experimentPersistence.ts
@@ -39,6 +39,41 @@ export function hashMethodLabPreregistration(value: MethodLabExperimentPreregist
   return hash(assertMethodLabExperimentPreregistration(value));
 }
 
+export async function readOwnedMethodLabExperimentPreregistration(input: {
+  experimentId: string;
+  ownerId: string;
+}) {
+  const experimentId = input.experimentId.trim();
+  const ownerId = input.ownerId.trim();
+  if (!experimentId || !ownerId) throw new Error('METHOD_LAB_PREREGISTRATION_OWNER_AND_EXPERIMENT_REQUIRED');
+
+  const preregistrationRef = methodLabPreregistrationId(experimentId);
+  const db = createServiceSupabaseClient();
+  const existing = await db.from('sfi_lab_analyses')
+    .select('id,owner_id,raw_analysis,created_at')
+    .eq('id', preregistrationRef)
+    .eq('owner_id', ownerId)
+    .maybeSingle();
+  if (existing.error) throw new Error(`METHOD_LAB_PREREGISTRATION_READ_FAILED:${existing.error.message}`);
+  if (!existing.data) throw new Error('METHOD_LAB_PREREGISTRATION_OWNER_SCOPE_REQUIRED');
+
+  const raw = record(existing.data.raw_analysis);
+  if (raw.phase !== 'PREREGISTERED' || raw.contractVersion !== METHOD_LAB_EXPERIMENT_CONTRACT_VERSION) {
+    throw new Error('METHOD_LAB_PREREGISTRATION_PERSISTED_CONTRACT_INVALID');
+  }
+  const preregistration = assertMethodLabExperimentPreregistration(raw.preregistration as MethodLabExperimentPreregistration);
+  if (preregistration.experimentId !== experimentId) throw new Error('METHOD_LAB_PREREGISTRATION_EXPERIMENT_ID_MISMATCH');
+  const definitionHash = hashMethodLabPreregistration(preregistration);
+  if (raw.definitionHash !== definitionHash) throw new Error('METHOD_LAB_PREREGISTRATION_IMMUTABILITY_CHECK_FAILED');
+
+  return {
+    preregistrationRef,
+    definitionHash,
+    preregistration,
+    createdAt: String(existing.data.created_at ?? preregistration.preregisteredAt),
+  };
+}
+
 export async function persistMethodLabExperimentPreregistration(input: {
   preregistration: MethodLabExperimentPreregistration;
   ownerId?: string | null;

--- a/src/lib/method-lab/preregistrationExport.test.ts
+++ b/src/lib/method-lab/preregistrationExport.test.ts
@@ -13,7 +13,9 @@ const preregistration: MethodLabExperimentPreregistration = {
   POPULATION_SYSTEM: { kind: 'SYSTEM', ref: 'case:1', description: 'Owner-scoped case.' },
   INPUTS: [
     { ref: 'case:1', role: 'CONTEXT', epistemicClass: 'DECLARED' },
+    { ref: 'context:missing', role: 'CONTEXT', epistemicClass: 'MISSING' },
     { ref: 'evidence:1', role: 'EVIDENCE', epistemicClass: 'OBSERVED' },
+    { ref: 'evidence:simulated', role: 'EVIDENCE', epistemicClass: 'SIMULATED' },
     { ref: 'model:gpt', role: 'MODEL', epistemicClass: 'DECLARED' },
     { ref: 'passport:bounded', role: 'PASSPORT', epistemicClass: 'DECLARED' },
     { ref: 'twin:private-ref', role: 'TWIN_STATE', epistemicClass: 'DERIVED' },
@@ -31,17 +33,27 @@ const preregistration: MethodLabExperimentPreregistration = {
 
 const definitionHash = 'a'.repeat(64);
 
-test('preregistration export is deterministic, registration-neutral, and payload-private', () => {
+test('preregistration export is deterministic, registration-neutral, payload-private, and epistemically lossless', () => {
   const first = buildMethodLabPreregistrationExport({ preregistration, definitionHash });
   const second = buildMethodLabPreregistrationExport({ preregistration: structuredClone(preregistration), definitionHash });
   assert.equal(first.contractVersion, METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION);
   assert.deepEqual(first, second);
   assert.match(first.exportHash, /^[a-f0-9]{64}$/);
   assert.equal(first.exportId, `method-lab:prereg-export:${preregistration.experimentId}:${definitionHash}`);
-  assert.deepEqual(first.REPRODUCIBILITY_REFS.evidenceRefs, ['evidence:1']);
-  assert.deepEqual(first.REPRODUCIBILITY_REFS.modelRefs, ['model:gpt']);
-  assert.deepEqual(first.REPRODUCIBILITY_REFS.passportRefs, ['passport:bounded']);
-  assert.deepEqual(first.REPRODUCIBILITY_REFS.twinStateRefs, ['twin:private-ref']);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.evidenceRefs, [
+    { ref: 'evidence:1', epistemicClass: 'OBSERVED' },
+    { ref: 'evidence:simulated', epistemicClass: 'SIMULATED' },
+  ]);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.modelRefs, [{ ref: 'model:gpt', epistemicClass: 'DECLARED' }]);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.passportRefs, [{ ref: 'passport:bounded', epistemicClass: 'DECLARED' }]);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.twinStateRefs, [{ ref: 'twin:private-ref', epistemicClass: 'DERIVED' }]);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.contextRefs, [
+    { ref: 'case:1', epistemicClass: 'DECLARED' },
+    { ref: 'context:missing', epistemicClass: 'MISSING' },
+  ]);
+  assert.ok(first.REPRODUCIBILITY_REFS.inputs.some((item) => item.ref === 'evidence:simulated' && item.role === 'EVIDENCE' && item.epistemicClass === 'SIMULATED'));
+  assert.ok(first.REPRODUCIBILITY_REFS.inputs.some((item) => item.ref === 'context:missing' && item.role === 'CONTEXT' && item.epistemicClass === 'MISSING'));
+  assert.equal(first.boundaries.epistemicClassesPreserved, true);
   assert.equal(first.boundaries.externalRegistrationClaim, false);
   assert.equal(first.boundaries.registrationState, 'NOT_REGISTERED_EXTERNALLY');
   assert.equal(first.boundaries.privateTwinPayloadIncluded, false);

--- a/src/lib/method-lab/preregistrationExport.test.ts
+++ b/src/lib/method-lab/preregistrationExport.test.ts
@@ -33,13 +33,19 @@ const preregistration: MethodLabExperimentPreregistration = {
 
 const definitionHash = 'a'.repeat(64);
 
-test('preregistration export is deterministic, registration-neutral, payload-private, and epistemically lossless', () => {
+test('preregistration export is deterministic, registration-neutral, payload-private, and reproducibility-complete', () => {
   const first = buildMethodLabPreregistrationExport({ preregistration, definitionHash });
   const second = buildMethodLabPreregistrationExport({ preregistration: structuredClone(preregistration), definitionHash });
   assert.equal(first.contractVersion, METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION);
   assert.deepEqual(first, second);
   assert.match(first.exportHash, /^[a-f0-9]{64}$/);
   assert.equal(first.exportId, `method-lab:prereg-export:${preregistration.experimentId}:${definitionHash}`);
+
+  assert.deepEqual(first.POPULATION_SYSTEM, preregistration.POPULATION_SYSTEM);
+  assert.deepEqual(first.CONTROL, preregistration.CONTROL);
+  assert.deepEqual(first.VARIANTS, preregistration.VARIANTS);
+  assert.deepEqual(first.VARIANTS[0].changes, { model: 'alternate' });
+
   assert.deepEqual(first.REPRODUCIBILITY_REFS.evidenceRefs, [
     { ref: 'evidence:1', epistemicClass: 'OBSERVED' },
     { ref: 'evidence:simulated', epistemicClass: 'SIMULATED' },
@@ -54,6 +60,7 @@ test('preregistration export is deterministic, registration-neutral, payload-pri
   assert.ok(first.REPRODUCIBILITY_REFS.inputs.some((item) => item.ref === 'evidence:simulated' && item.role === 'EVIDENCE' && item.epistemicClass === 'SIMULATED'));
   assert.ok(first.REPRODUCIBILITY_REFS.inputs.some((item) => item.ref === 'context:missing' && item.role === 'CONTEXT' && item.epistemicClass === 'MISSING'));
   assert.equal(first.boundaries.epistemicClassesPreserved, true);
+  assert.equal(first.boundaries.frozenArmsPreserved, true);
   assert.equal(first.boundaries.externalRegistrationClaim, false);
   assert.equal(first.boundaries.registrationState, 'NOT_REGISTERED_EXTERNALLY');
   assert.equal(first.boundaries.privateTwinPayloadIncluded, false);

--- a/src/lib/method-lab/preregistrationExport.test.ts
+++ b/src/lib/method-lab/preregistrationExport.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { METHOD_LAB_EXPERIMENT_CONTRACT_VERSION, type MethodLabExperimentPreregistration } from './experimentContract';
+import { buildMethodLabPreregistrationExport, METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION } from './preregistrationExport';
+
+const preregistration: MethodLabExperimentPreregistration = {
+  contractVersion: METHOD_LAB_EXPERIMENT_CONTRACT_VERSION,
+  experimentId: 'EXP-EXPORT-001',
+  experimentType: 'REENTRY',
+  METHOD: { methodId: 'method-lab-ui:reentry', version: 'SFI-METHOD-LAB-UI-1.0', description: 'Frozen reentry comparison.' },
+  HYPOTHESIS: { statement: 'A bounded configuration change alters the declared signal.', nullStatement: 'No declared signal changes.' },
+  T0: { cutoff: '2026-09-08T12:00:00.000Z', timezone: 'America/Mexico_City', frozenInputRefs: ['case:1','evidence:1','twin:private-ref'] },
+  POPULATION_SYSTEM: { kind: 'SYSTEM', ref: 'case:1', description: 'Owner-scoped case.' },
+  INPUTS: [
+    { ref: 'case:1', role: 'CONTEXT', epistemicClass: 'DECLARED' },
+    { ref: 'evidence:1', role: 'EVIDENCE', epistemicClass: 'OBSERVED' },
+    { ref: 'model:gpt', role: 'MODEL', epistemicClass: 'DECLARED' },
+    { ref: 'passport:bounded', role: 'PASSPORT', epistemicClass: 'DECLARED' },
+    { ref: 'twin:private-ref', role: 'TWIN_STATE', epistemicClass: 'DERIVED' },
+  ],
+  CONTROL: { kind: 'CONTROL', description: 'Frozen T0 control.', inputRefs: ['case:1','evidence:1','twin:private-ref'] },
+  VARIANTS: [{ variantId: 'variant-1', description: 'Change one configuration axis.', changes: { model: 'alternate' } }],
+  EXPECTED_SIGNAL: { description: 'Declared divergence.', measures: ['delta_decision'] },
+  FALSIFICATION: { condition: 'No divergence under the preregistered comparison.', requiredEvidence: ['evidence:1'] },
+  STOPPING_RULE: { condition: 'Stop after one comparison.', maxExecutions: 1 },
+  RETURN_WINDOW: { opensAt: '2026-09-08T12:00:00.000Z', closesAt: '2026-10-08T12:00:00.000Z', required: true },
+  preregisteredAt: '2026-09-08T11:59:00.000Z',
+  preregisteredBy: 'owner-private-id',
+  canonicalMutation: false,
+};
+
+const definitionHash = 'a'.repeat(64);
+
+test('preregistration export is deterministic, registration-neutral, and payload-private', () => {
+  const first = buildMethodLabPreregistrationExport({ preregistration, definitionHash });
+  const second = buildMethodLabPreregistrationExport({ preregistration: structuredClone(preregistration), definitionHash });
+  assert.equal(first.contractVersion, METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION);
+  assert.deepEqual(first, second);
+  assert.match(first.exportHash, /^[a-f0-9]{64}$/);
+  assert.equal(first.exportId, `method-lab:prereg-export:${preregistration.experimentId}:${definitionHash}`);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.evidenceRefs, ['evidence:1']);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.modelRefs, ['model:gpt']);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.passportRefs, ['passport:bounded']);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.twinStateRefs, ['twin:private-ref']);
+  assert.equal(first.boundaries.externalRegistrationClaim, false);
+  assert.equal(first.boundaries.registrationState, 'NOT_REGISTERED_EXTERNALLY');
+  assert.equal(first.boundaries.privateTwinPayloadIncluded, false);
+  assert.equal(first.boundaries.canonicalMutation, false);
+  assert.equal(JSON.stringify(first).includes('owner-private-id'), false);
+});
+
+test('preregistration export rejects unbound definition hashes', () => {
+  assert.throws(() => buildMethodLabPreregistrationExport({ preregistration, definitionHash: 'not-a-sha256' }), /DEFINITION_HASH_INVALID/);
+});

--- a/src/lib/method-lab/preregistrationExport.ts
+++ b/src/lib/method-lab/preregistrationExport.ts
@@ -1,0 +1,104 @@
+import { createHash } from 'node:crypto';
+import {
+  assertMethodLabExperimentPreregistration,
+  type MethodLabExperimentPreregistration,
+} from './experimentContract';
+
+export const METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION = 'SFI-METHOD-LAB-PREREGISTRATION-EXPORT-1.0' as const;
+
+export type MethodLabPreregistrationExport = {
+  contractVersion: typeof METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION;
+  exportId: string;
+  experimentId: string;
+  experimentType: MethodLabExperimentPreregistration['experimentType'];
+  definitionHash: string;
+  exportHash: string;
+  HYPOTHESIS: MethodLabExperimentPreregistration['HYPOTHESIS'];
+  T0: MethodLabExperimentPreregistration['T0'];
+  METHOD: MethodLabExperimentPreregistration['METHOD'];
+  STOPPING_TERMS: MethodLabExperimentPreregistration['STOPPING_RULE'];
+  EXPECTED_SIGNAL: MethodLabExperimentPreregistration['EXPECTED_SIGNAL'];
+  RETURN_CRITERIA: {
+    returnWindow: MethodLabExperimentPreregistration['RETURN_WINDOW'];
+    falsification: MethodLabExperimentPreregistration['FALSIFICATION'];
+  };
+  REPRODUCIBILITY_REFS: {
+    evidenceRefs: string[];
+    modelRefs: string[];
+    passportRefs: string[];
+    twinStateRefs: string[];
+    parameterRefs: string[];
+    contextRefs: string[];
+  };
+  boundaries: {
+    externalRegistrationClaim: false;
+    registrationState: 'NOT_REGISTERED_EXTERNALLY';
+    canonicalMutation: false;
+    privateTwinPayloadIncluded: false;
+    simulationBecomesObservation: false;
+  };
+};
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    const row = value as Record<string, unknown>;
+    return Object.fromEntries(Object.keys(row).sort().map((key) => [key, canonicalize(row[key])]));
+  }
+  return value;
+}
+
+function sha256(value: unknown) {
+  return createHash('sha256').update(JSON.stringify(canonicalize(value))).digest('hex');
+}
+
+function refsByRole(preregistration: MethodLabExperimentPreregistration, role: MethodLabExperimentPreregistration['INPUTS'][number]['role']) {
+  return [...new Set(preregistration.INPUTS.filter((input) => input.role === role).map((input) => input.ref))].sort();
+}
+
+export function buildMethodLabPreregistrationExport(input: {
+  preregistration: MethodLabExperimentPreregistration;
+  definitionHash: string;
+}): MethodLabPreregistrationExport {
+  const preregistration = assertMethodLabExperimentPreregistration(input.preregistration);
+  const definitionHash = input.definitionHash.trim();
+  if (!/^[a-f0-9]{64}$/i.test(definitionHash)) throw new Error('METHOD_LAB_PREREGISTRATION_EXPORT_DEFINITION_HASH_INVALID');
+
+  const stablePayload = {
+    experimentId: preregistration.experimentId,
+    experimentType: preregistration.experimentType,
+    definitionHash,
+    HYPOTHESIS: preregistration.HYPOTHESIS,
+    T0: preregistration.T0,
+    METHOD: preregistration.METHOD,
+    STOPPING_TERMS: preregistration.STOPPING_RULE,
+    EXPECTED_SIGNAL: preregistration.EXPECTED_SIGNAL,
+    RETURN_CRITERIA: {
+      returnWindow: preregistration.RETURN_WINDOW,
+      falsification: preregistration.FALSIFICATION,
+    },
+    REPRODUCIBILITY_REFS: {
+      evidenceRefs: refsByRole(preregistration, 'EVIDENCE'),
+      modelRefs: refsByRole(preregistration, 'MODEL'),
+      passportRefs: refsByRole(preregistration, 'PASSPORT'),
+      twinStateRefs: refsByRole(preregistration, 'TWIN_STATE'),
+      parameterRefs: refsByRole(preregistration, 'PARAMETER'),
+      contextRefs: refsByRole(preregistration, 'CONTEXT'),
+    },
+  };
+  const exportHash = sha256(stablePayload);
+
+  return {
+    contractVersion: METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION,
+    exportId: `method-lab:prereg-export:${preregistration.experimentId}:${definitionHash}`,
+    ...stablePayload,
+    exportHash,
+    boundaries: {
+      externalRegistrationClaim: false,
+      registrationState: 'NOT_REGISTERED_EXTERNALLY',
+      canonicalMutation: false,
+      privateTwinPayloadIncluded: false,
+      simulationBecomesObservation: false,
+    },
+  };
+}

--- a/src/lib/method-lab/preregistrationExport.ts
+++ b/src/lib/method-lab/preregistrationExport.ts
@@ -4,7 +4,7 @@ import {
   type MethodLabExperimentPreregistration,
 } from './experimentContract';
 
-export const METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION = 'SFI-METHOD-LAB-PREREGISTRATION-EXPORT-1.1' as const;
+export const METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION = 'SFI-METHOD-LAB-PREREGISTRATION-EXPORT-1.2' as const;
 
 type PreregistrationInput = MethodLabExperimentPreregistration['INPUTS'][number];
 type ReproducibilityRef = Pick<PreregistrationInput, 'ref' | 'role' | 'epistemicClass'>;
@@ -20,6 +20,9 @@ export type MethodLabPreregistrationExport = {
   HYPOTHESIS: MethodLabExperimentPreregistration['HYPOTHESIS'];
   T0: MethodLabExperimentPreregistration['T0'];
   METHOD: MethodLabExperimentPreregistration['METHOD'];
+  POPULATION_SYSTEM: MethodLabExperimentPreregistration['POPULATION_SYSTEM'];
+  CONTROL: MethodLabExperimentPreregistration['CONTROL'];
+  VARIANTS: MethodLabExperimentPreregistration['VARIANTS'];
   STOPPING_TERMS: MethodLabExperimentPreregistration['STOPPING_RULE'];
   EXPECTED_SIGNAL: MethodLabExperimentPreregistration['EXPECTED_SIGNAL'];
   RETURN_CRITERIA: {
@@ -42,6 +45,7 @@ export type MethodLabPreregistrationExport = {
     privateTwinPayloadIncluded: false;
     simulationBecomesObservation: false;
     epistemicClassesPreserved: true;
+    frozenArmsPreserved: true;
   };
 };
 
@@ -86,6 +90,9 @@ export function buildMethodLabPreregistrationExport(input: {
     HYPOTHESIS: preregistration.HYPOTHESIS,
     T0: preregistration.T0,
     METHOD: preregistration.METHOD,
+    POPULATION_SYSTEM: preregistration.POPULATION_SYSTEM,
+    CONTROL: preregistration.CONTROL,
+    VARIANTS: preregistration.VARIANTS,
     STOPPING_TERMS: preregistration.STOPPING_RULE,
     EXPECTED_SIGNAL: preregistration.EXPECTED_SIGNAL,
     RETURN_CRITERIA: {
@@ -116,6 +123,7 @@ export function buildMethodLabPreregistrationExport(input: {
       privateTwinPayloadIncluded: false,
       simulationBecomesObservation: false,
       epistemicClassesPreserved: true,
+      frozenArmsPreserved: true,
     },
   };
 }

--- a/src/lib/method-lab/preregistrationExport.ts
+++ b/src/lib/method-lab/preregistrationExport.ts
@@ -4,7 +4,11 @@ import {
   type MethodLabExperimentPreregistration,
 } from './experimentContract';
 
-export const METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION = 'SFI-METHOD-LAB-PREREGISTRATION-EXPORT-1.0' as const;
+export const METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION = 'SFI-METHOD-LAB-PREREGISTRATION-EXPORT-1.1' as const;
+
+type PreregistrationInput = MethodLabExperimentPreregistration['INPUTS'][number];
+type ReproducibilityRef = Pick<PreregistrationInput, 'ref' | 'role' | 'epistemicClass'>;
+type RoleRef = Pick<PreregistrationInput, 'ref' | 'epistemicClass'>;
 
 export type MethodLabPreregistrationExport = {
   contractVersion: typeof METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION;
@@ -23,12 +27,13 @@ export type MethodLabPreregistrationExport = {
     falsification: MethodLabExperimentPreregistration['FALSIFICATION'];
   };
   REPRODUCIBILITY_REFS: {
-    evidenceRefs: string[];
-    modelRefs: string[];
-    passportRefs: string[];
-    twinStateRefs: string[];
-    parameterRefs: string[];
-    contextRefs: string[];
+    inputs: ReproducibilityRef[];
+    evidenceRefs: RoleRef[];
+    modelRefs: RoleRef[];
+    passportRefs: RoleRef[];
+    twinStateRefs: RoleRef[];
+    parameterRefs: RoleRef[];
+    contextRefs: RoleRef[];
   };
   boundaries: {
     externalRegistrationClaim: false;
@@ -36,6 +41,7 @@ export type MethodLabPreregistrationExport = {
     canonicalMutation: false;
     privateTwinPayloadIncluded: false;
     simulationBecomesObservation: false;
+    epistemicClassesPreserved: true;
   };
 };
 
@@ -52,8 +58,17 @@ function sha256(value: unknown) {
   return createHash('sha256').update(JSON.stringify(canonicalize(value))).digest('hex');
 }
 
-function refsByRole(preregistration: MethodLabExperimentPreregistration, role: MethodLabExperimentPreregistration['INPUTS'][number]['role']) {
-  return [...new Set(preregistration.INPUTS.filter((input) => input.role === role).map((input) => input.ref))].sort();
+function refsByRole(preregistration: MethodLabExperimentPreregistration, role: PreregistrationInput['role']): RoleRef[] {
+  return preregistration.INPUTS
+    .filter((item) => item.role === role)
+    .map((item) => ({ ref: item.ref, epistemicClass: item.epistemicClass }))
+    .sort((left, right) => left.ref.localeCompare(right.ref) || left.epistemicClass.localeCompare(right.epistemicClass));
+}
+
+function allInputRefs(preregistration: MethodLabExperimentPreregistration): ReproducibilityRef[] {
+  return preregistration.INPUTS
+    .map((item) => ({ ref: item.ref, role: item.role, epistemicClass: item.epistemicClass }))
+    .sort((left, right) => left.ref.localeCompare(right.ref) || left.role.localeCompare(right.role) || left.epistemicClass.localeCompare(right.epistemicClass));
 }
 
 export function buildMethodLabPreregistrationExport(input: {
@@ -78,6 +93,7 @@ export function buildMethodLabPreregistrationExport(input: {
       falsification: preregistration.FALSIFICATION,
     },
     REPRODUCIBILITY_REFS: {
+      inputs: allInputRefs(preregistration),
       evidenceRefs: refsByRole(preregistration, 'EVIDENCE'),
       modelRefs: refsByRole(preregistration, 'MODEL'),
       passportRefs: refsByRole(preregistration, 'PASSPORT'),
@@ -99,6 +115,7 @@ export function buildMethodLabPreregistrationExport(input: {
       canonicalMutation: false,
       privateTwinPayloadIncluded: false,
       simulationBecomesObservation: false,
+      epistemicClassesPreserved: true,
     },
   };
 }


### PR DESCRIPTION
Parent: #403 / #389 / #405
Owner: SFI-02 · Twin + Method Lab
Integration authority: SFI-00
Assurance authority: SFI-08

## SFI PRECHECK
Existing capability inspected: canonical `SFI-METHOD-LAB-EXPERIMENT-1.0`, owner-scoped Method Lab UI, insert-only `sfi_lab_analyses` preregistration persistence, frozen T0, existing simulation/reentry boundaries.

Absorb vs create decision: ABSORB. This slice adds only a deterministic representation/export of an already-persisted preregistration and one owner-scoped read operation. It does not create a second Method Lab store, preregistration owner, external registry client, Twin store or evidence store.

Authoritative writer: unchanged. `persistMethodLabExperimentPreregistration` remains the preregistration writer. Export is read-only.

Persistence/lineage impact: no schema or migration delta. The export re-reads the persisted owner-scoped preregistration, recomputes and verifies the definition hash, then emits HYPOTHESIS/T0/METHOD/STOPPING TERMS/EXPECTED SIGNAL/RETURN CRITERIA plus reproducibility references.

Front delta: none.
Back delta: `export_preregistration` on the existing authenticated Method Lab interface.
DB delta: none.

Redundancy removed: no second preregistration, Method Lab, Twin, evidence, export-persistence or external-registry owner is introduced. The export is derived read-only from the canonical persisted preregistration.

Execution/ROOT boundary: export is representation only. It cannot execute an experiment, mutate canon, register externally, promote evidence, expand authority or expose a private Twin payload. ROOT authority is unchanged.

Rollback: revert PR #456. No data/schema rollback is required because the slice adds no migration and no new persistence writer; existing preregistration rows remain valid.

Privacy boundary: Twin payload is never embedded; only the preregistered Twin state reference may be exported. `privateTwinPayloadIncluded=false`.

Authority/epistemic boundary: export != external registration; `registrationState=NOT_REGISTERED_EXTERNALLY`; no OSF/registry success claim; no canonical mutation; simulation/reentry never inherits OBSERVED.

Verification: dedicated exact-head preregistration-export workflow, deterministic tests, existing Method Lab convergence/UI QA, repository SFI Verify/typecheck/build via normal PR CI.

Falsification: FAIL if export can read another owner’s preregistration, definition hash mismatch is tolerated, private Twin payload is exposed, external registration is claimed, or export mutates canon/persistence.

No self-merge until exact-head assurance is terminal.