### PR TITLE
fix(program): preserve completion receipts across unrelated changes

### DIFF
--- a/docs/program/SFI-COMPLETION-RECEIPTS.json
+++ b/docs/program/SFI-COMPLETION-RECEIPTS.json
@@ -1,10 +1,17 @@
 {
-  "contract": "SFI-PROGRAM-COMPLETION-RECEIPTS-1.2",
+  "contract": "SFI-PROGRAM-COMPLETION-RECEIPTS-1.3",
   "receipts": {
     "ISSUE154-001": {
       "status": "SATISFIED",
       "requirementHash": "sha256:b322414306b65e8e31cded71f49bbb1bf06e25089576a444a6061022b53e2d94",
       "head": "8f7cd40441770aed275bf8797dac1333126c8707",
+      "scopePaths": [
+        "src/lib/world-observatory/",
+        "src/app/api/field/map/world/",
+        "scripts/run-world-signal-observer-agent.ts",
+        "scripts/qa-sfi-discovery-operational.ts",
+        ".github/workflows/sfi-world-signal-observer.yml"
+      ],
       "evidence": [
         {
           "kind": "RETURN_RECEIPT",

--- a/scripts/lib/programCompletionReceipts.mjs
+++ b/scripts/lib/programCompletionReceipts.mjs
@@ -25,8 +25,12 @@ function invalid(receipt, error, expectedHash) {
 function validScopePath(value) {
   if (typeof value !== 'string') return false;
   const candidate = value.trim().replaceAll('\\', '/');
-  if (!candidate || candidate.startsWith('/') || candidate.includes('../') || candidate === '..') return false;
-  return !candidate.includes('\0');
+  if (!candidate || candidate.startsWith('/') || candidate.includes('../') || candidate === '..' || candidate.includes('\0')) return false;
+  const wildcardIndex = candidate.indexOf('*');
+  if (wildcardIndex < 0) return true;
+  return candidate.endsWith('/*') || candidate.endsWith('/**')
+    ? !candidate.slice(0, candidate.endsWith('/**') ? -3 : -2).includes('*')
+    : false;
 }
 
 export function evaluateCompletionReceipt(requirement, ledger, options = {}) {

--- a/scripts/lib/programCompletionReceipts.mjs
+++ b/scripts/lib/programCompletionReceipts.mjs
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 
-export const COMPLETION_RECEIPT_CONTRACT = 'SFI-PROGRAM-COMPLETION-RECEIPTS-1.2';
+export const COMPLETION_RECEIPT_CONTRACT = 'SFI-PROGRAM-COMPLETION-RECEIPTS-1.3';
 
 export function requirementHash(requirement) {
   const source = String(requirement?.source ?? '').trim();
@@ -22,6 +22,13 @@ function invalid(receipt, error, expectedHash) {
   return { state: 'INVALID', satisfied: false, receipt, error, expectedHash };
 }
 
+function validScopePath(value) {
+  if (typeof value !== 'string') return false;
+  const candidate = value.trim().replaceAll('\\', '/');
+  if (!candidate || candidate.startsWith('/') || candidate.includes('../') || candidate === '..') return false;
+  return !candidate.includes('\0');
+}
+
 export function evaluateCompletionReceipt(requirement, ledger, options = {}) {
   const receipt = ledger?.receipts?.[requirement.id];
   if (!receipt) return { state: 'ABSENT', satisfied: false, receipt: null, error: null };
@@ -29,6 +36,9 @@ export function evaluateCompletionReceipt(requirement, ledger, options = {}) {
   const expectedHash = requirementHash(requirement);
   if (receipt.status !== 'SATISFIED') return invalid(receipt, 'RECEIPT_STATUS_NOT_SATISFIED', expectedHash);
   if (receipt.requirementHash !== expectedHash) return invalid(receipt, 'REQUIREMENT_HASH_MISMATCH', expectedHash);
+  if (!Array.isArray(receipt.scopePaths) || receipt.scopePaths.length === 0 || receipt.scopePaths.some((value) => !validScopePath(value))) {
+    return invalid(receipt, 'REGRESSION_SCOPE_REQUIRED', expectedHash);
+  }
   if (typeof options.currentHead !== 'string' || !options.currentHead.trim()) return invalid(receipt, 'CURRENT_HEAD_REQUIRED', expectedHash);
   if (typeof receipt.head !== 'string' || !receipt.head.trim()) return invalid(receipt, 'VERIFIED_HEAD_REQUIRED', expectedHash);
   if (receipt.head !== options.currentHead) {

--- a/scripts/qa-sfi-program-completion-receipts.mjs
+++ b/scripts/qa-sfi-program-completion-receipts.mjs
@@ -4,22 +4,40 @@ import { evaluateCompletionReceipt, requirementHash } from './lib/programComplet
 const requirement = { id: 'QA-REQUIREMENT-001', source: 'QA canonical source', requirement: 'A bounded internal capability must preserve evidence and return proof.' };
 const hash = requirementHash(requirement);
 const verifiedHead = 'qa-code-head-001';
-const ledgerHead = 'qa-ledger-head-002';
+const descendantHead = 'qa-descendant-head-002';
 const observedEvidence = [
   { kind: 'GIT_COMMIT', ref: verifiedHead },
   { kind: 'WORKFLOW_RUN', ref: 'qa-workflow-001' },
   { kind: 'RETURN_RECEIPT', ref: 'artifacts/qa/return.json', sha256: 'sha256:qa' },
 ];
 const verifyEvidence = (evidence) => ({ ok: observedEvidence.some((candidate) => candidate.kind === evidence.kind && candidate.ref === evidence.ref) });
-const verifyLedgerOnlyDescendant = (receiptHead, currentHead) => ({ ok: receiptHead === verifiedHead && currentHead === ledgerHead });
 const valid = {
-  contract: 'SFI-PROGRAM-COMPLETION-RECEIPTS-1.2',
-  receipts: { [requirement.id]: { status: 'SATISFIED', requirementHash: hash, head: verifiedHead, evidence: observedEvidence, verifiedBy: 'SFI-08', returnState: 'RETURN_PASS' } },
+  contract: 'SFI-PROGRAM-COMPLETION-RECEIPTS-1.3',
+  receipts: { [requirement.id]: {
+    status: 'SATISFIED', requirementHash: hash, head: verifiedHead, scopePaths: ['src/lib/qa-owner/', 'scripts/qa-owner.ts'],
+    evidence: observedEvidence, verifiedBy: 'SFI-08', returnState: 'RETURN_PASS',
+  } },
 };
+
 assert.equal(evaluateCompletionReceipt(requirement, valid, { currentHead: verifiedHead, verifyEvidence }).satisfied, true, 'exact verified head remains valid');
-assert.equal(evaluateCompletionReceipt(requirement, valid, { currentHead: ledgerHead, verifyReceiptHead: verifyLedgerOnlyDescendant, verifyEvidence }).satisfied, true, 'ledger-only descendant must not self-invalidate durable receipt');
-assert.equal(evaluateCompletionReceipt(requirement, valid, { currentHead: ledgerHead, verifyEvidence }).error, 'VERIFIED_HEAD_RESOLVER_REQUIRED');
-assert.equal(evaluateCompletionReceipt(requirement, valid, { currentHead: 'changed-code-head', verifyReceiptHead: () => ({ ok: false, error: 'RECEIPT_HEAD_INVALIDATED_BY_CODE_CHANGE' }), verifyEvidence }).error, 'RECEIPT_HEAD_INVALIDATED_BY_CODE_CHANGE');
+assert.equal(evaluateCompletionReceipt(requirement, valid, {
+  currentHead: descendantHead,
+  verifyReceiptHead: (_receiptHead, _currentHead, receipt) => ({ ok: receipt.scopePaths.includes('src/lib/qa-owner/') }),
+  verifyEvidence,
+}).satisfied, true, 'unrelated descendant changes may preserve a scoped receipt');
+assert.equal(evaluateCompletionReceipt(requirement, valid, { currentHead: descendantHead, verifyEvidence }).error, 'VERIFIED_HEAD_RESOLVER_REQUIRED');
+assert.equal(evaluateCompletionReceipt(requirement, valid, {
+  currentHead: 'changed-owner-head',
+  verifyReceiptHead: () => ({ ok: false, error: 'RECEIPT_SCOPE_INVALIDATED_BY_CHANGE:src/lib/qa-owner/runtime.ts' }),
+  verifyEvidence,
+}).error, 'RECEIPT_SCOPE_INVALIDATED_BY_CHANGE:src/lib/qa-owner/runtime.ts');
+
+const noScope = structuredClone(valid); delete noScope.receipts[requirement.id].scopePaths;
+assert.equal(evaluateCompletionReceipt(requirement, noScope, { currentHead: verifiedHead, verifyEvidence }).error, 'REGRESSION_SCOPE_REQUIRED');
+const emptyScope = structuredClone(valid); emptyScope.receipts[requirement.id].scopePaths = [];
+assert.equal(evaluateCompletionReceipt(requirement, emptyScope, { currentHead: verifiedHead, verifyEvidence }).error, 'REGRESSION_SCOPE_REQUIRED');
+const unsafeScope = structuredClone(valid); unsafeScope.receipts[requirement.id].scopePaths = ['../escape'];
+assert.equal(evaluateCompletionReceipt(requirement, unsafeScope, { currentHead: verifiedHead, verifyEvidence }).error, 'REGRESSION_SCOPE_REQUIRED');
 
 const staleRequirement = structuredClone(valid); staleRequirement.receipts[requirement.id].requirementHash = 'sha256:stale';
 assert.equal(evaluateCompletionReceipt(requirement, staleRequirement, { currentHead: verifiedHead, verifyEvidence }).error, 'REQUIREMENT_HASH_MISMATCH');
@@ -38,5 +56,6 @@ externalWithoutObservation.receipts[requirement.id].externalObserved = true;
 assert.equal(evaluateCompletionReceipt(requirement, externalWithoutObservation, { currentHead: verifiedHead, verifyEvidence, external: true }).satisfied, true);
 assert.equal(evaluateCompletionReceipt(requirement, { receipts: {} }, { currentHead: verifiedHead, verifyEvidence }).state, 'ABSENT');
 
-console.log(JSON.stringify({ ok: true, contract: 'SFI-PROGRAM-COMPLETION-RECEIPTS-1.2', exactHeadValid: true, ledgerOnlyDescendantValid: true,
-  interveningCodeChangeFailsClosed: true, independentVerifierRequired: true, structuredEvidenceRequired: true, observedEvidenceResolverRequired: true, externalObservationRequired: true }));
+console.log(JSON.stringify({ ok: true, contract: 'SFI-PROGRAM-COMPLETION-RECEIPTS-1.3', exactHeadValid: true,
+  unrelatedDescendantChangePreservesScopedReceipt: true, scopedRegressionFailsClosed: true, regressionScopeRequired: true,
+  independentVerifierRequired: true, structuredEvidenceRequired: true, observedEvidenceResolverRequired: true, externalObservationRequired: true }));

--- a/scripts/sfi-program-completion-reconcile.mjs
+++ b/scripts/sfi-program-completion-reconcile.mjs
@@ -28,16 +28,26 @@ function safeRepositoryPath(value) {
   if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) throw new Error('EVIDENCE_PATH_OUTSIDE_REPOSITORY');
   return candidate;
 }
+function normalizeRepoPath(value) { return String(value || '').trim().replaceAll('\\', '/').replace(/^\.\//, ''); }
+function pathWithinScope(file, scope) {
+  const normalizedFile = normalizeRepoPath(file);
+  const normalizedScope = normalizeRepoPath(scope).replace(/\/\*\*$/, '/').replace(/\/\*$/, '/');
+  if (!normalizedFile || !normalizedScope) return false;
+  if (normalizedScope.endsWith('/')) return normalizedFile.startsWith(normalizedScope);
+  return normalizedFile === normalizedScope;
+}
 
-function verifyReceiptHead(verifiedHead, currentHead) {
+function verifyReceiptHead(verifiedHead, currentHead, receipt) {
   try {
     execFileSync('git', ['cat-file', '-e', `${verifiedHead}^{commit}`], { cwd: root, stdio: 'ignore' });
     execFileSync('git', ['merge-base', '--is-ancestor', verifiedHead, currentHead], { cwd: root, stdio: 'ignore' });
     const changed = execFileSync('git', ['diff', '--name-only', verifiedHead, currentHead], { cwd: root, encoding: 'utf8' })
       .split('\n').map((value) => value.trim()).filter(Boolean);
-    const disallowed = changed.filter((file) => file !== LEDGER_REPOSITORY_PATH);
-    if (disallowed.length) return { ok: false, error: `RECEIPT_HEAD_INVALIDATED_BY_CODE_CHANGE:${disallowed.join(',')}` };
-    return { ok: true, verifiedHead, currentHead, changed };
+    const scopePaths = Array.isArray(receipt?.scopePaths) ? receipt.scopePaths.map(normalizeRepoPath).filter(Boolean) : [];
+    if (!scopePaths.length) return { ok: false, error: 'RECEIPT_REGRESSION_SCOPE_REQUIRED' };
+    const touchedScope = changed.filter((file) => file !== LEDGER_REPOSITORY_PATH && scopePaths.some((scope) => pathWithinScope(file, scope)));
+    if (touchedScope.length) return { ok: false, error: `RECEIPT_SCOPE_INVALIDATED_BY_CHANGE:${touchedScope.join(',')}` };
+    return { ok: true, verifiedHead, currentHead, changed, scopePaths, touchedScope: [] };
   } catch { return { ok: false, error: 'RECEIPT_VERIFIED_HEAD_NOT_ANCESTOR' }; }
 }
 
@@ -88,8 +98,8 @@ for (const requirement of report.requirements ?? []) {
   requirement.evidence = [...new Set([...(requirement.evidence ?? []), ...(assessment.evidence ?? []).map((value) => `${value.kind}:${value.ref}`)])];
   requirement.trajectoryRef = `completion-receipt:${requirement.id}`;
   requirement.trajectoryKind = 'VERIFIED_COMPLETION_RECEIPT';
-  requirement.nextAction = 'Preserve evidence and observe regression/RETURN conditions; reopen only on falsifying evidence.';
-  requirement.returnCondition = 'Already met by the bound RETURN_PASS receipt; any later regression must create a new trajectory.';
+  requirement.nextAction = 'Preserve evidence and observe scoped regression/RETURN conditions; reopen only on falsifying evidence.';
+  requirement.returnCondition = 'Already met by the bound RETURN_PASS receipt; changes inside its declared regression scope invalidate it.';
   requirement.completionReceipt.receipt = assessment.receipt;
   requirement.completionReceipt.evidenceResults = assessment.evidenceResults;
   promoted += 1;
@@ -97,15 +107,16 @@ for (const requirement of report.requirements ?? []) {
 
 report.counts = Object.fromEntries(canonicalStatuses.map((status) => [status, (report.requirements ?? []).filter((r) => r.status === status).length]));
 report.counts.UNCLASSIFIED = (report.requirements ?? []).filter((r) => !canonicalStatuses.includes(r.status)).length;
-report.contract = 'SFI-PROGRAM-COMPLETION-CONTROLLER-1.3';
+report.contract = 'SFI-PROGRAM-COMPLETION-CONTROLLER-1.4';
 report.completionReceiptContract = ledger.contract;
 report.completionReceiptState = {
   ledgerPath: LEDGER_REPOSITORY_PATH, receiptCount: Object.keys(ledger.receipts ?? {}).length, promotedSatisfiedCount: promoted,
   invalidReceiptCount: invalidReceipts.length, invalidReceipts, currentHead: report.head, independentVerifier: 'SFI-08',
-  evidenceResolution: 'OBSERVED_REFERENCE_REQUIRED', verifiedHeadRule: 'EXACT_OR_LEDGER_ONLY_DESCENDANT',
+  evidenceResolution: 'OBSERVED_REFERENCE_REQUIRED', verifiedHeadRule: 'EXACT_OR_ANCESTOR_WITH_UNTOUCHED_DECLARED_REGRESSION_SCOPE',
 };
 report.qa = { ...(report.qa ?? {}), satisfiedReachableThroughBoundReceipt: true, completionReceiptsFailClosed: invalidReceipts.length === 0,
-  externalClassificationIndependentOfMutableStatus: true, selfAssertedEvidenceRejected: true, ledgerCommitDoesNotSelfInvalidateReceipt: true };
+  externalClassificationIndependentOfMutableStatus: true, selfAssertedEvidenceRejected: true, unrelatedCodeDoesNotInvalidateScopedReceipt: true,
+  scopedRegressionInvalidatesReceipt: true };
 for (const invalid of invalidReceipts) {
   report.hardDefects ??= [];
   report.hardDefects.push({ id: `${invalid.requirementId}:invalid-completion-receipt`, rule: 'INVALID_COMPLETION_RECEIPT', requirementId: invalid.requirementId, receiptError: invalid.error, trajectoryRef: '#405' });
@@ -117,8 +128,8 @@ const md = [
   '# SFI · Autonomous Program Completion Controller','',`**Contract:** ${report.contract}  `,`**HEAD:** ${report.head}  `,`**Generated:** ${report.generatedAt}  `,`**Receipt contract:** ${ledger.contract}  `,'',
   '## Classification',...Object.entries(report.counts).map(([key,value]) => `- ${key}: ${value}`),'','## Completion receipt assurance',
   `- receipts: ${report.completionReceiptState.receiptCount}`,`- promoted SATISFIED: ${promoted}`,`- invalid receipts: ${invalidReceipts.length}`,
-  `- current HEAD: ${report.head}`,'- verifier: SFI-08 only','- verified head: exact current HEAD or an ancestor separated only by the completion receipt ledger file',
-  '- rule: any intervening code/runtime/QA change invalidates the receipt','- rule: code/file presence and green CI alone never promote SATISFIED',
+  `- current HEAD: ${report.head}`,'- verifier: SFI-08 only','- verified head: exact current HEAD or an ancestor whose declared regression scope has not changed',
+  '- rule: a changed path inside receipt.scopePaths invalidates that receipt; unrelated changes do not','- rule: code/file presence and green CI alone never promote SATISFIED',
   '- rule: every evidence reference must resolve to observed immutable state','- external-only requirements require externalObserved=true','',
   '## Hard defects',...((report.hardDefects ?? []).length ? report.hardDefects.map((d) => `- ${d.rule}: ${d.requirementId}`) : ['- none']),'',
   '## Active completion trajectories',...(report.requirements ?? []).filter((r) => !['SATISFIED','SUPERSEDED_BY_AUTHORIZED_DECISION'].includes(r.status)).map((r) => `- **${r.id} · ${r.status} · ${r.owner} · ${r.trajectoryRef}** — ${r.requirement} — NEXT: ${r.nextAction}`),'',

--- a/scripts/sfi-program-completion-reconcile.mjs
+++ b/scripts/sfi-program-completion-reconcile.mjs
@@ -41,7 +41,9 @@ function verifyReceiptHead(verifiedHead, currentHead, receipt) {
   try {
     execFileSync('git', ['cat-file', '-e', `${verifiedHead}^{commit}`], { cwd: root, stdio: 'ignore' });
     execFileSync('git', ['merge-base', '--is-ancestor', verifiedHead, currentHead], { cwd: root, stdio: 'ignore' });
-    const changed = execFileSync('git', ['diff', '--name-only', verifiedHead, currentHead], { cwd: root, encoding: 'utf8' })
+    // Disable rename collapsing so moving an in-scope file out of its scope is observed as
+    // an in-scope deletion plus an out-of-scope addition rather than a single destination path.
+    const changed = execFileSync('git', ['diff', '--no-renames', '--name-only', verifiedHead, currentHead], { cwd: root, encoding: 'utf8' })
       .split('\n').map((value) => value.trim()).filter(Boolean);
     const scopePaths = Array.isArray(receipt?.scopePaths) ? receipt.scopePaths.map(normalizeRepoPath).filter(Boolean) : [];
     if (!scopePaths.length) return { ok: false, error: 'RECEIPT_REGRESSION_SCOPE_REQUIRED' };
@@ -116,7 +118,7 @@ report.completionReceiptState = {
 };
 report.qa = { ...(report.qa ?? {}), satisfiedReachableThroughBoundReceipt: true, completionReceiptsFailClosed: invalidReceipts.length === 0,
   externalClassificationIndependentOfMutableStatus: true, selfAssertedEvidenceRejected: true, unrelatedCodeDoesNotInvalidateScopedReceipt: true,
-  scopedRegressionInvalidatesReceipt: true };
+  scopedRegressionInvalidatesReceipt: true, scopeRenameCannotBypassInvalidation: true };
 for (const invalid of invalidReceipts) {
   report.hardDefects ??= [];
   report.hardDefects.push({ id: `${invalid.requirementId}:invalid-completion-receipt`, rule: 'INVALID_COMPLETION_RECEIPT', requirementId: invalid.requirementId, receiptError: invalid.error, trajectoryRef: '#405' });


### PR DESCRIPTION
Parent: #405 / #389
Owner: SFI-00 · Control Room
Assurance: SFI-08

Repair a completion-controller defect discovered while executing the remaining FULL REMAKE trajectories: contract 1.2 invalidates every existing SATISFIED receipt after any later code change anywhere in the repository. That makes finite multi-slice completion impossible after the first receipt.

## SFI PRECHECK
Existing capability inspected: Program Completion Controller 1.3, completion receipt contract 1.2, exact-head/ledger-only ancestry verifier, #462 WorldSignalObserver durable RETURN receipt.
Absorb vs create decision: ABSORB. Keep the existing receipt ledger and verifier; refine regression invalidation from repository-global to an explicit per-receipt regression scope.
Authoritative writer: unchanged: `docs/program/SFI-COMPLETION-RECEIPTS.json`, written only by bounded completion work and independently verified by SFI-08.
Persistence/lineage impact: receipt contract becomes 1.3 and requires non-empty safe `scopePaths`; existing ISSUE154-001 declares its World observation regression surface. Evidence refs, requirement hashes, immutable evidence, SFI-08 and RETURN_PASS remain mandatory.
Front delta: NONE.
Back delta: Controller 1.4 invalidates a receipt when a descendant changes a path inside that receipt's declared regression scope; unrelated code changes no longer erase previously observed completion.
DB delta: NONE.
Redundancy removed: repository-global invalidation that made sequential finite completion impossible.
Execution/ROOT boundary: no authority expansion; this changes only completion assurance semantics.
Rollback: revert this PR. The prior global invalidation behavior returns.
Verification: dedicated receipt QA must prove exact-head PASS, unrelated-change survival, scope-change FAIL, missing/unsafe scope FAIL, evidence resolver requirement, independent SFI-08 requirement and external-observation requirement. Existing World receipt must remain valid on the new contract.

Falsification: FAIL if a receipt survives a change inside its declared scope, if a receipt without a safe non-empty scope can become SATISFIED, or if evidence/RETURN/SFI-08 requirements are weakened.