### PR TITLE
fix(mcp): add dual-era MCP and OAuth discovery compatibility

### DIFF
--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -2,13 +2,12 @@ import { SFI_ROOT_SCOPES } from '@/lib/sfi/oauthConfig';
 
 export const dynamic = 'force-dynamic';
 
-const ISSUER = 'https://www.systemfriction.org';
-
-export async function GET() {
+export async function GET(request: Request) {
+  const issuer = new URL(request.url).origin;
   return Response.json({
-    issuer: ISSUER,
-    authorization_endpoint: `${ISSUER}/api/oauth/authorize`,
-    token_endpoint: `${ISSUER}/api/oauth/token`,
+    issuer,
+    authorization_endpoint: `${issuer}/api/oauth/authorize`,
+    token_endpoint: `${issuer}/api/oauth/token`,
     response_types_supported: ['code'],
     grant_types_supported: ['authorization_code'],
     token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,23 @@
+import { SFI_ROOT_SCOPES } from '@/lib/sfi/oauthConfig';
+
+export const dynamic = 'force-dynamic';
+
+const ISSUER = 'https://www.systemfriction.org';
+
+export async function GET() {
+  return Response.json({
+    issuer: ISSUER,
+    authorization_endpoint: `${ISSUER}/api/oauth/authorize`,
+    token_endpoint: `${ISSUER}/api/oauth/token`,
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code'],
+    token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+    code_challenge_methods_supported: ['S256'],
+    scopes_supported: [...SFI_ROOT_SCOPES],
+    authorization_response_iss_parameter_supported: true,
+  }, {
+    headers: {
+      'Cache-Control': 'public, max-age=300, stale-while-revalidate=300',
+    },
+  });
+}

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,17 @@
+export const dynamic = 'force-dynamic';
+
+const ISSUER = 'https://www.systemfriction.org';
+const RESOURCE = `${ISSUER}/api/mcp/authenticated`;
+
+export async function GET() {
+  return Response.json({
+    resource: RESOURCE,
+    authorization_servers: [ISSUER],
+    bearer_methods_supported: ['header'],
+    scopes_supported: ['observe', 'execute'],
+  }, {
+    headers: {
+      'Cache-Control': 'public, max-age=300, stale-while-revalidate=300',
+    },
+  });
+}

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,12 +1,11 @@
 export const dynamic = 'force-dynamic';
 
-const ISSUER = 'https://www.systemfriction.org';
-const RESOURCE = `${ISSUER}/api/mcp/authenticated`;
-
-export async function GET() {
+export async function GET(request: Request) {
+  const issuer = new URL(request.url).origin;
+  const resource = `${issuer}/api/mcp/authenticated`;
   return Response.json({
-    resource: RESOURCE,
-    authorization_servers: [ISSUER],
+    resource,
+    authorization_servers: [issuer],
     bearer_methods_supported: ['header'],
     scopes_supported: ['observe', 'execute'],
   }, {

--- a/src/app/api/mcp/authenticated/route.ts
+++ b/src/app/api/mcp/authenticated/route.ts
@@ -42,7 +42,7 @@ function method(value: unknown) {
   return typeof candidate === 'string' ? candidate : '';
 }
 
-function requestedProtocol(value: unknown) {
+function requestedProtocol(value: unknown): string {
   const candidate = text(row(row(value).params).protocolVersion);
   return LEGACY_MCP_PROTOCOL_VERSIONS.has(candidate) ? candidate : SFI_AUTHENTICATED_MACHINE_PROTOCOL_VERSION;
 }
@@ -53,7 +53,7 @@ function requestedGrantId(value: unknown) {
   return text(row(args.authorization).grantId);
 }
 
-function responseHeaders(protocolVersion = SFI_AUTHENTICATED_MACHINE_PROTOCOL_VERSION) {
+function responseHeaders(protocolVersion: string = SFI_AUTHENTICATED_MACHINE_PROTOCOL_VERSION) {
   return {
     'Cache-Control': 'no-store',
     'X-SFI-MCP-Server': SFI_AUTHENTICATED_MACHINE_SERVER_ID,
@@ -196,7 +196,9 @@ export async function POST(request: Request) {
     now: () => new Date(),
   });
 
-  const protocolVersion = requestMethod === 'initialize' ? requestedProtocol(payload) : SFI_AUTHENTICATED_MACHINE_PROTOCOL_VERSION;
+  const protocolVersion: string = requestMethod === 'initialize'
+    ? requestedProtocol(payload)
+    : SFI_AUTHENTICATED_MACHINE_PROTOCOL_VERSION;
   const body = requestMethod === 'initialize'
     ? negotiateLegacyInitialize(result.body, protocolVersion)
     : result.body;

--- a/src/app/api/mcp/authenticated/route.ts
+++ b/src/app/api/mcp/authenticated/route.ts
@@ -18,6 +18,8 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 export const maxDuration = 300;
 
+const LEGACY_MCP_PROTOCOL_VERSIONS = new Set(['2025-11-25', '2025-06-18', '2025-03-26']);
+
 type JsonObject = Record<string, unknown>;
 
 function row(value: unknown): JsonObject {
@@ -40,10 +42,23 @@ function method(value: unknown) {
   return typeof candidate === 'string' ? candidate : '';
 }
 
+function requestedProtocol(value: unknown) {
+  const candidate = text(row(row(value).params).protocolVersion);
+  return LEGACY_MCP_PROTOCOL_VERSIONS.has(candidate) ? candidate : SFI_AUTHENTICATED_MACHINE_PROTOCOL_VERSION;
+}
+
 function requestedGrantId(value: unknown) {
   const params = row(row(value).params);
   const args = row(params.arguments);
   return text(row(args.authorization).grantId);
+}
+
+function responseHeaders(protocolVersion = SFI_AUTHENTICATED_MACHINE_PROTOCOL_VERSION) {
+  return {
+    'Cache-Control': 'no-store',
+    'X-SFI-MCP-Server': SFI_AUTHENTICATED_MACHINE_SERVER_ID,
+    'X-SFI-MCP-Protocol': protocolVersion,
+  };
 }
 
 function errorResponse(
@@ -55,10 +70,27 @@ function errorResponse(
 ) {
   return Response.json({ jsonrpc: '2.0', id, error: { code, message, data } }, {
     status,
+    headers: responseHeaders(),
+  });
+}
+
+function oauthChallenge(request: Request, scope: string) {
+  const origin = new URL(request.url).origin;
+  return `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource", scope="${scope}"`;
+}
+
+function negotiateLegacyInitialize(body: JsonObject, protocolVersion: string) {
+  const result = row(body.result);
+  if (!Object.keys(result).length) return body;
+  return { ...body, result: { ...result, protocolVersion } };
+}
+
+export async function GET(request: Request) {
+  return new Response(null, {
+    status: 401,
     headers: {
-      'Cache-Control': 'no-store',
-      'X-SFI-MCP-Server': SFI_AUTHENTICATED_MACHINE_SERVER_ID,
-      'X-SFI-MCP-Protocol': SFI_AUTHENTICATED_MACHINE_PROTOCOL_VERSION,
+      ...responseHeaders(),
+      'WWW-Authenticate': oauthChallenge(request, 'observe'),
     },
   });
 }
@@ -75,13 +107,17 @@ export async function POST(request: Request) {
     return errorResponse(null, -32700, 'Parse error', { reason: 'INVALID_JSON' }, 400);
   }
 
-  const requiredScope = method(payload) === 'tools/call' ? 'execute' : 'observe';
+  const requestMethod = method(payload);
+  const requiredScope = requestMethod === 'tools/call' ? 'execute' : 'observe';
   const auth = authorizeExternalRequest(request, requiredScope);
   const credential = auth.credential;
   if (!credential) {
     return Response.json(externalAuthError(auth, requiredScope), {
       status: 401,
-      headers: { 'Cache-Control': 'no-store' },
+      headers: {
+        'Cache-Control': 'no-store',
+        'WWW-Authenticate': oauthChallenge(request, requiredScope),
+      },
     });
   }
 
@@ -94,6 +130,16 @@ export async function POST(request: Request) {
       reason: 'USER_BOUND_OAUTH_WITH_CLIENT_ID_REQUIRED',
       staticTokenExecutionAllowed: false,
     }, 403);
+  }
+
+  if (requestMethod === 'notifications/initialized') {
+    return new Response(null, { status: 202, headers: responseHeaders(requestedProtocol(payload)) });
+  }
+  if (requestMethod === 'ping') {
+    return Response.json({ jsonrpc: '2.0', id: requestId(payload), result: {} }, {
+      status: 200,
+      headers: responseHeaders(requestedProtocol(payload)),
+    });
   }
 
   const principal: SfiAuthenticatedMachinePrincipal = {
@@ -110,8 +156,8 @@ export async function POST(request: Request) {
   // state, execution context, or model context. If proof does not match the persisted
   // nonceHash for the requested grant, that admission is invisible to authorization
   // and the canonical adapter fails closed with its normal denial receipt.
-  const targetGrantId = method(payload) === 'tools/call' ? requestedGrantId(payload) : '';
-  const rawGrantNonce = method(payload) === 'tools/call'
+  const targetGrantId = requestMethod === 'tools/call' ? requestedGrantId(payload) : '';
+  const rawGrantNonce = requestMethod === 'tools/call'
     ? request.headers.get('x-sfi-capability-grant-nonce')?.trim() ?? ''
     : '';
   const presentedGrantNonceHash = rawGrantNonce ? capabilityGrantNonceHash(rawGrantNonce) : null;
@@ -150,12 +196,13 @@ export async function POST(request: Request) {
     now: () => new Date(),
   });
 
-  return Response.json(result.body, {
+  const protocolVersion = requestMethod === 'initialize' ? requestedProtocol(payload) : SFI_AUTHENTICATED_MACHINE_PROTOCOL_VERSION;
+  const body = requestMethod === 'initialize'
+    ? negotiateLegacyInitialize(result.body, protocolVersion)
+    : result.body;
+
+  return Response.json(body, {
     status: result.status,
-    headers: {
-      'Cache-Control': 'no-store',
-      'X-SFI-MCP-Server': SFI_AUTHENTICATED_MACHINE_SERVER_ID,
-      'X-SFI-MCP-Protocol': SFI_AUTHENTICATED_MACHINE_PROTOCOL_VERSION,
-    },
+    headers: responseHeaders(protocolVersion),
   });
 }

--- a/src/app/api/mcp/public/route.ts
+++ b/src/app/api/mcp/public/route.ts
@@ -1,6 +1,7 @@
 import {
   SFI_PUBLIC_MCP_PROTOCOL_VERSION,
   SFI_PUBLIC_MCP_SERVER_ID,
+  SFI_PUBLIC_MCP_SERVER_VERSION,
   dispatchPublicMcpRequest,
   isPublicMcpRequest,
   validatePublicMcpHttpEnvelope,
@@ -9,10 +10,31 @@ import { readGovernedPublicObservatoryState } from '@/lib/observatory/public/rea
 
 export const dynamic = 'force-dynamic';
 
+const LEGACY_MCP_PROTOCOL_VERSIONS = new Set(['2025-11-25', '2025-06-18', '2025-03-26']);
+const LEGACY_MCP_DEFAULT_VERSION = '2025-11-25';
+
+type JsonObject = Record<string, unknown>;
+
+function row(value: unknown): JsonObject {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonObject : {};
+}
+
 function requestId(value: unknown): string | number | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const id = (value as Record<string, unknown>).id;
   return typeof id === 'string' || typeof id === 'number' || id === null ? id : null;
+}
+
+function requestMethod(value: unknown) {
+  return typeof row(value).method === 'string' ? String(row(value).method) : '';
+}
+
+function responseHeaders(protocolVersion: string) {
+  return {
+    'Cache-Control': 'no-store',
+    'X-SFI-MCP-Server': SFI_PUBLIC_MCP_SERVER_ID,
+    'X-SFI-MCP-Protocol': protocolVersion,
+  };
 }
 
 function errorResponse(
@@ -21,6 +43,7 @@ function errorResponse(
   message: string,
   data: Record<string, unknown>,
   status: number,
+  protocolVersion = SFI_PUBLIC_MCP_PROTOCOL_VERSION,
 ) {
   return Response.json({
     jsonrpc: '2.0',
@@ -28,10 +51,36 @@ function errorResponse(
     error: { code, message, data },
   }, {
     status,
+    headers: responseHeaders(protocolVersion),
+  });
+}
+
+function legacyProtocolFor(payload: unknown) {
+  const requested = String(row(row(payload).params).protocolVersion || '').trim();
+  return LEGACY_MCP_PROTOCOL_VERSIONS.has(requested) ? requested : LEGACY_MCP_DEFAULT_VERSION;
+}
+
+function legacyInitialize(payload: unknown) {
+  const protocolVersion = legacyProtocolFor(payload);
+  return Response.json({
+    jsonrpc: '2.0',
+    id: requestId(payload),
+    result: {
+      protocolVersion,
+      capabilities: { tools: {}, resources: {} },
+      serverInfo: { name: SFI_PUBLIC_MCP_SERVER_ID, version: SFI_PUBLIC_MCP_SERVER_VERSION },
+      instructions: 'Public authoritative reads only. Missing and unavailable states remain explicit. This endpoint does not mutate institutional state.',
+    },
+  }, { status: 200, headers: responseHeaders(protocolVersion) });
+}
+
+export async function GET() {
+  return new Response(null, {
+    status: 405,
     headers: {
+      Allow: 'POST',
       'Cache-Control': 'no-store',
       'X-SFI-MCP-Server': SFI_PUBLIC_MCP_SERVER_ID,
-      'X-SFI-MCP-Protocol': SFI_PUBLIC_MCP_PROTOCOL_VERSION,
     },
   });
 }
@@ -52,14 +101,34 @@ export async function POST(request: Request) {
     return errorResponse(requestId(payload), -32600, 'Invalid Request', { reason: 'INVALID_JSON_RPC_REQUEST' }, 400);
   }
 
-  const envelopeErrors = validatePublicMcpHttpEnvelope({
-    protocolVersion: request.headers.get('mcp-protocol-version'),
-    method: request.headers.get('mcp-method'),
-    name: request.headers.get('mcp-name'),
-  }, payload);
+  const method = requestMethod(payload);
+  if (method === 'initialize') return legacyInitialize(payload);
+  if (method === 'notifications/initialized') return new Response(null, { status: 202, headers: responseHeaders(LEGACY_MCP_DEFAULT_VERSION) });
+  if (method === 'ping') {
+    const protocolVersion = request.headers.get('mcp-protocol-version') || LEGACY_MCP_DEFAULT_VERSION;
+    return Response.json({ jsonrpc: '2.0', id: requestId(payload), result: {} }, { status: 200, headers: responseHeaders(protocolVersion) });
+  }
 
-  if (envelopeErrors.length > 0) {
-    return errorResponse(requestId(payload), -32020, 'HeaderMismatch', { errors: envelopeErrors }, 400);
+  const declaredProtocol = request.headers.get('mcp-protocol-version');
+  const modernRequest = declaredProtocol === SFI_PUBLIC_MCP_PROTOCOL_VERSION || method === 'server/discover';
+
+  if (declaredProtocol && declaredProtocol !== SFI_PUBLIC_MCP_PROTOCOL_VERSION && !LEGACY_MCP_PROTOCOL_VERSIONS.has(declaredProtocol)) {
+    return errorResponse(requestId(payload), -32020, 'ProtocolVersionMismatch', {
+      requested: declaredProtocol,
+      supported: [SFI_PUBLIC_MCP_PROTOCOL_VERSION, ...LEGACY_MCP_PROTOCOL_VERSIONS],
+    }, 400, declaredProtocol);
+  }
+
+  if (modernRequest) {
+    const envelopeErrors = validatePublicMcpHttpEnvelope({
+      protocolVersion: declaredProtocol,
+      method: request.headers.get('mcp-method'),
+      name: request.headers.get('mcp-name'),
+    }, payload);
+
+    if (envelopeErrors.length > 0) {
+      return errorResponse(requestId(payload), -32020, 'HeaderMismatch', { errors: envelopeErrors }, 400);
+    }
   }
 
   const response = await dispatchPublicMcpRequest(payload, {
@@ -68,10 +137,6 @@ export async function POST(request: Request) {
 
   return Response.json(response, {
     status: 200,
-    headers: {
-      'Cache-Control': 'no-store',
-      'X-SFI-MCP-Server': SFI_PUBLIC_MCP_SERVER_ID,
-      'X-SFI-MCP-Protocol': SFI_PUBLIC_MCP_PROTOCOL_VERSION,
-    },
+    headers: responseHeaders(modernRequest ? SFI_PUBLIC_MCP_PROTOCOL_VERSION : declaredProtocol || LEGACY_MCP_DEFAULT_VERSION),
   });
 }

--- a/src/app/api/mcp/public/route.ts
+++ b/src/app/api/mcp/public/route.ts
@@ -43,7 +43,7 @@ function errorResponse(
   message: string,
   data: Record<string, unknown>,
   status: number,
-  protocolVersion = SFI_PUBLIC_MCP_PROTOCOL_VERSION,
+  protocolVersion: string = SFI_PUBLIC_MCP_PROTOCOL_VERSION,
 ) {
   return Response.json({
     jsonrpc: '2.0',
@@ -72,17 +72,6 @@ function legacyInitialize(payload: unknown) {
       instructions: 'Public authoritative reads only. Missing and unavailable states remain explicit. This endpoint does not mutate institutional state.',
     },
   }, { status: 200, headers: responseHeaders(protocolVersion) });
-}
-
-export async function GET() {
-  return new Response(null, {
-    status: 405,
-    headers: {
-      Allow: 'POST',
-      'Cache-Control': 'no-store',
-      'X-SFI-MCP-Server': SFI_PUBLIC_MCP_SERVER_ID,
-    },
-  });
 }
 
 export async function POST(request: Request) {

--- a/src/app/api/oauth/authorize/route.ts
+++ b/src/app/api/oauth/authorize/route.ts
@@ -33,10 +33,11 @@ function actorSlug(value: string) {
     .slice(0, 48);
 }
 
-function redirectOAuthError(redirectUri: string, state: string | null, error: string, description: string) {
+function redirectOAuthError(redirectUri: string, state: string | null, error: string, description: string, issuer: string) {
   const url = new URL(redirectUri);
   url.searchParams.set('error', error);
   url.searchParams.set('error_description', description);
+  url.searchParams.set('iss', issuer);
   if (state) url.searchParams.set('state', state);
   return NextResponse.redirect(url);
 }
@@ -46,6 +47,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ ok: false, error: 'oauth_not_configured' }, { status: 503 });
   }
 
+  const issuer = req.nextUrl.origin;
   const clientId = req.nextUrl.searchParams.get('client_id')?.trim() || '';
   const redirectUri = req.nextUrl.searchParams.get('redirect_uri')?.trim() || '';
   const responseType = req.nextUrl.searchParams.get('response_type')?.trim() || '';
@@ -95,7 +97,7 @@ export async function GET(req: NextRequest) {
       if (!redirectAlreadyAllowed) {
         return NextResponse.json({ ok: false, error: 'access_denied' }, { status: 403 });
       }
-      return redirectOAuthError(redirectUri, state, 'access_denied', 'An active SFI account is required.');
+      return redirectOAuthError(redirectUri, state, 'access_denied', 'An active SFI account is required.', issuer);
     }
     throw error;
   }
@@ -109,6 +111,7 @@ export async function GET(req: NextRequest) {
       state,
       'access_denied',
       'This self-service OAuth client is bound to a different SFI account.',
+      issuer,
     );
   }
 
@@ -129,21 +132,21 @@ export async function GET(req: NextRequest) {
   }
 
   if (responseType !== 'code') {
-    return redirectOAuthError(redirectUri, state, 'unsupported_response_type', 'SFI supports OAuth authorization_code only.');
+    return redirectOAuthError(redirectUri, state, 'unsupported_response_type', 'SFI supports OAuth authorization_code only.', issuer);
   }
   if (codeChallenge && codeChallengeMethod !== 'S256') {
-    return redirectOAuthError(redirectUri, state, 'invalid_request', 'Only PKCE S256 is supported.');
+    return redirectOAuthError(redirectUri, state, 'invalid_request', 'Only PKCE S256 is supported.', issuer);
   }
 
   const explicitlyRequestedScopes = rawScope
     ? [...new Set<string>(rawScope.split(/\s+/).filter(Boolean))]
     : null;
   if (explicitlyRequestedScopes?.some((scope) => !SFI_SUPPORTED_SCOPES.has(scope))) {
-    return redirectOAuthError(redirectUri, state, 'invalid_scope', 'One or more requested SFI scopes are not supported.');
+    return redirectOAuthError(redirectUri, state, 'invalid_scope', 'One or more requested SFI scopes are not supported.', issuer);
   }
   const clientScopes = new Set(client.allowedScopes);
   if (explicitlyRequestedScopes?.some((scope) => !clientScopes.has(scope))) {
-    return redirectOAuthError(redirectUri, state, 'invalid_scope', 'The OAuth client is not registered for one or more requested SFI scopes.');
+    return redirectOAuthError(redirectUri, state, 'invalid_scope', 'The OAuth client is not registered for one or more requested SFI scopes.', issuer);
   }
 
   const profileRole = String(context.profile.role || 'operator').toLowerCase();
@@ -166,11 +169,11 @@ export async function GET(req: NextRequest) {
   if (personalPrincipal) {
     grantedScopes = requestedScopes.filter((scope) => principalScopes.has(scope) && clientScopes.has(scope));
     if (!grantedScopes.length) {
-      return redirectOAuthError(redirectUri, state, 'invalid_scope', 'The requested scopes do not include a personal workspace capability.');
+      return redirectOAuthError(redirectUri, state, 'invalid_scope', 'The requested scopes do not include a personal workspace capability.', issuer);
     }
   } else {
     if (requestedScopes.some((scope) => !principalScopes.has(scope) || !clientScopes.has(scope))) {
-      return redirectOAuthError(redirectUri, state, 'invalid_scope', 'The authenticated SFI principal or OAuth client is not allowed to receive one or more requested scopes.');
+      return redirectOAuthError(redirectUri, state, 'invalid_scope', 'The authenticated SFI principal or OAuth client is not allowed to receive one or more requested scopes.', issuer);
     }
     grantedScopes = requestedScopes;
   }
@@ -202,11 +205,12 @@ export async function GET(req: NextRequest) {
   });
 
   if (stored.error) {
-    return redirectOAuthError(redirectUri, state, 'server_error', 'SFI could not issue an authorization code.');
+    return redirectOAuthError(redirectUri, state, 'server_error', 'SFI could not issue an authorization code.', issuer);
   }
 
   const callback = new URL(redirectUri);
   callback.searchParams.set('code', code);
+  callback.searchParams.set('iss', issuer);
   if (state) callback.searchParams.set('state', state);
   return NextResponse.redirect(callback);
 }


### PR DESCRIPTION
SFI-00 bounded interoperability closure for WS-04. Adds compatibility for current 2026-07-28 MCP plus handshake-era 2025 clients, OAuth protected-resource/authorization-server discovery, RFC 9207 issuer on authorization responses, and preserves OAuth+scope+capability-grant execution boundaries. No authority expansion, no persistence owner, no production deploy trigger.