### PR TITLE
fix(ai): refresh Anthropic and Gemini provider currency

### DIFF
--- a/scripts/qa-sfi-ai-governance.ts
+++ b/scripts/qa-sfi-ai-governance.ts
@@ -148,7 +148,9 @@ assert.match(spine,/cognitiveTwinContext: materialized\.runtimeProjection\.cogni
 
 assert.match(provider,/synthetic_fallback_suppressed/);
 assert.match(provider,/provider: 'degraded'/);
-assert.match(provider,/gemini-3\.7-flash/,'Gemini primary must not fall back to retired 1.5 defaults.');
+assert.match(provider,/claude-sonnet-5/,'Anthropic primary must not fall back to retired Claude 3 defaults.');
+assert.doesNotMatch(provider,/\?\? 'claude-3-5-sonnet-latest'/,'Retired Claude 3.5 default must not survive.');
+assert.match(provider,/gemini-3\.8-flash/,'Gemini primary must not fall back to retired 1.5 defaults.');
 assert.match(provider,/gemini-3\.5-flash-lite/,'Gemini fast lane missing.');
 for(const model of ['openai/gpt-oss-20b','openai/gpt-oss-120b','groq/compound','groq/compound-mini']) assert.ok(provider.includes(model),`Groq model lane missing: ${model}`);
 assert.match(provider,/router\.huggingface\.co\/v1\/chat\/completions/,'HF text generation must use Inference Providers router.');

--- a/src/lib/ai/providerRouter.operationBroker.test.ts
+++ b/src/lib/ai/providerRouter.operationBroker.test.ts
@@ -75,6 +75,30 @@ test('selection is per operation requirements rather than a permanent agent-to-m
   assert.notEqual(fast.candidates[0]?.model, deep.candidates[0]?.model);
 });
 
