### PR TITLE
fix(continuity): reseed institutional state after canonical reset

### DIFF
--- a/.github/workflows/sfi-continuity-reset-reseed.yml
+++ b/.github/workflows/sfi-continuity-reset-reseed.yml
@@ -5,16 +5,22 @@ on:
     paths:
       - 'scripts/db/sfi-canonical-reset-classification.mjs'
       - 'scripts/db/reset-sfi-operational-tables.mjs'
+      - 'scripts/db/verify-continuity-reseed-ready.mjs'
+      - 'scripts/db/preserve-institutional-integrations.ts'
       - 'scripts/qa-sfi-continuity-reset-reseed.mjs'
       - 'supabase/migrations/20260909154500_continuity_state_singleton_reseed.sql'
+      - '.github/workflows/sfi-db-canonical-reset.yml'
       - '.github/workflows/sfi-continuity-reset-reseed.yml'
   push:
     branches: [main]
     paths:
       - 'scripts/db/sfi-canonical-reset-classification.mjs'
       - 'scripts/db/reset-sfi-operational-tables.mjs'
+      - 'scripts/db/verify-continuity-reseed-ready.mjs'
+      - 'scripts/db/preserve-institutional-integrations.ts'
       - 'scripts/qa-sfi-continuity-reset-reseed.mjs'
       - 'supabase/migrations/20260909154500_continuity_state_singleton_reseed.sql'
+      - '.github/workflows/sfi-db-canonical-reset.yml'
       - '.github/workflows/sfi-continuity-reset-reseed.yml'
 
 permissions:

--- a/.github/workflows/sfi-continuity-reset-reseed.yml
+++ b/.github/workflows/sfi-continuity-reset-reseed.yml
@@ -1,0 +1,36 @@
+name: SFI Continuity Reset Reseed
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/db/sfi-canonical-reset-classification.mjs'
+      - 'scripts/db/reset-sfi-operational-tables.mjs'
+      - 'scripts/qa-sfi-continuity-reset-reseed.mjs'
+      - 'supabase/migrations/20260909154500_continuity_state_singleton_reseed.sql'
+      - '.github/workflows/sfi-continuity-reset-reseed.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/db/sfi-canonical-reset-classification.mjs'
+      - 'scripts/db/reset-sfi-operational-tables.mjs'
+      - 'scripts/qa-sfi-continuity-reset-reseed.mjs'
+      - 'supabase/migrations/20260909154500_continuity_state_singleton_reseed.sql'
+      - '.github/workflows/sfi-continuity-reset-reseed.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  continuity-reset-reseed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Falsify canonical-reset continuity singleton regression
+        run: node scripts/qa-sfi-continuity-reset-reseed.mjs
+      - name: Typecheck
+        run: npm run typecheck

--- a/.github/workflows/sfi-continuity-reset-reseed.yml
+++ b/.github/workflows/sfi-continuity-reset-reseed.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'scripts/db/sfi-canonical-reset-classification.mjs'
       - 'scripts/db/reset-sfi-operational-tables.mjs'
+      - 'scripts/db/continuity-reseed-gate.mjs'
       - 'scripts/db/verify-continuity-reseed-ready.mjs'
       - 'scripts/db/preserve-institutional-integrations.ts'
       - 'scripts/qa-sfi-continuity-reset-reseed.mjs'
@@ -16,6 +17,7 @@ on:
     paths:
       - 'scripts/db/sfi-canonical-reset-classification.mjs'
       - 'scripts/db/reset-sfi-operational-tables.mjs'
+      - 'scripts/db/continuity-reseed-gate.mjs'
       - 'scripts/db/verify-continuity-reseed-ready.mjs'
       - 'scripts/db/preserve-institutional-integrations.ts'
       - 'scripts/qa-sfi-continuity-reset-reseed.mjs'

--- a/.github/workflows/sfi-db-canonical-reset.yml
+++ b/.github/workflows/sfi-db-canonical-reset.yml
@@ -84,6 +84,12 @@ jobs:
           set -euo pipefail
           node scripts/db/resolve-reset-database-url.mjs
 
+      - name: Fail closed unless continuity reseed trigger is live
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/db/verify-continuity-reseed-ready.mjs pre
+
       - name: Export and validate canonical genesis configuration
         shell: bash
         run: |
@@ -134,6 +140,7 @@ jobs:
         run: |
           set -euo pipefail
           node scripts/db/reset-sfi-operational-tables.mjs
+          node scripts/db/verify-continuity-reseed-ready.mjs post | tee /tmp/sfi-continuity-reseed.json
           node --import tsx scripts/db/preserve-institutional-integrations.ts restore | tee /tmp/sfi-institutional-restore.json
           node --import tsx scripts/db/preserve-production-instrument-bank.ts restore | tee /tmp/sfi-instrument-restore.json
           node --import tsx scripts/db/preserve-institutional-integrations.ts verify
@@ -147,6 +154,7 @@ jobs:
           name: sfi-db-post-reset-genesis-${{ github.run_id }}
           path: |
             docs/db/SFI_CANONICAL_RESET_REPORT_*.json
+            /tmp/sfi-continuity-reseed.json
             /tmp/sfi-institutional-restore.json
             /tmp/sfi-instrument-restore.json
           if-no-files-found: error
@@ -166,6 +174,7 @@ jobs:
             echo '- Database route: **Supavisor session mode / IPv4 / SSL required**'
             echo '- Legacy preservation: **full longitudinal World corpus**'
             echo '- Protected World plane: source observations, friction readings, hypotheses, outcomes, learning events, WorldSpect snapshots, World Vector cycles/observations/reports/alerts'
+            echo '- Continuity singleton: **RESEED_MINIMAL; live AFTER TRUNCATE trigger required before destructive reset and post-reset singleton verified**'
             echo '- Registered institutional identities/OAuth configuration: **reseeded from canonical registry; no authority expansion; no usage history restored**'
             echo '- Production Instrument Bank configuration: **PRODUCTION + ELIGIBLE SFZ packages and rights evidence reseeded; render history not restored**'
             echo '- Twin/AMV/QA/governance/runtime learning outside the World corpus: **not imported**'

--- a/docs/db/SFI_FINAL_DATABASE_CLOSURE.md
+++ b/docs/db/SFI_FINAL_DATABASE_CLOSURE.md
@@ -1,8 +1,8 @@
 # SFI FINAL DATABASE CLOSURE
 
 Status: **EVIDENCE_FIRST_PRE_ASSURANCE_RESET**  
-Contract: `SFI-FINAL-DATABASE-CLOSURE-1.1`  
-Reset classification: `SFI-CANONICAL-RESET-CLASSIFICATION-1.1`  
+Contract: `SFI-FINAL-DATABASE-CLOSURE-1.2`  
+Reset classification: `SFI-CANONICAL-RESET-CLASSIFICATION-1.2`  
 Supersedes implementation intent of PR #210 and the former terminal-only reset order.
 
 ## Decision
@@ -26,7 +26,7 @@ The accumulated World observations and hypotheses are not cleanup residue. They 
 - `world_vector_reports`
 - `world_vector_alerts`
 
-All ten are `PRESERVE_DATA` under `SFI-CANONICAL-RESET-CLASSIFICATION-1.1`. Their exact row counts are captured in the V2 evidence snapshot and must be identical after reset. Moving any of these tables into purge is a new preservation-boundary decision requiring explicit sovereign authorization.
+All ten are `PRESERVE_DATA` under `SFI-CANONICAL-RESET-CLASSIFICATION-1.2`. Their exact row counts are captured in the V2 evidence snapshot and must be identical after reset. Moving any of these tables into purge is a new preservation-boundary decision requiring explicit sovereign authorization.
 
 ## Reset prerequisites
 
@@ -65,8 +65,8 @@ The reset does not use dependency-propagating truncation. The protected World pl
 At the current 164-table baseline:
 
 - `PRESERVE_DATA`: 10 tables — full World longitudinal corpus;
-- `RESEED_MINIMAL`: 7 tables — minimal profile/tenant/OAuth/account infrastructure;
-- `PURGE_DATA`: 147 tables — non-World QA, telemetry, runtime memory, Twin/AMV, governance residue and other operational history selected by the issue #430 policy;
+- `RESEED_MINIMAL`: 8 tables — minimal profile/tenant/OAuth/account infrastructure plus the required institutional continuity singleton;
+- `PURGE_DATA`: 146 tables — non-World QA, telemetry, runtime memory, Twin/AMV, governance residue and other operational history selected by the issue #430 policy;
 - `UNCLASSIFIED`: must be zero.
 
 A newly appearing public table is never deleted implicitly. It becomes `UNCLASSIFIED` and blocks the reset until intentionally classified.
