### PR TITLE
feat(case): add ROOT-only versioned private case brief assets

### DIFF
--- a/.github/workflows/sfi-private-case-brief.yml
+++ b/.github/workflows/sfi-private-case-brief.yml
@@ -1,0 +1,39 @@
+name: SFI Private Case Brief
+
+on:
+  pull_request:
+    paths:
+      - 'src/lib/sfi/case-platform/privateCaseBrief*.ts'
+      - 'src/app/api/root/private-case-brief/**'
+      - 'supabase/migrations/*private_case_assets*'
+      - 'scripts/qa-sfi-private-case-brief.ts'
+      - '.github/workflows/sfi-private-case-brief.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/lib/sfi/case-platform/privateCaseBrief*.ts'
+      - 'src/app/api/root/private-case-brief/**'
+      - 'supabase/migrations/*private_case_assets*'
+      - 'scripts/qa-sfi-private-case-brief.ts'
+      - '.github/workflows/sfi-private-case-brief.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Verify deterministic PDF, pagination, Unicode and cover lineage
+        run: node --import tsx --test src/lib/sfi/case-platform/privateCaseBriefContract.test.ts
+      - name: Verify ROOT/private/storage/state/rollback boundaries
+        run: npx tsx scripts/qa-sfi-private-case-brief.ts
+      - name: Typecheck
+        run: npm run typecheck

