### PR TITLE
fix(oauth): stabilize GPT issuer on Vercel hostname

### DIFF
--- a/scripts/merge-openapi-actions-compat.mjs
+++ b/scripts/merge-openapi-actions-compat.mjs
@@ -5,19 +5,22 @@ const canonicalPath = path.join(process.cwd(), 'public', 'openapi.json');
 const actionsPath = path.join(process.cwd(), 'public', 'openapi-actions.json');
 const canonical = JSON.parse(fs.readFileSync(canonicalPath, 'utf8'));
 const api = structuredClone(canonical);
-const canonicalOrigin = 'https://systemfriction.org';
+const apiOrigin = 'https://systemfriction.org';
+const oauthOrigin = 'https://system-friction.vercel.app';
 
-// GPT Actions must always use the institutional canonical origin even if an older
-// deployment/preview URL survives in a checked-in or intermediate projection.
-api.servers = [{ url: canonicalOrigin }];
-if (api.info) api.info.termsOfService = `${canonicalOrigin}/privacy`;
-if (api.externalDocs) api.externalDocs.url = `${canonicalOrigin}/privacy`;
+// The public institutional/API surface remains on systemfriction.org. OAuth for
+// ChatGPT Actions stays on the stable Vercel project hostname already registered
+// by the existing GPT client so authorization, issuer and token exchange use one
+// origin end-to-end.
+api.servers = [{ url: apiOrigin }];
+if (api.info) api.info.termsOfService = `${apiOrigin}/privacy`;
+if (api.externalDocs) api.externalDocs.url = `${apiOrigin}/privacy`;
 const oauthFlow = api.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode;
 if (oauthFlow) {
-  oauthFlow.authorizationUrl = `${canonicalOrigin}/api/oauth/authorize`;
-  oauthFlow.tokenUrl = `${canonicalOrigin}/api/oauth/token`;
+  oauthFlow.authorizationUrl = `${oauthOrigin}/api/oauth/authorize`;
+  oauthFlow.tokenUrl = `${oauthOrigin}/api/oauth/token`;
 }