+test('current Anthropic and Gemini routes are eligible for governed long-context operations', () => {
+  const anthropic = getLlmOperationPlan({
+    task: 'context_long',
+    requirements: {
+      ...qualityLong,
+      structuredOutput: false,
+      providerAllowlist: ['anthropic'],
+    },
+  });
+  assert.equal(anthropic.state, 'ATTEMPTABLE');
+  assert.ok(anthropic.candidates.length > 0);
+  assert.ok(anthropic.candidates.every((candidate) => candidate.provider === 'anthropic'));
+  assert.ok(anthropic.candidates.every((candidate) => !/^claude-3(?:[-.]|$)/i.test(candidate.model)));
+
+  const gemini = getLlmOperationPlan({
+    task: 'context_long',
+    requirements: { ...qualityLong, providerAllowlist: ['gemini'] },
+  });
+  assert.equal(gemini.state, 'ATTEMPTABLE');
+  assert.ok(gemini.candidates.length > 0);
+  assert.ok(gemini.candidates.every((candidate) => candidate.provider === 'gemini'));
+  assert.ok(gemini.candidates.every((candidate) => !/^gemini-1\.5(?:-|$)/i.test(candidate.model)));
+});
+
 test('provider allowlist and denylist are hard constraints; preference remains a request', () => {
   const allowed = getLlmOperationPlan({
     task: 'graph_interpretation',

--- a/src/lib/ai/providerRouter.ts
+++ b/src/lib/ai/providerRouter.ts
@@ -196,6 +196,10 @@ function envModel(...values: Array<string | undefined>) {
   return values.find((value) => typeof value === 'string' && value.trim().length > 0)?.trim() ?? null;
 }
 
+const RAW_ANTHROPIC_MODEL = envModel(process.env.ANTHROPIC_MODEL, process.env.CLAUDE_MODEL);
+const ANTHROPIC_PRIMARY_MIGRATION = RAW_ANTHROPIC_MODEL && /^(?:claude-3(?:[-.]|$)|claude-sonnet-4-20250514$|claude-opus-4-20250514$|claude-opus-4-1-20250805$)/i.test(RAW_ANTHROPIC_MODEL)
+  ? RAW_ANTHROPIC_MODEL
+  : null;
 const RAW_GEMINI_MODEL = envModel(process.env.GEMINI_MODEL, process.env.GOOGLE_MODEL);
 const GEMINI_PRIMARY_MIGRATION = RAW_GEMINI_MODEL && /^gemini-1\.5(?:-|$)/i.test(RAW_GEMINI_MODEL)
   ? RAW_GEMINI_MODEL
@@ -203,8 +207,8 @@ const GEMINI_PRIMARY_MIGRATION = RAW_GEMINI_MODEL && /^gemini-1\.5(?:-|$)/i.test
 
 const DEFAULTS = {
   openai: envModel(process.env.OPENAI_MODEL) ?? 'gpt-4o-mini',
-  anthropic: envModel(process.env.ANTHROPIC_MODEL, process.env.CLAUDE_MODEL) ?? 'claude-3-5-sonnet-latest',
-  gemini: GEMINI_PRIMARY_MIGRATION ? 'gemini-3.7-flash' : RAW_GEMINI_MODEL ?? 'gemini-3.7-flash',
+  anthropic: ANTHROPIC_PRIMARY_MIGRATION ? 'claude-sonnet-5' : RAW_ANTHROPIC_MODEL ?? 'claude-sonnet-5',
+  gemini: GEMINI_PRIMARY_MIGRATION ? 'gemini-3.8-flash' : RAW_GEMINI_MODEL ?? 'gemini-3.8-flash',
   geminiFast: envModel(process.env.GEMINI_FAST_MODEL) ?? 'gemini-3.5-flash-lite',
   groqFast: envModel(process.env.GROQ_MODEL, process.env.GROQ_FAST_MODEL) ?? 'openai/gpt-oss-20b',
   groqReasoning: envModel(process.env.GROQ_REASONING_MODEL) ?? 'openai/gpt-oss-120b',
@@ -240,7 +244,7 @@ export function getLlmModelCatalog(): LlmModelCapability[] {
   const localPrivacy = ['PUBLIC', 'INTERNAL', 'SENSITIVE', 'PRIVATE_LOCAL'];
   return [
     { provider: 'openai', model: DEFAULTS.openai, role: 'general', contextTokens: null, reasoning: true, reasoningClass: 'MEDIUM', structuredOutput: true, web: false, multimodal: false, computer: false, code: true, latencyClass: 'NORMAL', costClass: 'STANDARD', privacyClasses: hostedPrivacy, priority: 'balanced', configuredBy: ['OPENAI_MODEL'] },
-    { provider: 'anthropic', model: DEFAULTS.anthropic, role: 'quality reasoning / long context', contextTokens: null, reasoning: true, reasoningClass: 'HIGH', structuredOutput: false, web: false, multimodal: false, computer: false, code: true, latencyClass: 'NORMAL', costClass: 'QUALITY', privacyClasses: hostedPrivacy, priority: 'quality', configuredBy: ['ANTHROPIC_MODEL', 'CLAUDE_MODEL'] },
+    { provider: 'anthropic', model: DEFAULTS.anthropic, role: 'quality reasoning / long context', contextTokens: 1_000_000, reasoning: true, reasoningClass: 'HIGH', structuredOutput: false, web: false, multimodal: false, computer: false, code: true, latencyClass: 'NORMAL', costClass: 'QUALITY', privacyClasses: hostedPrivacy, priority: 'quality', configuredBy: ['ANTHROPIC_MODEL', 'CLAUDE_MODEL'] },
     { provider: 'gemini', model: DEFAULTS.gemini, role: 'quality reasoning / long context', contextTokens: 1_048_576, reasoning: true, reasoningClass: 'HIGH', structuredOutput: true, web: false, multimodal: false, computer: false, code: true, latencyClass: 'NORMAL', costClass: 'QUALITY', privacyClasses: hostedPrivacy, priority: 'quality', configuredBy: ['GEMINI_MODEL', 'GOOGLE_MODEL'] },
     { provider: 'gemini', model: DEFAULTS.geminiFast, role: 'high-throughput worker', contextTokens: null, reasoning: false, reasoningClass: 'LOW', structuredOutput: true, web: false, multimodal: false, computer: false, code: false, latencyClass: 'INTERACTIVE', costClass: 'ECONOMY', privacyClasses: hostedPrivacy, priority: 'speed', configuredBy: ['GEMINI_FAST_MODEL'] },
     { provider: 'groq', model: DEFAULTS.groqFast, role: 'fast worker / classification / structured output', contextTokens: 131_072, reasoning: true, reasoningClass: 'MEDIUM', structuredOutput: true, web: false, multimodal: false, computer: false, code: true, latencyClass: 'INTERACTIVE', costClass: 'ECONOMY', privacyClasses: hostedPrivacy, priority: 'speed', configuredBy: ['GROQ_MODEL', 'GROQ_FAST_MODEL'] },
@@ -522,7 +526,11 @@ export function getLlmProviderStatus(): LlmProviderStatus[] {
       lastErrorClass: latestFailure?.lastErrorClass ?? null,
       circuitOpen: Boolean(anyCircuit),
       circuitReason: anyCircuit?.reason ?? null,
-      migratedModelFrom: config.id === 'gemini' ? GEMINI_PRIMARY_MIGRATION : null,
+      migratedModelFrom: config.id === 'gemini'
+        ? GEMINI_PRIMARY_MIGRATION
+        : config.id === 'anthropic'
+          ? ANTHROPIC_PRIMARY_MIGRATION
+          : null,
       models: models.map((item, index) => {
         const telemetry = telemetryFor(config.id, item.model);
         const circuit = activeCircuit(config.id, item.model);
@@ -607,7 +615,6 @@ async function callProvider(config: ProviderConfig, model: string, input: {
       body: JSON.stringify({
         model,
         max_tokens: input.maxTokens,
-        temperature: 0.2,
         system: input.system,
         messages: [{ role: 'user', content: input.prompt }],
       }),
@@ -620,7 +627,6 @@ async function callProvider(config: ProviderConfig, model: string, input: {
   if (config.id === 'gemini') {
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(String(config.apiKey))}`;
     const generationConfig: Record<string, unknown> = { maxOutputTokens: input.maxTokens };
-    if (!/^gemini-3\.7(?:-|$)/i.test(model)) generationConfig.temperature = 0.2;
     const json = await fetchJson(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -738,6 +744,7 @@ export async function runLlmTask(input: {
   const started = Date.now();
   const configs = providerConfigs();
   const warnings: string[] = [];
+  if (ANTHROPIC_PRIMARY_MIGRATION) warnings.push(`anthropic_model_migrated:${ANTHROPIC_PRIMARY_MIGRATION}->${DEFAULTS.anthropic}`);
   if (GEMINI_PRIMARY_MIGRATION) warnings.push(`gemini_model_migrated:${GEMINI_PRIMARY_MIGRATION}->${DEFAULTS.gemini}`);
   const operationPlan = getLlmOperationPlan({
     task: input.task,


### PR DESCRIPTION
SFI-00 bounded WS-01 Operation-Level Model Broker repair. Replaces retired Claude 3 defaults with current Claude Sonnet 5, migrates retired configured Claude identifiers, restores long-context eligibility, removes non-default sampling parameters incompatible with current Claude, advances Gemini legacy migration/default to Gemini 3.8 Flash, and adds regression coverage. Capability metadata changes do not expand authority; model output remains MODEL_OUTPUT_NOT_OBSERVATION. No production deploy trigger.