### PR TITLE
fix(continuity): restore autonomous heartbeat with idle egress guard

### DIFF
--- a/.github/workflows/sfi-continuity-hourly.yml
+++ b/.github/workflows/sfi-continuity-hourly.yml
@@ -3,6 +3,7 @@ name: SFI Continuity Hourly
 on:
   schedule:
     - cron: '15 * * * *'
+    - cron: '45 * * * *'
   workflow_dispatch:
     inputs:
       cycle_id:

--- a/.github/workflows/sfi-continuity-hourly.yml
+++ b/.github/workflows/sfi-continuity-hourly.yml
@@ -2,7 +2,7 @@ name: SFI Continuity Hourly
 
 on:
   schedule:
-    - cron: '15,45 * * * *'
+    - cron: '15 * * * *'
   workflow_dispatch:
     inputs:
       cycle_id:

--- a/.github/workflows/sfi-continuity-hourly.yml
+++ b/.github/workflows/sfi-continuity-hourly.yml
@@ -1,12 +1,19 @@
 name: SFI Continuity Hourly
 
 on:
+  schedule:
+    - cron: '15,45 * * * *'
   workflow_dispatch:
     inputs:
       cycle_id:
         description: 'Optional existing universal cycleId to recover without opening a new cycle'
         required: false
         type: string
+  workflow_run:
+    workflows:
+      - SFI Vercel Prebuilt Production
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -19,8 +26,9 @@ concurrency:
 
 jobs:
   heartbeat:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     concurrency:
-      group: ${{ format('sfi-continuity-heartbeat-{0}', github.run_id) }}
+      group: ${{ github.event_name == 'workflow_run' && format('sfi-post-deploy-assurance-{0}', github.event.workflow_run.id) || format('sfi-continuity-heartbeat-{0}', github.run_id) }}
       cancel-in-progress: false
       queue: max
     runs-on: ubuntu-latest
@@ -31,11 +39,31 @@ jobs:
         shell: bash
         env:
           MANUAL_CYCLE_ID: ${{ inputs.cycle_id || '' }}
+          UPSTREAM_SHA: ${{ github.event.workflow_run.head_sha || '' }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           cycle_id="$MANUAL_CYCLE_ID"
           source="workflow_dispatch"
+
+          if [ -z "$cycle_id" ] && [ "${GITHUB_EVENT_NAME}" = "workflow_run" ] && [ -n "$UPSTREAM_SHA" ]; then
+            source="deployment_commit_marker"
+            commit_file="$RUNNER_TEMP/sfi-deployed-commit.json"
+            curl --fail-with-body --silent --show-error \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/commits/${UPSTREAM_SHA}" > "$commit_file"
+            cycle_id="$(python - "$commit_file" <<'PY'
+          import json, re, sys
+          with open(sys.argv[1], encoding='utf-8') as handle:
+              payload = json.load(handle)
+          message = ((payload.get('commit') or {}).get('message') or '')
+          match = re.search(r'\[sfi-cycle-proof:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\]', message)
+          print(match.group(1).lower() if match else '')
+          PY
+            )"
+          fi
+
           if [ -z "$cycle_id" ]; then
             source="none"
           fi
@@ -56,7 +84,55 @@ jobs:
           echo "::add-mask::$token"
           echo "token=$token" >> "$GITHUB_OUTPUT"
 
+      - name: Check whether continuity has real work
+        id: wakeup
+        shell: bash
+        env:
+          OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
+          SFI_WAKEUP_ENDPOINT: https://system-friction.vercel.app/api/cron/continuity-wakeup
+          CYCLE_ID: ${{ steps.target.outputs.cycle_id }}
+        run: |
+          set -euo pipefail
+          endpoint="$SFI_WAKEUP_ENDPOINT"
+          if [ -n "$CYCLE_ID" ]; then
+            encoded_cycle_id="$(python -c 'import os,urllib.parse; print(urllib.parse.quote(os.environ["CYCLE_ID"], safe=""))')"
+            endpoint="${endpoint}?cycleId=${encoded_cycle_id}"
+          fi
+
+          response_file="$RUNNER_TEMP/sfi-continuity-wakeup.json"
+          curl --fail-with-body --silent --show-error \
+            --connect-timeout 15 \
+            --max-time 60 \
+            -H "Authorization: Bearer ${OIDC_TOKEN}" \
+            -H "X-SFI-Continuity-Trigger: github-actions-oidc" \
+            "$endpoint" > "$response_file"
+
+          python - "$response_file" "$GITHUB_OUTPUT" "$GITHUB_STEP_SUMMARY" <<'PY'
+          import json, sys
+          response_file, output_path, summary_path = sys.argv[1], sys.argv[2], sys.argv[3]
+          with open(response_file, encoding='utf-8') as handle:
+              payload = json.load(handle)
+          if payload.get('ok') is not True:
+              raise SystemExit('continuity wakeup gate returned ok=false')
+          should_run = payload.get('shouldRun') is True
+          with open(output_path, 'a', encoding='utf-8') as handle:
+              handle.write(f"should_run={'true' if should_run else 'false'}\n")
+          print(json.dumps(payload, ensure_ascii=False, separators=(',', ':')))
+          if summary_path:
+              with open(summary_path, 'a', encoding='utf-8') as handle:
+                  handle.write('## SFI Continuity wakeup gate\n\n```json\n')
+                  handle.write(json.dumps(payload, ensure_ascii=False, indent=2))
+                  handle.write('\n```\n')
+          PY
+
+      - name: Record idle pulse without heavy runtime execution
+        if: steps.wakeup.outputs.should_run != 'true'
+        shell: bash
+        run: |
+          echo 'SFI_CONTINUITY_IDLE_NO_ACTIONABLE_WORK'
+
       - name: Execute governed SFI continuity heartbeat