-if (api['x-sfi-governance']) api['x-sfi-governance'].privacyPolicy = `${canonicalOrigin}/privacy`;
+if (api['x-sfi-governance']) api['x-sfi-governance'].privacyPolicy = `${apiOrigin}/privacy`;
 
 const conciseDescriptions = new Map([
   ['POST /api/external/v1/result', 'Persist a structured SFI analysis result without persisting raw binary content. Requires lab:write and preserves provenance/epistemic boundaries.'],
@@ -84,11 +87,12 @@ api['x-sfi-actions-compatibility'] = {
   contract: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.0',
   canonicalSource: '/openapi.json',
   projection: '/openapi-actions.json',
-  canonicalOrigin,
+  apiOrigin,
+  oauthOrigin,
   maxOperationDescriptionChars: 300,
   customHeaderParametersExcluded: true,
   authenticatedMcpRuntimeAuthorizationUnchanged: true,
 };
 
 fs.writeFileSync(actionsPath, `${JSON.stringify(api, null, 2)}\n`);
-console.log(JSON.stringify({ ok: true, contract: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.0', canonical: 'public/openapi.json', projection: 'public/openapi-actions.json', canonicalOrigin }, null, 2));
+console.log(JSON.stringify({ ok: true, contract: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.0', canonical: 'public/openapi.json', projection: 'public/openapi-actions.json', apiOrigin, oauthOrigin }, null, 2));

--- a/scripts/qa-sfi-sovereign-only-human-gates.ts
+++ b/scripts/qa-sfi-sovereign-only-human-gates.ts
@@ -19,6 +19,8 @@ const bootstrap = read('src/app/api/external/v1/bootstrap/route.ts');
 const manifest = read('src/app/api/external/v1/manifest/route.ts');
 const openapiMerge = read('scripts/merge-openapi-sovereign-gates.mjs');
 const actionsProjection = read('scripts/merge-openapi-actions-compat.mjs');
+const oauthMetadata = read('src/app/.well-known/oauth-authorization-server/route.ts');
+const protectedResourceMetadata = read('src/app/.well-known/oauth-protected-resource/route.ts');
 
 for (const invariant of [
   'initialApprovalRequired: false',
@@ -101,19 +103,27 @@ assert.match(openapiMerge, /required\.filter\(\(name\) => name !== 'confirm'\)/)
 assert.match(openapiMerge, /classify and use as a working source without ROOT approval/);
 assert.match(openapiMerge, /canonical evidence admission only when an explicit governed promotion boundary is crossed/);
 assert.doesNotMatch(openapiMerge, /ROOT accept\/reject/);
-assert.match(actionsProjection, /https:\/\/systemfriction\.org/);
-assert.match(actionsProjection, /authorizationUrl = `\$\{canonicalOrigin\}\/api\/oauth\/authorize`/);
-assert.match(actionsProjection, /tokenUrl = `\$\{canonicalOrigin\}\/api\/oauth\/token`/);
+
+// GPT Actions use the institutional domain for API calls but keep OAuth on the
+// stable Vercel project hostname already registered by the existing GPT client.
+assert.match(actionsProjection, /const apiOrigin = 'https:\/\/systemfriction\.org'/);
+assert.match(actionsProjection, /const oauthOrigin = 'https:\/\/system-friction\.vercel\.app'/);
+assert.match(actionsProjection, /authorizationUrl = `\$\{oauthOrigin\}\/api\/oauth\/authorize`/);
+assert.match(actionsProjection, /tokenUrl = `\$\{oauthOrigin\}\/api\/oauth\/token`/);
+assert.match(oauthMetadata, /const issuer = 'https:\/\/system-friction\.vercel\.app'/);
+assert.match(protectedResourceMetadata, /const oauthIssuer = 'https:\/\/system-friction\.vercel\.app'/);
+assert.match(protectedResourceMetadata, /const resourceOrigin = 'https:\/\/systemfriction\.org'/);
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-SOVEREIGN-ONLY-HUMAN-GATES-1.2',
+  contract: 'SFI-SOVEREIGN-ONLY-HUMAN-GATES-1.3',
   humanApprovalRequiredForRoutineCaseWork: false,
   humanApprovalRequiredForWorkingSources: false,
   humanApprovalRequiredForRoutineLabRun: false,
   duplicateExecutionConfirmationRequired: false,
   obsoleteRoutineHumanGatesPresent: false,
-  actionsCanonicalOriginEnforced: true,
+  actionsApiOrigin: 'https://systemfriction.org',
+  oauthIssuer: 'https://system-friction.vercel.app',
   sovereignBoundary: ['INSTITUTIONAL_CHANGE', 'CAPABILITY_IMPLEMENTATION', 'LEARNING_PROMOTION', 'RESERVED_EXTERNAL_OPERATION'],
   plainLanguageDefault: true,
   canonicalPromotionAutomatic: false,

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -2,8 +2,9 @@ import { SFI_ROOT_SCOPES } from '@/lib/sfi/oauthConfig';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: Request) {
-  const issuer = new URL(request.url).origin;
+const issuer = 'https://system-friction.vercel.app';
+
+export async function GET() {
   return Response.json({
     issuer,
     authorization_endpoint: `${issuer}/api/oauth/authorize`,

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,11 +1,12 @@
 export const dynamic = 'force-dynamic';
 
-export async function GET(request: Request) {
-  const issuer = new URL(request.url).origin;
-  const resource = `${issuer}/api/mcp/authenticated`;
+const oauthIssuer = 'https://system-friction.vercel.app';
+const resourceOrigin = 'https://systemfriction.org';
+
+export async function GET() {
   return Response.json({
-    resource,
-    authorization_servers: [issuer],
+    resource: `${resourceOrigin}/api/mcp/authenticated`,
+    authorization_servers: [oauthIssuer],
     bearer_methods_supported: ['header'],
     scopes_supported: ['observe', 'execute'],
   }, {


### PR DESCRIPTION
SFI PRECHECK
- Scope: restore one stable OAuth identity for ChatGPT Actions without changing institutional/API public origin.
- API surface remains https://systemfriction.org.
- OAuth authorization/token + metadata use https://system-friction.vercel.app, matching the existing GPT client configuration.
- Working-source autonomy and sovereign boundaries remain unchanged.
- No database mutation and no client secret rotation.
- One production deployment only after merge.

Expected result: ChatGPT receives a consistent authorization issuer/token origin and can complete the authorization-code exchange instead of leaving issued codes unconsumed.