@@ -79,7 +79,10 @@ After the purge, SFI reconstructs only the minimum current operating identity/co
 - one SFI account and founder membership/balance;
 - one personal tenant and founder ownership membership;
 - active founder OAuth client configuration required for the current integration, without authorization-code or usage history;
+- one required `sfi_continuity_state` singleton with `id=institution`, default `mode=NORMAL` and no inherited pre-reset runtime history;
 - one `SFI_CANONICAL_RESET_GENESIS` audit event bound to snapshot hash, external artifact and reset commit.
+
+The continuity singleton is schema-owned minimum infrastructure. Its disposition is `CONTINUITY_SINGLETON = RESEED_MINIMAL`: it is reconstructed after a bounded reset and is not treated as preserved historical operational state.
 
 The retired `seed-sfi-canonical-history.mjs` must not import QA reports, operational patches or runtime events as institutional history.
 
@@ -106,7 +109,7 @@ transactional purge + minimal genesis
    ↓
 verify all 10 World counts unchanged
    ↓
-verify non-World purge / Auth / ROOT / tenant / OAuth / RLS
+verify non-World purge / Auth / ROOT / tenant / OAuth / continuity singleton / RLS
    ↓
 Human E2E + GPT E2E + API/MCP E2E + persistence/reentry
    ↓
