### PR TITLE
feat(assurance): certify completion requirements in bounded batches

### DIFF
--- a/.github/workflows/sfi-completion-certification-batch.yml
+++ b/.github/workflows/sfi-completion-certification-batch.yml
@@ -40,12 +40,14 @@ jobs:
     timeout-minutes: 30
     env:
       SFI_CERTIFICATION_BATCH_LIMIT: ${{ inputs.batch_limit || '20' }}
+      SFI_EXPECTED_HEAD: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
     steps:
       - name: Checkout exact revision
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -55,6 +57,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Assert exact certification head
+        shell: bash
+        run: |
+          set -euo pipefail
+          observed="$(git rev-parse HEAD)"
+          test "$observed" = "$SFI_EXPECTED_HEAD"
+          echo "SFI-08 exact head: $observed"
 
       - name: Reconstruct canonical completion matrix
         env:

--- a/.github/workflows/sfi-completion-certification-batch.yml
+++ b/.github/workflows/sfi-completion-certification-batch.yml
@@ -1,0 +1,90 @@
+name: SFI-08 Completion Certification Batch
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/sfi-completion-certification-batch.yml'
+      - 'scripts/sfi-program-certification-batch.mjs'
+      - 'scripts/qa-sfi-program-certification-batch.mjs'
+      - 'scripts/lib/programCompletionReceipts.mjs'
+      - 'scripts/lib/programCompletionDiagnostics.mjs'
+      - 'docs/program/SFI-COMPLETION-RECEIPTS.json'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/sfi-completion-certification-batch.yml'
+      - 'scripts/sfi-program-certification-batch.mjs'
+      - 'scripts/qa-sfi-program-certification-batch.mjs'
+      - 'scripts/lib/programCompletionReceipts.mjs'
+      - 'scripts/lib/programCompletionDiagnostics.mjs'
+      - 'docs/program/SFI-COMPLETION-RECEIPTS.json'
+  workflow_dispatch:
+    inputs:
+      batch_limit:
+        description: 'Maximum completion requirements to certify in this bounded batch'
+        required: false
+        default: '20'
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: sfi08-completion-certification-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  certify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      SFI_CERTIFICATION_BATCH_LIMIT: ${{ inputs.batch_limit || '20' }}
+
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Reconstruct canonical completion matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/sfi-program-completion.mjs
+
+      - name: Falsify existing receipt promotion
+        run: node scripts/qa-sfi-program-completion-receipts.mjs
+
+      - name: Reconcile existing SFI-08 receipts
+        run: node scripts/sfi-program-completion-reconcile.mjs
+
+      - name: Enrich non-authoritative diagnostic lanes
+        run: node scripts/sfi-program-completion-diagnostics.mjs
+
+      - name: Execute bounded SFI-08 certification proofs
+        run: node scripts/sfi-program-certification-batch.mjs
+
+      - name: Falsify certification authority expansion
+        run: node scripts/qa-sfi-program-certification-batch.mjs
+
+      - name: Upload immutable certification RETURN
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sfi08-completion-certification-${{ github.run_id }}
+          path: |
+            artifacts/program-completion/completion.json
+            artifacts/program-completion/completion.md
+            artifacts/program-completion/certification-return.json
+          if-no-files-found: error
+          retention-days: 90

--- a/scripts/qa-sfi-program-certification-batch.mjs
+++ b/scripts/qa-sfi-program-certification-batch.mjs
@@ -2,10 +2,20 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import {
-  GLOBAL_REGRESSION_SCOPE,
-  SFI_COMPLETION_CERTIFICATION_BATCH_CONTRACT,
-} from './sfi-program-certification-batch.mjs';
+
+const SFI_COMPLETION_CERTIFICATION_BATCH_CONTRACT = 'SFI-SFI08-COMPLETION-CERTIFICATION-BATCH-1.0';
+const GLOBAL_REGRESSION_SCOPE = [
+  'src/**',
+  'scripts/**',
+  'packages/**',
+  'services/**',
+  '.github/workflows/**',
+  'public/**',
+  'package.json',
+  'package-lock.json',
+  'docs/program/**',
+  'docs/ROOT_WORLD_CASE_AND_DISCOVERY_ENGINE.md',
+];
 
 const root = process.cwd();
 const reportPath = path.join(root, 'artifacts', 'program-completion', 'completion.json');
@@ -23,7 +33,7 @@ assert.equal(certification.authority, 'ASSURANCE_ONLY');
 assert.equal(certification.head, report.head);
 assert.equal(certification.canonicalStatusMutation, false);
 assert.equal(certification.autoReceiptWrite, false);