--- a/scripts/qa-sfi-private-case-brief.ts
+++ b/scripts/qa-sfi-private-case-brief.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const read = (path: string) => readFileSync(path, 'utf8');
+const contract = read('src/lib/sfi/case-platform/privateCaseBriefContract.ts');
+const runtime = read('src/lib/sfi/case-platform/privateCaseBrief.ts');
+const route = read('src/app/api/root/private-case-brief/route.ts');
+const migration = read('supabase/migrations/20260909062000_create_private_case_assets_bucket.sql');
+
+assert.match(contract, /SFI-PRIVATE-CASE-BRIEF-ASSET-1\.1/);
+assert.match(contract, /SFI-CASE-COVER-BRIEF-1\.1/);
+assert.match(contract, /do not invent actor, place, company, rupture, outcome or logo/i);
+assert.match(contract, /externalImageGenerated: input\.externalImageGenerated === true/);
+assert.match(contract, /publicationState: 'PRIVATE_DRAFT'/);
+assert.match(contract, /%PDF-1\.4/);
+assert.match(contract, /Report != evidence\. Report != decision/);
+assert.match(contract, /WinAnsiEncoding/);
+assert.match(contract, /<U\+\$\{codePoint\.toString/);
+assert.doesNotMatch(contract, /normalize\('NFKD'\)/, 'institutional text must not be destructively transliterated');
+assert.match(contract, /const detailChunks = chunks\(detailLines, 47\)/, 'detail section must paginate');
+assert.match(contract, /\/Count \$\{pageCount\}/, 'PDF page tree must reflect dynamic pagination');
+
+assert.match(runtime, /\.eq\('object_kind', 'EVIDENCE'\)/, 'case-specific cover lineage must come only from admitted EVIDENCE objects');
+assert.match(runtime, /version: nullableText\(row\.version\)/);
+assert.match(runtime, /hash: nullableText\(row\.hash\)/);
+assert.match(runtime, /sourceEvidenceRefs: evidenceRefs/);
+assert.match(runtime, /evidence_refs: evidenceRefs/);
+assert.match(runtime, /validateSfiCaseObjectDraft\(draft\)/);
+assert.match(runtime, /caseStatus === 'REJECTED'/);
+assert.ok(
+  runtime.indexOf("caseStatus === 'REJECTED'") < runtime.indexOf('.upload(storagePath, pdf'),
+  'rejected case must fail before storage mutation',
+);
+assert.match(runtime, /safeVersion\(generatedAt, objectId\)/, 'version identity must include collision-safe nonce');
+assert.match(runtime, /\.from\('sfi_case_objects'\)\.delete\(\)\.eq\('id', objectId\)/, 'audit failure must compensate manifest persistence');
+assert.match(runtime, /removeStoredAsset\(input\.service, storagePath\)/, 'failed mutation must compensate storage');
+assert.match(runtime, /object_kind: 'REPORT'/);
+assert.match(runtime, /epistemic_role: 'PROJECTION'/);
+assert.match(runtime, /approvedBy: null/);
+assert.match(runtime, /approvedAt: null/);
+assert.match(runtime, /publicationState: 'PRIVATE_DRAFT'/);
+assert.match(runtime, /generatedImageBytesClaimed: false/);
+assert.doesNotMatch(runtime, /publicationState:\s*['"]PUBLIC/);
+assert.doesNotMatch(runtime, /\.getPublicUrl\(/);
+assert.match(runtime, /createSignedUrl\(storagePath, 300\)/);
+
+assert.match(route, /requireRootViewer\('root\.private_case_brief\.read'\)/);
+assert.match(route, /requireRootActor\('root\.private_case_brief\.generate'\)/);
+assert.match(route, /autoPublication: false/);
+assert.match(route, /humanApprovalRequired: true/);
+assert.match(route, /fabricatedImageBytes: false/);
+assert.match(route, /Cache-Control': 'private, no-store'/);
+
+assert.match(migration, /'sfi-case-assets'/);
+assert.match(migration, /false,/);
+assert.match(migration, /application\/pdf/);
+assert.match(migration, /no authenticated storage\.objects policy/i);
+assert.doesNotMatch(migration, /create policy/i, 'private asset bucket must not gain direct authenticated read policies');
+
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-PRIVATE-CASE-BRIEF-ASSET-1.1',
+  existingOwner: 'sfi_case_objects/REPORT',
+  privateStorage: 'sfi-case-assets',
+  rootOnly: true,
+  pdfAssembly: 'REAL_BYTES_PAGINATED',
+  unicodePolicy: 'WINANSI_PLUS_LOSSLESS_CODEPOINT_ESCAPE',
+  lineage: 'FULL_CANONICAL_REF',
+  rejectedCaseMutation: 'FAILS_BEFORE_UPLOAD',
+  auditFailure: 'COMPENSATING_ROLLBACK',
+  collisionSafeVersion: true,
+  externalImageBytesWithoutProvider: false,
+  humanApprovalRequired: true,
+  autoPublication: false,
+}, null, 2));

--- a/scripts/qa-sfi-private-case-brief.ts
+++ b/scripts/qa-sfi-private-case-brief.ts
@@ -44,6 +44,10 @@ assert.ok(
 );
 assert.match(runtime, /safeVersion\(generatedAt, objectId\)/, 'version identity must include collision-safe nonce');
 assert.match(runtime, /loadUnifontGlyphs\(requiredPrivateCaseBriefCodePoints\(renderInput\)\)/);
+assert.ok(
+  runtime.indexOf('loadUnifontGlyphs(requiredPrivateCaseBriefCodePoints(renderInput))') < runtime.indexOf('.upload(storagePath, pdf'),
+  'external glyph source must resolve before durable mutation',
+);
 assert.match(runtime, /recordCanonicalCaseObjectAtomic\(/, 'private brief must use the canonical atomic writer');
 assert.doesNotMatch(runtime, /\.from\('sfi_case_objects'\)\.insert\(/, 'private brief must not maintain a second manifest writer');
 assert.doesNotMatch(runtime, /\.from\('sfi_case_audit_events'\)\.insert\(/, 'private brief audit must be inside the database transaction');

--- a/scripts/qa-sfi-private-case-brief.ts
+++ b/scripts/qa-sfi-private-case-brief.ts
@@ -4,27 +4,38 @@ import { readFileSync } from 'node:fs';
 const read = (path: string) => readFileSync(path, 'utf8');
 const contract = read('src/lib/sfi/case-platform/privateCaseBriefContract.ts');
 const runtime = read('src/lib/sfi/case-platform/privateCaseBrief.ts');
+const canonicalWriter = read('src/lib/sfi/case-platform/canonicalCaseObjectWriter.ts');
+const unicodeProvider = read('src/lib/sfi/case-platform/unifontType3.ts');
 const route = read('src/app/api/root/private-case-brief/route.ts');
-const migration = read('supabase/migrations/20260909062000_create_private_case_assets_bucket.sql');
+const storageMigration = read('supabase/migrations/20260909062000_create_private_case_assets_bucket.sql');
+const atomicMigration = read('supabase/migrations/20260909080500_sfi_case_object_atomic_writer_v1.sql');
 
-assert.match(contract, /SFI-PRIVATE-CASE-BRIEF-ASSET-1\.1/);
+assert.match(contract, /SFI-PRIVATE-CASE-BRIEF-ASSET-1\.2/);
 assert.match(contract, /SFI-CASE-COVER-BRIEF-1\.1/);
 assert.match(contract, /do not invent actor, place, company, rupture, outcome or logo/i);
 assert.match(contract, /externalImageGenerated: input\.externalImageGenerated === true/);
 assert.match(contract, /publicationState: 'PRIVATE_DRAFT'/);
 assert.match(contract, /%PDF-1\.4/);
 assert.match(contract, /Report != evidence\. Report != decision/);
-assert.match(contract, /WinAnsiEncoding/);
-assert.match(contract, /<U\+\$\{codePoint\.toString/);
+assert.match(contract, /\/Subtype \/Type3/);
+assert.match(contract, /\/ToUnicode/);
+assert.match(contract, /beginbfchar/);
+assert.doesNotMatch(contract, /<U\+\$\{codePoint\.toString/, 'Unicode characters must not be replaced by visible code-point notation');
 assert.doesNotMatch(contract, /normalize\('NFKD'\)/, 'institutional text must not be destructively transliterated');
-assert.match(contract, /const detailChunks = chunks\(detailLines, 47\)/, 'detail section must paginate');
-assert.match(contract, /\/Count \$\{pageCount\}/, 'PDF page tree must reflect dynamic pagination');
+assert.match(contract, /const detailChunks = chunks\(detailLines\(input\), 47\)/, 'detail section must paginate');
+assert.match(contract, /\/Count \$\{pageStreams\.length\}/, 'PDF page tree must reflect dynamic pagination');
+
+assert.match(unicodeProvider, /SFI_UNIFONT_VERSION = '16\.0\.04'/);
+assert.match(unicodeProvider, /unifont-\$\{SFI_UNIFONT_VERSION\}\.hex\.gz/);
+assert.match(unicodeProvider, /gunzipSync/);
+assert.match(unicodeProvider, /SFI_PRIVATE_CASE_BRIEF_UNICODE_GLYPH_UNAVAILABLE/);
+assert.match(unicodeProvider, /NON_BMP_UNSUPPORTED/, 'unsupported glyph domains must fail closed rather than corrupt text');
 
 assert.match(runtime, /\.eq\('object_kind', 'EVIDENCE'\)/, 'case-specific cover lineage must come only from admitted EVIDENCE objects');
 assert.match(runtime, /version: nullableText\(row\.version\)/);
 assert.match(runtime, /hash: nullableText\(row\.hash\)/);
 assert.match(runtime, /sourceEvidenceRefs: evidenceRefs/);
-assert.match(runtime, /evidence_refs: evidenceRefs/);
+assert.match(runtime, /evidenceRefs,/);
 assert.match(runtime, /validateSfiCaseObjectDraft\(draft\)/);
 assert.match(runtime, /caseStatus === 'REJECTED'/);
 assert.ok(
@@ -32,10 +43,13 @@ assert.ok(
   'rejected case must fail before storage mutation',
 );
 assert.match(runtime, /safeVersion\(generatedAt, objectId\)/, 'version identity must include collision-safe nonce');
-assert.match(runtime, /\.from\('sfi_case_objects'\)\.delete\(\)\.eq\('id', objectId\)/, 'audit failure must compensate manifest persistence');
-assert.match(runtime, /removeStoredAsset\(input\.service, storagePath\)/, 'failed mutation must compensate storage');
-assert.match(runtime, /object_kind: 'REPORT'/);
-assert.match(runtime, /epistemic_role: 'PROJECTION'/);
+assert.match(runtime, /loadUnifontGlyphs\(requiredPrivateCaseBriefCodePoints\(renderInput\)\)/);
+assert.match(runtime, /recordCanonicalCaseObjectAtomic\(/, 'private brief must use the canonical atomic writer');
+assert.doesNotMatch(runtime, /\.from\('sfi_case_objects'\)\.insert\(/, 'private brief must not maintain a second manifest writer');
+assert.doesNotMatch(runtime, /\.from\('sfi_case_audit_events'\)\.insert\(/, 'private brief audit must be inside the database transaction');
+assert.match(runtime, /removeStoredAsset\(input\.service, storagePath\)/, 'failed database transaction must compensate only the uploaded storage object');
+assert.match(runtime, /kind: 'REPORT'/);
+assert.match(runtime, /epistemicRole: 'PROJECTION'/);
 assert.match(runtime, /approvedBy: null/);
 assert.match(runtime, /approvedAt: null/);
 assert.match(runtime, /publicationState: 'PRIVATE_DRAFT'/);
@@ -44,6 +58,18 @@ assert.doesNotMatch(runtime, /publicationState:\s*['"]PUBLIC/);
 assert.doesNotMatch(runtime, /\.getPublicUrl\(/);
 assert.match(runtime, /createSignedUrl\(storagePath, 300\)/);
 
+assert.match(canonicalWriter, /sfi_record_case_object_atomic_v1/);
+assert.match(canonicalWriter, /validateSfiCaseObjectDraft\(draft\)/);
+assert.match(canonicalWriter, /SFI_CASE_OBJECT_CANONICAL_HASH_REQUIRED/);
+assert.match(atomicMigration, /for update;/i, 'atomic writer must lock the case row');
+assert.match(atomicMigration, /v_case\.status = 'REJECTED'/);
+assert.match(atomicMigration, /insert into public\.sfi_case_objects/);
+assert.match(atomicMigration, /update public\.sfi_cases[\s\S]*updated_at = now\(\)/);
+assert.match(atomicMigration, /insert into public\.sfi_case_audit_events/);
+assert.match(atomicMigration, /'atomic',true/);
+assert.match(atomicMigration, /grant execute on function public\.sfi_record_case_object_atomic_v1[\s\S]*service_role/);
+assert.doesNotMatch(atomicMigration, /grant execute[\s\S]*authenticated/);
+
 assert.match(route, /requireRootViewer\('root\.private_case_brief\.read'\)/);
 assert.match(route, /requireRootActor\('root\.private_case_brief\.generate'\)/);
 assert.match(route, /autoPublication: false/);
@@ -51,23 +77,26 @@ assert.match(route, /humanApprovalRequired: true/);
 assert.match(route, /fabricatedImageBytes: false/);
 assert.match(route, /Cache-Control': 'private, no-store'/);
 
-assert.match(migration, /'sfi-case-assets'/);
-assert.match(migration, /false,/);
-assert.match(migration, /application\/pdf/);
-assert.match(migration, /no authenticated storage\.objects policy/i);
-assert.doesNotMatch(migration, /create policy/i, 'private asset bucket must not gain direct authenticated read policies');
+assert.match(storageMigration, /'sfi-case-assets'/);
+assert.match(storageMigration, /false,/);
+assert.match(storageMigration, /application\/pdf/);
+assert.match(storageMigration, /no authenticated storage\.objects policy/i);
+assert.doesNotMatch(storageMigration, /create policy/i, 'private asset bucket must not gain direct authenticated read policies');
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-PRIVATE-CASE-BRIEF-ASSET-1.1',
+  contract: 'SFI-PRIVATE-CASE-BRIEF-ASSET-1.2',
   existingOwner: 'sfi_case_objects/REPORT',
+  canonicalWriter: 'sfi_record_case_object_atomic_v1',
   privateStorage: 'sfi-case-assets',
   rootOnly: true,
-  pdfAssembly: 'REAL_BYTES_PAGINATED',
-  unicodePolicy: 'WINANSI_PLUS_LOSSLESS_CODEPOINT_ESCAPE',
+  pdfAssembly: 'REAL_BYTES_PAGINATED_TYPE3_UNICODE',
+  unicodePolicy: 'GNU_UNIFONT_TYPE3_PLUS_TOUNICODE_FAIL_CLOSED',
   lineage: 'FULL_CANONICAL_REF',
-  rejectedCaseMutation: 'FAILS_BEFORE_UPLOAD',
-  auditFailure: 'COMPENSATING_ROLLBACK',
+  rejectedCaseMutation: 'FAILS_BEFORE_UPLOAD_AND_INSIDE_TRANSACTION',
+  manifestAuditAtomicity: 'ONE_POSTGRES_TRANSACTION',
+  caseFreshness: 'UPDATED_AT_IN_ATOMIC_WRITER',
+  failedDatabaseMutation: 'STORAGE_ONLY_COMPENSATION',
   collisionSafeVersion: true,
   externalImageBytesWithoutProvider: false,
   humanApprovalRequired: true,

--- a/src/app/api/root/private-case-brief/route.ts
+++ b/src/app/api/root/private-case-brief/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { requireRootActor, requireRootViewer } from '@/lib/root/server';
+import { createRootPrivateCaseBrief, readRootPrivateCaseBrief } from '@/lib/sfi/case-platform/privateCaseBrief';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+export async function GET(request: Request) {
+  const gate = await requireRootViewer('root.private_case_brief.read');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+  const caseId = new URL(request.url).searchParams.get('caseId')?.trim() || '';
+  if (!caseId) return NextResponse.json({ ok: false, error: 'case_id_required' }, { status: 400 });
+  try {
+    const asset = await readRootPrivateCaseBrief({ service: gate.ctx.service, caseId });
+    if (!asset) return NextResponse.json({ ok: false, error: 'private_case_brief_not_found' }, { status: 404 });
+    return NextResponse.json({ ok: true, asset }, { headers: { 'Cache-Control': 'private, no-store' } });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : String(error) }, { status: 503 });
+  }
+}
+
+export async function POST(request: Request) {
+  const gate = await requireRootActor('root.private_case_brief.generate');
+  if (!gate.ok) return NextResponse.json(gate.body, { status: gate.status });
+  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+  const caseId = typeof body.caseId === 'string' ? body.caseId.trim() : '';
+  if (!caseId) return NextResponse.json({ ok: false, error: 'case_id_required' }, { status: 400 });
+  try {
+    const asset = await createRootPrivateCaseBrief({ service: gate.ctx.service, actorId: gate.ctx.user.id, caseId });
+    return NextResponse.json({ ok: true, asset, boundaries: {
+      private: true,
+      rootOnly: true,
+      autoPublication: false,
+      humanApprovalRequired: true,
+      fabricatedImageBytes: false,
+      reportIsEvidence: false,
+      reportIsDecision: false,
+    } }, { status: 201, headers: { 'Cache-Control': 'private, no-store' } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const status = message.includes('NOT_FOUND') ? 404 : message.includes('WRITE_FORBIDDEN') ? 409 : 503;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+}

--- a/src/lib/sfi/case-platform/canonicalCaseObjectWriter.ts
+++ b/src/lib/sfi/case-platform/canonicalCaseObjectWriter.ts
@@ -1,0 +1,63 @@
+import 'server-only';
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { validateSfiCaseObjectDraft, type SfiCaseObjectDraft, type SfiCaseObjectKind } from '@/core/case-platform';
+import type { SfiCanonicalRef, SfiEpistemicClass } from '@/core/contracts/sfi';
+
+export type CanonicalCaseObjectWrite = {
+  id: string;
+  caseId: string;
+  kind: SfiCaseObjectKind;
+  epistemicRole: SfiEpistemicClass;
+  canonicalRef: SfiCanonicalRef;
+  sourceRefs?: SfiCanonicalRef[];
+  recordRefs?: SfiCanonicalRef[];
+  evidenceRefs?: SfiCanonicalRef[];
+  payload?: Record<string, unknown>;
+  observedAt?: string | null;
+};
+
+export async function recordCanonicalCaseObjectAtomic(input: {
+  service: SupabaseClient;
+  actorId: string;
+  object: CanonicalCaseObjectWrite;
+  auditAction?: string;
+  auditContext?: Record<string, unknown>;
+}) {
+  const draft: SfiCaseObjectDraft = {
+    kind: input.object.kind,
+    epistemicRole: input.object.epistemicRole,
+    canonicalRef: input.object.canonicalRef,
+    sourceRefs: input.object.sourceRefs ?? [],
+    recordRefs: input.object.recordRefs ?? [],
+    evidenceRefs: input.object.evidenceRefs ?? [],
+  };
+  const violations = validateSfiCaseObjectDraft(draft);
+  if (violations.length) throw new Error(`SFI_CASE_OBJECT_INVALID:${violations.join(',')}`);
+  if (!input.object.id.trim()) throw new Error('SFI_CASE_OBJECT_ID_REQUIRED');
+  if (!input.object.caseId.trim()) throw new Error('SFI_CASE_OBJECT_CASE_ID_REQUIRED');
+  if (!input.object.canonicalRef.id.trim()) throw new Error('SFI_CASE_OBJECT_CANONICAL_REF_REQUIRED');
+  if (!input.object.canonicalRef.hash?.trim()) throw new Error('SFI_CASE_OBJECT_CANONICAL_HASH_REQUIRED');
+  if (input.object.observedAt && Number.isNaN(Date.parse(input.object.observedAt))) throw new Error('SFI_CASE_OBJECT_OBSERVED_AT_INVALID');
+
+  const result = await input.service.rpc('sfi_record_case_object_atomic_v1', {
+    p_case_id: input.object.caseId,
+    p_actor_id: input.actorId,
+    p_object: {
+      id: input.object.id,
+      kind: input.object.kind,
+      epistemicRole: input.object.epistemicRole,
+      canonicalRef: input.object.canonicalRef,
+      sourceRefs: input.object.sourceRefs ?? [],
+      recordRefs: input.object.recordRefs ?? [],
+      evidenceRefs: input.object.evidenceRefs ?? [],
+      payload: input.object.payload ?? {},
+      observedAt: input.object.observedAt ?? null,
+    },
+    p_audit_action: input.auditAction?.trim() || 'CASE_OBJECT_RECORDED',
+    p_audit_context: input.auditContext ?? {},
+  });
+  if (result.error) throw new Error(`SFI_CASE_OBJECT_ATOMIC_WRITE_FAILED:${result.error.message}`);
+  if (!result.data || typeof result.data !== 'object') throw new Error('SFI_CASE_OBJECT_ATOMIC_WRITE_EMPTY');
+  return result.data as Record<string, unknown>;
+}

--- a/src/lib/sfi/case-platform/privateCaseBrief.ts
+++ b/src/lib/sfi/case-platform/privateCaseBrief.ts
@@ -1,0 +1,232 @@
+import 'server-only';
+
+import { randomUUID } from 'node:crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { validateSfiCaseObjectDraft, type SfiCaseObjectDraft } from '@/core/case-platform';
+import type { SfiCanonicalRef } from '@/core/contracts/sfi';
+import {
+  SFI_CASE_ASSET_BUCKET,
+  SFI_PRIVATE_CASE_BRIEF_ASSET_CONTRACT,
+  buildSfiCaseCoverBrief,
+  formatCanonicalRef,
+  renderPrivateCaseBriefPdf,
+  sha256Hex,
+} from './privateCaseBriefContract';
+
+type Row = Record<string, unknown>;
+
+function record(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function nullableText(value: unknown) {
+  const valueText = text(value);
+  return valueText || null;
+}
+
+function canonicalRef(value: unknown): SfiCanonicalRef {
+  const row = record(value);
+  const id = text(row.id);
+  if (!id) throw new Error('SFI_PRIVATE_CASE_BRIEF_CORRUPT_EVIDENCE_REF');
+  return { id, version: nullableText(row.version), hash: nullableText(row.hash) };
+}
+
+function canonicalRefKey(ref: SfiCanonicalRef) {
+  return `${ref.id}\u0000${ref.version ?? ''}\u0000${ref.hash ?? ''}`;
+}
+
+function uniqueCanonicalRefs(values: unknown[]) {
+  const byKey = new Map<string, SfiCanonicalRef>();
+  for (const value of values) {
+    const ref = canonicalRef(value);
+    byKey.set(canonicalRefKey(ref), ref);
+  }
+  return [...byKey.values()].sort((a, b) => canonicalRefKey(a).localeCompare(canonicalRefKey(b)));
+}
+
+function safeVersion(now: Date, nonce: string) {
+  const timestamp = now.toISOString().replace(/\D/g, '').slice(0, 17);
+  const suffix = nonce.replace(/[^a-zA-Z0-9]/g, '').slice(0, 12);
+  return `${timestamp}-${suffix}`;
+}
+
+async function removeStoredAsset(service: SupabaseClient, storagePath: string) {
+  const removed = await service.storage.from(SFI_CASE_ASSET_BUCKET).remove([storagePath]);
+  return removed.error?.message ?? null;
+}
+
+export async function createRootPrivateCaseBrief(input: {
+  service: SupabaseClient;
+  actorId: string;
+  caseId: string;
+}) {
+  const caseId = input.caseId.trim();
+  if (!caseId) throw new Error('SFI_PRIVATE_CASE_BRIEF_CASE_REQUIRED');
+
+  const caseRead = await input.service.from('sfi_cases')
+    .select('id,owner_id,tenant_id,subject,scope,status,version')
+    .eq('id', caseId)
+    .is('deleted_at', null)
+    .maybeSingle();
+  if (caseRead.error) throw new Error(`SFI_PRIVATE_CASE_BRIEF_CASE_READ_FAILED:${caseRead.error.message}`);
+  if (!caseRead.data) throw new Error('SFI_PRIVATE_CASE_BRIEF_CASE_NOT_FOUND');
+
+  const caseStatus = text(caseRead.data.status);
+  if (caseStatus === 'REJECTED') throw new Error('SFI_CASE_OBJECT_WRITE_FORBIDDEN:REJECTED');
+
+  const evidenceRead = await input.service.from('sfi_case_objects')
+    .select('canonical_ref')
+    .eq('case_id', caseId)
+    .eq('owner_id', caseRead.data.owner_id)
+    .eq('tenant_id', caseRead.data.tenant_id)
+    .eq('object_kind', 'EVIDENCE')
+    .order('created_at', { ascending: true });
+  if (evidenceRead.error) throw new Error(`SFI_PRIVATE_CASE_BRIEF_EVIDENCE_READ_FAILED:${evidenceRead.error.message}`);
+  const evidenceRefs = uniqueCanonicalRefs(((evidenceRead.data ?? []) as Row[]).map((row) => row.canonical_ref));
+
+  const generatedAt = new Date();
+  const objectId = randomUUID();
+  const version = safeVersion(generatedAt, objectId);
+  const coverBrief = buildSfiCaseCoverBrief({ caseId, sourceEvidenceRefs: evidenceRefs });
+  const pdf = renderPrivateCaseBriefPdf({
+    caseId,
+    version,
+    subject: text(caseRead.data.subject),
+    scope: text(caseRead.data.scope),
+    generatedAt: generatedAt.toISOString(),
+    evidenceRefs,
+    coverBrief,
+  });
+  const pdfSha256 = sha256Hex(pdf);
+  const storagePath = `${caseRead.data.tenant_id}/${caseId}/${version}/case-brief-${pdfSha256.slice(0, 12)}.pdf`;
+  const briefRef: SfiCanonicalRef = {
+    id: `sfi-private-case-brief:${caseId}:${version}`,
+    version,
+    hash: pdfSha256,
+  };
+  const payload = {
+    contract: SFI_PRIVATE_CASE_BRIEF_ASSET_CONTRACT,
+    caseId,
+    version,
+    assetType: 'PRIVATE_CASE_BRIEF_PDF',
+    privateStorage: true,
+    storageBucket: SFI_CASE_ASSET_BUCKET,
+    storagePath,
+    mimeType: 'application/pdf',
+    byteLength: pdf.byteLength,
+    sha256: pdfSha256,
+    sourceEvidenceRefs: evidenceRefs,
+    sourceEvidenceIds: evidenceRefs.map((ref) => ref.id),
+    sourceEvidenceLabels: evidenceRefs.map(formatCanonicalRef),
+    coverBrief,
+    imageProvider: {
+      state: 'NOT_CONFIGURED',
+      provider: null,
+      model: null,
+      generatedImageBytesClaimed: false,
+      rule: 'No external cover-image bytes are claimed without a configured provider receipt.',
+    },
+    generatedAt: generatedAt.toISOString(),
+    generatedBy: input.actorId,
+    approvedBy: null,
+    approvedAt: null,
+    publicationState: 'PRIVATE_DRAFT',
+    executionAuthority: false,
+    canonicalPromotion: false,
+    limitations: evidenceRefs.length ? [] : ['NO_ADMITTED_CASE_EVIDENCE_REFS_AT_ASSEMBLY_TIME'],
+  };
+
+  const draft: SfiCaseObjectDraft = {
+    kind: 'REPORT',
+    epistemicRole: 'PROJECTION',
+    canonicalRef: briefRef,
+    sourceRefs: [],
+    recordRefs: [],
+    evidenceRefs,
+  };
+  const violations = validateSfiCaseObjectDraft(draft);
+  if (violations.length) throw new Error(`SFI_PRIVATE_CASE_BRIEF_OBJECT_INVALID:${violations.join(',')}`);
+
+  const upload = await input.service.storage.from(SFI_CASE_ASSET_BUCKET).upload(storagePath, pdf, {
+    contentType: 'application/pdf',
+    cacheControl: '0',
+    upsert: false,
+  });
+  if (upload.error) throw new Error(`SFI_PRIVATE_CASE_BRIEF_UPLOAD_FAILED:${upload.error.message}`);
+
+  const inserted = await input.service.from('sfi_case_objects').insert({
+    id: objectId,
+    case_id: caseId,
+    owner_id: caseRead.data.owner_id,
+    tenant_id: caseRead.data.tenant_id,
+    object_kind: 'REPORT',
+    epistemic_role: 'PROJECTION',
+    canonical_ref: briefRef,
+    source_refs: [],
+    record_refs: [],
+    evidence_refs: evidenceRefs,
+    payload,
+    observed_at: null,
+  }).select('id,created_at').single();
+  if (inserted.error || !inserted.data) {
+    const storageRollbackError = await removeStoredAsset(input.service, storagePath);
+    if (storageRollbackError) {
+      throw new Error(`SFI_PRIVATE_CASE_BRIEF_PERSIST_FAILED_ROLLBACK_FAILED:${inserted.error?.message ?? 'unknown'}:${storageRollbackError}`);
+    }
+    throw new Error(`SFI_PRIVATE_CASE_BRIEF_PERSIST_FAILED:${inserted.error?.message ?? 'unknown'}`);
+  }
+
+  const audit = await input.service.from('sfi_case_audit_events').insert({
+    case_id: caseId,
+    tenant_id: caseRead.data.tenant_id,
+    actor_id: input.actorId,
+    action: 'case.private_brief.generated',
+    before_state: null,
+    after_state: { objectId, canonicalRef: briefRef, publicationState: 'PRIVATE_DRAFT' },
+    context: { storagePath, pdfSha256, evidenceRefs },
+  });
+  if (audit.error) {
+    const objectRollback = await input.service.from('sfi_case_objects').delete().eq('id', objectId);
+    const storageRollbackError = await removeStoredAsset(input.service, storagePath);
+    if (objectRollback.error || storageRollbackError) {
+      throw new Error(`SFI_PRIVATE_CASE_BRIEF_AUDIT_FAILED_ROLLBACK_FAILED:${audit.error.message}:${objectRollback.error?.message ?? 'object_rollback_ok'}:${storageRollbackError ?? 'storage_rollback_ok'}`);
+    }
+    throw new Error(`SFI_PRIVATE_CASE_BRIEF_AUDIT_FAILED:${audit.error.message}`);
+  }
+
+  return { ok: true as const, objectId, canonicalRef: briefRef, payload, createdAt: inserted.data.created_at };
+}
+
+export async function readRootPrivateCaseBrief(input: {
+  service: SupabaseClient;
+  caseId: string;
+}) {
+  const latest = await input.service.from('sfi_case_objects')
+    .select('id,canonical_ref,payload,created_at')
+    .eq('case_id', input.caseId)
+    .eq('object_kind', 'REPORT')
+    .eq('epistemic_role', 'PROJECTION')
+    .filter('payload->>contract', 'eq', SFI_PRIVATE_CASE_BRIEF_ASSET_CONTRACT)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (latest.error) throw new Error(`SFI_PRIVATE_CASE_BRIEF_READ_FAILED:${latest.error.message}`);
+  if (!latest.data) return null;
+  const payload = latest.data.payload as Row;
+  const storagePath = text(payload.storagePath);
+  if (!storagePath) throw new Error('SFI_PRIVATE_CASE_BRIEF_STORAGE_PATH_MISSING');
+  const signed = await input.service.storage.from(SFI_CASE_ASSET_BUCKET).createSignedUrl(storagePath, 300);
+  if (signed.error || !signed.data?.signedUrl) throw new Error(`SFI_PRIVATE_CASE_BRIEF_SIGN_FAILED:${signed.error?.message ?? 'unknown'}`);
+  return {
+    id: latest.data.id,
+    canonicalRef: latest.data.canonical_ref,
+    payload,
+    createdAt: latest.data.created_at,
+    signedUrl: signed.data.signedUrl,
+    signedUrlExpiresInSeconds: 300,
+  };
+}

--- a/src/lib/sfi/case-platform/privateCaseBrief.ts
+++ b/src/lib/sfi/case-platform/privateCaseBrief.ts
@@ -4,14 +4,17 @@ import { randomUUID } from 'node:crypto';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { validateSfiCaseObjectDraft, type SfiCaseObjectDraft } from '@/core/case-platform';
 import type { SfiCanonicalRef } from '@/core/contracts/sfi';
+import { recordCanonicalCaseObjectAtomic } from './canonicalCaseObjectWriter';
 import {
   SFI_CASE_ASSET_BUCKET,
   SFI_PRIVATE_CASE_BRIEF_ASSET_CONTRACT,
   buildSfiCaseCoverBrief,
   formatCanonicalRef,
   renderPrivateCaseBriefPdf,
+  requiredPrivateCaseBriefCodePoints,
   sha256Hex,
 } from './privateCaseBriefContract';
+import { loadUnifontGlyphs, SFI_UNIFONT_SOURCE, SFI_UNIFONT_VERSION } from './unifontType3';
 
 type Row = Record<string, unknown>;
 
@@ -92,7 +95,7 @@ export async function createRootPrivateCaseBrief(input: {
   const objectId = randomUUID();
   const version = safeVersion(generatedAt, objectId);
   const coverBrief = buildSfiCaseCoverBrief({ caseId, sourceEvidenceRefs: evidenceRefs });
-  const pdf = renderPrivateCaseBriefPdf({
+  const renderInput = {
     caseId,
     version,
     subject: text(caseRead.data.subject),
@@ -100,7 +103,9 @@ export async function createRootPrivateCaseBrief(input: {
     generatedAt: generatedAt.toISOString(),
     evidenceRefs,
     coverBrief,
-  });
+  };
+  const unicodeGlyphs = await loadUnifontGlyphs(requiredPrivateCaseBriefCodePoints(renderInput));
+  const pdf = renderPrivateCaseBriefPdf(renderInput, unicodeGlyphs);
   const pdfSha256 = sha256Hex(pdf);
   const storagePath = `${caseRead.data.tenant_id}/${caseId}/${version}/case-brief-${pdfSha256.slice(0, 12)}.pdf`;
   const briefRef: SfiCanonicalRef = {
@@ -123,6 +128,15 @@ export async function createRootPrivateCaseBrief(input: {
     sourceEvidenceIds: evidenceRefs.map((ref) => ref.id),
     sourceEvidenceLabels: evidenceRefs.map(formatCanonicalRef),
     coverBrief,
+    unicodeFont: {
+      state: 'EMBEDDED_TYPE3',
+      family: 'GNU Unifont',
+      version: SFI_UNIFONT_VERSION,
+      source: SFI_UNIFONT_SOURCE,
+      authoredCodePointsPreserved: true,
+      toUnicodeCMap: true,
+      sourceFetchedBeforeMutation: true,
+    },
     imageProvider: {
       state: 'NOT_CONFIGURED',
       provider: null,
@@ -158,47 +172,45 @@ export async function createRootPrivateCaseBrief(input: {
   });
   if (upload.error) throw new Error(`SFI_PRIVATE_CASE_BRIEF_UPLOAD_FAILED:${upload.error.message}`);
 
-  const inserted = await input.service.from('sfi_case_objects').insert({
-    id: objectId,
-    case_id: caseId,
-    owner_id: caseRead.data.owner_id,
-    tenant_id: caseRead.data.tenant_id,
-    object_kind: 'REPORT',
-    epistemic_role: 'PROJECTION',
-    canonical_ref: briefRef,
-    source_refs: [],
-    record_refs: [],
-    evidence_refs: evidenceRefs,
-    payload,
-    observed_at: null,
-  }).select('id,created_at').single();
-  if (inserted.error || !inserted.data) {
+  let persisted: Record<string, unknown>;
+  try {
+    persisted = await recordCanonicalCaseObjectAtomic({
+      service: input.service,
+      actorId: input.actorId,
+      object: {
+        id: objectId,
+        caseId,
+        kind: 'REPORT',
+        epistemicRole: 'PROJECTION',
+        canonicalRef: briefRef,
+        sourceRefs: [],
+        recordRefs: [],
+        evidenceRefs,
+        payload,
+        observedAt: null,
+      },
+      auditAction: 'case.private_brief.generated',
+      auditContext: { storagePath, pdfSha256, evidenceRefs, publicationState: 'PRIVATE_DRAFT' },
+    });
+  } catch (error) {
     const storageRollbackError = await removeStoredAsset(input.service, storagePath);
+    const reason = error instanceof Error ? error.message : String(error);
     if (storageRollbackError) {
-      throw new Error(`SFI_PRIVATE_CASE_BRIEF_PERSIST_FAILED_ROLLBACK_FAILED:${inserted.error?.message ?? 'unknown'}:${storageRollbackError}`);
+      throw new Error(`SFI_PRIVATE_CASE_BRIEF_ATOMIC_PERSIST_FAILED_STORAGE_ROLLBACK_FAILED:${reason}:${storageRollbackError}`);
     }
-    throw new Error(`SFI_PRIVATE_CASE_BRIEF_PERSIST_FAILED:${inserted.error?.message ?? 'unknown'}`);
+    throw new Error(`SFI_PRIVATE_CASE_BRIEF_ATOMIC_PERSIST_FAILED:${reason}`);
   }
 
-  const audit = await input.service.from('sfi_case_audit_events').insert({
-    case_id: caseId,
-    tenant_id: caseRead.data.tenant_id,
-    actor_id: input.actorId,
-    action: 'case.private_brief.generated',
-    before_state: null,
-    after_state: { objectId, canonicalRef: briefRef, publicationState: 'PRIVATE_DRAFT' },
-    context: { storagePath, pdfSha256, evidenceRefs },
-  });
-  if (audit.error) {
-    const objectRollback = await input.service.from('sfi_case_objects').delete().eq('id', objectId);
-    const storageRollbackError = await removeStoredAsset(input.service, storagePath);
-    if (objectRollback.error || storageRollbackError) {
-      throw new Error(`SFI_PRIVATE_CASE_BRIEF_AUDIT_FAILED_ROLLBACK_FAILED:${audit.error.message}:${objectRollback.error?.message ?? 'object_rollback_ok'}:${storageRollbackError ?? 'storage_rollback_ok'}`);
-    }
-    throw new Error(`SFI_PRIVATE_CASE_BRIEF_AUDIT_FAILED:${audit.error.message}`);
-  }
-
-  return { ok: true as const, objectId, canonicalRef: briefRef, payload, createdAt: inserted.data.created_at };
+  const persistedObject = record(persisted.object);
+  if (text(persistedObject.id) !== objectId) throw new Error('SFI_PRIVATE_CASE_BRIEF_ATOMIC_WRITER_ID_MISMATCH');
+  return {
+    ok: true as const,
+    objectId,
+    canonicalRef: briefRef,
+    payload,
+    createdAt: text(persistedObject.created_at) || generatedAt.toISOString(),
+    atomic: persisted.atomic === true,
+  };
 }
 
 export async function readRootPrivateCaseBrief(input: {

--- a/src/lib/sfi/case-platform/privateCaseBriefContract.test.ts
+++ b/src/lib/sfi/case-platform/privateCaseBriefContract.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildSfiCaseCoverBrief, renderPrivateCaseBriefPdf, sha256Hex } from './privateCaseBriefContract';
+
+const evidence = (id: string, version: string | null = null, hash: string | null = null) => ({ id, version, hash });
+
+test('cover brief preserves complete evidence identity and remains evidence-bounded', () => {
+  const brief = buildSfiCaseCoverBrief({
+    caseId: 'CASE-001',
+    sourceEvidenceRefs: [
+      evidence('evidence:b', 'v2', 'hash-b'),
+      evidence('evidence:a', 'v1', 'hash-a'),
+      evidence('evidence:a', 'v1', 'hash-a'),
+    ],
+  });
+  assert.deepEqual(brief.sourceEvidenceRefs, [
+    evidence('evidence:a', 'v1', 'hash-a'),
+    evidence('evidence:b', 'v2', 'hash-b'),
+  ]);
+  assert.equal(brief.externalImageGenerated, false);
+  assert.equal(brief.provider, null);
+  assert.equal(brief.approvalRequired, true);
+  assert.equal(brief.publicationState, 'PRIVATE_DRAFT');
+  assert.equal(brief.visibleTextAllowed, false);
+  assert.match(brief.prompt, /evidence:a@v1#hash-a/);
+  assert.match(brief.prompt, /Do not render the reference identifiers as visible text/);
+});
+
+test('no-evidence cover brief refuses case-specific invention', () => {
+  const brief = buildSfiCaseCoverBrief({ caseId: 'CASE-EMPTY', sourceEvidenceRefs: [] });
+  assert.match(brief.prompt, /do not invent actor, place, company, rupture, outcome or logo/i);
+});
+
+test('private brief renderer emits deterministic PDF and preserves international text without question-mark loss', () => {
+  const refs = [evidence('evidence:a', 'v1', 'sha256:abc')];
+  const coverBrief = buildSfiCaseCoverBrief({ caseId: 'CASE-001', sourceEvidenceRefs: refs });
+  const input = {
+    caseId: 'CASE-001',
+    version: '20260909000100123-abcd1234',
+    subject: 'Decisión pública — México / 王',
+    scope: 'Reconstrucción bounded: señal, fricción y continuidad.',
+    generatedAt: '2026-09-09T06:20:00.000Z',
+    evidenceRefs: refs,
+    coverBrief,
+  };
+  const first = renderPrivateCaseBriefPdf(input);
+  const second = renderPrivateCaseBriefPdf(input);
+  const raw = first.toString('ascii');
+  assert.ok(first.byteLength > 1200);
+  assert.equal(first.subarray(0, 8).toString('ascii'), '%PDF-1.4');
+  assert.match(first.subarray(-32).toString('ascii'), /%%EOF/);
+  assert.match(raw, /WinAnsiEncoding/);
+  assert.match(raw, /<U\+738B>/, 'non-WinAnsi characters must preserve their Unicode code point visibly');
+  assert.doesNotMatch(raw, /Decisi\?n|M\?xico|Reconstrucci\?n/);
+  assert.equal(sha256Hex(first), sha256Hex(second));
+  assert.equal(first.equals(second), true);
+});
+
+test('detail renderer paginates long evidence lineage instead of clipping it', () => {
+  const refs = Array.from({ length: 140 }, (_, index) => evidence(`evidence:${String(index).padStart(3, '0')}`, `v${index}`, `hash-${index}`));
+  const coverBrief = buildSfiCaseCoverBrief({ caseId: 'CASE-LONG', sourceEvidenceRefs: refs });
+  const pdf = renderPrivateCaseBriefPdf({
+    caseId: 'CASE-LONG',
+    version: '20260909000100123-long',
+    subject: 'Long evidence case',
+    scope: 'A deliberately long detail section that must continue across multiple pages.',
+    generatedAt: '2026-09-09T06:20:00.000Z',
+    evidenceRefs: refs,
+    coverBrief,
+  });
+  const raw = pdf.toString('ascii');
+  const count = Number(raw.match(/\/Count (\d+)/)?.[1] ?? '0');
+  assert.ok(count >= 5, `expected multi-page PDF, got ${count} pages`);
+  assert.match(raw, /evidence:139@v139#hash-139/);
+  assert.match(raw, /Publication requires separate human\/governance authorization/);
+});

--- a/src/lib/sfi/case-platform/privateCaseBriefContract.test.ts
+++ b/src/lib/sfi/case-platform/privateCaseBriefContract.test.ts
@@ -1,8 +1,28 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { buildSfiCaseCoverBrief, renderPrivateCaseBriefPdf, sha256Hex } from './privateCaseBriefContract';
+import {
+  buildSfiCaseCoverBrief,
+  renderPrivateCaseBriefPdf,
+  requiredPrivateCaseBriefCodePoints,
+  sha256Hex,
+  type PrivateCaseBriefRenderInput,
+} from './privateCaseBriefContract';
+import { parseUnifontHex, type SfiUnifontGlyph } from './unifontType3';
 
 const evidence = (id: string, version: string | null = null, hash: string | null = null) => ({ id, version, hash });
+
+function fixtureGlyphs(input: PrivateCaseBriefRenderInput) {
+  const glyphs = new Map<number, SfiUnifontGlyph>();
+  for (const codePoint of requiredPrivateCaseBriefCodePoints(input)) {
+    const width: 8 | 16 = codePoint > 0xff ? 16 : 8;
+    const mask = width === 8 ? 0xff : 0xffff;
+    const rows = codePoint === 0x20
+      ? Array.from({ length: 16 }, () => 0)
+      : Array.from({ length: 16 }, (_, row) => ((codePoint * (row + 3)) ^ (0x5a5a >>> (row % 4))) & mask);
+    glyphs.set(codePoint, { codePoint, width, rows });
+  }
+  return glyphs;
+}
 
 test('cover brief preserves complete evidence identity and remains evidence-bounded', () => {
   const brief = buildSfiCaseCoverBrief({
@@ -31,27 +51,44 @@ test('no-evidence cover brief refuses case-specific invention', () => {
   assert.match(brief.prompt, /do not invent actor, place, company, rupture, outcome or logo/i);
 });
 
-test('private brief renderer emits deterministic PDF and preserves international text without question-mark loss', () => {
+test('Unifont parser preserves requested glyph identities across scripts', () => {
+  const requested = new Set([0x738b, 0x0416, 0x0639]);
+  const source = [
+    `0416:${'18'.repeat(16)}`,
+    `0639:${'3C'.repeat(16)}`,
+    `738B:${'0180'.repeat(16)}`,
+  ].join('\n');
+  const parsed = parseUnifontHex(source, requested);
+  assert.equal(parsed.get(0x738b)?.width, 16);
+  assert.equal(parsed.get(0x0416)?.width, 8);
+  assert.equal(parsed.get(0x0639)?.rows.length, 16);
+});
+
+test('private brief renderer emits deterministic Type3 PDF with authored Unicode ToUnicode mappings', () => {
   const refs = [evidence('evidence:a', 'v1', 'sha256:abc')];
   const coverBrief = buildSfiCaseCoverBrief({ caseId: 'CASE-001', sourceEvidenceRefs: refs });
-  const input = {
+  const input: PrivateCaseBriefRenderInput = {
     caseId: 'CASE-001',
     version: '20260909000100123-abcd1234',
-    subject: 'Decisión pública — México / 王',
+    subject: 'Decisión pública — México / 王 / Ж / ع',
     scope: 'Reconstrucción bounded: señal, fricción y continuidad.',
     generatedAt: '2026-09-09T06:20:00.000Z',
     evidenceRefs: refs,
     coverBrief,
   };
-  const first = renderPrivateCaseBriefPdf(input);
-  const second = renderPrivateCaseBriefPdf(input);
+  const glyphs = fixtureGlyphs(input);
+  const first = renderPrivateCaseBriefPdf(input, glyphs);
+  const second = renderPrivateCaseBriefPdf(input, glyphs);
   const raw = first.toString('ascii');
   assert.ok(first.byteLength > 1200);
   assert.equal(first.subarray(0, 8).toString('ascii'), '%PDF-1.4');
   assert.match(first.subarray(-32).toString('ascii'), /%%EOF/);
-  assert.match(raw, /WinAnsiEncoding/);
-  assert.match(raw, /<U\+738B>/, 'non-WinAnsi characters must preserve their Unicode code point visibly');
-  assert.doesNotMatch(raw, /Decisi\?n|M\?xico|Reconstrucci\?n/);
+  assert.match(raw, /\/Subtype \/Type3/);
+  assert.match(raw, /\/ToUnicode/);
+  assert.match(raw, /<[0-9A-F]{2}> <738B>/, 'Chinese authored code point must have a real ToUnicode mapping');
+  assert.match(raw, /<[0-9A-F]{2}> <0416>/, 'Cyrillic authored code point must have a real ToUnicode mapping');
+  assert.match(raw, /<[0-9A-F]{2}> <0639>/, 'Arabic authored code point must have a real ToUnicode mapping');
+  assert.doesNotMatch(raw, /<U\+[0-9A-F]+>/, 'code-point escape notation is not a glyph');
   assert.equal(sha256Hex(first), sha256Hex(second));
   assert.equal(first.equals(second), true);
 });
@@ -59,7 +96,7 @@ test('private brief renderer emits deterministic PDF and preserves international
 test('detail renderer paginates long evidence lineage instead of clipping it', () => {
   const refs = Array.from({ length: 140 }, (_, index) => evidence(`evidence:${String(index).padStart(3, '0')}`, `v${index}`, `hash-${index}`));
   const coverBrief = buildSfiCaseCoverBrief({ caseId: 'CASE-LONG', sourceEvidenceRefs: refs });
-  const pdf = renderPrivateCaseBriefPdf({
+  const input: PrivateCaseBriefRenderInput = {
     caseId: 'CASE-LONG',
     version: '20260909000100123-long',
     subject: 'Long evidence case',
@@ -67,10 +104,11 @@ test('detail renderer paginates long evidence lineage instead of clipping it', (
     generatedAt: '2026-09-09T06:20:00.000Z',
     evidenceRefs: refs,
     coverBrief,
-  });
+  };
+  const pdf = renderPrivateCaseBriefPdf(input, fixtureGlyphs(input));
   const raw = pdf.toString('ascii');
   const count = Number(raw.match(/\/Count (\d+)/)?.[1] ?? '0');
   assert.ok(count >= 5, `expected multi-page PDF, got ${count} pages`);
-  assert.match(raw, /evidence:139@v139#hash-139/);
-  assert.match(raw, /Publication requires separate human\/governance authorization/);
+  assert.match(raw, /\/ToUnicode/);
+  assert.doesNotMatch(raw, /<U\+/);
 });

--- a/src/lib/sfi/case-platform/privateCaseBriefContract.ts
+++ b/src/lib/sfi/case-platform/privateCaseBriefContract.ts
@@ -1,0 +1,224 @@
+import { createHash } from 'node:crypto';
+import type { SfiCanonicalRef } from '@/core/contracts/sfi';
+
+export const SFI_PRIVATE_CASE_BRIEF_ASSET_CONTRACT = 'SFI-PRIVATE-CASE-BRIEF-ASSET-1.1' as const;
+export const SFI_CASE_COVER_BRIEF_CONTRACT = 'SFI-CASE-COVER-BRIEF-1.1' as const;
+export const SFI_CASE_ASSET_BUCKET = 'sfi-case-assets' as const;
+
+const BASE_COVER_BRIEF = 'Refined high-end editorial cover for a System Friction Institute case brief. Deep black field, restrained warm-gold illumination, precise institutional geometry and a central real-world operational metaphor. Show signal, structure, interruption and unresolved continuity without using dashboard UI, infographic blocks, logos from the observed company or unverified claims. Minimal, sovereign, contemporary, cinematic, evidence-oriented. No visible text unless typography is added later by the document renderer.';
+
+export type SfiCaseCoverBrief = {
+  contract: typeof SFI_CASE_COVER_BRIEF_CONTRACT;
+  caseId: string;
+  prompt: string;
+  sourceEvidenceRefs: SfiCanonicalRef[];
+  visibleTextAllowed: false;
+  externalImageGenerated: boolean;
+  provider: string | null;
+  model: string | null;
+  approvalRequired: true;
+  publicationState: 'PRIVATE_DRAFT';
+};
+
+function nullableText(value: string | null | undefined) {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed || null;
+}
+
+function normalizeRef(ref: SfiCanonicalRef): SfiCanonicalRef {
+  const id = ref.id.trim();
+  if (!id) throw new Error('SFI_CASE_COVER_EVIDENCE_REF_ID_REQUIRED');
+  return { id, version: nullableText(ref.version), hash: nullableText(ref.hash) };
+}
+
+function refKey(ref: SfiCanonicalRef) {
+  return `${ref.id}\u0000${ref.version ?? ''}\u0000${ref.hash ?? ''}`;
+}
+
+export function formatCanonicalRef(ref: SfiCanonicalRef) {
+  return `${ref.id}${ref.version ? `@${ref.version}` : ''}${ref.hash ? `#${ref.hash}` : ''}`;
+}
+
+export function buildSfiCaseCoverBrief(input: {
+  caseId: string;
+  sourceEvidenceRefs: SfiCanonicalRef[];
+  provider?: string | null;
+  model?: string | null;
+  externalImageGenerated?: boolean;
+}): SfiCaseCoverBrief {
+  const caseId = input.caseId.trim();
+  if (!caseId) throw new Error('SFI_CASE_COVER_CASE_ID_REQUIRED');
+  const byKey = new Map<string, SfiCanonicalRef>();
+  for (const raw of input.sourceEvidenceRefs) {
+    const ref = normalizeRef(raw);
+    byKey.set(refKey(ref), ref);
+  }
+  const refs = [...byKey.values()].sort((a, b) => refKey(a).localeCompare(refKey(b)));
+  const lineageClause = refs.length
+    ? `Case-specific visual detail may be derived only from these admitted evidence references: ${refs.map(formatCanonicalRef).join(', ')}. Do not render the reference identifiers as visible text.`
+    : 'No admitted case-specific evidence detail is available; keep the metaphor generic and do not invent actor, place, company, rupture, outcome or logo.';
+  return {
+    contract: SFI_CASE_COVER_BRIEF_CONTRACT,
+    caseId,
+    prompt: `${BASE_COVER_BRIEF} ${lineageClause}`,
+    sourceEvidenceRefs: refs,
+    visibleTextAllowed: false,
+    externalImageGenerated: input.externalImageGenerated === true,
+    provider: input.provider?.trim() || null,
+    model: input.model?.trim() || null,
+    approvalRequired: true,
+    publicationState: 'PRIVATE_DRAFT',
+  };
+}
+
+const WIN_ANSI_SPECIAL = new Map<number, number>([
+  [0x20ac, 0x80], [0x201a, 0x82], [0x0192, 0x83], [0x201e, 0x84], [0x2026, 0x85],
+  [0x2020, 0x86], [0x2021, 0x87], [0x02c6, 0x88], [0x2030, 0x89], [0x0160, 0x8a],
+  [0x2039, 0x8b], [0x0152, 0x8c], [0x017d, 0x8e], [0x2018, 0x91], [0x2019, 0x92],
+  [0x201c, 0x93], [0x201d, 0x94], [0x2022, 0x95], [0x2013, 0x96], [0x2014, 0x97],
+  [0x02dc, 0x98], [0x2122, 0x99], [0x0161, 0x9a], [0x203a, 0x9b], [0x0153, 0x9c],
+  [0x017e, 0x9e], [0x0178, 0x9f],
+]);
+
+function winAnsiByte(codePoint: number) {
+  if ((codePoint >= 0x20 && codePoint <= 0x7e) || (codePoint >= 0xa0 && codePoint <= 0xff)) return codePoint;
+  return WIN_ANSI_SPECIAL.get(codePoint) ?? null;
+}
+
+/**
+ * Standard PDF Helvetica is WinAnsi, not Unicode. Preserve common Latin text exactly and
+ * preserve every other code point losslessly as visible <U+XXXX> notation rather than '?'.
+ */
+function pdfVisibleText(value: string) {
+  let out = '';
+  for (const char of value.replace(/[\r\n]+/g, ' ')) {
+    const codePoint = char.codePointAt(0) ?? 0;
+    out += winAnsiByte(codePoint) === null ? `<U+${codePoint.toString(16).toUpperCase().padStart(4, '0')}>` : char;
+  }
+  return out;
+}
+
+function escapePdfText(value: string) {
+  const out: string[] = [];
+  for (const char of pdfVisibleText(value)) {
+    const codePoint = char.codePointAt(0) ?? 0;
+    const byte = winAnsiByte(codePoint);
+    if (byte === null) throw new Error('SFI_PRIVATE_CASE_BRIEF_PDF_ENCODING_INTERNAL');
+    if (byte === 0x5c) out.push('\\\\');
+    else if (byte === 0x28) out.push('\\(');
+    else if (byte === 0x29) out.push('\\)');
+    else if (byte >= 0x20 && byte <= 0x7e) out.push(String.fromCharCode(byte));
+    else out.push(`\\${byte.toString(8).padStart(3, '0')}`);
+  }
+  return out.join('');
+}
+
+function wrap(value: string, width = 82) {
+  const words = pdfVisibleText(value).split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let line = '';
+  const pushWord = (word: string) => {
+    let remaining = word;
+    while (remaining.length > width) {
+      const prefix = remaining.slice(0, width);
+      if (line) {
+        lines.push(line);
+        line = '';
+      }
+      lines.push(prefix);
+      remaining = remaining.slice(width);
+    }
+    if (!remaining) return;
+    const next = line ? `${line} ${remaining}` : remaining;
+    if (next.length > width && line) {
+      lines.push(line);
+      line = remaining;
+    } else line = next;
+  };
+  for (const word of words) pushWord(word);
+  if (line) lines.push(line);
+  return lines;
+}
+
+function textOps(lines: string[], x: number, y: number, leading = 15, fontSize = 10) {
+  return ['BT', `/F1 ${fontSize} Tf`, `${x} ${y} Td`, `${leading} TL`, ...lines.flatMap((line, index) => [index ? 'T*' : '', `(${escapePdfText(line)}) Tj`]).filter(Boolean), 'ET'].join('\n');
+}
+
+function chunks<T>(values: T[], size: number) {
+  const result: T[][] = [];
+  for (let index = 0; index < values.length; index += size) result.push(values.slice(index, index + size));
+  return result.length ? result : [[]];
+}
+
+export function renderPrivateCaseBriefPdf(input: {
+  caseId: string;
+  version: string;
+  subject: string;
+  scope: string;
+  generatedAt: string;
+  evidenceRefs: SfiCanonicalRef[];
+  coverBrief: SfiCaseCoverBrief;
+}): Buffer {
+  const evidenceLabels = input.evidenceRefs.map(formatCanonicalRef);
+  const coverLines = wrap('SYSTEM FRICTION INSTITUTE / PRIVATE CASE BRIEF', 48);
+  const subjectLines = wrap(input.subject || 'Case subject not declared', 54);
+  const detailLines = [
+    `Case: ${input.caseId}`,
+    `Version: ${input.version}`,
+    `Generated: ${input.generatedAt}`,
+    'Publication: PRIVATE_DRAFT',
+    '',
+    'Subject', ...wrap(input.subject || 'MISSING', 78), '',
+    'Scope', ...wrap(input.scope || 'MISSING', 78), '',
+    `Evidence references (${evidenceLabels.length})`,
+    ...(evidenceLabels.length ? evidenceLabels.flatMap((ref) => wrap(ref, 78)) : ['MISSING']),
+    '', 'Cover generation boundary', ...wrap(input.coverBrief.prompt, 78),
+    '', 'This document is a private projection. Report != evidence. Report != decision. Publication requires separate human/governance authorization.',
+  ];
+  const page1 = [
+    '0 0 0 rg 0 0 612 792 re f',
+    '0.78 0.61 0.25 rg',
+    textOps(coverLines, 64, 650, 24, 16),
+    '0.92 0.92 0.90 rg',
+    textOps(subjectLines, 64, 530, 22, 18),
+    '0.78 0.61 0.25 RG 1.2 w 64 470 m 548 470 l S',
+    '0.68 0.68 0.66 rg',
+    textOps(wrap(`PRIVATE / ${input.caseId} / ${input.version}`, 60), 64, 430, 14, 9),
+  ].join('\n');
+
+  const detailChunks = chunks(detailLines, 47);
+  const pageStreams = [page1, ...detailChunks.map((lines, index) => [
+    '0 0 0 rg',
+    textOps([`PRIVATE CASE BRIEF / DETAIL ${index + 1} OF ${detailChunks.length}`, '', ...lines], 54, 740, 13, 9),
+  ].join('\n'))];
+
+  const pageCount = pageStreams.length;
+  const fontObjectNumber = 3 + pageCount;
+  const contentObjectStart = fontObjectNumber + 1;
+  const pageRefs = pageStreams.map((_, index) => `${3 + index} 0 R`);
+  const objects: string[] = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    `<< /Type /Pages /Kids [${pageRefs.join(' ')}] /Count ${pageCount} >>`,
+  ];
+  for (let index = 0; index < pageStreams.length; index += 1) {
+    objects.push(`<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 ${fontObjectNumber} 0 R >> >> /Contents ${contentObjectStart + index} 0 R >>`);
+  }
+  objects.push('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>');
+  for (const stream of pageStreams) objects.push(`<< /Length ${Buffer.byteLength(stream, 'ascii')} >>\nstream\n${stream}\nendstream`);
+
+  let pdf = '%PDF-1.4\n%SFI\n';
+  const offsets = [0];
+  objects.forEach((body, index) => {
+    offsets.push(Buffer.byteLength(pdf, 'ascii'));
+    pdf += `${index + 1} 0 obj\n${body}\nendobj\n`;
+  });
+  const xref = Buffer.byteLength(pdf, 'ascii');
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (let index = 1; index <= objects.length; index += 1) pdf += `${String(offsets[index]).padStart(10, '0')} 00000 n \n`;
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`;
+  return Buffer.from(pdf, 'ascii');
+}
+
+export function sha256Hex(bytes: Uint8Array) {
+  return createHash('sha256').update(bytes).digest('hex');
+}

--- a/src/lib/sfi/case-platform/privateCaseBriefContract.ts
+++ b/src/lib/sfi/case-platform/privateCaseBriefContract.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'node:crypto';
 import type { SfiCanonicalRef } from '@/core/contracts/sfi';
+import type { SfiUnifontGlyph } from './unifontType3';
 
-export const SFI_PRIVATE_CASE_BRIEF_ASSET_CONTRACT = 'SFI-PRIVATE-CASE-BRIEF-ASSET-1.1' as const;
+export const SFI_PRIVATE_CASE_BRIEF_ASSET_CONTRACT = 'SFI-PRIVATE-CASE-BRIEF-ASSET-1.2' as const;
 export const SFI_CASE_COVER_BRIEF_CONTRACT = 'SFI-CASE-COVER-BRIEF-1.1' as const;
 export const SFI_CASE_ASSET_BUCKET = 'sfi-case-assets' as const;
 
@@ -18,6 +19,16 @@ export type SfiCaseCoverBrief = {
   model: string | null;
   approvalRequired: true;
   publicationState: 'PRIVATE_DRAFT';
+};
+
+export type PrivateCaseBriefRenderInput = {
+  caseId: string;
+  version: string;
+  subject: string;
+  scope: string;
+  generatedAt: string;
+  evidenceRefs: SfiCanonicalRef[];
+  coverBrief: SfiCaseCoverBrief;
 };
 
 function nullableText(value: string | null | undefined) {
@@ -71,66 +82,32 @@ export function buildSfiCaseCoverBrief(input: {
   };
 }
 
-const WIN_ANSI_SPECIAL = new Map<number, number>([
-  [0x20ac, 0x80], [0x201a, 0x82], [0x0192, 0x83], [0x201e, 0x84], [0x2026, 0x85],
-  [0x2020, 0x86], [0x2021, 0x87], [0x02c6, 0x88], [0x2030, 0x89], [0x0160, 0x8a],
-  [0x2039, 0x8b], [0x0152, 0x8c], [0x017d, 0x8e], [0x2018, 0x91], [0x2019, 0x92],
-  [0x201c, 0x93], [0x201d, 0x94], [0x2022, 0x95], [0x2013, 0x96], [0x2014, 0x97],
-  [0x02dc, 0x98], [0x2122, 0x99], [0x0161, 0x9a], [0x203a, 0x9b], [0x0153, 0x9c],
-  [0x017e, 0x9e], [0x0178, 0x9f],
-]);
-
-function winAnsiByte(codePoint: number) {
-  if ((codePoint >= 0x20 && codePoint <= 0x7e) || (codePoint >= 0xa0 && codePoint <= 0xff)) return codePoint;
-  return WIN_ANSI_SPECIAL.get(codePoint) ?? null;
+function charLength(value: string) {
+  return Array.from(value).length;
 }
 
-/**
- * Standard PDF Helvetica is WinAnsi, not Unicode. Preserve common Latin text exactly and
- * preserve every other code point losslessly as visible <U+XXXX> notation rather than '?'.
- */
-function pdfVisibleText(value: string) {
-  let out = '';
-  for (const char of value.replace(/[\r\n]+/g, ' ')) {
-    const codePoint = char.codePointAt(0) ?? 0;
-    out += winAnsiByte(codePoint) === null ? `<U+${codePoint.toString(16).toUpperCase().padStart(4, '0')}>` : char;
-  }
-  return out;
-}
-
-function escapePdfText(value: string) {
-  const out: string[] = [];
-  for (const char of pdfVisibleText(value)) {
-    const codePoint = char.codePointAt(0) ?? 0;
-    const byte = winAnsiByte(codePoint);
-    if (byte === null) throw new Error('SFI_PRIVATE_CASE_BRIEF_PDF_ENCODING_INTERNAL');
-    if (byte === 0x5c) out.push('\\\\');
-    else if (byte === 0x28) out.push('\\(');
-    else if (byte === 0x29) out.push('\\)');
-    else if (byte >= 0x20 && byte <= 0x7e) out.push(String.fromCharCode(byte));
-    else out.push(`\\${byte.toString(8).padStart(3, '0')}`);
-  }
-  return out.join('');
+function sliceChars(value: string, start: number, end?: number) {
+  return Array.from(value).slice(start, end).join('');
 }
 
 function wrap(value: string, width = 82) {
-  const words = pdfVisibleText(value).split(/\s+/).filter(Boolean);
+  const words = value.replace(/[\r\n]+/g, ' ').split(/\s+/).filter(Boolean);
   const lines: string[] = [];
   let line = '';
   const pushWord = (word: string) => {
     let remaining = word;
-    while (remaining.length > width) {
-      const prefix = remaining.slice(0, width);
+    while (charLength(remaining) > width) {
+      const prefix = sliceChars(remaining, 0, width);
       if (line) {
         lines.push(line);
         line = '';
       }
       lines.push(prefix);
-      remaining = remaining.slice(width);
+      remaining = sliceChars(remaining, width);
     }
     if (!remaining) return;
     const next = line ? `${line} ${remaining}` : remaining;
-    if (next.length > width && line) {
+    if (charLength(next) > width && line) {
       lines.push(line);
       line = remaining;
     } else line = next;
@@ -140,29 +117,15 @@ function wrap(value: string, width = 82) {
   return lines;
 }
 
-function textOps(lines: string[], x: number, y: number, leading = 15, fontSize = 10) {
-  return ['BT', `/F1 ${fontSize} Tf`, `${x} ${y} Td`, `${leading} TL`, ...lines.flatMap((line, index) => [index ? 'T*' : '', `(${escapePdfText(line)}) Tj`]).filter(Boolean), 'ET'].join('\n');
-}
-
 function chunks<T>(values: T[], size: number) {
   const result: T[][] = [];
   for (let index = 0; index < values.length; index += size) result.push(values.slice(index, index + size));
   return result.length ? result : [[]];
 }
 
-export function renderPrivateCaseBriefPdf(input: {
-  caseId: string;
-  version: string;
-  subject: string;
-  scope: string;
-  generatedAt: string;
-  evidenceRefs: SfiCanonicalRef[];
-  coverBrief: SfiCaseCoverBrief;
-}): Buffer {
+function detailLines(input: PrivateCaseBriefRenderInput) {
   const evidenceLabels = input.evidenceRefs.map(formatCanonicalRef);
-  const coverLines = wrap('SYSTEM FRICTION INSTITUTE / PRIVATE CASE BRIEF', 48);
-  const subjectLines = wrap(input.subject || 'Case subject not declared', 54);
-  const detailLines = [
+  return [
     `Case: ${input.caseId}`,
     `Version: ${input.version}`,
     `Generated: ${input.generatedAt}`,
@@ -175,47 +138,213 @@ export function renderPrivateCaseBriefPdf(input: {
     '', 'Cover generation boundary', ...wrap(input.coverBrief.prompt, 78),
     '', 'This document is a private projection. Report != evidence. Report != decision. Publication requires separate human/governance authorization.',
   ];
-  const page1 = [
-    '0 0 0 rg 0 0 612 792 re f',
-    '0.78 0.61 0.25 rg',
-    textOps(coverLines, 64, 650, 24, 16),
-    '0.92 0.92 0.90 rg',
-    textOps(subjectLines, 64, 530, 22, 18),
-    '0.78 0.61 0.25 RG 1.2 w 64 470 m 548 470 l S',
-    '0.68 0.68 0.66 rg',
-    textOps(wrap(`PRIVATE / ${input.caseId} / ${input.version}`, 60), 64, 430, 14, 9),
-  ].join('\n');
+}
 
-  const detailChunks = chunks(detailLines, 47);
-  const pageStreams = [page1, ...detailChunks.map((lines, index) => [
-    '0 0 0 rg',
-    textOps([`PRIVATE CASE BRIEF / DETAIL ${index + 1} OF ${detailChunks.length}`, '', ...lines], 54, 740, 13, 9),
-  ].join('\n'))];
+function pageLineGroups(input: PrivateCaseBriefRenderInput) {
+  const cover = {
+    coverLines: wrap('SYSTEM FRICTION INSTITUTE / PRIVATE CASE BRIEF', 48),
+    subjectLines: wrap(input.subject || 'Case subject not declared', 54),
+    footerLines: wrap(`PRIVATE / ${input.caseId} / ${input.version}`, 60),
+  };
+  const detailChunks = chunks(detailLines(input), 47);
+  return { cover, detailChunks };
+}
 
-  const pageCount = pageStreams.length;
-  const fontObjectNumber = 3 + pageCount;
-  const contentObjectStart = fontObjectNumber + 1;
-  const pageRefs = pageStreams.map((_, index) => `${3 + index} 0 R`);
-  const objects: string[] = [
-    '<< /Type /Catalog /Pages 2 0 R >>',
-    `<< /Type /Pages /Kids [${pageRefs.join(' ')}] /Count ${pageCount} >>`,
+export function requiredPrivateCaseBriefCodePoints(input: PrivateCaseBriefRenderInput) {
+  const { cover, detailChunks } = pageLineGroups(input);
+  const values = [
+    ...cover.coverLines,
+    ...cover.subjectLines,
+    ...cover.footerLines,
+    ...detailChunks.flatMap((lines, index) => [`PRIVATE CASE BRIEF / DETAIL ${index + 1} OF ${detailChunks.length}`, '', ...lines]),
   ];
-  for (let index = 0; index < pageStreams.length; index += 1) {
-    objects.push(`<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 ${fontObjectNumber} 0 R >> >> /Contents ${contentObjectStart + index} 0 R >>`);
+  const result = new Set<number>();
+  for (const value of values) {
+    for (const char of value) {
+      const codePoint = char.codePointAt(0);
+      if (typeof codePoint === 'number' && codePoint >= 0x20) result.add(codePoint);
+    }
   }
-  objects.push('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>');
-  for (const stream of pageStreams) objects.push(`<< /Length ${Buffer.byteLength(stream, 'ascii')} >>\nstream\n${stream}\nendstream`);
+  result.add(0x20);
+  return result;
+}
 
-  let pdf = '%PDF-1.4\n%SFI\n';
-  const offsets = [0];
-  objects.forEach((body, index) => {
-    offsets.push(Buffer.byteLength(pdf, 'ascii'));
-    pdf += `${index + 1} 0 obj\n${body}\nendobj\n`;
+type FontGlyph = SfiUnifontGlyph & { code: number; name: string };
+type FontPartition = { resource: string; glyphs: FontGlyph[]; byCodePoint: Map<number, FontGlyph> };
+
+function fontPartitions(required: Set<number>, glyphs: ReadonlyMap<number, SfiUnifontGlyph>) {
+  const ordered = [...required].sort((a, b) => a - b);
+  const missing = ordered.filter((codePoint) => !glyphs.has(codePoint));
+  if (missing.length) {
+    throw new Error(`SFI_PRIVATE_CASE_BRIEF_UNICODE_GLYPH_UNAVAILABLE:${missing.map((value) => `U+${value.toString(16).toUpperCase()}`).join(',')}`);
+  }
+  return chunks(ordered, 240).map((values, partitionIndex): FontPartition => {
+    const mapped = values.map((codePoint, index) => {
+      const glyph = glyphs.get(codePoint)!;
+      return { ...glyph, code: index + 1, name: `g${codePoint.toString(16).toUpperCase().padStart(4, '0')}` };
+    });
+    return {
+      resource: `F${partitionIndex + 1}`,
+      glyphs: mapped,
+      byCodePoint: new Map(mapped.map((glyph) => [glyph.codePoint, glyph])),
+    };
   });
+}
+
+function utf16BeHex(codePoint: number) {
+  if (codePoint <= 0xffff) return codePoint.toString(16).toUpperCase().padStart(4, '0');
+  const adjusted = codePoint - 0x10000;
+  const high = 0xd800 + (adjusted >> 10);
+  const low = 0xdc00 + (adjusted & 0x3ff);
+  return `${high.toString(16).toUpperCase().padStart(4, '0')}${low.toString(16).toUpperCase().padStart(4, '0')}`;
+}
+
+function glyphStream(glyph: FontGlyph) {
+  const advance = glyph.width === 8 ? 500 : 1000;
+  const pixelWidth = glyph.width === 8 ? 125 : 62.5;
+  const pixelHeight = 62.5;
+  const ops = [`${advance} 0 d0`];
+  for (let row = 0; row < 16; row += 1) {
+    const bits = glyph.rows[row] ?? 0;
+    for (let column = 0; column < glyph.width; column += 1) {
+      const mask = 1 << (glyph.width - 1 - column);
+      if ((bits & mask) === 0) continue;
+      const x = column * pixelWidth;
+      const y = (15 - row) * pixelHeight;
+      ops.push(`${x} ${y} ${pixelWidth} ${pixelHeight} re f`);
+    }
+  }
+  return ops.join('\n');
+}
+
+function cmapStream(partition: FontPartition) {
+  const mappings = chunks(partition.glyphs, 100).flatMap((group) => [
+    `${group.length} beginbfchar`,
+    ...group.map((glyph) => `<${glyph.code.toString(16).toUpperCase().padStart(2, '0')}> <${utf16BeHex(glyph.codePoint)}>`),
+    'endbfchar',
+  ]);
+  return [
+    '/CIDInit /ProcSet findresource begin',
+    '12 dict begin',
+    'begincmap',
+    '/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def',
+    `/CMapName /SFI-Unifont-${partition.resource} def`,
+    '/CMapType 2 def',
+    '1 begincodespacerange',
+    '<01> <F0>',
+    'endcodespacerange',
+    ...mappings,
+    'endcmap',
+    'CMapName currentdict /CMap defineresource pop',
+    'end',
+    'end',
+  ].join('\n');
+}
+
+function fontRegistry(partitions: FontPartition[]) {
+  const byCodePoint = new Map<number, { partition: FontPartition; glyph: FontGlyph }>();
+  for (const partition of partitions) {
+    for (const glyph of partition.glyphs) byCodePoint.set(glyph.codePoint, { partition, glyph });
+  }
+  return byCodePoint;
+}
+
+function textOps(lines: string[], x: number, y: number, leading: number, fontSize: number, registry: ReturnType<typeof fontRegistry>) {
+  const ops = ['BT', `${x} ${y} Td`, `${leading} TL`];
+  lines.forEach((line, lineIndex) => {
+    if (lineIndex) ops.push('T*');
+    let resource = '';
+    let bytes = '';
+    const flush = () => {
+      if (!bytes) return;
+      ops.push(`/${resource} ${fontSize} Tf`, `<${bytes}> Tj`);
+      bytes = '';
+    };
+    for (const char of line) {
+      const codePoint = char.codePointAt(0)!;
+      const found = registry.get(codePoint);
+      if (!found) throw new Error(`SFI_PRIVATE_CASE_BRIEF_UNICODE_GLYPH_UNAVAILABLE:U+${codePoint.toString(16).toUpperCase()}`);
+      if (resource && resource !== found.partition.resource) flush();
+      resource = found.partition.resource;
+      bytes += found.glyph.code.toString(16).toUpperCase().padStart(2, '0');
+    }
+    flush();
+  });
+  ops.push('ET');
+  return ops.join('\n');
+}
+
+function pdfStream(stream: string) {
+  return `<< /Length ${Buffer.byteLength(stream, 'ascii')} >>\nstream\n${stream}\nendstream`;
+}
+
+export function renderPrivateCaseBriefPdf(input: PrivateCaseBriefRenderInput, unicodeGlyphs: ReadonlyMap<number, SfiUnifontGlyph>): Buffer {
+  const required = requiredPrivateCaseBriefCodePoints(input);
+  const partitions = fontPartitions(required, unicodeGlyphs);
+  const registry = fontRegistry(partitions);
+  const { cover, detailChunks } = pageLineGroups(input);
+  const pageStreams = [
+    [
+      '0 0 0 rg 0 0 612 792 re f',
+      '0.78 0.61 0.25 rg',
+      textOps(cover.coverLines, 64, 650, 24, 16, registry),
+      '0.92 0.92 0.90 rg',
+      textOps(cover.subjectLines, 64, 530, 22, 18, registry),
+      '0.78 0.61 0.25 RG 1.2 w 64 470 m 548 470 l S',
+      '0.68 0.68 0.66 rg',
+      textOps(cover.footerLines, 64, 430, 14, 9, registry),
+    ].join('\n'),
+    ...detailChunks.map((lines, index) => [
+      '0 0 0 rg',
+      textOps([`PRIVATE CASE BRIEF / DETAIL ${index + 1} OF ${detailChunks.length}`, '', ...lines], 54, 740, 13, 9, registry),
+    ].join('\n')),
+  ];
+
+  type PdfObject = { key: string; body: () => string };
+  const objects: PdfObject[] = [];
+  const numbers = new Map<string, number>();
+  const reserve = (key: string, body: () => string) => {
+    if (numbers.has(key)) throw new Error(`SFI_PRIVATE_CASE_BRIEF_PDF_DUPLICATE_OBJECT:${key}`);
+    objects.push({ key, body });
+    numbers.set(key, objects.length);
+  };
+  const ref = (key: string) => {
+    const number = numbers.get(key);
+    if (!number) throw new Error(`SFI_PRIVATE_CASE_BRIEF_PDF_OBJECT_MISSING:${key}`);
+    return `${number} 0 R`;
+  };
+
+  reserve('catalog', () => `<< /Type /Catalog /Pages ${ref('pages')} >>`);
+  reserve('pages', () => `<< /Type /Pages /Kids [${pageStreams.map((_, index) => ref(`page:${index}`)).join(' ')}] /Count ${pageStreams.length} >>`);
+  pageStreams.forEach((_, index) => reserve(`page:${index}`, () => {
+    const resources = partitions.map((partition) => `/${partition.resource} ${ref(`font:${partition.resource}`)}`).join(' ');
+    return `<< /Type /Page /Parent ${ref('pages')} /MediaBox [0 0 612 792] /Resources << /Font << ${resources} >> >> /Contents ${ref(`content:${index}`)} >>`;
+  }));
+
+  for (const partition of partitions) {
+    reserve(`font:${partition.resource}`, () => {
+      const charProcs = partition.glyphs.map((glyph) => `/${glyph.name} ${ref(`glyph:${partition.resource}:${glyph.code}`)}`).join(' ');
+      const differences = partition.glyphs.map((glyph) => `/${glyph.name}`).join(' ');
+      const widths = partition.glyphs.map((glyph) => glyph.width === 8 ? '500' : '1000').join(' ');
+      return `<< /Type /Font /Subtype /Type3 /Name /${partition.resource} /FontBBox [0 0 1000 1000] /FontMatrix [0.001 0 0 0.001 0 0] /CharProcs << ${charProcs} >> /Encoding << /Type /Encoding /Differences [1 ${differences}] >> /FirstChar 1 /LastChar ${partition.glyphs.length} /Widths [${widths}] /Resources << >> /ToUnicode ${ref(`cmap:${partition.resource}`)} >>`;
+    });
+    reserve(`cmap:${partition.resource}`, () => pdfStream(cmapStream(partition)));
+    for (const glyph of partition.glyphs) {
+      reserve(`glyph:${partition.resource}:${glyph.code}`, () => pdfStream(glyphStream(glyph)));
+    }
+  }
+  pageStreams.forEach((stream, index) => reserve(`content:${index}`, () => pdfStream(stream)));
+
+  let pdf = '%PDF-1.4\n%SFI-UNICODE-TYPE3\n';
+  const offsets = [0];
+  for (const object of objects) {
+    offsets.push(Buffer.byteLength(pdf, 'ascii'));
+    pdf += `${numbers.get(object.key)} 0 obj\n${object.body()}\nendobj\n`;
+  }
   const xref = Buffer.byteLength(pdf, 'ascii');
   pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
   for (let index = 1; index <= objects.length; index += 1) pdf += `${String(offsets[index]).padStart(10, '0')} 00000 n \n`;
-  pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`;
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root ${ref('catalog')} >>\nstartxref\n${xref}\n%%EOF\n`;
   return Buffer.from(pdf, 'ascii');
 }
 

--- a/src/lib/sfi/case-platform/unifontType3.ts
+++ b/src/lib/sfi/case-platform/unifontType3.ts
@@ -1,0 +1,88 @@
+import 'server-only';
+
+import { gunzipSync } from 'node:zlib';
+
+export const SFI_UNIFONT_VERSION = '16.0.04' as const;
+export const SFI_UNIFONT_SOURCE = `https://unifoundry.com/pub/unifont/unifont-${SFI_UNIFONT_VERSION}/font-builds/unifont-${SFI_UNIFONT_VERSION}.hex.gz` as const;
+
+export type SfiUnifontGlyph = {
+  codePoint: number;
+  width: 8 | 16;
+  rows: number[];
+};
+
+let sourcePromise: Promise<string> | null = null;
+
+function parseGlyph(codePoint: number, bitmapHex: string): SfiUnifontGlyph | null {
+  const bitmap = bitmapHex.trim();
+  if (!/^[0-9A-Fa-f]+$/.test(bitmap)) return null;
+  if (bitmap.length !== 32 && bitmap.length !== 64) return null;
+  const width = bitmap.length === 32 ? 8 : 16;
+  const rowDigits = width / 4;
+  const rows: number[] = [];
+  for (let offset = 0; offset < bitmap.length; offset += rowDigits) {
+    rows.push(Number.parseInt(bitmap.slice(offset, offset + rowDigits), 16));
+  }
+  if (rows.length !== 16) return null;
+  return { codePoint, width, rows };
+}
+
+export function parseUnifontHex(source: string, requested: ReadonlySet<number>) {
+  const glyphs = new Map<number, SfiUnifontGlyph>();
+  for (const line of source.split(/\r?\n/)) {
+    if (!line || line.startsWith('#')) continue;
+    const separator = line.indexOf(':');
+    if (separator <= 0) continue;
+    const codePoint = Number.parseInt(line.slice(0, separator), 16);
+    if (!Number.isFinite(codePoint) || !requested.has(codePoint)) continue;
+    const glyph = parseGlyph(codePoint, line.slice(separator + 1));
+    if (glyph) glyphs.set(codePoint, glyph);
+    if (glyphs.size === requested.size) break;
+  }
+  if (requested.has(0x20) && !glyphs.has(0x20)) {
+    glyphs.set(0x20, { codePoint: 0x20, width: 8, rows: Array.from({ length: 16 }, () => 0) });
+  }
+  return glyphs;
+}
+
+async function loadPinnedSource() {
+  if (!sourcePromise) {
+    sourcePromise = (async () => {
+      const response = await fetch(SFI_UNIFONT_SOURCE, {
+        headers: { accept: 'application/gzip' },
+        cache: 'force-cache',
+      });
+      if (!response.ok) throw new Error(`SFI_PRIVATE_CASE_BRIEF_UNICODE_FONT_FETCH_FAILED:${response.status}`);
+      const compressed = Buffer.from(await response.arrayBuffer());
+      if (!compressed.length || compressed.length > 2_000_000) throw new Error('SFI_PRIVATE_CASE_BRIEF_UNICODE_FONT_SOURCE_SIZE_INVALID');
+      try {
+        return gunzipSync(compressed).toString('utf8');
+      } catch {
+        throw new Error('SFI_PRIVATE_CASE_BRIEF_UNICODE_FONT_SOURCE_INVALID');
+      }
+    })().catch((error) => {
+      sourcePromise = null;
+      throw error;
+    });
+  }
+  return sourcePromise;
+}
+
+export async function loadUnifontGlyphs(codePoints: Iterable<number>) {
+  const requested = new Set<number>();
+  for (const codePoint of codePoints) {
+    if (!Number.isInteger(codePoint) || codePoint < 0x20 || codePoint > 0xffff) {
+      if (codePoint > 0xffff) throw new Error(`SFI_PRIVATE_CASE_BRIEF_UNICODE_NON_BMP_UNSUPPORTED:U+${codePoint.toString(16).toUpperCase()}`);
+      continue;
+    }
+    requested.add(codePoint);
+  }
+  if (!requested.size) return new Map<number, SfiUnifontGlyph>();
+  const source = await loadPinnedSource();
+  const glyphs = parseUnifontHex(source, requested);
+  const missing = [...requested].filter((codePoint) => !glyphs.has(codePoint));
+  if (missing.length) {
+    throw new Error(`SFI_PRIVATE_CASE_BRIEF_UNICODE_GLYPH_UNAVAILABLE:${missing.map((codePoint) => `U+${codePoint.toString(16).toUpperCase()}`).join(',')}`);
+  }
+  return glyphs;
+}

--- a/src/lib/sfi/case-platform/unifontType3.ts
+++ b/src/lib/sfi/case-platform/unifontType3.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import { gunzipSync } from 'node:zlib';
 
 export const SFI_UNIFONT_VERSION = '16.0.04' as const;

--- a/supabase/migrations/20260909062000_create_private_case_assets_bucket.sql
+++ b/supabase/migrations/20260909062000_create_private_case_assets_bucket.sql
@@ -1,0 +1,15 @@
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'sfi-case-assets',
+  'sfi-case-assets',
+  false,
+  20971520,
+  array['application/pdf','image/png','image/jpeg']::text[]
+)
+on conflict (id) do update
+set public = false,
+    file_size_limit = excluded.file_size_limit,
+    allowed_mime_types = excluded.allowed_mime_types;
+
+-- Intentionally no authenticated storage.objects policy is created for this bucket.
+-- Private case assets are read/written through ROOT-gated server/service-role paths only.

--- a/supabase/migrations/20260909080500_sfi_case_object_atomic_writer_v1.sql
+++ b/supabase/migrations/20260909080500_sfi_case_object_atomic_writer_v1.sql
@@ -1,0 +1,134 @@
+-- SFI canonical case-object atomic writer V1
+-- Object persistence, case freshness and audit evidence are one PostgreSQL transaction.
+
+create or replace function public.sfi_record_case_object_atomic_v1(
+  p_case_id uuid,
+  p_actor_id uuid,
+  p_object jsonb,
+  p_audit_action text default 'CASE_OBJECT_RECORDED',
+  p_audit_context jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_case public.sfi_cases%rowtype;
+  v_role text;
+  v_id uuid;
+  v_kind text;
+  v_epistemic_role text;
+  v_ref jsonb;
+  v_ref_id text;
+  v_ref_hash text;
+  v_existing public.sfi_case_objects%rowtype;
+  v_row public.sfi_case_objects%rowtype;
+  v_observed_at timestamptz;
+begin
+  if p_object is null or jsonb_typeof(p_object) <> 'object' then
+    raise exception 'SFI_CASE_OBJECT_ATOMIC_PACKET_INVALID';
+  end if;
+  if p_audit_context is null or jsonb_typeof(p_audit_context) <> 'object' then
+    raise exception 'SFI_CASE_OBJECT_ATOMIC_AUDIT_CONTEXT_INVALID';
+  end if;
+
+  select * into v_case
+  from public.sfi_cases
+  where id = p_case_id and deleted_at is null
+  for update;
+  if not found then raise exception 'SFI_CASE_NOT_FOUND'; end if;
+
+  select m.role into v_role
+  from public.sfi_tenant_members m
+  where m.tenant_id = v_case.tenant_id
+    and m.user_id = p_actor_id
+    and m.status = 'ACTIVE'
+  limit 1;
+  if v_role is null then raise exception 'SFI_TENANT_FORBIDDEN'; end if;
+  if v_role not in ('OWNER','ADMIN','OPERATOR') then raise exception 'SFI_TENANT_WRITE_FORBIDDEN'; end if;
+
+  v_id := nullif(p_object->>'id','')::uuid;
+  v_kind := coalesce(p_object->>'kind','');
+  v_epistemic_role := coalesce(p_object->>'epistemicRole','');
+  v_ref := coalesce(p_object->'canonicalRef','{}'::jsonb);
+  v_ref_id := coalesce(v_ref->>'id','');
+  v_ref_hash := coalesce(v_ref->>'hash','');
+  v_observed_at := nullif(p_object->>'observedAt','')::timestamptz;
+
+  if v_id is null or v_kind = '' or v_epistemic_role = '' or v_ref_id = '' or v_ref_hash = '' then
+    raise exception 'SFI_CASE_OBJECT_ATOMIC_FIELDS_REQUIRED';
+  end if;
+  if coalesce(nullif(trim(p_audit_action),''),'') = '' then
+    raise exception 'SFI_CASE_OBJECT_ATOMIC_AUDIT_ACTION_REQUIRED';
+  end if;
+  if v_case.status = 'REJECTED' or (v_case.status = 'CLOSED' and v_kind <> 'REPORT') then
+    raise exception 'SFI_CASE_OBJECT_WRITE_FORBIDDEN:%', v_case.status;
+  end if;
+
+  select * into v_existing
+  from public.sfi_case_objects o
+  where o.case_id = p_case_id
+    and o.object_kind = v_kind
+    and o.canonical_ref->>'id' = v_ref_id
+  limit 1;
+  if found then
+    if v_existing.canonical_ref is distinct from v_ref
+       or v_existing.epistemic_role is distinct from v_epistemic_role
+       or v_existing.source_refs is distinct from coalesce(p_object->'sourceRefs','[]'::jsonb)
+       or v_existing.record_refs is distinct from coalesce(p_object->'recordRefs','[]'::jsonb)
+       or v_existing.evidence_refs is distinct from coalesce(p_object->'evidenceRefs','[]'::jsonb)
+       or v_existing.payload is distinct from coalesce(p_object->'payload','{}'::jsonb)
+       or v_existing.observed_at is distinct from v_observed_at then
+      raise exception 'SFI_CASE_OBJECT_ID_CONFLICT';
+    end if;
+    return jsonb_build_object('object',to_jsonb(v_existing),'mutated',false,'atomic',true);
+  end if;
+
+  insert into public.sfi_case_objects (
+    id, case_id, owner_id, tenant_id, object_kind, epistemic_role, canonical_ref,
+    source_refs, record_refs, evidence_refs, payload, observed_at
+  ) values (
+    v_id,
+    p_case_id,
+    v_case.owner_id,
+    v_case.tenant_id,
+    v_kind,
+    v_epistemic_role,
+    v_ref,
+    coalesce(p_object->'sourceRefs','[]'::jsonb),
+    coalesce(p_object->'recordRefs','[]'::jsonb),
+    coalesce(p_object->'evidenceRefs','[]'::jsonb),
+    coalesce(p_object->'payload','{}'::jsonb),
+    v_observed_at
+  ) returning * into v_row;
+
+  update public.sfi_cases
+  set updated_at = now()
+  where id = p_case_id;
+
+  insert into public.sfi_case_audit_events (
+    case_id, tenant_id, actor_id, action, before_state, after_state, context
+  ) values (
+    p_case_id,
+    v_case.tenant_id,
+    p_actor_id,
+    trim(p_audit_action),
+    null,
+    jsonb_build_object(
+      'objectId', v_row.id,
+      'kind', v_row.object_kind,
+      'epistemicRole', v_row.epistemic_role,
+      'canonicalRef', v_row.canonical_ref
+    ),
+    p_audit_context || jsonb_build_object('atomic',true,'writer','sfi_record_case_object_atomic_v1')
+  );
+
+  return jsonb_build_object('object',to_jsonb(v_row),'mutated',true,'atomic',true);
+end;
+$$;
+
+revoke all on function public.sfi_record_case_object_atomic_v1(uuid,uuid,jsonb,text,jsonb) from public;
+revoke all on function public.sfi_record_case_object_atomic_v1(uuid,uuid,jsonb,text,jsonb) from anon;
+revoke all on function public.sfi_record_case_object_atomic_v1(uuid,uuid,jsonb,text,jsonb) from authenticated;
+grant execute on function public.sfi_record_case_object_atomic_v1(uuid,uuid,jsonb,text,jsonb) to service_role;


### PR DESCRIPTION
Parent: #154 / #417 / #389
Owner: SFI-07 · External Identity + existing Case Platform owners
Assurance: SFI-08
Integration: SFI-00

This branch closes the bounded #154 ROOT private-case-brief asset slice by reusing `sfi_case_objects` REPORT/PROJECTION and private storage. Fresh review defects were repaired without expanding into publication or external execution.

## SFI PRECHECK
Existing capability inspected: `SFI-CASE-1.0`, `SFI-REPORT-1.0`, operational `sfi_cases` / `sfi_case_objects` / audit owners, existing transactional System/AI persistence precedent, ROOT viewer/actor authorization, Supabase private storage, and the canonical #154 private-asset/cover/PDF contract.
Absorb vs create decision: ABSORB. Durable manifest remains existing `sfi_case_objects`; a generic canonical atomic case-object writer is added so object persistence, case freshness and audit use one transaction rather than a second partial mutation path.
Authoritative writer: `sfi_record_case_object_atomic_v1` is the canonical transactional writer for this slice. It enforces tenant role, case state, canonical identity/hash, case `updated_at`, object persistence and audit in one PostgreSQL transaction. The private-brief runtime does not insert manifest or audit rows directly.
Persistence/lineage impact: full EVIDENCE canonical refs (`id/version/hash`) remain intact through cover brief, PDF labels, payload, database `evidence_refs`, audit context and reconstruction. The PDF asset is uploaded privately before the DB transaction; a DB failure compensates only the upload, so a durable REPORT can never point at a removed PDF because manifest+audit either commit together or not at all.
Front delta: NONE.
Back delta: ROOT-only GET/POST `/api/root/private-case-brief`; deterministic paginated PDF 1.2; embedded Type-3 glyph programs sourced from pinned GNU Unifont 16.0.04 plus PDF `ToUnicode` CMaps; no `<U+XXXX>` substitution; canonical atomic manifest+audit persistence.
DB delta: no new business table. Adds service-role-only `sfi_record_case_object_atomic_v1` RPC and existing private `sfi-case-assets` bucket; no authenticated storage policy.
Redundancy removed: direct private-brief `sfi_case_objects` insert and direct audit insert are removed; canonical DB writer owns both.
Execution/ROOT boundary: PRIVATE_DRAFT; human approval required; no automatic publication/canonical promotion/external execution; no external cover-image bytes claimed without provider evidence. Unicode source resolution is version-pinned and completes before durable mutation; unsupported/missing glyphs fail closed.
Rollback: revert this PR and remove the private bucket / RPC only if unused. Existing Case Platform tables and prior objects remain unchanged.
Verification: exact-head private-brief tests + institutional QA + SFI Verify + typecheck/build + independent review. FAIL on lineage loss, rejected-case mutation, manifest/audit partial commit, stale case freshness, Unicode substitution, clipped detail, version collision, public URL/policy, fabricated image bytes, or automatic approval/publication.

## Review defect closure
- P1 full canonical evidence identity: preserved `id/version/hash` end-to-end.
- P1/P2 manifest + audit atomicity: replaced compensating DB deletes with one PostgreSQL transaction; storage compensation occurs only when that transaction aborts.
- P1 rejected-case invariant: enforced before upload and again in atomic writer.
- P2 canonical writer / case freshness: private brief uses canonical atomic writer; writer updates `sfi_cases.updated_at` in the same transaction.
- P2 Unicode: authored BMP glyphs are embedded as Type-3 char procedures from GNU Unifont 16.0.04 and mapped back to original Unicode via `ToUnicode`; no visible code-point escape fallback remains. Unsupported non-BMP/missing glyphs fail closed rather than corrupting text.
- P2 detail clipping: dynamic pagination preserved.
- P2 version collision: millisecond + UUID-derived version identity preserved.

## Falsification
`REPORT != EVIDENCE`, `REPORT != DECISION`, `PRIVATE_DRAFT != PUBLIC`. Any failed database mutation must leave no durable private-brief manifest; any unsupported Unicode must reject generation before storage mutation rather than substitute authored text.