@@ -132,6 +135,7 @@ A clean database is an operational hygiene state. It does not validate historica
 ```text
 DATABASE_CLEANUP = EVIDENCE_FIRST_PRE_ASSURANCE_RESET
 WORLD_LONGITUDINAL_CORPUS = PRESERVE_DATA
+CONTINUITY_SINGLETON = RESEED_MINIMAL
 FINAL_E2E = AFTER_CLEAN_GENESIS
 RESET_EXECUTED = NO
 PR_210_IMPLEMENTATION = SUPERSEDED_BY_CURRENT_ARCHITECTURE

--- a/scripts/db/continuity-reseed-gate.mjs
+++ b/scripts/db/continuity-reseed-gate.mjs
@@ -1,0 +1,100 @@
+import { spawnSync } from 'node:child_process';
+
+export const SFI_CONTINUITY_RESEED_CONTRACT = 'SFI-CONTINUITY-STATE-SINGLETON-RESEED-1.0';
+export const SFI_CONTINUITY_RESEED_GATE_CONTRACT = 'SFI-CONTINUITY-RESET-RESEED-RUNTIME-GATE-1.1';
+
+function pgEnvironment(rawUrl) {
+  const url = new URL(rawUrl);
+  return {
+    ...process.env,
+    PGHOST: url.hostname,
+    PGPORT: url.port || '5432',
+    PGUSER: decodeURIComponent(url.username),
+    PGPASSWORD: decodeURIComponent(url.password),
+    PGDATABASE: decodeURIComponent(url.pathname.replace(/^\//, '')),
+    PGSSLMODE: process.env.PGSSLMODE || 'require',
+  };
+}
+
+function runPsql(databaseUrl, sql) {
+  const result = spawnSync('psql', [
+    '--no-psqlrc', '--set', 'ON_ERROR_STOP=1', '--tuples-only', '--no-align', '--command', sql,
+  ], {
+    env: pgEnvironment(databaseUrl),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`psql failed: ${String(result.stderr || result.stdout).trim()}`);
+  return String(result.stdout || '').trim();
+}
+
+export function verifyContinuityReseedReady(databaseUrl, mode) {
+  if (!databaseUrl) throw new Error('SFI_CONTINUITY_RESEED_DATABASE_REQUIRED');
+  if (!['pre', 'post'].includes(mode)) throw new Error('SFI_CONTINUITY_RESEED_MODE_INVALID');
+
+  const readiness = JSON.parse(runPsql(databaseUrl, `
+select json_build_object(
+  'table_exists', to_regclass('public.sfi_continuity_state') is not null,
+  'function_exists', to_regprocedure('public.sfi_reseed_continuity_state_after_truncate()') is not null,
+  'function_contract_bound', coalesce((
+    select position('${SFI_CONTINUITY_RESEED_CONTRACT}' in pg_get_functiondef(p.oid)) > 0
+       and position('institution' in pg_get_functiondef(p.oid)) > 0
+    from pg_proc p
+    join pg_namespace n on n.oid=p.pronamespace
+    where n.nspname='public' and p.proname='sfi_reseed_continuity_state_after_truncate' and p.pronargs=0
+    limit 1
+  ), false),
+  'trigger_bound', coalesce((
+    select pg_get_triggerdef(t.oid, true) ilike '%AFTER TRUNCATE ON sfi_continuity_state%'
+       and t.tgfoid = to_regprocedure('public.sfi_reseed_continuity_state_after_truncate()')
+       and t.tgenabled <> 'D'
+    from pg_trigger t
+    join pg_class c on c.oid=t.tgrelid
+    join pg_namespace n on n.oid=c.relnamespace
+    where n.nspname='public'
+      and c.relname='sfi_continuity_state'
+      and t.tgname='sfi_continuity_state_reseed_after_truncate'
+      and not t.tgisinternal
+    limit 1
+  ), false)
+)::text;
+`));
+
+  if (!readiness.table_exists || !readiness.function_exists || !readiness.function_contract_bound || !readiness.trigger_bound) {
+    throw new Error(`SFI_CONTINUITY_RESEED_NOT_READY:${JSON.stringify(readiness)}`);
+  }
+
+  if (mode === 'post') {
+    const singleton = JSON.parse(runPsql(databaseUrl, `
+select json_build_object(
+  'row_count', count(*),
+  'institution_count', count(*) filter (where id='institution'),
+  'institution_mode', max(mode) filter (where id='institution'),
+  'founder_available', bool_and(founder_available) filter (where id='institution'),
+  'contract', max(metadata->>'contract') filter (where id='institution'),
+  'reseeded_by', max(metadata->>'reseededBy') filter (where id='institution')
+) from public.sfi_continuity_state;
+`));
+    if (
+      Number(singleton.row_count) !== 1
+      || Number(singleton.institution_count) !== 1
+      || singleton.institution_mode !== 'NORMAL'
+      || singleton.founder_available !== true
+      || singleton.contract !== SFI_CONTINUITY_RESEED_CONTRACT
+      || singleton.reseeded_by !== 'SFI_CONTINUITY_STATE_TRUNCATE_TRIGGER'
+    ) {
+      throw new Error(`SFI_CONTINUITY_SINGLETON_POST_RESET_INVALID:${JSON.stringify(singleton)}`);
+    }
+    return { ok:true, contract:SFI_CONTINUITY_RESEED_GATE_CONTRACT, mode, readiness, singleton, authorityExpansion:false };
+  }
+
+  return {
+    ok:true,
+    contract:SFI_CONTINUITY_RESEED_GATE_CONTRACT,
+    mode,
+    readiness,
+    destructiveResetAllowedByThisGate:true,
+    authorityExpansion:false,
+  };
+}

--- a/scripts/db/preserve-institutional-integrations.ts
+++ b/scripts/db/preserve-institutional-integrations.ts
@@ -1,6 +1,7 @@
 import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { SFI_INSTITUTIONAL_MEMBERS } from '../../src/lib/system/access/institutionalMembers';
+import { SFI_CANONICAL_RESET_CONTRACT } from './sfi-canonical-reset-classification.mjs';
 
 const databaseUrl = process.env.DATABASE_URL || process.env.DIRECT_URL || process.env.CONNECTION_STRING;
 const statePath = process.env.SFI_INSTITUTIONAL_INTEGRATION_STATE || '/tmp/sfi-institutional-integrations.json';
@@ -62,7 +63,7 @@ if (mode === 'verify') {
     if ((member.role as string) === 'root' || (member.role as string) === 'system') throw new Error('SFI_INSTITUTIONAL_GENESIS_SOVEREIGN_ROLE_FORBIDDEN');
     for (const client of item.clients) if (!client.client_id || !client.client_secret_hash || !client.redirect_uris?.length) throw new Error(`SFI_INSTITUTIONAL_OAUTH_CONFIG_INCOMPLETE:${item.email}`);
   }
-  console.log(JSON.stringify({ ok:true, contract:state.contract, authorityExpansion:false, registeredMembersOnly:true }));
+  console.log(JSON.stringify({ ok:true, contract:state.contract, authorityExpansion:false, registeredMembersOnly:true, resetContract:SFI_CANONICAL_RESET_CONTRACT }));
 }
 
 if (mode === 'restore') {
@@ -73,11 +74,11 @@ if (mode === 'restore') {
   const statements: string[] = ['begin;'];
   for (const item of state.members) {
     const member = registryByEmail.get(item.email.toLowerCase())!;
-    const access = { display_title:member.title, observatory:member.modules.observatory, planner:member.modules.field, simulator:member.modules.studio, social:member.modules.worldField, field:member.modules.field, studio:member.modules.studio, world_field:member.modules.worldField, root:member.modules.root, root_observe:member.modules.root, full_access:false, executor:false, root_execution:false, governance_write:false, sovereign_actions:false, canonical_promotion:false, external_agent:true, external_role:member.external.role, external_scopes:member.external.scopes, external_oauth_role:member.external.role, external_oauth_scopes:member.external.scopes, external_studio_owner_scoped:true, genesis_contract:'SFI-CANONICAL-RESET-CLASSIFICATION-1.1' };
+    const access = { display_title:member.title, observatory:member.modules.observatory, planner:member.modules.field, simulator:member.modules.studio, social:member.modules.worldField, field:member.modules.field, studio:member.modules.studio, world_field:member.modules.worldField, root:member.modules.root, root_observe:member.modules.root, full_access:false, executor:false, root_execution:false, governance_write:false, sovereign_actions:false, canonical_promotion:false, external_agent:true, external_role:member.external.role, external_scopes:member.external.scopes, external_oauth_role:member.external.role, external_oauth_scopes:member.external.scopes, external_studio_owner_scoped:true, genesis_contract:SFI_CANONICAL_RESET_CONTRACT };
     statements.push(`insert into public.profiles(user_id,email,alias,role,subscription_tier,module_access,last_seen_at,created_at,updated_at) values (${q(item.user_id)}::uuid,${q(member.email)},${q(member.displayName)},${q(member.role)},'enterprise',${q(JSON.stringify(access))}::jsonb,now(),now(),now()) on conflict (user_id) do update set email=excluded.email,alias=excluded.alias,role=excluded.role,subscription_tier=excluded.subscription_tier,module_access=excluded.module_access,last_seen_at=now(),updated_at=now();`);
     statements.push(`insert into public.account_members(account_id,user_id,role) values (${q(accountId)}::uuid,${q(item.user_id)}::uuid,${q(member.role)}) on conflict (account_id,user_id) do update set role=excluded.role;`);
     statements.push(`insert into public.sfi_tenant_members(tenant_id,user_id,role,status) values (${q(tenantId)}::uuid,${q(item.user_id)}::uuid,'OPERATOR','ACTIVE') on conflict (tenant_id,user_id) do update set role='OPERATOR',status='ACTIVE';`);
-    for (const client of item.clients) statements.push(`insert into public.sfi_oauth_clients(id,client_id,client_secret_hash,name,created_by,redirect_uris,allowed_scopes,audience,status,metadata,last_used_at,created_at,updated_at) values (${q(client.id)}::uuid,${q(client.client_id)},${q(client.client_secret_hash)},${q(client.name)},${q(item.user_id)}::uuid,${arr(client.redirect_uris || [])},${arr([...member.external.scopes])},${q(client.audience)},'ACTIVE',jsonb_build_object('genesis',true,'reseededBy','SFI_CANONICAL_RESET','institutionalRegistryBound',true),null,now(),now()) on conflict (id) do update set client_id=excluded.client_id,client_secret_hash=excluded.client_secret_hash,name=excluded.name,created_by=excluded.created_by,redirect_uris=excluded.redirect_uris,allowed_scopes=excluded.allowed_scopes,audience=excluded.audience,status='ACTIVE',metadata=excluded.metadata,last_used_at=null,updated_at=now();`);
+    for (const client of item.clients) statements.push(`insert into public.sfi_oauth_clients(id,client_id,client_secret_hash,name,created_by,redirect_uris,allowed_scopes,audience,status,metadata,last_used_at,created_at,updated_at) values (${q(client.id)}::uuid,${q(client.client_id)},${q(client.client_secret_hash)},${q(client.name)},${q(item.user_id)}::uuid,${arr(client.redirect_uris || [])},${arr([...member.external.scopes])},${q(client.audience)},'ACTIVE',jsonb_build_object('genesis',true,'reseededBy','SFI_CANONICAL_RESET','resetContract',${q(SFI_CANONICAL_RESET_CONTRACT)},'institutionalRegistryBound',true),null,now(),now()) on conflict (id) do update set client_id=excluded.client_id,client_secret_hash=excluded.client_secret_hash,name=excluded.name,created_by=excluded.created_by,redirect_uris=excluded.redirect_uris,allowed_scopes=excluded.allowed_scopes,audience=excluded.audience,status='ACTIVE',metadata=excluded.metadata,last_used_at=null,updated_at=now();`);
   }
   statements.push('commit;');
   runPsql(statements.join('\n'));
@@ -85,9 +86,10 @@ if (mode === 'restore') {
   const observedProfiles = Number(runPsql('select count(*)::text from public.profiles;'));
   if (observedProfiles !== expectedProfiles) throw new Error(`SFI_GENESIS_PROFILE_COUNT_MISMATCH:${observedProfiles}:${expectedProfiles}`);
   for (const item of state.members) {
-    const row = JSON.parse(runPsql(`select json_build_object('role',role,'full_access',coalesce((module_access->>'full_access')::boolean,false),'governance_write',coalesce((module_access->>'governance_write')::boolean,false),'sovereign_actions',coalesce((module_access->>'sovereign_actions')::boolean,false),'canonical_promotion',coalesce((module_access->>'canonical_promotion')::boolean,false),'account_role',(select role from public.account_members am where am.user_id=profiles.user_id limit 1),'tenant_role',(select role from public.sfi_tenant_members tm where tm.user_id=profiles.user_id limit 1),'oauth',(select count(*) from public.sfi_oauth_clients c where c.created_by=profiles.user_id and c.status='ACTIVE'))::text from public.profiles where user_id=${q(item.user_id)}::uuid;`));
+    const row = JSON.parse(runPsql(`select json_build_object('role',role,'full_access',coalesce((module_access->>'full_access')::boolean,false),'governance_write',coalesce((module_access->>'governance_write')::boolean,false),'sovereign_actions',coalesce((module_access->>'sovereign_actions')::boolean,false),'canonical_promotion',coalesce((module_access->>'canonical_promotion')::boolean,false),'genesis_contract',module_access->>'genesis_contract','account_role',(select role from public.account_members am where am.user_id=profiles.user_id limit 1),'tenant_role',(select role from public.sfi_tenant_members tm where tm.user_id=profiles.user_id limit 1),'oauth',(select count(*) from public.sfi_oauth_clients c where c.created_by=profiles.user_id and c.status='ACTIVE'))::text from public.profiles where user_id=${q(item.user_id)}::uuid;`));
     const member = registryByEmail.get(item.email.toLowerCase())!;
     if (row.role !== member.role || row.full_access || row.governance_write || row.sovereign_actions || row.canonical_promotion) throw new Error(`SFI_INSTITUTIONAL_AUTHORITY_EXPANDED:${item.email}`);
+    if (row.genesis_contract !== SFI_CANONICAL_RESET_CONTRACT) throw new Error(`SFI_INSTITUTIONAL_RESET_PROVENANCE_MISMATCH:${item.email}:${row.genesis_contract}`);
     if (row.account_role !== member.role || row.tenant_role !== 'OPERATOR') throw new Error(`SFI_INSTITUTIONAL_MEMBERSHIP_MISMATCH:${item.email}`);
     if (Number(row.oauth) !== item.clients.length) throw new Error(`SFI_INSTITUTIONAL_OAUTH_COUNT_MISMATCH:${item.email}`);
     const expectedScopes = [...member.external.scopes].sort();
@@ -97,5 +99,5 @@ if (mode === 'restore') {
       if (JSON.stringify(observed) !== JSON.stringify(expectedScopes)) throw new Error(`SFI_INSTITUTIONAL_OAUTH_SCOPE_MISMATCH:${item.email}`);
     }
   }
-  console.log(JSON.stringify({ ok:true, contract:state.contract, institutionalMembersRestored:state.members.length, authorityExpansion:false, historicalUsageRestored:false }));
+  console.log(JSON.stringify({ ok:true, contract:state.contract, resetContract:SFI_CANONICAL_RESET_CONTRACT, institutionalMembersRestored:state.members.length, authorityExpansion:false, historicalUsageRestored:false }));
 }

--- a/scripts/db/reset-sfi-operational-tables.mjs
+++ b/scripts/db/reset-sfi-operational-tables.mjs
@@ -10,6 +10,10 @@ import {
   CLASSIFIED_PUBLIC_TABLES,
   auditPublicTableClassification,
 } from './sfi-canonical-reset-classification.mjs';
+import {
+  SFI_CONTINUITY_RESEED_CONTRACT,
+  verifyContinuityReseedReady,
+} from './continuity-reseed-gate.mjs';
 
 const databaseUrl = process.env.DATABASE_URL || process.env.DIRECT_URL || process.env.CONNECTION_STRING;
 const confirm = process.env.SFI_DB_RESET_CONFIRM;
@@ -109,6 +113,8 @@ function jsonObjectFromPairs(output) {
   }
   return result;
 }
+
+const continuityPreflight = verifyContinuityReseedReady(databaseUrl, 'pre');
 
 const snapshot = await verifyDbEvidenceReceipt(snapshotReceiptPath, {
   maxAgeMinutes: Number(process.env.SFI_DB_SNAPSHOT_MAX_AGE_MINUTES || 180),
@@ -285,6 +291,16 @@ ${preserveExpectedChecks}
     execute format('select count(*) from public.%I',table_name) into observed_count;
     if observed_count <> 0 then raise exception 'Purge table % is not empty after canonical reset: %',table_name,observed_count; end if;
   end loop;
+  select count(*) into observed_count from public.sfi_continuity_state;
+  if observed_count <> 1 then raise exception 'Expected exactly one post-reset continuity singleton, found %',observed_count; end if;
+  select count(*) into observed_count
+  from public.sfi_continuity_state
+  where id='institution'
+    and mode='NORMAL'
+    and founder_available=true
+    and metadata->>'contract'='${SFI_CONTINUITY_RESEED_CONTRACT}'
+    and metadata->>'reseededBy'='SFI_CONTINUITY_STATE_TRUNCATE_TRIGGER';
+  if observed_count <> 1 then raise exception 'Continuity singleton was not reseeded with canonical provenance before commit'; end if;
   select count(*) into observed_count from public.root_audit_events where action='SFI_CANONICAL_RESET_GENESIS';
   if observed_count <> 1 then raise exception 'Expected exactly one post-reset genesis audit event, found %',observed_count; end if;
   select count(*) into observed_count from public.profiles;
@@ -306,6 +322,7 @@ commit;
 `;
 
 runPsql(transactionSql, { capture: true });