-assert.deepEqual(certification.regressionScope, [...GLOBAL_REGRESSION_SCOPE]);
+assert.deepEqual(certification.regressionScope, GLOBAL_REGRESSION_SCOPE);
 assert.ok(certification.selectedCount <= certification.batchLimit);
 assert.equal(certification.selectedCount, certification.requirements.length);
 assert.equal(certification.failedProofCount, 0);

--- a/scripts/qa-sfi-program-certification-batch.mjs
+++ b/scripts/qa-sfi-program-certification-batch.mjs
@@ -64,8 +64,10 @@ for (const item of certification.requirements) {
     assert.equal(fs.existsSync(path.join(root, proofPath)), true, `proof file missing: ${proofPath}`);
     const support = item.semanticSupport.find((entry) => entry.path === proofPath);
     assert.ok(support?.supported, `semantic proof linkage required: ${item.id}:${proofPath}`);
-    assert.ok((support.matchedIdentifiers?.length || 0) >= 1 || (support.matchedTerms?.length || 0) >= 2,
-      `semantic evidence threshold not met: ${item.id}:${proofPath}`);
+    const idCount = support.matchedIdentifiers?.length || 0;
+    const termCount = support.matchedTerms?.length || 0;
+    assert.ok(idCount >= 2 || (idCount >= 1 && termCount >= 2) || termCount >= 3,
+      `tight semantic evidence threshold not met: ${item.id}:${proofPath}`);
   }
 }
 

--- a/scripts/qa-sfi-program-certification-batch.mjs
+++ b/scripts/qa-sfi-program-certification-batch.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  GLOBAL_REGRESSION_SCOPE,
+  SFI_COMPLETION_CERTIFICATION_BATCH_CONTRACT,
+} from './sfi-program-certification-batch.mjs';
+
+const root = process.cwd();
+const reportPath = path.join(root, 'artifacts', 'program-completion', 'completion.json');
+const returnPath = path.join(root, 'artifacts', 'program-completion', 'certification-return.json');
+
+assert.equal(fs.existsSync(reportPath), true, 'completion report required');
+assert.equal(fs.existsSync(returnPath), true, 'certification return required');
+
+const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+const certification = JSON.parse(fs.readFileSync(returnPath, 'utf8'));
+
+assert.equal(certification.contract, SFI_COMPLETION_CERTIFICATION_BATCH_CONTRACT);
+assert.equal(certification.verifier, 'SFI-08');
+assert.equal(certification.authority, 'ASSURANCE_ONLY');
+assert.equal(certification.head, report.head);
+assert.equal(certification.canonicalStatusMutation, false);
+assert.equal(certification.autoReceiptWrite, false);
+assert.deepEqual(certification.regressionScope, [...GLOBAL_REGRESSION_SCOPE]);
+assert.ok(certification.selectedCount <= certification.batchLimit);
+assert.equal(certification.selectedCount, certification.requirements.length);
+assert.equal(certification.failedProofCount, 0);
+assert.equal(certification.returnState, 'RETURN_PASS');
+assert.deepEqual(certification.canonicalCountsBefore, report.counts);
+
+const requirementById = new Map((report.requirements || []).map((item) => [item.id, item]));
+const seen = new Set();
+for (const item of certification.requirements) {
+  assert.equal(seen.has(item.id), false, `duplicate certification id: ${item.id}`);
+  seen.add(item.id);
+  const source = requirementById.get(item.id);
+  assert.ok(source, `unknown completion requirement: ${item.id}`);
+  assert.equal(source.status, item.canonicalStatus, `canonical status mutated: ${item.id}`);
+  assert.equal(source.diagnostic?.state, 'IMPLEMENTATION_EVIDENCE_PRESENT_UNCERTIFIED');
+  assert.equal(source.completionReceipt?.state, 'ABSENT');
+  assert.equal(item.diagnosticState, source.diagnostic.state);
+  assert.ok(Array.isArray(item.proofPaths) && item.proofPaths.length > 0, `proof path required: ${item.id}`);
+  assert.equal(item.proofPass, true, `proof must pass: ${item.id}`);
+  for (const proofPath of item.proofPaths) {
+    assert.ok(certification.proofCatalog.includes(proofPath), `proof must come from SFI Verify catalog: ${item.id}:${proofPath}`);
+    assert.ok(item.evidencePaths.includes(proofPath), `proof must be declared by requirement evidence: ${item.id}:${proofPath}`);
+    assert.equal(fs.existsSync(path.join(root, proofPath)), true, `proof file missing: ${proofPath}`);
+  }
+}
+
+for (const execution of certification.proofExecutions || []) {
+  assert.equal(execution.ok, true, `executed proof failed: ${execution.path}`);
+  assert.ok(certification.proofCatalog.includes(execution.path), `executed proof outside catalog: ${execution.path}`);
+}
+
+assert.ok(!certification.requirements.some((item) => item.canonicalStatus === 'SATISFIED'), 'already satisfied requirement must not be recertified');
+assert.ok(!certification.requirements.some((item) => item.diagnosticState === 'PRODUCTION_RETURN_PENDING'), 'production RETURN cannot be certified from repository QA');
+assert.ok(!certification.requirements.some((item) => item.diagnosticState === 'EXTERNAL_ACTION_PENDING'), 'external action cannot be certified from repository QA');
+
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-SFI08-COMPLETION-CERTIFICATION-BATCH-QA-1.0',
+  selectedCount: certification.selectedCount,
+  proofExecutionCount: certification.proofExecutions.length,
+  canonicalStatusMutation: false,
+  autoReceiptWrite: false,
+  returnState: certification.returnState,
+}));

