### PR TITLE
fix(method-lab): preserve preregistration reproducibility semantics

### DIFF
--- a/src/lib/method-lab/preregistrationExport.test.ts
+++ b/src/lib/method-lab/preregistrationExport.test.ts
@@ -13,7 +13,9 @@ const preregistration: MethodLabExperimentPreregistration = {
   POPULATION_SYSTEM: { kind: 'SYSTEM', ref: 'case:1', description: 'Owner-scoped case.' },
   INPUTS: [
     { ref: 'case:1', role: 'CONTEXT', epistemicClass: 'DECLARED' },
+    { ref: 'context:missing', role: 'CONTEXT', epistemicClass: 'MISSING' },
     { ref: 'evidence:1', role: 'EVIDENCE', epistemicClass: 'OBSERVED' },
+    { ref: 'evidence:simulated', role: 'EVIDENCE', epistemicClass: 'SIMULATED' },
     { ref: 'model:gpt', role: 'MODEL', epistemicClass: 'DECLARED' },
     { ref: 'passport:bounded', role: 'PASSPORT', epistemicClass: 'DECLARED' },
     { ref: 'twin:private-ref', role: 'TWIN_STATE', epistemicClass: 'DERIVED' },
@@ -31,17 +33,32 @@ const preregistration: MethodLabExperimentPreregistration = {
 
 const definitionHash = 'a'.repeat(64);
 
-test('preregistration export is deterministic, registration-neutral, and payload-private', () => {
+test('preregistration export is deterministic, registration-neutral, payload-private, and reproducibility-complete', () => {
   const first = buildMethodLabPreregistrationExport({ preregistration, definitionHash });
   const second = buildMethodLabPreregistrationExport({ preregistration: structuredClone(preregistration), definitionHash });
   assert.equal(first.contractVersion, METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION);
   assert.deepEqual(first, second);
   assert.match(first.exportHash, /^[a-f0-9]{64}$/);
   assert.equal(first.exportId, `method-lab:prereg-export:${preregistration.experimentId}:${definitionHash}`);
-  assert.deepEqual(first.REPRODUCIBILITY_REFS.evidenceRefs, ['evidence:1']);
-  assert.deepEqual(first.REPRODUCIBILITY_REFS.modelRefs, ['model:gpt']);
-  assert.deepEqual(first.REPRODUCIBILITY_REFS.passportRefs, ['passport:bounded']);
-  assert.deepEqual(first.REPRODUCIBILITY_REFS.twinStateRefs, ['twin:private-ref']);
+  assert.deepEqual(first.POPULATION_SYSTEM, preregistration.POPULATION_SYSTEM);
+  assert.deepEqual(first.CONTROL, preregistration.CONTROL);
+  assert.deepEqual(first.VARIANTS, preregistration.VARIANTS);
+  assert.deepEqual(first.VARIANTS[0].changes, { model: 'alternate' });
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.evidenceRefs, [
+    { ref: 'evidence:1', epistemicClass: 'OBSERVED' },
+    { ref: 'evidence:simulated', epistemicClass: 'SIMULATED' },
+  ]);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.modelRefs, [{ ref: 'model:gpt', epistemicClass: 'DECLARED' }]);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.passportRefs, [{ ref: 'passport:bounded', epistemicClass: 'DECLARED' }]);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.twinStateRefs, [{ ref: 'twin:private-ref', epistemicClass: 'DERIVED' }]);
+  assert.deepEqual(first.REPRODUCIBILITY_REFS.contextRefs, [
+    { ref: 'case:1', epistemicClass: 'DECLARED' },
+    { ref: 'context:missing', epistemicClass: 'MISSING' },
+  ]);
+  assert.ok(first.REPRODUCIBILITY_REFS.inputs.some((item) => item.ref === 'evidence:simulated' && item.role === 'EVIDENCE' && item.epistemicClass === 'SIMULATED'));
+  assert.ok(first.REPRODUCIBILITY_REFS.inputs.some((item) => item.ref === 'context:missing' && item.role === 'CONTEXT' && item.epistemicClass === 'MISSING'));
+  assert.equal(first.boundaries.epistemicClassesPreserved, true);
+  assert.equal(first.boundaries.frozenArmsPreserved, true);
   assert.equal(first.boundaries.externalRegistrationClaim, false);
   assert.equal(first.boundaries.registrationState, 'NOT_REGISTERED_EXTERNALLY');
   assert.equal(first.boundaries.privateTwinPayloadIncluded, false);

--- a/src/lib/method-lab/preregistrationExport.ts
+++ b/src/lib/method-lab/preregistrationExport.ts
@@ -4,7 +4,11 @@ import {
   type MethodLabExperimentPreregistration,
 } from './experimentContract';
 
-export const METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION = 'SFI-METHOD-LAB-PREREGISTRATION-EXPORT-1.0' as const;
+export const METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION = 'SFI-METHOD-LAB-PREREGISTRATION-EXPORT-1.2' as const;
+
+type PreregistrationInput = MethodLabExperimentPreregistration['INPUTS'][number];
+type ReproducibilityRef = Pick<PreregistrationInput, 'ref' | 'role' | 'epistemicClass'>;
+type RoleRef = Pick<PreregistrationInput, 'ref' | 'epistemicClass'>;
 
 export type MethodLabPreregistrationExport = {
   contractVersion: typeof METHOD_LAB_PREREGISTRATION_EXPORT_CONTRACT_VERSION;
@@ -16,6 +20,9 @@ export type MethodLabPreregistrationExport = {
   HYPOTHESIS: MethodLabExperimentPreregistration['HYPOTHESIS'];
   T0: MethodLabExperimentPreregistration['T0'];
   METHOD: MethodLabExperimentPreregistration['METHOD'];
+  POPULATION_SYSTEM: MethodLabExperimentPreregistration['POPULATION_SYSTEM'];
+  CONTROL: MethodLabExperimentPreregistration['CONTROL'];
+  VARIANTS: MethodLabExperimentPreregistration['VARIANTS'];
   STOPPING_TERMS: MethodLabExperimentPreregistration['STOPPING_RULE'];
   EXPECTED_SIGNAL: MethodLabExperimentPreregistration['EXPECTED_SIGNAL'];
   RETURN_CRITERIA: {
@@ -23,12 +30,13 @@ export type MethodLabPreregistrationExport = {
     falsification: MethodLabExperimentPreregistration['FALSIFICATION'];
   };
   REPRODUCIBILITY_REFS: {
-    evidenceRefs: string[];
-    modelRefs: string[];
-    passportRefs: string[];
-    twinStateRefs: string[];
-    parameterRefs: string[];
-    contextRefs: string[];
+    inputs: ReproducibilityRef[];
+    evidenceRefs: RoleRef[];
+    modelRefs: RoleRef[];
+    passportRefs: RoleRef[];
+    twinStateRefs: RoleRef[];
+    parameterRefs: RoleRef[];
+    contextRefs: RoleRef[];
   };
   boundaries: {
     externalRegistrationClaim: false;
@@ -36,6 +44,8 @@ export type MethodLabPreregistrationExport = {
     canonicalMutation: false;
     privateTwinPayloadIncluded: false;
     simulationBecomesObservation: false;
+    epistemicClassesPreserved: true;
+    frozenArmsPreserved: true;
   };
 };
 
@@ -52,8 +62,17 @@ function sha256(value: unknown) {
   return createHash('sha256').update(JSON.stringify(canonicalize(value))).digest('hex');
 }
 
-function refsByRole(preregistration: MethodLabExperimentPreregistration, role: MethodLabExperimentPreregistration['INPUTS'][number]['role']) {
-  return [...new Set(preregistration.INPUTS.filter((input) => input.role === role).map((input) => input.ref))].sort();
+function refsByRole(preregistration: MethodLabExperimentPreregistration, role: PreregistrationInput['role']): RoleRef[] {
+  return preregistration.INPUTS
+    .filter((item) => item.role === role)
+    .map((item) => ({ ref: item.ref, epistemicClass: item.epistemicClass }))
+    .sort((left, right) => left.ref.localeCompare(right.ref) || left.epistemicClass.localeCompare(right.epistemicClass));
+}
+
+function allInputRefs(preregistration: MethodLabExperimentPreregistration): ReproducibilityRef[] {
+  return preregistration.INPUTS
+    .map((item) => ({ ref: item.ref, role: item.role, epistemicClass: item.epistemicClass }))
+    .sort((left, right) => left.ref.localeCompare(right.ref) || left.role.localeCompare(right.role) || left.epistemicClass.localeCompare(right.epistemicClass));
 }
 
 export function buildMethodLabPreregistrationExport(input: {
@@ -71,6 +90,9 @@ export function buildMethodLabPreregistrationExport(input: {
     HYPOTHESIS: preregistration.HYPOTHESIS,
     T0: preregistration.T0,
     METHOD: preregistration.METHOD,
+    POPULATION_SYSTEM: preregistration.POPULATION_SYSTEM,
+    CONTROL: preregistration.CONTROL,
+    VARIANTS: preregistration.VARIANTS,
     STOPPING_TERMS: preregistration.STOPPING_RULE,
     EXPECTED_SIGNAL: preregistration.EXPECTED_SIGNAL,
     RETURN_CRITERIA: {
@@ -78,6 +100,7 @@ export function buildMethodLabPreregistrationExport(input: {
       falsification: preregistration.FALSIFICATION,
     },
     REPRODUCIBILITY_REFS: {
+      inputs: allInputRefs(preregistration),
       evidenceRefs: refsByRole(preregistration, 'EVIDENCE'),
       modelRefs: refsByRole(preregistration, 'MODEL'),
       passportRefs: refsByRole(preregistration, 'PASSPORT'),
@@ -99,6 +122,8 @@ export function buildMethodLabPreregistrationExport(input: {
       canonicalMutation: false,
       privateTwinPayloadIncluded: false,
       simulationBecomesObservation: false,
+      epistemicClassesPreserved: true,
+      frozenArmsPreserved: true,
     },
   };
 }


### PR DESCRIPTION
Parent: #403 / follow-up to merged #458. Owner: SFI-02 · Twin + Method Lab. Assurance: SFI-08. Integration: SFI-00.

This is a bounded corrective slice for two P1 findings discovered during independent review of the preregistration export:
1. Reproducibility refs must retain their epistemic class, so OBSERVED/SIMULATED/MISSING/etc. cannot collapse into an untyped string ref.
2. The export must carry the frozen POPULATION_SYSTEM, CONTROL and VARIANTS (including variant changes), otherwise a recipient cannot reconstruct the preregistered comparison.

Contract advances to SFI-METHOD-LAB-PREREGISTRATION-EXPORT-1.2. No new writer, table, route, authority, external registry, Twin payload, or canonical mutation is introduced. Export remains owner-scoped and read-only; EXPORT != EXTERNAL REGISTRATION.

Falsification: fail if epistemic class is lost, simulated/missing inputs can be confused with observed material, control/variant/population arms are omitted, private Twin payload appears, or external registration/canon promotion is claimed.