+const continuityPostflight = verifyContinuityReseedReady(databaseUrl, 'post');
 
 const postPreserveCounts = jsonObjectFromPairs(runPsql(PRESERVE_DATA_TABLES.map((table) => `select ${sqlLiteral(table)}||'|'||count(*)::text from public.${ident(table)};`).join('\n')));
 const postInfrastructureCounts = jsonObjectFromPairs(runPsql([
@@ -317,10 +334,12 @@ const postInfrastructureCounts = jsonObjectFromPairs(runPsql([
   "select 'account_members|'||count(*)::text from public.account_members;",
   "select 'account_balance|'||count(*)::text from public.account_balance;",
   "select 'root_audit_events|'||count(*)::text from public.root_audit_events;",
+  "select 'sfi_continuity_state|'||count(*)::text from public.sfi_continuity_state;",
 ].join('\n')));
 
 const report = {
-  ok: PRESERVE_DATA_TABLES.every((table) => postPreserveCounts[table] === Number(preserveCounts[table])),
+  ok: continuityPostflight.ok === true
+    && PRESERVE_DATA_TABLES.every((table) => postPreserveCounts[table] === Number(preserveCounts[table])),
   contract: SFI_CANONICAL_RESET_CONTRACT,
   reset_at: new Date().toISOString(),
   snapshot: {
@@ -333,13 +352,18 @@ const report = {
     reseed_minimal: RESEED_MINIMAL_TABLES, purge_data_count: PURGE_DATA_TABLES.length,
     unclassified: liveClassification.unclassified,
   },
+  continuity_reseed: {
+    preflight: continuityPreflight,
+    postflight: continuityPostflight,
+  },
   preserved_counts_before: preserveCounts,
   preserved_counts_after: postPreserveCounts,
   genesis_infrastructure_counts: postInfrastructureCounts,
   founder_oauth_clients_reseeded: currentFounderOauthCount,
   invariants: [
     'EXTERNAL_PROOF_UPLOADED_BEFORE_RESET','NO_DEPENDENCY_PROPAGATION','LIVE_SCHEMA_EQUALS_SNAPSHOT','UNCLASSIFIED_ZERO',
-    'WORLD_COUNTS_UNCHANGED','LEGACY_LEARNING_NOT_IMPORTED','LEGACY_CANONICAL_HISTORY_NOT_IMPORTED','ONE_POST_RESET_GENESIS_EVENT',
+    'WORLD_COUNTS_UNCHANGED','CONTINUITY_RESEED_TRIGGER_BOUND','CONTINUITY_SINGLETON_VERIFIED_BEFORE_COMMIT',
+    'LEGACY_LEARNING_NOT_IMPORTED','LEGACY_CANONICAL_HISTORY_NOT_IMPORTED','ONE_POST_RESET_GENESIS_EVENT',
   ],
 };
 

--- a/scripts/db/sfi-canonical-reset-classification.mjs
+++ b/scripts/db/sfi-canonical-reset-classification.mjs
@@ -1,4 +1,4 @@
-export const SFI_CANONICAL_RESET_CONTRACT = 'SFI-CANONICAL-RESET-CLASSIFICATION-1.1';
+export const SFI_CANONICAL_RESET_CONTRACT = 'SFI-CANONICAL-RESET-CLASSIFICATION-1.2';
 
 // Founder-directed preservation boundary (2026-09-07): World observation and
 // hypothesis history is institutional evidence and must never be discarded by
@@ -20,7 +20,8 @@ export const PRESERVE_DATA_TABLES = [
 ];
 
 // These rows do NOT survive as legacy data. They are cleared and deterministically
-// re-created from auth/current configuration after the reset so SFI can operate.
+// re-created from auth/current configuration or schema-owned singleton defaults
+// after the reset so SFI can operate.
 export const RESEED_MINIMAL_TABLES = [
   'profiles',
   'sfi_tenants',
@@ -29,6 +30,7 @@ export const RESEED_MINIMAL_TABLES = [
   'accounts',
   'account_members',
   'account_balance',
+  'sfi_continuity_state',
 ];
 
 // Explicit snapshot of every other public table observed live at the reset-design
@@ -114,7 +116,6 @@ export const PURGE_DATA_TABLES = [
   'sfi_cognitive_twin_runs',
   'sfi_continuity_reports',
   'sfi_continuity_runs',
-  'sfi_continuity_state',
   'sfi_cultural_references',
   'sfi_discovery_queries',
   'sfi_discovery_query_runs',

--- a/scripts/db/verify-continuity-reseed-ready.mjs
+++ b/scripts/db/verify-continuity-reseed-ready.mjs
@@ -1,71 +1,9 @@
-import { spawnSync } from 'node:child_process';
+import { verifyContinuityReseedReady } from './continuity-reseed-gate.mjs';
 
 const databaseUrl = process.env.DATABASE_URL || process.env.DIRECT_URL || process.env.CONNECTION_STRING;
 const mode = String(process.argv[2] || '').toLowerCase();
 if (!databaseUrl) throw new Error('SFI_CONTINUITY_RESEED_DATABASE_REQUIRED');
 if (!['pre', 'post'].includes(mode)) throw new Error('Usage: verify-continuity-reseed-ready.mjs <pre|post>');
 
-function pgEnvironment(rawUrl) {
-  const url = new URL(rawUrl);
-  return {
-    ...process.env,
-    PGHOST: url.hostname,
-    PGPORT: url.port || '5432',
-    PGUSER: decodeURIComponent(url.username),
-    PGPASSWORD: decodeURIComponent(url.password),
-    PGDATABASE: decodeURIComponent(url.pathname.replace(/^\//, '')),
-    PGSSLMODE: process.env.PGSSLMODE || 'require',
-  };
-}
-
-function runPsql(sql) {
-  const result = spawnSync('psql', [
-    '--no-psqlrc', '--set', 'ON_ERROR_STOP=1', '--tuples-only', '--no-align', '--command', sql,
-  ], {
-    env: pgEnvironment(databaseUrl),
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) throw new Error(`psql failed: ${String(result.stderr || result.stdout).trim()}`);
-  return String(result.stdout || '').trim();
-}
-
-const readiness = JSON.parse(runPsql(`
-select json_build_object(
-  'table_exists', to_regclass('public.sfi_continuity_state') is not null,
-  'function_exists', to_regprocedure('public.sfi_reseed_continuity_state_after_truncate()') is not null,
-  'trigger_exists', exists (
-    select 1
-    from pg_trigger t
-    join pg_class c on c.oid=t.tgrelid
-    join pg_namespace n on n.oid=c.relnamespace
-    where n.nspname='public'
-      and c.relname='sfi_continuity_state'
-      and t.tgname='sfi_continuity_state_reseed_after_truncate'
-      and not t.tgisinternal
-      and t.tgenabled <> 'D'
-  )
-)::text;
-`));
-
-if (!readiness.table_exists || !readiness.function_exists || !readiness.trigger_exists) {
-  throw new Error(`SFI_CONTINUITY_RESEED_NOT_READY:${JSON.stringify(readiness)}`);
-}
-
-if (mode === 'post') {
-  const singleton = JSON.parse(runPsql(`
-select json_build_object(
-  'row_count', count(*),
-  'institution_count', count(*) filter (where id='institution'),
-  'institution_mode', max(mode) filter (where id='institution'),
-  'founder_available', bool_and(founder_available) filter (where id='institution')
-) from public.sfi_continuity_state;
-`));
-  if (Number(singleton.row_count) !== 1 || Number(singleton.institution_count) !== 1 || singleton.institution_mode !== 'NORMAL' || singleton.founder_available !== true) {
-    throw new Error(`SFI_CONTINUITY_SINGLETON_POST_RESET_INVALID:${JSON.stringify(singleton)}`);
-  }
-  console.log(JSON.stringify({ ok:true, contract:'SFI-CONTINUITY-RESET-RESEED-RUNTIME-GATE-1.0', mode, readiness, singleton, authorityExpansion:false }));
-} else {
-  console.log(JSON.stringify({ ok:true, contract:'SFI-CONTINUITY-RESET-RESEED-RUNTIME-GATE-1.0', mode, readiness, destructiveResetAllowedByThisGate:true, authorityExpansion:false }));
-}
+const result = verifyContinuityReseedReady(databaseUrl, mode);
+console.log(JSON.stringify(result));

--- a/scripts/db/verify-continuity-reseed-ready.mjs
+++ b/scripts/db/verify-continuity-reseed-ready.mjs
@@ -1,0 +1,71 @@
+import { spawnSync } from 'node:child_process';
+
+const databaseUrl = process.env.DATABASE_URL || process.env.DIRECT_URL || process.env.CONNECTION_STRING;
+const mode = String(process.argv[2] || '').toLowerCase();
+if (!databaseUrl) throw new Error('SFI_CONTINUITY_RESEED_DATABASE_REQUIRED');
+if (!['pre', 'post'].includes(mode)) throw new Error('Usage: verify-continuity-reseed-ready.mjs <pre|post>');
+
+function pgEnvironment(rawUrl) {
+  const url = new URL(rawUrl);
+  return {
+    ...process.env,
+    PGHOST: url.hostname,
+    PGPORT: url.port || '5432',
+    PGUSER: decodeURIComponent(url.username),
+    PGPASSWORD: decodeURIComponent(url.password),
+    PGDATABASE: decodeURIComponent(url.pathname.replace(/^\//, '')),
+    PGSSLMODE: process.env.PGSSLMODE || 'require',
+  };
+}
+
+function runPsql(sql) {
+  const result = spawnSync('psql', [
+    '--no-psqlrc', '--set', 'ON_ERROR_STOP=1', '--tuples-only', '--no-align', '--command', sql,
+  ], {
+    env: pgEnvironment(databaseUrl),
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`psql failed: ${String(result.stderr || result.stdout).trim()}`);
+  return String(result.stdout || '').trim();
+}
+
+const readiness = JSON.parse(runPsql(`
+select json_build_object(
+  'table_exists', to_regclass('public.sfi_continuity_state') is not null,
+  'function_exists', to_regprocedure('public.sfi_reseed_continuity_state_after_truncate()') is not null,
+  'trigger_exists', exists (
+    select 1
+    from pg_trigger t
+    join pg_class c on c.oid=t.tgrelid
+    join pg_namespace n on n.oid=c.relnamespace
+    where n.nspname='public'
+      and c.relname='sfi_continuity_state'
+      and t.tgname='sfi_continuity_state_reseed_after_truncate'
+      and not t.tgisinternal
+      and t.tgenabled <> 'D'
+  )
+)::text;
+`));
+
+if (!readiness.table_exists || !readiness.function_exists || !readiness.trigger_exists) {
+  throw new Error(`SFI_CONTINUITY_RESEED_NOT_READY:${JSON.stringify(readiness)}`);
+}
+
+if (mode === 'post') {
+  const singleton = JSON.parse(runPsql(`
+select json_build_object(
+  'row_count', count(*),
+  'institution_count', count(*) filter (where id='institution'),
+  'institution_mode', max(mode) filter (where id='institution'),
+  'founder_available', bool_and(founder_available) filter (where id='institution')
+) from public.sfi_continuity_state;
+`));
+  if (Number(singleton.row_count) !== 1 || Number(singleton.institution_count) !== 1 || singleton.institution_mode !== 'NORMAL' || singleton.founder_available !== true) {
+    throw new Error(`SFI_CONTINUITY_SINGLETON_POST_RESET_INVALID:${JSON.stringify(singleton)}`);
+  }
+  console.log(JSON.stringify({ ok:true, contract:'SFI-CONTINUITY-RESET-RESEED-RUNTIME-GATE-1.0', mode, readiness, singleton, authorityExpansion:false }));
+} else {
+  console.log(JSON.stringify({ ok:true, contract:'SFI-CONTINUITY-RESET-RESEED-RUNTIME-GATE-1.0', mode, readiness, destructiveResetAllowedByThisGate:true, authorityExpansion:false }));
+}

--- a/scripts/qa-sfi-continuity-reset-reseed.mjs
+++ b/scripts/qa-sfi-continuity-reset-reseed.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const classification = fs.readFileSync('scripts/db/sfi-canonical-reset-classification.mjs', 'utf8');
+const reset = fs.readFileSync('scripts/db/reset-sfi-operational-tables.mjs', 'utf8');
+const migration = fs.readFileSync('supabase/migrations/20260909154500_continuity_state_singleton_reseed.sql', 'utf8');
+const originMigration = fs.readFileSync('supabase/migrations/20260807003000_sfi_continuity_runtime.sql', 'utf8');
+
+assert.match(classification, /SFI-CANONICAL-RESET-CLASSIFICATION-1\.2/);
+const reseedBlock = classification.match(/export const RESEED_MINIMAL_TABLES = \[([\s\S]*?)\];/)?.[1] ?? '';
+const purgeBlock = classification.match(/export const PURGE_DATA_TABLES = \[([\s\S]*?)\];/)?.[1] ?? '';
+assert.match(reseedBlock, /'sfi_continuity_state'/, 'continuity singleton must be classified RESEED_MINIMAL');
+assert.doesNotMatch(purgeBlock, /'sfi_continuity_state'/, 'continuity singleton must not be classified PURGE_DATA');
+
+assert.match(reset, /const nonPreserveTables = \[\.\.\.PURGE_DATA_TABLES, \.\.\.RESEED_MINIMAL_TABLES\]/, 'reset must truncate reseed tables before deterministic reconstruction');
+assert.match(reset, /const purgeWithoutGenesis = PURGE_DATA_TABLES\.filter/, 'purge-zero checks must be derived only from PURGE_DATA_TABLES');
+
+assert.match(originMigration, /insert into public\.sfi_continuity_state \(id\) values \('institution'\) on conflict \(id\) do nothing/i, 'original continuity singleton contract missing');
+assert.match(migration, /SFI-CONTINUITY-STATE-SINGLETON-RESEED-1\.0/);
+assert.match(migration, /after truncate on public\.sfi_continuity_state/i, 'AFTER TRUNCATE repair trigger missing');
+assert.match(migration, /insert into public\.sfi_continuity_state/i, 'singleton reseed insert missing');
+assert.match(migration, /'institution'/, 'institution singleton identity missing');
+assert.match(migration, /'NORMAL'/, 'post-reset default continuity mode missing');
+assert.match(migration, /on conflict \(id\) do nothing/i, 'reseed must be idempotent and must not overwrite a real state');
+assert.doesNotMatch(migration, /delete from public\.sfi_continuity_state/i, 'repair may not destructively delete continuity state');
+
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-CONTINUITY-RESET-RESEED-QA-1.0',
+  stateOwner: 'public.sfi_continuity_state',
+  singleton: 'institution',
+  resetDisposition: 'RESEED_MINIMAL',
+  truncateRecovery: true,
+  idempotent: true,
+  preResetHistoryPreserved: false,
+  authorityExpansion: false,
+}, null, 2));

--- a/scripts/qa-sfi-continuity-reset-reseed.mjs
+++ b/scripts/qa-sfi-continuity-reset-reseed.mjs
@@ -5,6 +5,9 @@ const classification = fs.readFileSync('scripts/db/sfi-canonical-reset-classific
 const reset = fs.readFileSync('scripts/db/reset-sfi-operational-tables.mjs', 'utf8');
 const migration = fs.readFileSync('supabase/migrations/20260909154500_continuity_state_singleton_reseed.sql', 'utf8');
 const originMigration = fs.readFileSync('supabase/migrations/20260807003000_sfi_continuity_runtime.sql', 'utf8');
+const runtimeGate = fs.readFileSync('scripts/db/verify-continuity-reseed-ready.mjs', 'utf8');
+const destructiveWorkflow = fs.readFileSync('.github/workflows/sfi-db-canonical-reset.yml', 'utf8');
+const integrationRestore = fs.readFileSync('scripts/db/preserve-institutional-integrations.ts', 'utf8');
 
 assert.match(classification, /SFI-CANONICAL-RESET-CLASSIFICATION-1\.2/);
 const reseedBlock = classification.match(/export const RESEED_MINIMAL_TABLES = \[([\s\S]*?)\];/)?.[1] ?? '';
@@ -24,13 +27,39 @@ assert.match(migration, /'NORMAL'/, 'post-reset default continuity mode missing'
 assert.match(migration, /on conflict \(id\) do nothing/i, 'reseed must be idempotent and must not overwrite a real state');
 assert.doesNotMatch(migration, /delete from public\.sfi_continuity_state/i, 'repair may not destructively delete continuity state');
 
+assert.match(runtimeGate, /SFI-CONTINUITY-RESET-RESEED-RUNTIME-GATE-1\.0/);
+assert.match(runtimeGate, /sfi_continuity_state_reseed_after_truncate/);
+assert.match(runtimeGate, /sfi_reseed_continuity_state_after_truncate/);
+assert.match(runtimeGate, /SFI_CONTINUITY_RESEED_NOT_READY/);
+assert.match(runtimeGate, /SFI_CONTINUITY_SINGLETON_POST_RESET_INVALID/);
+assert.match(runtimeGate, /row_count/);
+assert.match(runtimeGate, /institution_count/);
+assert.match(runtimeGate, /institution_mode/);
+assert.match(runtimeGate, /founder_available/);
+
+const preGate = destructiveWorkflow.indexOf('node scripts/db/verify-continuity-reseed-ready.mjs pre');
+const resetCall = destructiveWorkflow.indexOf('node scripts/db/reset-sfi-operational-tables.mjs');
+const postGate = destructiveWorkflow.indexOf('node scripts/db/verify-continuity-reseed-ready.mjs post');
+assert.ok(preGate >= 0 && resetCall >= 0 && postGate >= 0, 'destructive workflow must bind pre/reset/post continuity gates');
+assert.ok(preGate < resetCall, 'continuity trigger readiness must be observed before destructive reset');
+assert.ok(resetCall < postGate, 'continuity singleton must be verified immediately after destructive reset');
+assert.match(destructiveWorkflow, /\/tmp\/sfi-continuity-reseed\.json/);
+
+assert.match(integrationRestore, /SFI_CANONICAL_RESET_CONTRACT/);
+assert.match(integrationRestore, /genesis_contract:SFI_CANONICAL_RESET_CONTRACT/);
+assert.match(integrationRestore, /SFI_INSTITUTIONAL_RESET_PROVENANCE_MISMATCH/);
+assert.doesNotMatch(integrationRestore, /genesis_contract:'SFI-CANONICAL-RESET-CLASSIFICATION-1\.1'/, 'restored institutional profiles may not persist stale reset provenance');
+
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-CONTINUITY-RESET-RESEED-QA-1.0',
+  contract: 'SFI-CONTINUITY-RESET-RESEED-QA-1.1',
   stateOwner: 'public.sfi_continuity_state',
   singleton: 'institution',
   resetDisposition: 'RESEED_MINIMAL',
   truncateRecovery: true,
+  runtimePreflightRequired: true,
+  postResetSingletonVerification: true,
+  restoredIntegrationProvenanceBoundToCurrentContract: true,
   idempotent: true,
   preResetHistoryPreserved: false,
   authorityExpansion: false,

--- a/scripts/qa-sfi-continuity-reset-reseed.mjs
+++ b/scripts/qa-sfi-continuity-reset-reseed.mjs
@@ -6,6 +6,7 @@ const reset = fs.readFileSync('scripts/db/reset-sfi-operational-tables.mjs', 'ut
 const migration = fs.readFileSync('supabase/migrations/20260909154500_continuity_state_singleton_reseed.sql', 'utf8');
 const originMigration = fs.readFileSync('supabase/migrations/20260807003000_sfi_continuity_runtime.sql', 'utf8');
 const runtimeGate = fs.readFileSync('scripts/db/verify-continuity-reseed-ready.mjs', 'utf8');
+const gateOwner = fs.readFileSync('scripts/db/continuity-reseed-gate.mjs', 'utf8');
 const destructiveWorkflow = fs.readFileSync('.github/workflows/sfi-db-canonical-reset.yml', 'utf8');
 const integrationRestore = fs.readFileSync('scripts/db/preserve-institutional-integrations.ts', 'utf8');
 
@@ -17,6 +18,11 @@ assert.doesNotMatch(purgeBlock, /'sfi_continuity_state'/, 'continuity singleton 
 
 assert.match(reset, /const nonPreserveTables = \[\.\.\.PURGE_DATA_TABLES, \.\.\.RESEED_MINIMAL_TABLES\]/, 'reset must truncate reseed tables before deterministic reconstruction');
 assert.match(reset, /const purgeWithoutGenesis = PURGE_DATA_TABLES\.filter/, 'purge-zero checks must be derived only from PURGE_DATA_TABLES');
+assert.match(reset, /verifyContinuityReseedReady\(databaseUrl, 'pre'\)/, 'canonical writer must fail closed on continuity reseed readiness before destructive work');
+assert.match(reset, /CONTINUITY_SINGLETON_VERIFIED_BEFORE_COMMIT/);
+assert.match(reset, /metadata->>'contract'='\$\{SFI_CONTINUITY_RESEED_CONTRACT\}'/, 'transaction must verify continuity provenance before commit');
+assert.match(reset, /metadata->>'reseededBy'='SFI_CONTINUITY_STATE_TRUNCATE_TRIGGER'/);
+assert.match(reset, /verifyContinuityReseedReady\(databaseUrl, 'post'\)/, 'canonical writer must verify continuity state again after commit');
 
 assert.match(originMigration, /insert into public\.sfi_continuity_state \(id\) values \('institution'\) on conflict \(id\) do nothing/i, 'original continuity singleton contract missing');
 assert.match(migration, /SFI-CONTINUITY-STATE-SINGLETON-RESEED-1\.0/);
@@ -27,20 +33,24 @@ assert.match(migration, /'NORMAL'/, 'post-reset default continuity mode missing'
 assert.match(migration, /on conflict \(id\) do nothing/i, 'reseed must be idempotent and must not overwrite a real state');
 assert.doesNotMatch(migration, /delete from public\.sfi_continuity_state/i, 'repair may not destructively delete continuity state');
 
-assert.match(runtimeGate, /SFI-CONTINUITY-RESET-RESEED-RUNTIME-GATE-1\.0/);
-assert.match(runtimeGate, /sfi_continuity_state_reseed_after_truncate/);
-assert.match(runtimeGate, /sfi_reseed_continuity_state_after_truncate/);
-assert.match(runtimeGate, /SFI_CONTINUITY_RESEED_NOT_READY/);
-assert.match(runtimeGate, /SFI_CONTINUITY_SINGLETON_POST_RESET_INVALID/);
-assert.match(runtimeGate, /row_count/);
-assert.match(runtimeGate, /institution_count/);
-assert.match(runtimeGate, /institution_mode/);
-assert.match(runtimeGate, /founder_available/);
+assert.match(runtimeGate, /verifyContinuityReseedReady/);
+assert.match(gateOwner, /SFI-CONTINUITY-RESET-RESEED-RUNTIME-GATE-1\.1/);
+assert.match(gateOwner, /SFI-CONTINUITY-STATE-SINGLETON-RESEED-1\.0/);
+assert.match(gateOwner, /sfi_continuity_state_reseed_after_truncate/);
+assert.match(gateOwner, /sfi_reseed_continuity_state_after_truncate/);
+assert.match(gateOwner, /pg_get_triggerdef/);
+assert.match(gateOwner, /t\.tgfoid = to_regprocedure/);
+assert.match(gateOwner, /function_contract_bound/);
+assert.match(gateOwner, /trigger_bound/);
+assert.match(gateOwner, /SFI_CONTINUITY_RESEED_NOT_READY/);
+assert.match(gateOwner, /SFI_CONTINUITY_SINGLETON_POST_RESET_INVALID/);
+assert.match(gateOwner, /metadata->>'contract'/);
+assert.match(gateOwner, /metadata->>'reseededBy'/);
 
 const preGate = destructiveWorkflow.indexOf('node scripts/db/verify-continuity-reseed-ready.mjs pre');
 const resetCall = destructiveWorkflow.indexOf('node scripts/db/reset-sfi-operational-tables.mjs');
 const postGate = destructiveWorkflow.indexOf('node scripts/db/verify-continuity-reseed-ready.mjs post');
-assert.ok(preGate >= 0 && resetCall >= 0 && postGate >= 0, 'destructive workflow must bind pre/reset/post continuity gates');
+assert.ok(preGate >= 0 && resetCall >= 0 && postGate >= 0, 'destructive workflow must retain explicit pre/reset/post continuity gates in addition to writer-owned enforcement');
 assert.ok(preGate < resetCall, 'continuity trigger readiness must be observed before destructive reset');
 assert.ok(resetCall < postGate, 'continuity singleton must be verified immediately after destructive reset');
 assert.match(destructiveWorkflow, /\/tmp\/sfi-continuity-reseed\.json/);
@@ -52,13 +62,16 @@ assert.doesNotMatch(integrationRestore, /genesis_contract:'SFI-CANONICAL-RESET-C
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-CONTINUITY-RESET-RESEED-QA-1.1',
+  contract: 'SFI-CONTINUITY-RESET-RESEED-QA-1.2',
   stateOwner: 'public.sfi_continuity_state',
   singleton: 'institution',
   resetDisposition: 'RESEED_MINIMAL',
   truncateRecovery: true,
-  runtimePreflightRequired: true,
+  writerOwnedPreflightRequired: true,
+  inTransactionSingletonVerification: true,
   postResetSingletonVerification: true,
+  triggerFunctionBindingVerified: true,
+  singletonProvenanceVerified: true,
   restoredIntegrationProvenanceBoundToCurrentContract: true,
   idempotent: true,
   preResetHistoryPreserved: false,

--- a/scripts/qa-sfi-final-debt-closure.ts
+++ b/scripts/qa-sfi-final-debt-closure.ts
@@ -90,7 +90,7 @@ assert.ok(snapshotSource.includes('reset-classification.json'), 'database_snapsh
 assert.ok(snapshotSource.includes('preserve_exact_counts'), 'database_snapshot_missing_preserve_counts');
 assert.ok(snapshotVerifier.includes('SFI_DB_EVIDENCE_RECEIPT_V2'), 'database_snapshot_verifier_not_v2');
 assert.ok(snapshotVerifier.includes('reset_classification_sha256'), 'database_snapshot_verifier_missing_classification_hash');
-assert.ok(resetClassification.includes('SFI-CANONICAL-RESET-CLASSIFICATION-1.1'), 'database_reset_missing_world_preservation_amendment');
+assert.ok(resetClassification.includes('SFI-CANONICAL-RESET-CLASSIFICATION-1.2'), 'database_reset_missing_continuity_reseed_amendment');
 for (const worldTable of [
   'world_source_observations',
   'world_friction_readings',
@@ -105,6 +105,7 @@ for (const worldTable of [
 ]) {
   assert.ok(resetClassification.includes(`'${worldTable}'`), `database_reset_missing_protected_world_table:${worldTable}`);
 }
+assert.ok(resetClassification.includes("'sfi_continuity_state'"), 'database_reset_missing_continuity_singleton_reseed_classification');
 assert.ok(
   resetWorkflow.indexOf('Upload proof before any destructive statement') < resetWorkflow.indexOf('Execute founder-authorized canonical reset'),
   'database_reset_external_proof_must_precede_destruction',
@@ -113,12 +114,13 @@ assert.ok(
 const databaseClosure = read('docs/db/SFI_FINAL_DATABASE_CLOSURE.md');
 assert.ok(databaseClosure.includes('EVIDENCE_FIRST_PRE_ASSURANCE_RESET'), 'database_cleanup_missing_current_execution_order');
 assert.ok(databaseClosure.includes('FINAL_E2E_AFTER_CLEAN_GENESIS'), 'database_cleanup_missing_post_reset_assurance_order');
-assert.ok(databaseClosure.includes('SFI-CANONICAL-RESET-CLASSIFICATION-1.1'), 'database_cleanup_missing_world_preservation_contract');
+assert.ok(databaseClosure.includes('SFI-CANONICAL-RESET-CLASSIFICATION-1.2'), 'database_cleanup_missing_continuity_reseed_contract');
+assert.ok(databaseClosure.includes('CONTINUITY_SINGLETON = RESEED_MINIMAL'), 'database_cleanup_missing_continuity_singleton_disposition');
 assert.ok(databaseClosure.includes('PR_210_IMPLEMENTATION = SUPERSEDED_BY_CURRENT_ARCHITECTURE'), 'database_cleanup_missing_legacy_disposition');
 
 console.log(JSON.stringify({
   ok: true,
-  debtClosure: 'SFI-FINAL-DEBT-CLOSURE-1.1',
+  debtClosure: 'SFI-FINAL-DEBT-CLOSURE-1.2',
   decisionTransfer: {
     protocol: SFI_DT_EXP_001_FREEZE.protocol,
     status: SFI_DT_EXP_001_FREEZE.status,
@@ -136,6 +138,7 @@ console.log(JSON.stringify({
     externalProofArtifactRequired: true,
     exactTargetBindingRequired: true,
     protectedWorldTables: 10,
+    continuitySingleton: 'RESEED_MINIMAL',
     legacyPr210: 'SUPERSEDED_BY_CURRENT_ARCHITECTURE',
   },
 }, null, 2));

--- a/scripts/qa-sfi-operational-reset.ts
+++ b/scripts/qa-sfi-operational-reset.ts
@@ -21,6 +21,7 @@ const snapshotWorkflow = read('.github/workflows/sfi-db-proof-snapshot.yml');
 const resetWorkflow = read('.github/workflows/sfi-db-canonical-reset.yml');
 const readiness = read('src/lib/root/closure/readInstitutionalReadiness.ts');
 const proof = read('src/lib/root/closure/fullCycleVerification.ts');
+const continuityReseed = read('supabase/migrations/20260909154500_continuity_state_singleton_reseed.sql');
 
 const WORLD_LONGITUDINAL_TABLES = [
   'world_source_observations',
@@ -35,7 +36,7 @@ const WORLD_LONGITUDINAL_TABLES = [
   'world_vector_alerts',
 ] as const;
 
-assert.equal(SFI_CANONICAL_RESET_CONTRACT, 'SFI-CANONICAL-RESET-CLASSIFICATION-1.1');
+assert.equal(SFI_CANONICAL_RESET_CONTRACT, 'SFI-CANONICAL-RESET-CLASSIFICATION-1.2');
 assert.deepEqual(PRESERVE_DATA_TABLES, WORLD_LONGITUDINAL_TABLES);
 assert.deepEqual(RESEED_MINIMAL_TABLES, [
   'profiles',
@@ -45,8 +46,9 @@ assert.deepEqual(RESEED_MINIMAL_TABLES, [
   'accounts',
   'account_members',
   'account_balance',
+  'sfi_continuity_state',
 ]);
-assert.equal(PURGE_DATA_TABLES.length, 147, 'live reset baseline must explicitly classify all 147 non-World/non-genesis public tables');
+assert.equal(PURGE_DATA_TABLES.length, 146, 'live reset baseline must explicitly classify all 146 non-World/non-genesis public tables');
 assert.equal(CLASSIFIED_PUBLIC_TABLES.length, 164, 'reset baseline must classify every public table observed after Discovery integration');
 assert.equal(new Set(CLASSIFIED_PUBLIC_TABLES).size, CLASSIFIED_PUBLIC_TABLES.length, 'reset classification must contain no duplicate table');
 for (const table of PRESERVE_DATA_TABLES) assert.equal(classifyPublicTable(table), 'PRESERVE_DATA');
@@ -60,8 +62,8 @@ const exactAudit = auditPublicTableClassification(CLASSIFIED_PUBLIC_TABLES);
 assert.equal(exactAudit.unclassified.length, 0);
 assert.equal(exactAudit.classifiedButNotObserved.length, 0);
 assert.equal(exactAudit.preserveData.length, 10);
-assert.equal(exactAudit.reseedMinimal.length, 7);
-assert.equal(exactAudit.purgeData.length, 147);
+assert.equal(exactAudit.reseedMinimal.length, 8);
+assert.equal(exactAudit.purgeData.length, 146);
 
 for (const table of ['epistemic_events','sfi_amv_memory','policy_decisions','action_proposals','sfi_cognitive_twin_memory','sfi_cognitive_twin_runs','platform_metric_snapshots']) {
   assert.ok(PURGE_DATA_TABLES.includes(table), `non-World legacy/runtime table must be explicitly purged: ${table}`);
@@ -69,6 +71,8 @@ for (const table of ['epistemic_events','sfi_amv_memory','policy_decisions','act
 assert.ok(PURGE_DATA_TABLES.includes('root_audit_events'), 'pre-reset ROOT audit history must be purged before one new genesis receipt is inserted');
 assert.ok(PURGE_DATA_TABLES.includes('sfi_oauth_authorization_codes'), 'OAuth authorization-code history must not survive reset');
 assert.ok(PURGE_DATA_TABLES.includes('usage_ledger'), 'usage telemetry must not survive as legacy institutional state');
+assert.ok(RESEED_MINIMAL_TABLES.includes('sfi_continuity_state'), 'continuity singleton is required infrastructure and must be reseeded');
+assert.ok(!PURGE_DATA_TABLES.includes('sfi_continuity_state'), 'continuity singleton may not be validated as a permanently empty purge table');
 
 assert.match(snapshot, /SFI_DB_EVIDENCE_SNAPSHOT_V2/);
 assert.match(snapshot, /SFI_DB_EVIDENCE_RECEIPT_V2/);
@@ -117,6 +121,14 @@ assert.doesNotMatch(reset, /LATEST_EXPORT\.txt/);
 assert.doesNotMatch(reset, /SFI_FULL_CYCLE_PROOF_/);
 assert.doesNotMatch(reset, /SFI_CLEANUP_PLAN_/);
 assert.doesNotMatch(reset, /deleteAllRowsByKnownColumns/);
+
+assert.match(continuityReseed, /SFI-CONTINUITY-STATE-SINGLETON-RESEED-1\.0/);
+assert.match(continuityReseed, /after truncate on public\.sfi_continuity_state/i);
+assert.match(continuityReseed, /insert into public\.sfi_continuity_state/i);
+assert.match(continuityReseed, /'institution'/);
+assert.match(continuityReseed, /'NORMAL'/);
+assert.match(continuityReseed, /on conflict \(id\) do nothing/i);
+assert.doesNotMatch(continuityReseed, /delete from public\.sfi_continuity_state/i);
 
 assert.match(legacySeed, /SFI-LEGACY-CANONICAL-HISTORY-SEED-RETIRED-1\.0/);
 assert.match(legacySeed, /QA reports, operational patches and runtime events/);
@@ -181,6 +193,7 @@ console.log(JSON.stringify({
     'WORLD_OBSERVATIONS_HYPOTHESES_OUTCOMES_LEARNING_NEVER_PURGED',
     'WORLDSPECT_AND_WORLD_VECTOR_HISTORY_NEVER_PURGED',
     'MINIMAL_INFRASTRUCTURE_IS_RESEEDED_NOT_PRESERVED',
+    'CONTINUITY_SINGLETON_RESEEDED_AFTER_TRUNCATE',
     'NO_TRUNCATE_DEPENDENCY_PROPAGATION',
     'WORLD_EXACT_COUNTS_MUST_SURVIVE',
     'TWIN_AMV_QA_GOVERNANCE_RUNTIME_HISTORY_PURGED',

--- a/supabase/migrations/20260909154500_continuity_state_singleton_reseed.sql
+++ b/supabase/migrations/20260909154500_continuity_state_singleton_reseed.sql
@@ -1,0 +1,61 @@
+-- SFI-CONTINUITY-STATE-SINGLETON-RESEED-1.0
+-- A canonical reset may clear operational history, but it must not leave the
+-- institutional continuity control plane without its required singleton.
+-- This trigger reconstructs only the schema-owned default state after TRUNCATE;
+-- it does not preserve pre-reset runtime mode/history.
+
+create or replace function public.sfi_reseed_continuity_state_after_truncate()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  insert into public.sfi_continuity_state (
+    id,
+    mode,
+    founder_available,
+    metadata,
+    updated_at
+  ) values (
+    'institution',
+    'NORMAL',
+    true,
+    jsonb_build_object(
+      'genesis', true,
+      'reseededBy', 'SFI_CONTINUITY_STATE_TRUNCATE_TRIGGER',
+      'contract', 'SFI-CONTINUITY-STATE-SINGLETON-RESEED-1.0'
+    ),
+    now()
+  )
+  on conflict (id) do nothing;
+
+  return null;
+end;
+$$;
+
+drop trigger if exists sfi_continuity_state_reseed_after_truncate on public.sfi_continuity_state;
+create trigger sfi_continuity_state_reseed_after_truncate
+after truncate on public.sfi_continuity_state
+for each statement
+execute function public.sfi_reseed_continuity_state_after_truncate();
+
+-- Repair already-empty environments idempotently without rewriting a real state.
+insert into public.sfi_continuity_state (
+  id,
+  mode,
+  founder_available,
+  metadata
+) values (
+  'institution',
+  'NORMAL',
+  true,
+  jsonb_build_object(
+    'genesis', true,
+    'reseededBy', 'SFI_CONTINUITY_STATE_SINGLETON_MIGRATION',
+    'contract', 'SFI-CONTINUITY-STATE-SINGLETON-RESEED-1.0'
+  )
+)
+on conflict (id) do nothing;
+
+comment on function public.sfi_reseed_continuity_state_after_truncate() is
+  'Recreates the required institution continuity singleton after bounded operational resets. It restores defaults only; it does not preserve pre-reset operational history.';


### PR DESCRIPTION
Parent: #405 / #389 / #431
Owner: SFI-00 · Control Room
Assurance: SFI-08
Integration: SFI-00

Observed production defect: after the canonical DB reset, `public.sfi_continuity_state` had no `institution` singleton. The production continuity heartbeat returned HTTP 500. The singleton was restored idempotently in production and the exact same heartbeat rerun succeeded. This PR prevents recurrence.

## SFI PRECHECK
Existing capability inspected: existing SFI continuity runtime, original continuity migration singleton seed, canonical reset classification/reset owner, current production heartbeat and reset evidence contract.
Absorb vs create decision: ABSORB. Reclassify the existing continuity singleton as RESEED_MINIMAL and add schema-owned post-TRUNCATE reconstruction. No second continuity state owner.
Authoritative writer: `public.sfi_continuity_state` remains the sole state owner. Runtime mutation paths remain unchanged.
Persistence/lineage impact: pre-reset continuity operational state/history is intentionally not preserved by a clean genesis reset; only the required default singleton is reconstructed. Continuity runs/reports/health history remain purge-classified.
Front delta: none.
Back delta: canonical reset classification 1.2 + idempotent AFTER TRUNCATE singleton reseed + deterministic regression QA.
DB delta: one trigger function and one AFTER TRUNCATE trigger on the existing `public.sfi_continuity_state`; no table/schema-owner expansion.
Redundancy removed: removes the invalid classification of `sfi_continuity_state` as PURGE_DATA while runtime requires the singleton to exist.
Execution/ROOT boundary: no authority expansion. The trigger restores only `id=institution`, `mode=NORMAL`, `founder_available=true` after a reset; it never overwrites a real existing state.
Rollback: revert classification + migration; production singleton remains readable but future canonical reset would again require explicit repair.
Verification: production incident reproduction was `continuity_state` empty -> HTTP 500. After idempotent singleton restoration, rerun of SFI Continuity Hourly attempt 2 completed SUCCESS. PR adds static falsification + typecheck; repository SFI Verify remains required.

## Scope lock
IN: recurrence prevention for the observed post-reset continuity singleton failure.
OUT: continuity authority/model changes, new timers, new state owners, Vercel deployment, unrelated Full Remake requirements.

`MERGED != MIGRATION_APPLIED != OBSERVED_IN_PRODUCTION != RETURN_PASS` remains binding.