--- a/scripts/qa-sfi-program-certification-batch.mjs
+++ b/scripts/qa-sfi-program-certification-batch.mjs
@@ -2,8 +2,9 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
-const SFI_COMPLETION_CERTIFICATION_BATCH_CONTRACT = 'SFI-SFI08-COMPLETION-CERTIFICATION-BATCH-1.0';
+const SFI_COMPLETION_CERTIFICATION_BATCH_CONTRACT = 'SFI-SFI08-COMPLETION-CERTIFICATION-BATCH-1.1';
 const GLOBAL_REGRESSION_SCOPE = [
   'src/**',
   'scripts/**',
@@ -26,10 +27,13 @@ assert.equal(fs.existsSync(returnPath), true, 'certification return required');
 
 const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
 const certification = JSON.parse(fs.readFileSync(returnPath, 'utf8'));
+const actualHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
 
 assert.equal(certification.contract, SFI_COMPLETION_CERTIFICATION_BATCH_CONTRACT);
 assert.equal(certification.verifier, 'SFI-08');
 assert.equal(certification.authority, 'ASSURANCE_ONLY');
+assert.equal(certification.head, actualHead);
+assert.equal(certification.expectedHead, actualHead);
 assert.equal(certification.head, report.head);
 assert.equal(certification.canonicalStatusMutation, false);
 assert.equal(certification.autoReceiptWrite, false);
@@ -53,11 +57,21 @@ for (const item of certification.requirements) {
   assert.equal(item.diagnosticState, source.diagnostic.state);
   assert.ok(Array.isArray(item.proofPaths) && item.proofPaths.length > 0, `proof path required: ${item.id}`);
   assert.equal(item.proofPass, true, `proof must pass: ${item.id}`);
+  assert.equal(item.semanticSupport.length, item.proofPaths.length, `semantic support required per proof: ${item.id}`);
   for (const proofPath of item.proofPaths) {
-    assert.ok(certification.proofCatalog.includes(proofPath), `proof must come from SFI Verify catalog: ${item.id}:${proofPath}`);
+    assert.ok(certification.proofCatalog.includes(proofPath), `proof must come from SFI Verify run commands: ${item.id}:${proofPath}`);
     assert.ok(item.evidencePaths.includes(proofPath), `proof must be declared by requirement evidence: ${item.id}:${proofPath}`);
     assert.equal(fs.existsSync(path.join(root, proofPath)), true, `proof file missing: ${proofPath}`);
+    const support = item.semanticSupport.find((entry) => entry.path === proofPath);
+    assert.ok(support?.supported, `semantic proof linkage required: ${item.id}:${proofPath}`);
+    assert.ok((support.matchedIdentifiers?.length || 0) >= 1 || (support.matchedTerms?.length || 0) >= 2,
+      `semantic evidence threshold not met: ${item.id}:${proofPath}`);
   }
+}
+
+for (const rejected of certification.rejectedSemanticLinks || []) {
+  assert.ok(Array.isArray(rejected.declaredProofs) && rejected.declaredProofs.length > 0);
+  assert.ok((rejected.support || []).every((entry) => entry.supported === false), `rejected item contains supported proof: ${rejected.id}`);
 }
 
 for (const execution of certification.proofExecutions || []) {
@@ -71,8 +85,10 @@ assert.ok(!certification.requirements.some((item) => item.diagnosticState === 'E
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-SFI08-COMPLETION-CERTIFICATION-BATCH-QA-1.0',
+  contract: 'SFI-SFI08-COMPLETION-CERTIFICATION-BATCH-QA-1.1',
+  head: actualHead,
   selectedCount: certification.selectedCount,
+  semanticRejectedCount: certification.semanticRejectedCount,
   proofExecutionCount: certification.proofExecutions.length,
   canonicalStatusMutation: false,
   autoReceiptWrite: false,

--- a/scripts/sfi-program-certification-batch.mjs
+++ b/scripts/sfi-program-certification-batch.mjs
@@ -10,7 +10,7 @@ const outPath = path.join(root, 'artifacts', 'program-completion', 'certificatio
 const verifyWorkflowPath = path.join(root, '.github', 'workflows', 'sfi-verify.yml');
 const packagePath = path.join(root, 'package.json');
 
-export const SFI_COMPLETION_CERTIFICATION_BATCH_CONTRACT = 'SFI-SFI08-COMPLETION-CERTIFICATION-BATCH-1.0';
+export const SFI_COMPLETION_CERTIFICATION_BATCH_CONTRACT = 'SFI-SFI08-COMPLETION-CERTIFICATION-BATCH-1.1';
 export const GLOBAL_REGRESSION_SCOPE = Object.freeze([
   'src/**',
   'scripts/**',
@@ -22,6 +22,11 @@ export const GLOBAL_REGRESSION_SCOPE = Object.freeze([
   'package-lock.json',
   'docs/program/**',
   'docs/ROOT_WORLD_CASE_AND_DISCOVERY_ENGINE.md',
+]);
+
+const GENERIC_PROOF_TERMS = new Set([
+  'about','after','again','against','allow','allows','already','always','another','appropriate','architecture','before','being','cannot','canonical','complete','completion','current','demonstrate','evidence','existing','explicit','external','green','implementation','institutional','internal','model','operation','operational','proof','public','required','requires','return','runtime','should','state','system','through','under','where','while','without','would','owner','source','support','supports','verify','verified','verification',
+  'como','cuando','desde','debe','deben','donde','entre','estado','evidencia','para','puede','sistema','sobre','todos',
 ]);
 
 function normalizeRepoPath(value) {
@@ -50,12 +55,40 @@ function npmRunsFromText(text) {
   return out;
 }
 
+function workflowRunCommands(text) {
+  const lines = String(text || '').split('\n');
+  const commands = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const match = line.match(/^(\s*)run:\s*(.*)$/);
+    if (!match) continue;
+    const indent = match[1].length;
+    const inline = match[2].trim();
+    if (inline && inline !== '|' && inline !== '>') {
+      commands.push(inline);
+      continue;
+    }
+    const block = [];
+    for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+      const child = lines[cursor];
+      if (child.trim() === '') { block.push(''); continue; }
+      const childIndent = child.match(/^\s*/)?.[0].length ?? 0;
+      if (childIndent <= indent) break;
+      block.push(child.slice(Math.min(child.length, indent + 2)));
+      index = cursor;
+    }
+    commands.push(block.join('\n'));
+  }
+  return commands;
+}
+
 function executedProofCatalog() {
   const verifyText = fs.readFileSync(verifyWorkflowPath, 'utf8');
   const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
   const scripts = pkg.scripts || {};
-  const paths = new Set(repositoryPathsFromText(verifyText));
-  const queue = [...new Set(npmRunsFromText(verifyText))];
+  const runCommands = workflowRunCommands(verifyText);
+  const paths = new Set(runCommands.flatMap(repositoryPathsFromText));
+  const queue = [...new Set(runCommands.flatMap(npmRunsFromText))];
   const seenScripts = new Set();
 
   while (queue.length) {
@@ -71,6 +104,36 @@ function executedProofCatalog() {
     .filter(proofLike)
     .filter((repoPath) => fs.existsSync(path.join(root, repoPath)))
     .sort();
+}
+
+function normalizedWords(value) {
+  return String(value || '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .match(/[a-z0-9_:-]{4,}/g) || [];
+}
+
+function semanticTerms(requirementText) {
+  return [...new Set(normalizedWords(requirementText).filter((token) => token.length >= 5 && !GENERIC_PROOF_TERMS.has(token)))];
+}
+
+function strongIdentifiers(requirementText) {
+  const raw = String(requirementText || '');
+  const code = [...raw.matchAll(/`([^`]+)`/g)].flatMap((match) => normalizedWords(match[1]));
+  const acronyms = (raw.match(/\b[A-Z][A-Z0-9_-]{2,}\b/g) || []).map((value) => value.toLowerCase());
+  const camel = (raw.match(/\b[A-Z][A-Za-z0-9]*[A-Z][A-Za-z0-9]*\b/g) || []).map((value) => value.toLowerCase());
+  return [...new Set([...code, ...acronyms, ...camel].filter((token) => !GENERIC_PROOF_TERMS.has(token) && token !== 'sfi'))];
+}
+
+function semanticSupport(requirementText, repoPath) {
+  const proofText = fs.readFileSync(path.join(root, repoPath), 'utf8').normalize('NFKD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+  const terms = semanticTerms(requirementText);
+  const identifiers = strongIdentifiers(requirementText);
+  const matchedTerms = terms.filter((token) => proofText.includes(token));
+  const matchedIdentifiers = identifiers.filter((token) => proofText.includes(token));
+  const supported = matchedIdentifiers.length >= 1 || matchedTerms.length >= 2;
+  return { supported, terms, identifiers, matchedTerms, matchedIdentifiers };
 }
 
 function commandForProof(repoPath) {
@@ -111,17 +174,29 @@ function executeProof(repoPath) {
 function main() {
   if (!fs.existsSync(reportPath)) throw new Error('SFI_PROGRAM_COMPLETION_DIAGNOSTIC_ARTIFACT_MISSING');
   const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+  const actualHead = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+  const expectedHead = String(process.env.SFI_EXPECTED_HEAD || actualHead).trim();
+  if (actualHead !== expectedHead) throw new Error(`SFI_CERTIFICATION_NOT_EXACT_HEAD:${actualHead}:${expectedHead}`);
+  if (report.head !== actualHead) throw new Error(`SFI_CONTROLLER_HEAD_MISMATCH:${report.head}:${actualHead}`);
+
   const proofCatalog = executedProofCatalog();
   const proofSet = new Set(proofCatalog);
   const batchLimit = Math.max(1, Math.min(50, Number.parseInt(process.env.SFI_CERTIFICATION_BATCH_LIMIT || '20', 10) || 20));
 
   const eligible = [];
+  const rejectedSemanticLinks = [];
   for (const requirement of report.requirements || []) {
     if (requirement?.diagnostic?.state !== 'IMPLEMENTATION_EVIDENCE_PRESENT_UNCERTIFIED') continue;
     if (requirement?.completionReceipt?.state && requirement.completionReceipt.state !== 'ABSENT') continue;
-    const proofPaths = [...new Set((requirement.evidence || []).map(normalizeRepoPath).filter((repoPath) => proofSet.has(repoPath)))];
-    if (!proofPaths.length) continue;
-    eligible.push({ requirement, proofPaths });
+    const declaredProofs = [...new Set((requirement.evidence || []).map(normalizeRepoPath).filter((repoPath) => proofSet.has(repoPath)))];
+    if (!declaredProofs.length) continue;
+    const support = declaredProofs.map((repoPath) => ({ path: repoPath, ...semanticSupport(requirement.requirement, repoPath) }));
+    const proofPaths = support.filter((entry) => entry.supported).map((entry) => entry.path);
+    if (!proofPaths.length) {
+      rejectedSemanticLinks.push({ id: requirement.id, requirement: requirement.requirement, declaredProofs, support });
+      continue;
+    }
+    eligible.push({ requirement, proofPaths, support });
   }
 
   const selected = eligible.slice(0, batchLimit);
@@ -135,11 +210,14 @@ function main() {
     generatedAt: new Date().toISOString(),
     verifier: 'SFI-08',
     authority: 'ASSURANCE_ONLY',
-    head: report.head,
+    head: actualHead,
+    expectedHead,
     controllerContract: report.contract,
     diagnosticContract: report.diagnosticContract || null,
     batchLimit,
     eligibleCount: eligible.length,
+    semanticRejectedCount: rejectedSemanticLinks.length,
+    rejectedSemanticLinks,
     selectedCount: selected.length,
     remainingEligibleAfterBatch: Math.max(0, eligible.length - selected.length),
     canonicalCountsBefore: report.counts,
@@ -148,7 +226,7 @@ function main() {
     regressionScope: [...GLOBAL_REGRESSION_SCOPE],
     proofCatalog,
     proofExecutions,
-    requirements: selected.map(({ requirement, proofPaths }) => ({
+    requirements: selected.map(({ requirement, proofPaths, support }) => ({
       id: requirement.id,
       owner: requirement.owner,
       source: requirement.source,
@@ -158,6 +236,7 @@ function main() {
       diagnosticState: requirement.diagnostic.state,
       evidencePaths: [...(requirement.evidence || [])],
       proofPaths,
+      semanticSupport: support.filter((entry) => proofPaths.includes(entry.path)),
       proofPass: proofPaths.every((repoPath) => executionByPath.get(repoPath)?.ok === true),
     })),
     returnState: failed.length ? 'RETURN_FAIL' : 'RETURN_PASS',
@@ -171,6 +250,7 @@ function main() {
     contract: certification.contract,
     head: certification.head,
     eligibleCount: certification.eligibleCount,
+    semanticRejectedCount: certification.semanticRejectedCount,
     selectedCount: certification.selectedCount,
     remainingEligibleAfterBatch: certification.remainingEligibleAfterBatch,
     uniqueProofCount: uniqueProofPaths.length,

--- a/scripts/sfi-program-certification-batch.mjs
+++ b/scripts/sfi-program-certification-batch.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { requirementHash } from './lib/programCompletionReceipts.mjs';
+
+const root = process.cwd();
+const reportPath = path.join(root, 'artifacts', 'program-completion', 'completion.json');
+const outPath = path.join(root, 'artifacts', 'program-completion', 'certification-return.json');
+const verifyWorkflowPath = path.join(root, '.github', 'workflows', 'sfi-verify.yml');
+const packagePath = path.join(root, 'package.json');
+
+export const SFI_COMPLETION_CERTIFICATION_BATCH_CONTRACT = 'SFI-SFI08-COMPLETION-CERTIFICATION-BATCH-1.0';
+export const GLOBAL_REGRESSION_SCOPE = Object.freeze([
+  'src/**',
+  'scripts/**',
+  'packages/**',
+  'services/**',
+  '.github/workflows/**',
+  'public/**',
+  'package.json',
+  'package-lock.json',
+  'docs/program/**',
+  'docs/ROOT_WORLD_CASE_AND_DISCOVERY_ENGINE.md',
+]);
+
+function normalizeRepoPath(value) {
+  return String(value || '').trim().replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function proofLike(repoPath) {
+  const normalized = normalizeRepoPath(repoPath);
+  const base = path.posix.basename(normalized);
+  return /(^|\/)qa-[^/]+\.(?:ts|tsx|mjs|js|cjs)$/.test(normalized)
+    || /\.test\.(?:ts|tsx|mjs|js|cjs)$/.test(normalized)
+    || base === 'check-domain-boundaries.mjs'
+    || base === 'studio-audio-engine-smoke.cjs';
+}
+
+function repositoryPathsFromText(text) {
+  const matches = String(text || '').match(/(?:scripts|src|packages|services)\/[A-Za-z0-9_@.\/[\]-]+\.(?:ts|tsx|mjs|cjs|js)/g) || [];
+  return matches.map(normalizeRepoPath);
+}
+
+function npmRunsFromText(text) {
+  const out = [];
+  const re = /npm\s+run\s+([A-Za-z0-9:_-]+)/g;
+  let match;
+  while ((match = re.exec(String(text || '')))) out.push(match[1]);
+  return out;
+}
+
+function executedProofCatalog() {
+  const verifyText = fs.readFileSync(verifyWorkflowPath, 'utf8');
+  const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+  const scripts = pkg.scripts || {};
+  const paths = new Set(repositoryPathsFromText(verifyText));
+  const queue = [...new Set(npmRunsFromText(verifyText))];
+  const seenScripts = new Set();
+
+  while (queue.length) {
+    const name = queue.shift();
+    if (!name || seenScripts.has(name)) continue;
+    seenScripts.add(name);
+    const command = String(scripts[name] || '');
+    for (const repoPath of repositoryPathsFromText(command)) paths.add(repoPath);
+    for (const nested of npmRunsFromText(command)) if (!seenScripts.has(nested)) queue.push(nested);
+  }
+
+  return [...paths]
+    .filter(proofLike)
+    .filter((repoPath) => fs.existsSync(path.join(root, repoPath)))
+    .sort();
+}
+
+function commandForProof(repoPath) {
+  if (/\.test\.(?:ts|tsx)$/.test(repoPath)) return { bin: 'node', args: ['--import', 'tsx', '--test', repoPath] };
+  if (/\.test\.(?:mjs|js|cjs)$/.test(repoPath)) return { bin: 'node', args: ['--test', repoPath] };
+  if (/\.(?:ts|tsx)$/.test(repoPath)) return { bin: 'npx', args: ['tsx', repoPath] };
+  return { bin: 'node', args: [repoPath] };
+}
+
+function executeProof(repoPath) {
+  const command = commandForProof(repoPath);
+  const startedAt = Date.now();
+  try {
+    execFileSync(command.bin, command.args, {
+      cwd: root,
+      encoding: 'utf8',
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 180_000,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return { path: repoPath, ok: true, durationMs: Date.now() - startedAt, command: [command.bin, ...command.args] };
+  } catch (error) {
+    const stdout = typeof error?.stdout === 'string' ? error.stdout.slice(-4000) : '';
+    const stderr = typeof error?.stderr === 'string' ? error.stderr.slice(-4000) : '';
+    return {
+      path: repoPath,
+      ok: false,
+      durationMs: Date.now() - startedAt,
+      command: [command.bin, ...command.args],
+      error: error instanceof Error ? error.message : String(error),
+      stdout,
+      stderr,
+    };
+  }
+}
+
+function main() {
+  if (!fs.existsSync(reportPath)) throw new Error('SFI_PROGRAM_COMPLETION_DIAGNOSTIC_ARTIFACT_MISSING');
+  const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+  const proofCatalog = executedProofCatalog();
+  const proofSet = new Set(proofCatalog);
+  const batchLimit = Math.max(1, Math.min(50, Number.parseInt(process.env.SFI_CERTIFICATION_BATCH_LIMIT || '20', 10) || 20));
+
+  const eligible = [];
+  for (const requirement of report.requirements || []) {
+    if (requirement?.diagnostic?.state !== 'IMPLEMENTATION_EVIDENCE_PRESENT_UNCERTIFIED') continue;
+    if (requirement?.completionReceipt?.state && requirement.completionReceipt.state !== 'ABSENT') continue;
+    const proofPaths = [...new Set((requirement.evidence || []).map(normalizeRepoPath).filter((repoPath) => proofSet.has(repoPath)))];
+    if (!proofPaths.length) continue;
+    eligible.push({ requirement, proofPaths });
+  }
+
+  const selected = eligible.slice(0, batchLimit);
+  const uniqueProofPaths = [...new Set(selected.flatMap((item) => item.proofPaths))].sort();
+  const proofExecutions = uniqueProofPaths.map(executeProof);
+  const failed = proofExecutions.filter((result) => !result.ok);
+  const executionByPath = new Map(proofExecutions.map((result) => [result.path, result]));
+
+  const certification = {
+    contract: SFI_COMPLETION_CERTIFICATION_BATCH_CONTRACT,
+    generatedAt: new Date().toISOString(),
+    verifier: 'SFI-08',
+    authority: 'ASSURANCE_ONLY',
+    head: report.head,
+    controllerContract: report.contract,
+    diagnosticContract: report.diagnosticContract || null,
+    batchLimit,
+    eligibleCount: eligible.length,
+    selectedCount: selected.length,
+    remainingEligibleAfterBatch: Math.max(0, eligible.length - selected.length),
+    canonicalCountsBefore: report.counts,
+    canonicalStatusMutation: false,
+    autoReceiptWrite: false,
+    regressionScope: [...GLOBAL_REGRESSION_SCOPE],
+    proofCatalog,
+    proofExecutions,
+    requirements: selected.map(({ requirement, proofPaths }) => ({
+      id: requirement.id,
+      owner: requirement.owner,
+      source: requirement.source,
+      requirement: requirement.requirement,
+      requirementHash: requirementHash(requirement),
+      canonicalStatus: requirement.status,
+      diagnosticState: requirement.diagnostic.state,
+      evidencePaths: [...(requirement.evidence || [])],
+      proofPaths,
+      proofPass: proofPaths.every((repoPath) => executionByPath.get(repoPath)?.ok === true),
+    })),
+    returnState: failed.length ? 'RETURN_FAIL' : 'RETURN_PASS',
+    failedProofCount: failed.length,
+  };
+
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, `${JSON.stringify(certification, null, 2)}\n`);
+  console.log(JSON.stringify({
+    ok: failed.length === 0,
+    contract: certification.contract,
+    head: certification.head,
+    eligibleCount: certification.eligibleCount,
+    selectedCount: certification.selectedCount,
+    remainingEligibleAfterBatch: certification.remainingEligibleAfterBatch,
+    uniqueProofCount: uniqueProofPaths.length,
+    failedProofCount: failed.length,
+    returnState: certification.returnState,
+  }));
+
+  if (failed.length) process.exitCode = 2;
+}
+
+main();

--- a/scripts/sfi-program-certification-batch.mjs
+++ b/scripts/sfi-program-certification-batch.mjs
@@ -132,7 +132,9 @@ function semanticSupport(requirementText, repoPath) {
   const identifiers = strongIdentifiers(requirementText);
   const matchedTerms = terms.filter((token) => proofText.includes(token));
   const matchedIdentifiers = identifiers.filter((token) => proofText.includes(token));
-  const supported = matchedIdentifiers.length >= 1 || matchedTerms.length >= 2;
+  const supported = matchedIdentifiers.length >= 2
+    || (matchedIdentifiers.length >= 1 && matchedTerms.length >= 2)
+    || matchedTerms.length >= 3;
   return { supported, terms, identifiers, matchedTerms, matchedIdentifiers };
 }
 


### PR DESCRIPTION
Parent: #418 / #405 / #389
Owner: SFI-08 · Assurance & Release
Assurance: SFI-08 executable batch verifier
Integration: SFI-00

This bounded slice adds an assurance-only completion certification batch. It does not relax canonical completion status and does not auto-write receipts. It selects at most 20 currently uncertified requirements only when the requirement's own repository evidence includes an explicit QA/test path that is actually executed by the canonical SFI Verify workflow; those proof paths are then executed again on the exact certification head.

## SFI PRECHECK
Existing capability inspected: `SFI-PROGRAM-COMPLETION-CONTROLLER-1.4`, `SFI-PROGRAM-COMPLETION-DIAGNOSTICS-1.0`, `SFI-PROGRAM-COMPLETION-RECEIPTS-1.3`, `.github/workflows/sfi-verify.yml`, package QA scripts, exact-head workflow evidence and current 216-requirement reconstruction.
Absorb vs create decision: ABSORB. Certification consumes the existing Controller diagnostic artifact and existing SFI Verify proof catalog; it creates no second completion controller, no second status vocabulary and no second authority ledger.
Authoritative writer: `docs/program/SFI-COMPLETION-RECEIPTS.json` remains the only durable completion-receipt ledger and is not written by this slice. Canonical status remains owned by Controller reconciliation of independently valid SFI-08 receipts.
Persistence/lineage impact: no DB mutation. The new workflow emits an immutable `certification-return.json` Actions artifact tied to exact `GITHUB_SHA`; later SFI-00 may author ledger receipts only from observed successful certification and SFI Verify runs.
Front delta: none.
Back delta: add `SFI-SFI08-COMPLETION-CERTIFICATION-BATCH-1.0`, deterministic proof-catalog extraction from canonical SFI Verify/package scripts, bounded selection (default 20), direct proof execution, QA and artifact retention.
DB delta: none.
Redundancy removed: replaces manual one-requirement-at-a-time certification with one bounded SFI-08 assurance mechanism while retaining the existing Controller and receipt ledger as sole completion owners.
Execution/ROOT boundary: assurance-only. No ROOT authority, external action, deployment, publication, institutional mutation or SATISFIED promotion is performed. Production/external diagnostic lanes are excluded from repository-only certification.
Rollback: remove the new certification workflow and two scripts; Controller, diagnostics, SFI Verify and existing receipt reconciliation continue unchanged.
Verification: exact-head `SFI-08 Completion Certification Batch` must RETURN_PASS with every selected proof executed successfully; exact-head SFI Verify must independently pass; QA must prove no status mutation, no auto receipt write, no production/external certification, unique requirement IDs and proof paths drawn only from each requirement's declared evidence and the canonical SFI Verify proof catalog.

## Conservative regression rule
Receipts produced from a successful batch will use a deliberately broad regression scope (`src/**`, `scripts/**`, `packages/**`, `services/**`, `.github/workflows/**`, `public/**`, package manifests and canonical program docs). Any later meaningful code/workflow/program change therefore invalidates the batch receipts until re-certified; only the receipt ledger itself can be updated without invalidating the prior exact-head proof.

OUT: automatic ledger mutation, automatic SATISFIED promotion, production RETURN, external account/registry actions, Vercel deployment, relaxed evidence rules.