+        if: steps.wakeup.outputs.should_run == 'true'
         shell: bash
         env:
           OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
@@ -72,6 +148,8 @@ jobs:
           fi
 
           response_file="$RUNNER_TEMP/sfi-continuity-response.json"
+          # Never retry the whole effectful heartbeat. A transport failure can
+          # occur after governed effects have already committed.
           curl --fail-with-body --silent --show-error \
             --connect-timeout 15 \
             --max-time 300 \
@@ -87,6 +165,7 @@ jobs:
               payload = json.load(handle)
 
           core = payload.get('coreHeartbeat') or {}
+          lane_status = payload.get('laneStatus') or {}
           universal = payload.get('universalCycleContinuation') or {}
           before = payload.get('returnPlanUpgradeBefore') or {}
           after = payload.get('returnPlanUpgradeAfter') or {}
@@ -101,6 +180,7 @@ jobs:
               'requestedCycleId': payload.get('requestedCycleId'),
               'targetSource': target_source,
               'coreHeartbeat': core,
+              'laneStatus': lane_status,
               'returnPlanUpgradeBefore': {'ok': before.get('ok'), 'processed': before.get('processed'), 'results': before.get('results', [])},
               'universal': {
                   'ok': universal.get('ok'),

--- a/scripts/qa-sfi-operational-reset.ts
+++ b/scripts/qa-sfi-operational-reset.ts
@@ -48,8 +48,8 @@ assert.deepEqual(RESEED_MINIMAL_TABLES, [
   'account_balance',
   'sfi_continuity_state',
 ]);
-assert.equal(PURGE_DATA_TABLES.length, 146, 'live reset baseline must explicitly classify all 146 non-World/non-genesis public tables');
-assert.equal(CLASSIFIED_PUBLIC_TABLES.length, 164, 'reset baseline must classify every public table observed after Discovery integration');
+assert.equal(PURGE_DATA_TABLES.length, 147, 'live reset baseline must explicitly classify all 147 non-World/non-genesis public tables');
+assert.equal(CLASSIFIED_PUBLIC_TABLES.length, 165, 'reset baseline must classify every public table observed after Discovery integration');
 assert.equal(new Set(CLASSIFIED_PUBLIC_TABLES).size, CLASSIFIED_PUBLIC_TABLES.length, 'reset classification must contain no duplicate table');
 for (const table of PRESERVE_DATA_TABLES) assert.equal(classifyPublicTable(table), 'PRESERVE_DATA');
 for (const table of RESEED_MINIMAL_TABLES) assert.equal(classifyPublicTable(table), 'RESEED_MINIMAL');
@@ -63,7 +63,7 @@ assert.equal(exactAudit.unclassified.length, 0);
 assert.equal(exactAudit.classifiedButNotObserved.length, 0);
 assert.equal(exactAudit.preserveData.length, 10);
 assert.equal(exactAudit.reseedMinimal.length, 8);
-assert.equal(exactAudit.purgeData.length, 146);
+assert.equal(exactAudit.purgeData.length, 147);
 
 for (const table of ['epistemic_events','sfi_amv_memory','policy_decisions','action_proposals','sfi_cognitive_twin_memory','sfi_cognitive_twin_runs','platform_metric_snapshots']) {
   assert.ok(PURGE_DATA_TABLES.includes(table), `non-World legacy/runtime table must be explicitly purged: ${table}`);

--- a/src/app/api/cron/continuity-wakeup/route.ts
+++ b/src/app/api/cron/continuity-wakeup/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { verifyGitHubActionsOidcToken } from '@/lib/continuity/githubActionsOidc';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+type AuthorizedTrigger = 'vercel_cron' | 'github_actions_oidc' | 'development';
+type Row = Record<string, unknown>;
+
+const ACTIVE_PROPOSAL_STATUSES = ['proposed', 'waiting_evidence', 'design_approved', 'queued', 'accepted'];
+const TERMINAL_CASE_STATUSES = new Set(['closed', 'completed', 'cancelled', 'canceled', 'rejected', 'archived']);
+const UNIVERSAL_LIFECYCLE_EVENTS = [
+  'SFI_UNIVERSAL_CYCLE_RESUMED',
+  'SFI_UNIVERSAL_COGNITIVE_CHECKPOINT',
+  'SFI_UNIVERSAL_COGNITIVE_CYCLE_EXECUTED',
+  'SFI_UNIVERSAL_AI_SYNTHESIS_COMPLETED',
+  'SFI_UNIVERSAL_RETURN_PLAN_RECORDED',
+  'SFI_UNIVERSAL_RETURN_RECORDED',
+  'SFI_UNIVERSAL_CYCLE_CLOSED',
+];
+
+function bearer(request: NextRequest) {
+  const match = (request.headers.get('authorization') ?? '').match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() ?? '';
+}
+
+async function authorize(request: NextRequest): Promise<{ ok: true; trigger: AuthorizedTrigger } | { ok: false }> {
+  const token = bearer(request);
+  const secret = process.env.SFI_CONTINUITY_CRON_SECRET || process.env.CRON_SECRET || '';
+
+  if (!token && !secret && process.env.NODE_ENV !== 'production') {
+    return { ok: true, trigger: 'development' };
+  }
+
+  if (secret && token === secret) {
+    return { ok: true, trigger: 'vercel_cron' };
+  }
+
+  if (token) {
+    const oidc = await verifyGitHubActionsOidcToken(token);
+    if (oidc.ok) return { ok: true, trigger: 'github_actions_oidc' };
+  }
+
+  return { ok: false };
+}
+
+function hasOpenUniversalCycle(events: Row[]) {
+  const latestByLogbook = new Map<string, string>();
+  for (const event of events) {
+    const logbookId = typeof event.logbook_id === 'string' ? event.logbook_id : '';
+    const eventName = typeof event.event_name === 'string' ? event.event_name : '';
+    if (!logbookId || !eventName || latestByLogbook.has(logbookId)) continue;
+    latestByLogbook.set(logbookId, eventName);
+  }
+  return [...latestByLogbook.values()].some((eventName) => eventName !== 'SFI_UNIVERSAL_CYCLE_CLOSED');
+}
+
+export async function GET(request: NextRequest) {
+  const authorization = await authorize(request);
+  if (!authorization.ok) {
+    return NextResponse.json({ ok: false, error: 'unauthorized_continuity_wakeup' }, { status: 401 });
+  }
+
+  const requestedCycleId = request.nextUrl.searchParams.get('cycleId')?.trim() || null;
+  if (requestedCycleId) {
+    return NextResponse.json({
+      ok: true,
+      trigger: authorization.trigger,
+      shouldRun: true,
+      reason: 'TARGETED_EXISTING_CYCLE',
+      requestedCycleId,
+    });
+  }
+
+  const db = createServiceSupabaseClient();
+  const [state, proposals, cases, lifecycle, studio] = await Promise.all([
+    db.from('sfi_continuity_state').select('mode').eq('id', 'institution').maybeSingle(),
+    db.from('action_proposals').select('id,status').in('status', ACTIVE_PROPOSAL_STATUSES).limit(1),
+    db.from('sfi_cases').select('id,status').is('deleted_at', null).order('updated_at', { ascending: false }).limit(20),
+    db.from('epistemic_events')
+      .select('sequence,event_name,logbook_id')
+      .in('event_name', UNIVERSAL_LIFECYCLE_EVENTS)
+      .order('sequence', { ascending: false })
+      .limit(500),
+    db.from('studio_objects').select('id,title,status').ilike('title', '%FI-001%').limit(1),
+  ]);
+
+  const readError = state.error ?? proposals.error ?? cases.error ?? lifecycle.error ?? studio.error;
+  if (readError) {
+    return NextResponse.json({
+      ok: true,
+      trigger: authorization.trigger,
+      shouldRun: true,
+      reason: 'WORK_GATE_READ_FAILED_FAIL_OPEN',
+      diagnostic: { code: readError.code ?? null, message: readError.message },
+    });
+  }
+
+  const continuityMode = typeof state.data?.mode === 'string' ? state.data.mode : 'NORMAL';
+  const activeProposal = (proposals.data ?? []).length > 0;
+  const activeCase = ((cases.data ?? []) as Row[]).some((item) => {
+    const status = typeof item.status === 'string' ? item.status.toLowerCase() : '';
+    return !TERMINAL_CASE_STATUSES.has(status);
+  });
+  const openUniversalCycle = hasOpenUniversalCycle(((lifecycle.data ?? []) as Row[]));
+  const activeStudioExperiment = (studio.data ?? []).length > 0;
+  const nonNormalContinuityMode = continuityMode !== 'NORMAL';
+  const shouldRun = activeProposal || activeCase || openUniversalCycle || activeStudioExperiment || nonNormalContinuityMode;
+
+  return NextResponse.json({
+    ok: true,
+    trigger: authorization.trigger,
+    shouldRun,
+    reason: shouldRun ? 'ACTIONABLE_CONTINUITY_WORK' : 'IDLE_NO_ACTIONABLE_WORK',
+    state: {
+      continuityMode,
+      activeProposal,
+      activeCase,
+      openUniversalCycle,
+      activeStudioExperiment,
+    },
+    boundary: 'Read-only scheduler gate. It never creates continuity runs, health checks, evidence, memory, RETURN, learning, canon, or external actions.',
+  }, { headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function POST(request: NextRequest) {
+  return GET(request);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,10 @@
       "schedule": "25 7 * * *"
     },
     {
+      "path": "/api/cron/continuity-heartbeat",
+      "schedule": "15 7 * * *"
+    },
+    {
       "path": "/api/cron/sfi-institutional-cycle",
       "schedule": "35 7 * * *"
     },


### PR DESCRIPTION
## Purpose
Restore autonomous SFI continuity without restoring the prior idle read/write amplification.

## Human behavior
- SFI wakes automatically once per hour at minute 15 and after a successful production deploy.
- Before running the full continuity engine it performs a narrow read-only check for actual pending work.
- If there is no pending case, proposal, universal cycle, FI-001 Studio experiment, or non-NORMAL continuity mode, the run exits IDLE and does not create continuity runs, capability-health rows, evidence, memory, RETURN, learning or canon.
- A targeted existing cycle always runs.
- If the gate cannot read state, it fails open so existing continuity semantics decide rather than silently abandoning work.
- The existing daily Vercel heartbeat remains a low-frequency fallback.

## SFI PRECHECK
Owner: SFI-00 / continuity scheduler and existing continuity runtime.
Existing capability inspected: existing `sfi-continuity-hourly.yml`, `/api/cron/continuity-heartbeat`, universal-cycle continuation, Studio autonomy continuation, governed execution router, continuity state/runs, GitHub OIDC boundary, Vercel cron fallback and current empty post-reset operational tables.
Absorb vs create decision: absorb the existing heartbeat and scheduler. Add only a bounded read-only wakeup gate because the existing heartbeat is effectful and cannot safely serve as the frequent idle probe itself. No second continuity runtime or scheduler is introduced.
Authoritative writer: unchanged. Existing continuity/runtime/event/memory/RETURN writers remain authoritative. The wakeup gate has no writer.
Persistence/lineage impact: none from the wakeup gate. When work exists, the existing heartbeat preserves current persistence and lineage semantics. Idle checks persist nothing.
Front delta: none.
Back delta: one read-only scheduler gate; restore the canonical hourly GitHub schedule and post-deploy trigger; retain daily Vercel fallback.
DB delta: none.
Redundancy removed: prevents an idle scheduler invocation from executing all heavy heartbeat lanes merely to determine that no work exists.
Execution/ROOT boundary: unchanged. Routine work continues inside existing authority; institutional/canonical change, material capability change, learning promotion and reserved external/irreversible operations remain sovereign-gated.
Rollback: revert PR #485. No DB rollback is required because there is no migration or data mutation.
Verification: canonical preflight, continuity ledger-read recovery, post-deploy assurance coordination, SFI Verify/typecheck/build, SFI-08 completion certification, CodeQL; after merge and controlled production deploy, verify one empty-state IDLE wakeup and one targeted/actionable path without fabricated work.

## Scope
- one read-only scheduler gate endpoint;
- restore canonical hourly GitHub heartbeat and post-deploy trigger;
- retain daily Vercel fallback;
- no database schema change;
- no authority/canon/learning semantics change;
- no new persistence owner.

Production deployment remains separate from merge and must be verified against the exact deployed SHA.