### PR TITLE
fix(sfi): close runtime boundaries and publish Notas Temporales

### DIFF
--- a/.github/workflows/sfi-discovery-emitter.yml
+++ b/.github/workflows/sfi-discovery-emitter.yml
@@ -75,8 +75,8 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - name: Verify canonical registry, query mesh, emitter, exposure and institutional lenses
-        run: node --import tsx --test src/lib/discovery/canonicalObjectRegistry.test.ts src/lib/discovery/discoveryMesh.test.ts src/lib/discovery/discoveryEmitter.test.ts src/lib/discovery/exposureProjection.test.ts src/lib/discovery/institutionalDiscoveryMesh.test.ts
+      - name: Verify canonical registry, publication body, query mesh, emitter, exposure and institutional lenses
+        run: node --import tsx --test src/lib/publications/editorialContent.test.ts src/lib/discovery/canonicalObjectRegistry.test.ts src/lib/discovery/discoveryMesh.test.ts src/lib/discovery/discoveryEmitter.test.ts src/lib/discovery/exposureProjection.test.ts src/lib/discovery/institutionalDiscoveryMesh.test.ts
       - name: Verify durable discovery, exposure and authority boundaries
         run: npx tsx scripts/qa-sfi-discovery-operational.ts && npx tsx scripts/qa-sfi-discovery-emitter.ts && npx tsx scripts/qa-sfi-discovery-exposure.ts
       - name: Verify canonical publication namespace gate

--- a/.github/workflows/sfi-discovery-emitter.yml
+++ b/.github/workflows/sfi-discovery-emitter.yml
@@ -5,9 +5,11 @@ on:
     paths:
       - 'src/lib/discovery/**'
       - 'src/lib/research/**'
+      - 'src/lib/publications/**'
       - 'src/components/research/**'
       - 'src/app/research/**'
       - 'src/app/publications/**'
+      - 'src/app/library/**'
       - 'public/library/**'
       - 'src/app/feed.xml/**'
       - 'src/app/feed.atom/**'
@@ -34,9 +36,11 @@ on:
     paths:
       - 'src/lib/discovery/**'
       - 'src/lib/research/**'
+      - 'src/lib/publications/**'
       - 'src/components/research/**'
       - 'src/app/research/**'
       - 'src/app/publications/**'
+      - 'src/app/library/**'
       - 'public/library/**'
       - 'src/app/feed.xml/**'
       - 'src/app/feed.atom/**'

--- a/.github/workflows/sfi-self-development.yml
+++ b/.github/workflows/sfi-self-development.yml
@@ -19,10 +19,6 @@ on:
   schedule:
     - cron: '23 3 * * *'
   workflow_dispatch:
-  workflow_run:
-    workflows:
-      - SFI Continuity Hourly
-    types: [completed]
 
 permissions:
   contents: write
@@ -35,7 +31,6 @@ concurrency:
 
 jobs:
   observe-repair-return:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/src/app/api/cron/continuity-heartbeat/route.ts
+++ b/src/app/api/cron/continuity-heartbeat/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { readContinuityActionableWorkGate } from '@/lib/continuity/actionableWorkGate';
 import { runContinuityHeartbeat, runOperationalTransitionWatchdog } from '@/lib/continuity/runtime';
 import { runOperationalAutoAdvance } from '@/lib/continuity/operationalAutoAdvance';
 import { runStudioAutonomyContinuation } from '@/lib/continuity/studioAutonomy';
@@ -158,6 +159,21 @@ export async function GET(request: NextRequest) {
   if (!authorization.ok) return NextResponse.json({ ok: false, error: 'unauthorized_continuity_cron' }, { status: 401 });
 
   const requestedCycleId = request.nextUrl.searchParams.get('cycleId')?.trim() || undefined;
+  const actionableGate = await readContinuityActionableWorkGate({ requestedCycleId });
+
+  if (!actionableGate.shouldRun) {
+    return NextResponse.json({
+      ok: true,
+      trigger: authorization.trigger,
+      requestedCycleId: requestedCycleId ?? null,
+      mode: actionableGate.state?.continuityMode ?? 'NORMAL',
+      status: 'IDLE',
+      reason: actionableGate.reason,
+      actionableGate,
+      writesPerformed: false,
+      executionRule: 'Idle heartbeat exits before continuity probes or governed continuation lanes. No continuity run, health check, evidence, memory, RETURN, learning, canon or external action is created.',
+    }, { headers: { 'Cache-Control': 'no-store' } });
+  }
 
   try {
     const result = await runContinuityHeartbeat(authorization.trigger);
@@ -220,9 +236,6 @@ export async function GET(request: NextRequest) {
           })),
     ]);
 
-    // Evidence acquisition and risk assessment above may make routine proposals
-    // eligible. Advance those now, without inventing a ROOT approval. Sovereign
-    // or material external operations remain stopped by the decision boundary.
     const operationalAutoAdvance = emergencyHalt
       ? { ok: true as const, halted: true as const, processed: 0, results: [] }
       : await runOperationalAutoAdvance({ limit: 10 }).catch((error) => ({
@@ -298,6 +311,7 @@ export async function GET(request: NextRequest) {
       ok: gateReceipt.overallOk,
       trigger: authorization.trigger,
       requestedCycleId: requestedCycleId ?? null,
+      actionableGate,
       ...result,
       coreHeartbeat,
       laneStatus,
@@ -312,7 +326,7 @@ export async function GET(request: NextRequest) {
       targetCycleState,
       executionRule: emergencyHalt
         ? 'EMERGENCY_HALT suppresses transition writes, operational auto-advance, governed execution dispatch, universal cognitive continuation, empirical continuation and learning writes. Continuity probes may record the halted heartbeat only.'
-        : 'One heartbeat owns the complete governed continuation path. Routine evidence review, risk assessment, operational authorization, execution, RETURN, calibration and methodological closure proceed without founder approval while remaining inside existing authority. Institutional/canonical change, material capability change, learning promotion and reserved material external/irreversible operations stop at the sovereign boundary. Missing evidence remains missing; no RETURN, canon mutation or external authority is fabricated.',
+        : 'One heartbeat owns the complete governed continuation path only after the read-only actionable-work gate admits real pending work. Routine evidence review, risk assessment, operational authorization, execution, RETURN, calibration and methodological closure proceed without founder approval while remaining inside existing authority. Institutional/canonical change, material capability change, learning promotion and reserved material external/irreversible operations stop at the sovereign boundary. Missing evidence remains missing; no RETURN, canon mutation or external authority is fabricated.',
     });
   } catch (error) {
     return NextResponse.json({

--- a/src/app/api/cron/continuity-wakeup/route.ts
+++ b/src/app/api/cron/continuity-wakeup/route.ts
@@ -1,24 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+import { readContinuityActionableWorkGate } from '@/lib/continuity/actionableWorkGate';
 import { verifyGitHubActionsOidcToken } from '@/lib/continuity/githubActionsOidc';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 type AuthorizedTrigger = 'vercel_cron' | 'github_actions_oidc' | 'development';
-type Row = Record<string, unknown>;
-
-const ACTIVE_PROPOSAL_STATUSES = ['proposed', 'waiting_evidence', 'design_approved', 'queued', 'accepted'];
-const TERMINAL_CASE_STATUSES = new Set(['closed', 'completed', 'cancelled', 'canceled', 'rejected', 'archived']);
-const UNIVERSAL_LIFECYCLE_EVENTS = [
-  'SFI_UNIVERSAL_CYCLE_RESUMED',
-  'SFI_UNIVERSAL_COGNITIVE_CHECKPOINT',
-  'SFI_UNIVERSAL_COGNITIVE_CYCLE_EXECUTED',
-  'SFI_UNIVERSAL_AI_SYNTHESIS_COMPLETED',
-  'SFI_UNIVERSAL_RETURN_PLAN_RECORDED',
-  'SFI_UNIVERSAL_RETURN_RECORDED',
-  'SFI_UNIVERSAL_CYCLE_CLOSED',
-];
 
 function bearer(request: NextRequest) {
   const match = (request.headers.get('authorization') ?? '').match(/^Bearer\s+(.+)$/i);
@@ -45,17 +32,6 @@ async function authorize(request: NextRequest): Promise<{ ok: true; trigger: Aut
   return { ok: false };
 }
 
-function hasOpenUniversalCycle(events: Row[]) {
-  const latestByLogbook = new Map<string, string>();
-  for (const event of events) {
-    const logbookId = typeof event.logbook_id === 'string' ? event.logbook_id : '';
-    const eventName = typeof event.event_name === 'string' ? event.event_name : '';
-    if (!logbookId || !eventName || latestByLogbook.has(logbookId)) continue;
-    latestByLogbook.set(logbookId, eventName);
-  }
-  return [...latestByLogbook.values()].some((eventName) => eventName !== 'SFI_UNIVERSAL_CYCLE_CLOSED');
-}
-
 export async function GET(request: NextRequest) {
   const authorization = await authorize(request);
   if (!authorization.ok) {
@@ -63,63 +39,12 @@ export async function GET(request: NextRequest) {
   }
 
   const requestedCycleId = request.nextUrl.searchParams.get('cycleId')?.trim() || null;
-  if (requestedCycleId) {
-    return NextResponse.json({
-      ok: true,
-      trigger: authorization.trigger,
-      shouldRun: true,
-      reason: 'TARGETED_EXISTING_CYCLE',
-      requestedCycleId,
-    });
-  }
-
-  const db = createServiceSupabaseClient();
-  const [state, proposals, cases, lifecycle, studio] = await Promise.all([
-    db.from('sfi_continuity_state').select('mode').eq('id', 'institution').maybeSingle(),
-    db.from('action_proposals').select('id,status').in('status', ACTIVE_PROPOSAL_STATUSES).limit(1),
-    db.from('sfi_cases').select('id,status').is('deleted_at', null).order('updated_at', { ascending: false }).limit(20),
-    db.from('epistemic_events')
-      .select('sequence,event_name,logbook_id')
-      .in('event_name', UNIVERSAL_LIFECYCLE_EVENTS)
-      .order('sequence', { ascending: false })
-      .limit(500),
-    db.from('studio_objects').select('id,title,status').ilike('title', '%FI-001%').limit(1),
-  ]);
-
-  const readError = state.error ?? proposals.error ?? cases.error ?? lifecycle.error ?? studio.error;
-  if (readError) {
-    return NextResponse.json({
-      ok: true,
-      trigger: authorization.trigger,
-      shouldRun: true,
-      reason: 'WORK_GATE_READ_FAILED_FAIL_OPEN',
-      diagnostic: { code: readError.code ?? null, message: readError.message },
-    });
-  }
-
-  const continuityMode = typeof state.data?.mode === 'string' ? state.data.mode : 'NORMAL';
-  const activeProposal = (proposals.data ?? []).length > 0;
-  const activeCase = ((cases.data ?? []) as Row[]).some((item) => {
-    const status = typeof item.status === 'string' ? item.status.toLowerCase() : '';
-    return !TERMINAL_CASE_STATUSES.has(status);
-  });
-  const openUniversalCycle = hasOpenUniversalCycle(((lifecycle.data ?? []) as Row[]));
-  const activeStudioExperiment = (studio.data ?? []).length > 0;
-  const nonNormalContinuityMode = continuityMode !== 'NORMAL';
-  const shouldRun = activeProposal || activeCase || openUniversalCycle || activeStudioExperiment || nonNormalContinuityMode;
+  const gate = await readContinuityActionableWorkGate({ requestedCycleId });
 
   return NextResponse.json({
     ok: true,
     trigger: authorization.trigger,
-    shouldRun,
-    reason: shouldRun ? 'ACTIONABLE_CONTINUITY_WORK' : 'IDLE_NO_ACTIONABLE_WORK',
-    state: {
-      continuityMode,
-      activeProposal,
-      activeCase,
-      openUniversalCycle,
-      activeStudioExperiment,
-    },
+    ...gate,
     boundary: 'Read-only scheduler gate. It never creates continuity runs, health checks, evidence, memory, RETURN, learning, canon, or external actions.',
   }, { headers: { 'Cache-Control': 'no-store' } });
 }

--- a/src/app/api/cron/sfi-institutional-cycle/route.ts
+++ b/src/app/api/cron/sfi-institutional-cycle/route.ts
@@ -26,8 +26,11 @@ async function readScheduledCycleGate() {
     readInstitutionalAttractor(),
   ]);
 
-  const readErrors = [rootEvidence.error?.message, evidenceLedger.error?.message]
-    .filter((value): value is string => Boolean(value));
+  const readErrors = [
+    rootEvidence.error?.message,
+    evidenceLedger.error?.message,
+    ...attractorState.warnings,
+  ].filter((value): value is string => Boolean(value));
   if (readErrors.length) {
     return {
       shouldRun: false as const,

--- a/src/app/api/cron/sfi-institutional-cycle/route.ts
+++ b/src/app/api/cron/sfi-institutional-cycle/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { runIntegratedInstitutionalCycle } from '@/core/cognitive-twin/integratedInstitutionalCycle';
+import { readInstitutionalAttractor } from '@/lib/institution/institutionalAttractor';
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -16,8 +18,58 @@ function authorized(request: NextRequest) {
   return request.headers.get('authorization') === `Bearer ${configured}`;
 }
 
+async function readScheduledCycleGate() {
+  const db = createServiceSupabaseClient();
+  const [rootEvidence, evidenceLedger, attractorState] = await Promise.all([
+    db.from('root_evidence_entries').select('id').limit(1),
+    db.from('sfi_evidence_ledger').select('id').limit(1),
+    readInstitutionalAttractor(),
+  ]);
+
+  const readErrors = [rootEvidence.error?.message, evidenceLedger.error?.message]
+    .filter((value): value is string => Boolean(value));
+  if (readErrors.length) {
+    return {
+      shouldRun: false as const,
+      reason: 'INSTITUTIONAL_CYCLE_GATE_READ_FAILED' as const,
+      state: null,
+      errors: readErrors,
+    };
+  }
+
+  const state = {
+    rootEvidencePresent: (rootEvidence.data?.length ?? 0) > 0,
+    evidenceLedgerPresent: (evidenceLedger.data?.length ?? 0) > 0,
+    attractorDeclared: Boolean(attractorState.attractor),
+  };
+
+  return {
+    shouldRun: state.rootEvidencePresent || state.evidenceLedgerPresent || state.attractorDeclared,
+    reason: state.rootEvidencePresent || state.evidenceLedgerPresent || state.attractorDeclared
+      ? 'ACTIONABLE_INSTITUTIONAL_INPUT'
+      : 'IDLE_NO_INSTITUTIONAL_INPUT',
+    state,
+    errors: [],
+  } as const;
+}
+
 export async function POST(request: NextRequest) {
   if (!authorized(request)) return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
+
+  const gate = await readScheduledCycleGate();
+  if (!gate.shouldRun) {
+    const gateFailure = gate.reason === 'INSTITUTIONAL_CYCLE_GATE_READ_FAILED';
+    return NextResponse.json({
+      ok: !gateFailure,
+      status: gateFailure ? 'DEGRADED' : 'IDLE',
+      reason: gate.reason,
+      gate: gate.state,
+      errors: gate.errors,
+      writesPerformed: false,
+      executionRule: 'A scheduled institutional cycle requires persisted institutional evidence or a declared institutional attractor. Missing purpose, empty targets and absence of institutional input do not authorize agent execution, Cognitive Twin synchronization, checkpoints, RETURN planning or memory writes. ROOT manual execution remains a separate governed path.',
+    }, { status: gateFailure ? 503 : 200, headers: { 'Cache-Control': 'no-store' } });
+  }
+
   const result = await runIntegratedInstitutionalCycle('scheduled');
   return NextResponse.json(result, { status: result.ok ? 200 : 207 });
 }

--- a/src/app/api/worldspect/ingest/route.ts
+++ b/src/app/api/worldspect/ingest/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import type { SourceObservation } from '@/lib/worldspect/source-adapter-contract'
 import { buildCulturalSourceObservation } from '@/lib/worldspect/cultural-vector'
 import { persistWorldSpectObservations, runWorldSpectAdapters } from '@/lib/worldspect/runAdapters'
@@ -13,6 +13,49 @@ function record(value: unknown): Record<string, unknown> {
 function num(value: unknown, fallback = 0) {
   const parsed = Number(value ?? fallback)
   return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function ingestSecret() {
+  return process.env.WORLDSPECT_INGEST_SECRET
+    || process.env.WORLDSPECT_CRON_SECRET
+    || process.env.CRON_SECRET
+    || ''
+}
+
+function bearerToken(request: NextRequest) {
+  const authorization = request.headers.get('authorization') ?? ''
+  const match = authorization.match(/^Bearer\s+(.+)$/i)
+  return match?.[1]?.trim() ?? ''
+}
+
+function authorizeIngest(request: NextRequest) {
+  const secret = ingestSecret()
+  const token = bearerToken(request)
+  const production = process.env.NODE_ENV === 'production'
+
+  if (!secret && production) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({
+        ok: false,
+        error: 'worldspect_ingest_secret_missing',
+        message: 'WORLDSPECT_INGEST_SECRET, WORLDSPECT_CRON_SECRET or CRON_SECRET must be configured in production.',
+      }, { status: 503 }),
+    }
+  }
+
+  if (!secret && !production) {
+    return { ok: true as const, warnings: ['worldspect_ingest_secret_missing_local_dev_allowed'] }
+  }
+
+  if (!token || token !== secret) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ ok: false, error: 'unauthorized_worldspect_ingest' }, { status: 401 }),
+    }
+  }
+
+  return { ok: true as const, warnings: [] }
 }
 
 function manualCulturalObservation(body: Record<string, unknown>): SourceObservation[] {
@@ -34,7 +77,10 @@ function manualCulturalObservation(body: Record<string, unknown>): SourceObserva
   return observations
 }
 
-export async function POST(request: Request) {
+export async function POST(request: NextRequest) {
+  const authorization = authorizeIngest(request)
+  if (!authorization.ok) return authorization.response
+
   const observationStartedAt = new Date().toISOString()
   const body = record(await request.json().catch(() => ({})))
   const observations = manualCulturalObservation(body)
@@ -51,6 +97,7 @@ export async function POST(request: Request) {
       degraded_sources: result.degraded_sources,
       cognitiveSpineContrast: result.cognitiveSpineContrast,
       cognitiveSpineContrastWarning: result.cognitiveSpineContrastWarning,
+      warnings: authorization.warnings,
     })
   }
 
@@ -70,5 +117,6 @@ export async function POST(request: Request) {
     degraded_sources: result.degraded_sources,
     cognitiveSpineContrast: result.cognitiveSpineContrast,
     cognitiveSpineContrastWarning: result.cognitiveSpineContrastWarning,
+    warnings: authorization.warnings,
   })
 }

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import docs from '../../../data/sfi/sf_docs_frontmatter.json';
+import { SFI_CANONICAL_OBJECT_REGISTRY, canonicalPublicationDisposition } from '@/lib/discovery/canonicalObjectRegistry';
+import { editorialPublicationForSlug } from '@/lib/publications/editorialContent';
 import './library.css';
 
 type Doc = {
@@ -27,6 +29,9 @@ type Doc = {
 };
 
 const corpus = docs as Doc[];
+const publications = SFI_CANONICAL_OBJECT_REGISTRY
+  .filter((record) => record.objectType === 'PUBLICATION' && canonicalPublicationDisposition(record).disposition === 'PUBLISH')
+  .map((record) => ({ record, editorial: editorialPublicationForSlug(record.slug) }));
 
 export default function LibraryPage() {
   const [query, setQuery] = useState('');
@@ -40,13 +45,38 @@ export default function LibraryPage() {
   const hashed = corpus.filter((doc) => doc.contentHash).length;
 
   return <main className="sfiLibrary">
-    <header className="libraryTop"><div><Link href="/root">SFI / ROOT</Link><span>LIBRARY · DOCUMENTARY CORPUS</span></div><nav><Link href="/observatory">OBSERVATORIO</Link><Link href="/method-lab">METHOD LAB</Link><Link href="/twin">TWIN</Link></nav></header>
+    <header className="libraryTop"><div><Link href="/root">SFI / ROOT</Link><span>LIBRARY · PUBLICATIONS + DOCUMENTARY CORPUS</span></div><nav><Link href="/observatory">OBSERVATORIO</Link><Link href="/method-lab">METHOD LAB</Link><Link href="/twin">TWIN</Link></nav></header>
 
-    <section className="libraryHero"><div><span>CATÁLOGO DOCUMENTAL CANÓNICO</span><h1>Library</h1><p>Este plano recupera el corpus documental que ya existe en SFI. Expone identidad, serie, resumen, versión, estabilidad, variables MIHM, patrones y hashes. El dataset compacto excluye deliberadamente los cuerpos completos; por eso esta interfaz no inventa un lector que aún no está materializado.</p></div><div className="libraryMetrics"><b>{corpus.length}</b><span>documentos</span><b>{series}</b><span>series</span><b>{hashed}</b><span>con hash</span></div></section>
+    <section className="libraryHero"><div><span>ÍNDICE INSTITUCIONAL</span><h1>Library</h1><p>Library reúne dos planos que no deben confundirse: publicaciones canónicas de SFI, cada una con su propia URL y estado editorial, y el corpus técnico que conserva métodos, fórmulas, patrones, workbooks y referencias. Publicar no convierte una pieza en evidencia externa ni demuestra Discovery: la vuelve una superficie canónica disponible para ser encontrada.</p></div><div className="libraryMetrics"><b>{publications.length}</b><span>publicaciones</span><b>{corpus.length}</b><span>documentos técnicos</span><b>{hashed}</b><span>con hash</span></div></section>
 
-    <section className="libraryBoundary"><b>BOUNDARY</b><span>CATALOG / METADATA = AVAILABLE</span><span>FULL DOCUMENT BODY READER = NOT MATERIALIZED</span><span>NO REDIRECT TO ROOT</span></section>
+    <section style={{ padding: '32px 0 10px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, alignItems: 'end', borderBottom: '1px solid rgba(202,160,92,.24)', paddingBottom: 14, marginBottom: 18 }}>
+        <div><span style={{ letterSpacing: '.18em', fontSize: 11, color: '#a98954' }}>PUBLICACIONES CANÓNICAS</span><h2 style={{ margin: '7px 0 0', fontSize: 'clamp(28px,4vw,44px)', fontWeight: 400 }}>Publicaciones</h2></div>
+        <Link href="/root/discovery" style={{ color: '#caa05c', fontSize: 12, letterSpacing: '.12em' }}>DISCOVERY MESH →</Link>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(300px,1fr))', gap: 18 }}>
+        {publications.map(({ record, editorial }) => <article key={record.id} style={{ border: '1px solid rgba(202,160,92,.24)', padding: 24, background: 'rgba(202,160,92,.025)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, fontSize: 11, letterSpacing: '.12em', color: '#9f845b' }}><span>{editorial?.series ?? 'SFI PUBLICATION'}</span><span>{editorial?.issue ?? `v${record.version}`}</span></div>
+          <h3 style={{ fontSize: 32, fontWeight: 400, margin: '20px 0 8px' }}>{record.title}</h3>
+          {editorial?.subtitle ? <p style={{ color: '#d0b985', fontSize: 18 }}>{editorial.subtitle}</p> : null}
+          <p style={{ lineHeight: 1.7 }}>{record.summary}</p>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, margin: '22px 0', fontSize: 12 }}>
+            <span><b style={{ display: 'block', color: '#9f845b' }}>TIPO</b>{editorial?.editorialKind ?? record.objectType}</span>
+            <span><b style={{ display: 'block', color: '#9f845b' }}>ESTADO</b>{record.publication.state}</span>
+            <span><b style={{ display: 'block', color: '#9f845b' }}>EPISTÉMICO</b>{record.epistemicState}</span>
+            <span><b style={{ display: 'block', color: '#9f845b' }}>DISCOVERY</b>EXPOSURE AL PUBLICAR</span>
+          </div>
+          <Link href={`/publications/${record.slug}`} style={{ color: '#d5ad69', letterSpacing: '.12em', fontSize: 12 }}>ABRIR PUBLICACIÓN →</Link>
+        </article>)}
+      </div>
+      {!publications.length && <div className="libraryEmpty">No hay publicaciones canónicas admitidas.</div>}
+    </section>
 
-    <section className="librarySearch"><label>BUSCAR EN EL CORPUS<input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="fricción, MIHM, observador, coordinación, SF_P_…"/></label><span>{filtered.length} / {corpus.length}</span></section>
+    <section className="libraryBoundary"><b>BOUNDARY</b><span>PUBLICATION = CANONICAL OBJECT</span><span>EXPOSURE ≠ DISCOVERY ≠ PULL ≠ RETURN</span><span>TECHNICAL CORPUS ≠ PUBLICATION BY DEFAULT</span></section>
+
+    <section style={{ paddingTop: 30 }}><span style={{ letterSpacing: '.18em', fontSize: 11, color: '#a98954' }}>CORPUS TÉCNICO</span><h2 style={{ margin: '7px 0 4px', fontSize: 'clamp(28px,4vw,44px)', fontWeight: 400 }}>Métodos, fórmulas y documentos</h2><p style={{ maxWidth: 820, lineHeight: 1.7 }}>Este plano conserva el catálogo técnico preexistente: identidad documental, series, variables MIHM, patrones, hashes y referencias. Una pieza técnica puede ser públicamente accesible sin quedar admitida automáticamente como publicación canónica.</p></section>
+
+    <section className="librarySearch"><label>BUSCAR EN EL CORPUS TÉCNICO<input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="fricción, MIHM, observador, coordinación, SF_P_…"/></label><span>{filtered.length} / {corpus.length}</span></section>
 
     <section className="libraryGrid">{filtered.map((doc) => <article key={doc.id}>
       <div className="libraryDocHead"><span>{doc.doc_id ?? doc.id}</span><span>{doc.version ? `v${doc.version}` : 'VERSION —'}</span></div>
@@ -58,6 +88,6 @@ export default function LibraryPage() {
       <footer><span>{doc.first_published ?? 'fecha —'}</span><span>{doc.contentHash ? `hash ${doc.contentHash}` : 'hash —'}</span><span>{typeof doc.contentLength === 'number' ? `${doc.contentLength} chars source` : 'length —'}</span></footer>
     </article>)}</section>
 
-    {!filtered.length && <div className="libraryEmpty">No hay documentos que coincidan con ese filtro.</div>}
+    {!filtered.length && <div className="libraryEmpty">No hay documentos técnicos que coincidan con ese filtro.</div>}
   </main>;
 }

--- a/src/app/publications/[slug]/page.tsx
+++ b/src/app/publications/[slug]/page.tsx
@@ -10,18 +10,17 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { slug } = await params;
   const landing = publicResearchLandingForSlug('PUBLICATION', slug);
   if (!landing) return {};
-  const publication = editorialPublicationForSlug(slug);
   const title = `${landing.node.title} · System Friction Institute`;
   return {
     title,
-    description: publication?.deck ?? landing.node.summary,
+    description: landing.node.summary,
     alternates: { canonical: landing.canonicalUrl },
     openGraph: {
       type: 'article',
       url: landing.canonicalUrl,
       siteName: 'System Friction Institute',
       title,
-      description: publication?.deck ?? landing.node.summary,
+      description: landing.node.summary,
     },
     other: {
       'sfi-canonical-object': landing.node.canonicalObjectId,

--- a/src/app/publications/[slug]/page.tsx
+++ b/src/app/publications/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { PublicResearchLandingView } from '@/components/research/PublicResearchLandingView';
+import { editorialPublicationForSlug } from '@/lib/publications/editorialContent';
 import { publicResearchLandingForSlug } from '@/lib/research/publicResearchLanding';
 
 type PageProps = { params: Promise<{ slug: string }> };
@@ -9,17 +10,18 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { slug } = await params;
   const landing = publicResearchLandingForSlug('PUBLICATION', slug);
   if (!landing) return {};
+  const publication = editorialPublicationForSlug(slug);
   const title = `${landing.node.title} · System Friction Institute`;
   return {
     title,
-    description: landing.node.summary,
+    description: publication?.deck ?? landing.node.summary,
     alternates: { canonical: landing.canonicalUrl },
     openGraph: {
       type: 'article',
       url: landing.canonicalUrl,
       siteName: 'System Friction Institute',
       title,
-      description: landing.node.summary,
+      description: publication?.deck ?? landing.node.summary,
     },
     other: {
       'sfi-canonical-object': landing.node.canonicalObjectId,
@@ -33,5 +35,50 @@ export default async function PublicationLandingPage({ params }: PageProps) {
   const { slug } = await params;
   const landing = publicResearchLandingForSlug('PUBLICATION', slug);
   if (!landing) notFound();
-  return <PublicResearchLandingView landing={landing} />;
+  const publication = editorialPublicationForSlug(slug);
+
+  return <>
+    <PublicResearchLandingView landing={landing} />
+    {publication ? <section style={{ background: '#0d0d09', color: '#d8c6a0', padding: '64px 28px 96px', fontFamily: 'Georgia, serif' }}>
+      <article style={{ maxWidth: 980, margin: '0 auto' }}>
+        <header style={{ borderBottom: '1px solid rgba(202,160,92,.25)', paddingBottom: 32 }}>
+          <small style={{ letterSpacing: '.2em', color: '#b78d50' }}>{publication.series} · {publication.issue} · {publication.editorialKind}</small>
+          <h2 style={{ fontSize: 'clamp(38px,5vw,68px)', fontWeight: 400, margin: '16px 0 10px', color: '#ead5aa' }}>{publication.subtitle}</h2>
+          <p style={{ fontSize: 21, lineHeight: 1.7, color: '#c9b993', maxWidth: 860 }}>{publication.deck}</p>
+          <blockquote style={{ margin: '30px 0 0', padding: '18px 22px', borderLeft: '2px solid #b78d50', color: '#e1c995', fontSize: 22 }}>{publication.motto}</blockquote>
+        </header>
+
+        {publication.sections.map((section) => <section key={section.id} id={section.id} style={{ paddingTop: 52 }}>
+          <small style={{ letterSpacing: '.18em', color: '#9f845b' }}>{section.id.toUpperCase()}</small>
+          <h3 style={{ fontSize: 'clamp(28px,4vw,44px)', fontWeight: 400, color: '#e5ce9d', margin: '10px 0 20px' }}>{section.title}</h3>
+          {section.paragraphs.map((paragraph) => <p key={paragraph} style={{ fontSize: 18, lineHeight: 1.85, color: '#bdb09a' }}>{paragraph}</p>)}
+          {section.items?.length ? <ul style={{ paddingLeft: 24, lineHeight: 1.85, fontSize: 17, color: '#bdb09a' }}>{section.items.map((item) => <li key={item} style={{ marginBottom: 8 }}>{item}</li>)}</ul> : null}
+        </section>)}
+
+        <section style={{ paddingTop: 56 }}>
+          <small style={{ letterSpacing: '.18em', color: '#9f845b' }}>CADENCIA EDITORIAL</small>
+          <h3 style={{ fontSize: 38, fontWeight: 400, color: '#e5ce9d', margin: '10px 0 24px' }}>Cuándo observar y cuándo publicar</h3>
+          <div style={{ display: 'grid', gap: 12 }}>
+            {publication.cadence.map((item) => <div key={item.interval} style={{ display: 'grid', gridTemplateColumns: 'minmax(100px,140px) minmax(180px,240px) 1fr', gap: 16, borderTop: '1px solid rgba(202,160,92,.18)', padding: '18px 0' }}>
+              <strong style={{ color: '#d5ad69' }}>{item.interval}</strong><span>{item.name}</span><span style={{ color: '#a99c87', lineHeight: 1.6 }}>{item.scope}</span>
+            </div>)}
+          </div>
+        </section>
+
+        <section style={{ paddingTop: 56 }}>
+          <small style={{ letterSpacing: '.18em', color: '#9f845b' }}>WORLD SPECTOR VECTOR · 16×16</small>
+          <h3 style={{ fontSize: 38, fontWeight: 400, color: '#e5ce9d', margin: '10px 0 24px' }}>Dominios de observación</h3>
+          <ol style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(250px,1fr))', gap: '10px 34px', paddingLeft: 24, lineHeight: 1.7, color: '#bdb09a' }}>
+            {publication.domains.map((domain) => <li key={domain}>{domain}</li>)}
+          </ol>
+        </section>
+
+        <section style={{ marginTop: 56, border: '1px solid rgba(202,160,92,.24)', padding: 28 }}>
+          <small style={{ letterSpacing: '.18em', color: '#b78d50' }}>FRONTERA EPISTÉMICA</small>
+          <h3 style={{ fontSize: 30, fontWeight: 400, color: '#e5ce9d' }}>Lo que esta publicación no autoriza a afirmar</h3>
+          {publication.epistemicBoundary.map((boundary) => <p key={boundary} style={{ color: '#bdb09a', lineHeight: 1.75, borderTop: '1px solid rgba(202,160,92,.12)', paddingTop: 12 }}>{boundary}</p>)}
+        </section>
+      </article>
+    </section> : null}
+  </>;
 }

--- a/src/core/cognitive-twin/institutionalIntegration.ts
+++ b/src/core/cognitive-twin/institutionalIntegration.ts
@@ -96,13 +96,44 @@ async function syncMethodLabRuns(limit = 100): Promise<SyncResult> {
   return { source:'method_lab', ok:failed===0, observed:rows.length, synced, failed, warning:failed ? `${failed}_method_lab_runs_failed` : null };
 }
 
+async function existingWorldSpectTwinExperienceRefs(limit = 1000) {
+  const db = createServiceSupabaseClient();
+  const existing = await db.from('epistemic_events')
+    .select('source')
+    .eq('event_name', 'cognitive_twin.experience.recorded')
+    .order('sequence', { ascending: false })
+    .limit(limit);
+  if (existing.error) return { ok:false as const, refs:new Set<string>(), error:existing.error.message };
+
+  const refs = new Set<string>();
+  for (const item of (existing.data ?? []) as Row[]) {
+    const source = record(item.source);
+    if (text(source.sourceType) !== 'worldspect_snapshots') continue;
+    const sourceId = text(source.sourceId);
+    if (sourceId) refs.add(sourceId);
+  }
+  return { ok:true as const, refs, error:null };
+}
+
 async function syncObservatoryState(limit = 60): Promise<SyncResult> {
   const db = createServiceSupabaseClient();
-  const result = await db.from('worldspect_snapshots').select('id,observed_at,created_at,source_state,confidence,wsi,nti,ingest_mode,sources').order('observed_at', { ascending: false }).limit(limit);
+  const [result, existing] = await Promise.all([
+    db.from('worldspect_snapshots').select('id,observed_at,created_at,source_state,confidence,wsi,nti,ingest_mode,sources').order('observed_at', { ascending: false }).limit(limit),
+    existingWorldSpectTwinExperienceRefs(),
+  ]);
   if (result.error) return { source:'observatory', ok:false, observed:0, synced:0, failed:0, warning:result.error.message };
+  if (!existing.ok) return { source:'observatory', ok:false, observed:0, synced:0, failed:0, warning:`observatory_sync_identity_read_failed:${existing.error}` };
+
   const rows = (result.data ?? []) as Row[];
+  const candidates = existing.refs.size === 0
+    ? rows.slice(0, 1)
+    : rows.filter((row) => {
+        const id = text(row.id) ?? text(row.observed_at);
+        return Boolean(id) && !existing.refs.has(String(id));
+      });
+
   let synced = 0; let failed = 0;
-  for (const row of rows) {
+  for (const row of candidates) {
     const id = text(row.id) ?? text(row.observed_at);
     if (!id) { failed += 1; continue; }
     const sources = Array.isArray(row.sources) ? row.sources.map(record) : [];
@@ -114,12 +145,20 @@ async function syncObservatoryState(limit = 60): Promise<SyncResult> {
         epistemicClass:simulatedSources === sources.length && sources.length ? 'SIMULATED' : 'DERIVED_FROM_OBSERVATIONS',
         observedAt:text(row.observed_at) ?? text(row.created_at), sourceState:text(row.source_state), confidence:number(row.confidence),
         wsi:number(row.wsi), nti:number(row.nti), ingestMode:text(row.ingest_mode), sourceCount:sources.length, simulatedSourceCount:simulatedSources,
-        rule:'Observatory snapshots enter candidate Twin memory with their original epistemic boundary and require verification/promotion before canonical consumption.',
+        rule:'Only previously unsynchronized WorldSpect snapshots may enter candidate Twin memory. On a clean memory baseline, only the latest persisted snapshot is admitted; historical World state is not replayed as new institutional experience. Candidate memory retains the original epistemic boundary and requires verification/promotion before canonical consumption.',
       },
     });
     if (persisted.ok) synced += 1; else failed += 1;
   }
-  return { source:'observatory', ok:failed===0, observed:rows.length, synced, failed, warning:failed ? `${failed}_observatory_snapshots_failed` : null };
+  const bootstrapBounded = existing.refs.size === 0 && rows.length > 1;
+  return {
+    source:'observatory',
+    ok:failed===0,
+    observed:rows.length,
+    synced,
+    failed,
+    warning:failed ? `${failed}_observatory_snapshots_failed` : bootstrapBounded ? 'observatory_clean_baseline_bootstrap_latest_only' : null,
+  };
 }
 
 async function probe(input: IntegrationOrgan) {

--- a/src/core/cognitive-twin/institutionalIntegration.ts
+++ b/src/core/cognitive-twin/institutionalIntegration.ts
@@ -96,44 +96,49 @@ async function syncMethodLabRuns(limit = 100): Promise<SyncResult> {
   return { source:'method_lab', ok:failed===0, observed:rows.length, synced, failed, warning:failed ? `${failed}_method_lab_runs_failed` : null };
 }
 
-async function existingWorldSpectTwinExperienceRefs(limit = 1000) {
+async function latestWorldSpectTwinExperienceRef() {
   const db = createServiceSupabaseClient();
   const existing = await db.from('epistemic_events')
     .select('source')
     .eq('event_name', 'cognitive_twin.experience.recorded')
+    .eq('source->>sourceType', 'worldspect_snapshots')
     .order('sequence', { ascending: false })
-    .limit(limit);
-  if (existing.error) return { ok:false as const, refs:new Set<string>(), error:existing.error.message };
+    .limit(1)
+    .maybeSingle();
+  if (existing.error) return { ok:false as const, sourceRef:null, observedAt:null, error:existing.error.message };
+  if (!existing.data) return { ok:true as const, sourceRef:null, observedAt:null, error:null };
 
-  const refs = new Set<string>();
-  for (const item of (existing.data ?? []) as Row[]) {
-    const source = record(item.source);
-    if (text(source.sourceType) !== 'worldspect_snapshots') continue;
-    const sourceId = text(source.sourceId);
-    if (sourceId) refs.add(sourceId);
-  }
-  return { ok:true as const, refs, error:null };
+  const sourceRef = text(record(existing.data.source).sourceId);
+  if (!sourceRef) return { ok:false as const, sourceRef:null, observedAt:null, error:'worldspect_experience_source_ref_missing' };
+
+  const marker = await db.from('worldspect_snapshots')
+    .select('id,observed_at')
+    .eq('id', sourceRef)
+    .maybeSingle();
+  if (marker.error) return { ok:false as const, sourceRef, observedAt:null, error:marker.error.message };
+  const observedAt = text(marker.data?.observed_at);
+  if (!marker.data || !observedAt) return { ok:false as const, sourceRef, observedAt:null, error:'worldspect_experience_watermark_snapshot_missing' };
+
+  return { ok:true as const, sourceRef, observedAt, error:null };
 }
 
 async function syncObservatoryState(limit = 60): Promise<SyncResult> {
   const db = createServiceSupabaseClient();
-  const [result, existing] = await Promise.all([
-    db.from('worldspect_snapshots').select('id,observed_at,created_at,source_state,confidence,wsi,nti,ingest_mode,sources').order('observed_at', { ascending: false }).limit(limit),
-    existingWorldSpectTwinExperienceRefs(),
-  ]);
+  const marker = await latestWorldSpectTwinExperienceRef();
+  if (!marker.ok) return { source:'observatory', ok:false, observed:0, synced:0, failed:0, warning:`observatory_sync_identity_read_failed:${marker.error}` };
+
+  let query = db.from('worldspect_snapshots')
+    .select('id,observed_at,created_at,source_state,confidence,wsi,nti,ingest_mode,sources');
+  query = marker.observedAt
+    ? query.gt('observed_at', marker.observedAt).order('observed_at', { ascending: true }).limit(limit)
+    : query.order('observed_at', { ascending: false }).limit(1);
+
+  const result = await query;
   if (result.error) return { source:'observatory', ok:false, observed:0, synced:0, failed:0, warning:result.error.message };
-  if (!existing.ok) return { source:'observatory', ok:false, observed:0, synced:0, failed:0, warning:`observatory_sync_identity_read_failed:${existing.error}` };
 
   const rows = (result.data ?? []) as Row[];
-  const candidates = existing.refs.size === 0
-    ? rows.slice(0, 1)
-    : rows.filter((row) => {
-        const id = text(row.id) ?? text(row.observed_at);
-        return Boolean(id) && !existing.refs.has(String(id));
-      });
-
   let synced = 0; let failed = 0;
-  for (const row of candidates) {
+  for (const row of rows) {
     const id = text(row.id) ?? text(row.observed_at);
     if (!id) { failed += 1; continue; }
     const sources = Array.isArray(row.sources) ? row.sources.map(record) : [];
@@ -145,19 +150,19 @@ async function syncObservatoryState(limit = 60): Promise<SyncResult> {
         epistemicClass:simulatedSources === sources.length && sources.length ? 'SIMULATED' : 'DERIVED_FROM_OBSERVATIONS',
         observedAt:text(row.observed_at) ?? text(row.created_at), sourceState:text(row.source_state), confidence:number(row.confidence),
         wsi:number(row.wsi), nti:number(row.nti), ingestMode:text(row.ingest_mode), sourceCount:sources.length, simulatedSourceCount:simulatedSources,
-        rule:'Only previously unsynchronized WorldSpect snapshots may enter candidate Twin memory. On a clean memory baseline, only the latest persisted snapshot is admitted; historical World state is not replayed as new institutional experience. Candidate memory retains the original epistemic boundary and requires verification/promotion before canonical consumption.',
+        rule:'WorldSpect synchronization is watermark-bound. A clean baseline admits only the latest persisted snapshot; later cycles admit only snapshots observed after the last WorldSpect experience already recorded by the Twin. Candidate memory retains the original epistemic boundary and requires verification/promotion before canonical consumption.',
       },
     });
     if (persisted.ok) synced += 1; else failed += 1;
   }
-  const bootstrapBounded = existing.refs.size === 0 && rows.length > 1;
+
   return {
     source:'observatory',
     ok:failed===0,
     observed:rows.length,
     synced,
     failed,
-    warning:failed ? `${failed}_observatory_snapshots_failed` : bootstrapBounded ? 'observatory_clean_baseline_bootstrap_latest_only' : null,
+    warning:failed ? `${failed}_observatory_snapshots_failed` : !marker.sourceRef && rows.length ? 'observatory_clean_baseline_bootstrap_latest_only' : null,
   };
 }
 

--- a/src/lib/continuity/actionableWorkGate.ts
+++ b/src/lib/continuity/actionableWorkGate.ts
@@ -50,17 +50,20 @@ export async function readContinuityActionableWorkGate(input?: { requestedCycleI
   ]);
 
   const readError = state.error ?? proposals.error ?? cases.error ?? lifecycle.error ?? studio.error;
-  if (readError) {
+  const missingContinuityState = !state.error && !state.data;
+  if (readError || missingContinuityState) {
     return {
       shouldRun: true as const,
       reason: 'WORK_GATE_READ_FAILED_FAIL_OPEN' as const,
       requestedCycleId: null,
       state: null,
-      diagnostic: { code: readError.code ?? null, message: readError.message },
+      diagnostic: readError
+        ? { code: readError.code ?? null, message: readError.message }
+        : { code: 'CONTINUITY_STATE_MISSING', message: 'Required sfi_continuity_state institution row is absent.' },
     };
   }
 
-  const continuityMode = typeof state.data?.mode === 'string' ? state.data.mode : 'NORMAL';
+  const continuityMode = typeof state.data.mode === 'string' ? state.data.mode : 'NORMAL';
   const activeProposal = (proposals.data ?? []).length > 0;
   const activeCase = ((cases.data ?? []) as Row[]).some((item) => {
     const status = typeof item.status === 'string' ? item.status.toLowerCase() : '';

--- a/src/lib/continuity/actionableWorkGate.ts
+++ b/src/lib/continuity/actionableWorkGate.ts
@@ -1,0 +1,86 @@
+import { createServiceSupabaseClient } from '@/runtime/supabase/server';
+
+type Row = Record<string, unknown>;
+
+const ACTIVE_PROPOSAL_STATUSES = ['proposed', 'waiting_evidence', 'design_approved', 'queued', 'accepted'];
+const TERMINAL_CASE_STATUSES = new Set(['closed', 'completed', 'cancelled', 'canceled', 'rejected', 'archived']);
+const UNIVERSAL_LIFECYCLE_EVENTS = [
+  'SFI_UNIVERSAL_CYCLE_RESUMED',
+  'SFI_UNIVERSAL_COGNITIVE_CHECKPOINT',
+  'SFI_UNIVERSAL_COGNITIVE_CYCLE_EXECUTED',
+  'SFI_UNIVERSAL_AI_SYNTHESIS_COMPLETED',
+  'SFI_UNIVERSAL_RETURN_PLAN_RECORDED',
+  'SFI_UNIVERSAL_RETURN_RECORDED',
+  'SFI_UNIVERSAL_CYCLE_CLOSED',
+];
+
+function hasOpenUniversalCycle(events: Row[]) {
+  const latestByLogbook = new Map<string, string>();
+  for (const event of events) {
+    const logbookId = typeof event.logbook_id === 'string' ? event.logbook_id : '';
+    const eventName = typeof event.event_name === 'string' ? event.event_name : '';
+    if (!logbookId || !eventName || latestByLogbook.has(logbookId)) continue;
+    latestByLogbook.set(logbookId, eventName);
+  }
+  return [...latestByLogbook.values()].some((eventName) => eventName !== 'SFI_UNIVERSAL_CYCLE_CLOSED');
+}
+
+export async function readContinuityActionableWorkGate(input?: { requestedCycleId?: string | null }) {
+  const requestedCycleId = input?.requestedCycleId?.trim() || null;
+  if (requestedCycleId) {
+    return {
+      shouldRun: true as const,
+      reason: 'TARGETED_EXISTING_CYCLE' as const,
+      requestedCycleId,
+      state: null,
+    };
+  }
+
+  const db = createServiceSupabaseClient();
+  const [state, proposals, cases, lifecycle, studio] = await Promise.all([
+    db.from('sfi_continuity_state').select('mode').eq('id', 'institution').maybeSingle(),
+    db.from('action_proposals').select('id,status').in('status', ACTIVE_PROPOSAL_STATUSES).limit(1),
+    db.from('sfi_cases').select('id,status').is('deleted_at', null).order('updated_at', { ascending: false }).limit(20),
+    db.from('epistemic_events')
+      .select('sequence,event_name,logbook_id')
+      .in('event_name', UNIVERSAL_LIFECYCLE_EVENTS)
+      .order('sequence', { ascending: false })
+      .limit(500),
+    db.from('studio_objects').select('id,title,status').ilike('title', '%FI-001%').limit(1),
+  ]);
+
+  const readError = state.error ?? proposals.error ?? cases.error ?? lifecycle.error ?? studio.error;
+  if (readError) {
+    return {
+      shouldRun: true as const,
+      reason: 'WORK_GATE_READ_FAILED_FAIL_OPEN' as const,
+      requestedCycleId: null,
+      state: null,
+      diagnostic: { code: readError.code ?? null, message: readError.message },
+    };
+  }
+
+  const continuityMode = typeof state.data?.mode === 'string' ? state.data.mode : 'NORMAL';
+  const activeProposal = (proposals.data ?? []).length > 0;
+  const activeCase = ((cases.data ?? []) as Row[]).some((item) => {
+    const status = typeof item.status === 'string' ? item.status.toLowerCase() : '';
+    return !TERMINAL_CASE_STATUSES.has(status);
+  });
+  const openUniversalCycle = hasOpenUniversalCycle(((lifecycle.data ?? []) as Row[]));
+  const activeStudioExperiment = (studio.data ?? []).length > 0;
+  const nonNormalContinuityMode = continuityMode !== 'NORMAL';
+  const shouldRun = activeProposal || activeCase || openUniversalCycle || activeStudioExperiment || nonNormalContinuityMode;
+
+  return {
+    shouldRun,
+    reason: shouldRun ? 'ACTIONABLE_CONTINUITY_WORK' as const : 'IDLE_NO_ACTIONABLE_WORK' as const,
+    requestedCycleId: null,
+    state: {
+      continuityMode,
+      activeProposal,
+      activeCase,
+      openUniversalCycle,
+      activeStudioExperiment,
+    },
+  };
+}

--- a/src/lib/continuity/actionableWorkGate.ts
+++ b/src/lib/continuity/actionableWorkGate.ts
@@ -50,7 +50,8 @@ export async function readContinuityActionableWorkGate(input?: { requestedCycleI
   ]);
 
   const readError = state.error ?? proposals.error ?? cases.error ?? lifecycle.error ?? studio.error;
-  const missingContinuityState = !state.error && !state.data;
+  const continuityState = state.data;
+  const missingContinuityState = !state.error && !continuityState;
   if (readError || missingContinuityState) {
     return {
       shouldRun: true as const,
@@ -63,7 +64,11 @@ export async function readContinuityActionableWorkGate(input?: { requestedCycleI
     };
   }
 
-  const continuityMode = typeof state.data.mode === 'string' ? state.data.mode : 'NORMAL';
+  if (!continuityState) {
+    throw new Error('CONTINUITY_STATE_UNREACHABLE_AFTER_GUARD');
+  }
+
+  const continuityMode = typeof continuityState.mode === 'string' ? continuityState.mode : 'NORMAL';
   const activeProposal = (proposals.data ?? []).length > 0;
   const activeCase = ((cases.data ?? []) as Row[]).some((item) => {
     const status = typeof item.status === 'string' ? item.status.toLowerCase() : '';

--- a/src/lib/discovery/canonicalObjectRegistry.ts
+++ b/src/lib/discovery/canonicalObjectRegistry.ts
@@ -368,7 +368,58 @@ export function validateCanonicalObjectRegistry(records: readonly SfiCanonicalOb
   return [...new Set(errors)].sort();
 }
 
-export const SFI_CANONICAL_OBJECT_REGISTRY: readonly SfiCanonicalObjectRecord[] = Object.freeze([]);
+const NOTAS_TEMPORALES_SOURCE = 'https://github.com/Aptymok/system-friction/blob/main/src/lib/publications/editorialContent.ts';
+
+export const SFI_CANONICAL_OBJECT_REGISTRY: readonly SfiCanonicalObjectRecord[] = Object.freeze([
+  {
+    contract: SFI_CANONICAL_OBJECT_CONTRACT,
+    id: 'SFI-PUB-NT-001',
+    objectKey: canonicalObjectKey('PUBLICATION', 'notas-temporales-v1'),
+    objectType: 'PUBLICATION',
+    slug: 'notas-temporales-v1',
+    canonicalUrl: canonicalUrlFor('PUBLICATION', 'notas-temporales-v1'),
+    title: 'Notas Temporales',
+    summary: 'Observación sistémica para un mundo en transición: una publicación periódica de SFI para registrar señales, evidencia, convergencias y preguntas sin confundir observación con predicción.',
+    bodyRef: 'src/lib/publications/editorialContent.ts#SFI_NOTAS_TEMPORALES_V1',
+    epistemicState: 'DECLARED',
+    version: '1.0',
+    language: 'es',
+    authors: ['System Friction Institute'],
+    methods: ['World Spector Vector 16x16', 'Discovery Mesh'],
+    relatedObjects: [],
+    sourceRefs: [NOTAS_TEMPORALES_SOURCE],
+    publicState: 'PUBLIC',
+    license: 'CC BY 4.0',
+    createdAt: '2026-09-12T00:00:00-06:00',
+    updatedAt: '2026-09-12T00:00:00-06:00',
+    entity: {
+      entityId: SFI_ENTITY_ID,
+      relation: 'PUBLISHED_BY',
+    },
+    publication: {
+      state: 'PUBLISHED',
+      explicit: true,
+    },
+    eligibility: {
+      privacyClass: 'PUBLIC',
+      publicEligible: true,
+      securityEligible: true,
+    },
+    rights: {
+      state: 'OPEN',
+    },
+    evidenceIdentity: {
+      state: 'VALID',
+      refs: [NOTAS_TEMPORALES_SOURCE],
+    },
+    limitations: [
+      'The publication defines an observation and editorial method; it does not assert that every signal named by the method has already been observed.',
+      'Publication establishes EXPOSURE only. Discovery, Recognition, Interaction, PULL and RETURN require independent evidence.',
+      'Derived relationships and model output remain distinct from observed external evidence.',
+    ],
+    missing: [],
+  },
+]);
 
 export function publicCanonicalObjectUrls(records: readonly SfiCanonicalObjectRecord[] = SFI_CANONICAL_OBJECT_REGISTRY): string[] {
   if (validateCanonicalObjectRegistry(records).length) return [];

--- a/src/lib/discovery/canonicalObjectRegistry.ts
+++ b/src/lib/discovery/canonicalObjectRegistry.ts
@@ -370,6 +370,10 @@ export function validateCanonicalObjectRegistry(records: readonly SfiCanonicalOb
 
 const NOTAS_TEMPORALES_SOURCE = 'https://github.com/Aptymok/system-friction/blob/main/src/lib/publications/editorialContent.ts';
 
+// Runtime/event/database-derived objects have no automatic path into canon.
+// This collection intentionally remains empty; explicit repository admission is the only publication source.
+export const SFI_RUNTIME_DERIVED_CANONICAL_OBJECTS: readonly SfiCanonicalObjectRecord[] = Object.freeze([]);
+
 export const SFI_CANONICAL_OBJECT_REGISTRY: readonly SfiCanonicalObjectRecord[] = Object.freeze([
   {
     contract: SFI_CANONICAL_OBJECT_CONTRACT,

--- a/src/lib/publications/editorialContent.test.ts
+++ b/src/lib/publications/editorialContent.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  SFI_EDITORIAL_PUBLICATION_CONTENT_CONTRACT,
+  SFI_EDITORIAL_PUBLICATIONS,
+  SFI_NOTAS_TEMPORALES_V1,
+  editorialPublicationForSlug,
+} from './editorialContent';
+
+test('Notas Temporales v1 preserves one canonical editorial identity and the 16-domain observation frame', () => {
+  assert.equal(SFI_NOTAS_TEMPORALES_V1.contract, SFI_EDITORIAL_PUBLICATION_CONTENT_CONTRACT);
+  assert.equal(SFI_NOTAS_TEMPORALES_V1.slug, 'notas-temporales-v1');
+  assert.equal(SFI_NOTAS_TEMPORALES_V1.editorialKind, 'TEMPORAL_NOTE');
+  assert.equal(SFI_NOTAS_TEMPORALES_V1.issue, 'v1.0');
+  assert.equal(SFI_NOTAS_TEMPORALES_V1.domains.length, 16);
+  assert.equal(new Set(SFI_NOTAS_TEMPORALES_V1.domains).size, 16);
+  assert.deepEqual(SFI_NOTAS_TEMPORALES_V1.cadence.map((item) => item.interval), [
+    'DIARIA', 'SEMANAL', 'MENSUAL', 'TRIMESTRAL', 'ANUAL',
+  ]);
+});
+
+test('editorial body cannot collapse publication exposure into Discovery or RETURN', () => {
+  const boundary = SFI_NOTAS_TEMPORALES_V1.epistemicBoundary.join(' ');
+  assert.match(boundary, /Publicación equivale a EXPOSURE/);
+  assert.match(boundary, /no a Discovery/i);
+  assert.match(boundary, /RETURN/);
+  assert.match(boundary, /Coincidencia temporal no establece causalidad/);
+});
+
+test('editorial lookup exposes only registered publication bodies', () => {
+  assert.equal(SFI_EDITORIAL_PUBLICATIONS.length, 1);
+  assert.equal(editorialPublicationForSlug('notas-temporales-v1')?.title, 'Notas Temporales');
+  assert.equal(editorialPublicationForSlug('notas-inexistentes'), null);
+});

--- a/src/lib/publications/editorialContent.ts
+++ b/src/lib/publications/editorialContent.ts
@@ -1,0 +1,138 @@
+export const SFI_EDITORIAL_PUBLICATION_CONTENT_CONTRACT = 'SFI-EDITORIAL-PUBLICATION-CONTENT-1.0' as const;
+
+export type SfiEditorialPublicationSection = {
+  id: string;
+  title: string;
+  paragraphs: readonly string[];
+  items?: readonly string[];
+};
+
+export type SfiEditorialPublication = {
+  contract: typeof SFI_EDITORIAL_PUBLICATION_CONTENT_CONTRACT;
+  slug: string;
+  editorialKind: 'TEMPORAL_NOTE';
+  series: string;
+  issue: string;
+  title: string;
+  subtitle: string;
+  motto: string;
+  deck: string;
+  publishedAt: string;
+  sections: readonly SfiEditorialPublicationSection[];
+  cadence: readonly { interval: string; name: string; scope: string }[];
+  domains: readonly string[];
+  epistemicBoundary: readonly string[];
+};
+
+export const SFI_NOTAS_TEMPORALES_V1: SfiEditorialPublication = Object.freeze({
+  contract: SFI_EDITORIAL_PUBLICATION_CONTENT_CONTRACT,
+  slug: 'notas-temporales-v1',
+  editorialKind: 'TEMPORAL_NOTE',
+  series: 'SFI · Notas Temporales',
+  issue: 'v1.0',
+  title: 'Notas Temporales',
+  subtitle: 'Observación sistémica para un mundo en transición',
+  motto: 'El futuro no se adivina, se observa a tiempo.',
+  deck: 'Una serie documental periódica para registrar, relacionar y traducir señales relevantes del entorno sin confundir observación con predicción. Las Notas Temporales conectan evidencia pública, cambios externos, memoria institucional y el World Spector Vector 16×16 para hacer visibles fricciones, convergencias y preguntas que merecen seguimiento.',
+  publishedAt: '2026-09-12T00:00:00-06:00',
+  sections: Object.freeze([
+    {
+      id: 'que-son',
+      title: 'Qué son las Notas Temporales',
+      paragraphs: Object.freeze([
+        'Notas Temporales es la superficie editorial periódica del System Friction Institute para observar cambios mientras todavía están ocurriendo. Su función no es producir una voz profética ni convertir cada señal en una tesis institucional. Su función es dejar un registro legible de qué cambió, qué evidencia existe, qué relación puede tener con otros dominios y qué todavía no sabemos.',
+        'Cada nota puede integrar señales externas, datos y fuentes públicas, cambios regulatorios o institucionales, observaciones de campo, preguntas del fundador y del equipo, y relaciones derivadas por los instrumentos de SFI. Esas capas deben permanecer identificables. Una observación externa no se vuelve cierta porque un modelo la interprete, y una interpretación no se vuelve evidencia porque resulte plausible.',
+        'La serie existe para reducir una falla recurrente en sistemas complejos: reconocer demasiado tarde que varias señales pequeñas ya estaban formando una trayectoria. Documentar temprano no elimina la incertidumbre; permite que la incertidumbre tenga fecha, fuente, contexto y posibilidad de contraste posterior.',
+      ]),
+      items: Object.freeze([
+        'Señales tempranas y cambios de estado.',
+        'Contexto, narrativa y relaciones entre dominios.',
+        'Datos, fuentes y evidencia identificable.',
+        'Análisis relacional mediante el World Spector Vector 16×16.',
+        'Observaciones, hipótesis y recomendaciones claramente separadas.',
+      ]),
+    },
+    {
+      id: 'proposito',
+      title: 'Propósito: transformar incertidumbre en claridad operativa',
+      paragraphs: Object.freeze([
+        'Una Nota Temporal tiene valor cuando permite entender mejor una situación antes de que la fricción se convierta en crisis o antes de que una oportunidad deje de ser accesible. Esto exige observar eventos puntuales, pero también la velocidad y dirección con la que distintos dominios empiezan a tocarse.',
+        'El objetivo institucional es conectar puntos sin fabricar causalidad. Cuando tecnología, regulación, trabajo, energía, biodiversidad y cultura se mueven simultáneamente, la nota debe mostrar dónde existe evidencia de convergencia, dónde sólo existe coincidencia temporal y qué observación futura podría distinguir una de otra.',
+        'La utilidad final no es acumular texto. Es construir memoria institucional: que SFI pueda regresar meses después, comparar lo que veía entonces con lo que ocurrió después y aprender tanto de los aciertos como de las hipótesis que no sobrevivieron al contraste.',
+      ]),
+    },
+    {
+      id: 'metodo',
+      title: 'Método de observación',
+      paragraphs: Object.freeze([
+        'El ciclo editorial parte de una recolección deliberadamente heterogénea: fuentes oficiales, datos, noticias verificables, literatura académica, publicaciones técnicas, observaciones de campo y señales culturales. La heterogeneidad no autoriza a mezclar niveles de evidencia; obliga a etiquetarlos.',
+        'Después se filtra por relevancia, procedencia, confiabilidad y relación con los dominios del vector. La fase de análisis busca recurrencias, anomalías, sincronías y tensiones entre dominios. La interpretación traduce esos patrones a implicaciones posibles, pero conserva visibles las alternativas y los faltantes. Finalmente, la documentación fija la nota, sus fuentes y sus límites; sólo después puede alimentar seguimiento, alertas, hipótesis o propuestas de intervención gobernadas.',
+      ]),
+      items: Object.freeze([
+        '1 · Recolección — observar fuentes y señales con procedencia identificable.',
+        '2 · Filtrado — separar relevancia, confiabilidad, ruido y faltantes.',
+        '3 · Análisis — cruzar dominios y relaciones del grafo 16×16.',
+        '4 · Interpretación — formular implicaciones sin promoverlas automáticamente a hechos.',
+        '5 · Documentación — publicar lenguaje humano, fuentes, estado epistémico y limitaciones.',
+        '6 · Acción — sólo cuando corresponde, abrir seguimiento, alerta, hipótesis o intervención bajo autoridad explícita.',
+      ]),
+    },
+    {
+      id: 'convergencia',
+      title: 'Qué significa observar convergencia',
+      paragraphs: Object.freeze([
+        'SFI presta atención especial a transiciones que no pertenecen a una sola industria o institución. Un cambio legal, un nuevo umbral energético, una capacidad tecnológica, una transformación demográfica o una perturbación ecológica pueden avanzar con relojes distintos y, aun así, encontrarse en un mismo sistema.',
+        'Las Notas de Convergencia observan particularmente la distancia entre desarrollo tecnológico e integración humana, institucional y biodiversa. Una tecnología puede madurar técnicamente antes de que existan reglas, capacidades organizacionales, aceptación social o condiciones bioéticas para integrarla. Esa distancia constituye una fricción observable y no debe reducirse a entusiasmo tecnológico ni a rechazo preventivo.',
+        'La bioética aparece aquí como restricción de diseño: la integración tecnológica se observa también por su efecto sobre personas, otras formas de vida, territorio, energía y biosfera. El vector no pregunta únicamente qué puede desplegarse, sino qué relaciones y costos se vuelven visibles cuando algo se despliega.',
+      ]),
+    },
+    {
+      id: 'discovery',
+      title: 'Publicación, Discovery y RETURN',
+      paragraphs: Object.freeze([
+        'Publicar una nota sólo demuestra EXPOSURE: SFI colocó un objeto canónico en una superficie donde puede ser encontrado. No demuestra que alguien lo haya descubierto. Discovery requiere evidencia de recuperación o hallazgo por un tercero; Recognition requiere evidencia de que ese tercero identificó correctamente el objeto o a SFI; Interaction, Relation, Propagation, PULL y RETURN requieren evidencia adicional.',
+        'Esta separación evita que métricas internas de publicación se conviertan artificialmente en legitimidad externa. Discovery Mesh sirve para transportar una identidad canónica coherente a HTML, feeds, sitemap y superficies de máquina y, después, registrar qué parte de esa exposición produjo una relación observable con el exterior.',
+      ]),
+    },
+  ]),
+  cadence: Object.freeze([
+    { interval: 'DIARIA', name: 'Notas de pulso', scope: 'Señales rápidas, eventos relevantes y actualizaciones críticas; típicamente 1–3 páginas.' },
+    { interval: 'SEMANAL', name: 'Notas de convergencia', scope: 'Cruces entre dominios, tendencias y cambios cuya relación merece seguimiento; típicamente 5–10 páginas.' },
+    { interval: 'MENSUAL', name: 'Cuadernos institucionales', scope: 'Análisis profundo por dominio, mapas, indicadores, contradicciones y memoria del periodo; típicamente 15–30 páginas.' },
+    { interval: 'TRIMESTRAL', name: 'Anexos estratégicos', scope: 'Evaluación de impactos, escenarios, aprendizaje y actualización de relaciones sistémicas; normalmente 30+ páginas.' },
+    { interval: 'ANUAL', name: 'Compendio SFI', scope: 'Síntesis longitudinal del año, tesis que sobrevivieron, hipótesis rechazadas y evolución de marcos.' },
+  ]),
+  domains: Object.freeze([
+    'Política y gobernanza',
+    'Economía y finanzas',
+    'Legislación y regulación',
+    'Tecnología y ciencia',
+    'Sociedad y demografía',
+    'Trabajo y producción',
+    'Educación y conocimiento',
+    'Salud y bienestar',
+    'Medio ambiente y biodiversidad',
+    'Energía y recursos',
+    'Infraestructura y territorio',
+    'Cultura y narrativa',
+    'Seguridad y riesgos',
+    'Geopolítica',
+    'Mercados y cadenas de suministro',
+    'Ética y conciencia',
+  ]),
+  epistemicBoundary: Object.freeze([
+    'No son predicciones. Una proyección debe declararse como proyección y conservar sus supuestos.',
+    'Modelo, IA o análisis derivado no equivalen a observación del mundo.',
+    'Coincidencia temporal no establece causalidad.',
+    'MISSING permanece visible; no se rellena narrativamente.',
+    'Publicación equivale a EXPOSURE, no a Discovery, Recognition, PULL ni RETURN.',
+  ]),
+});
+
+export const SFI_EDITORIAL_PUBLICATIONS: readonly SfiEditorialPublication[] = Object.freeze([
+  SFI_NOTAS_TEMPORALES_V1,
+]);
+
+export function editorialPublicationForSlug(slug: string) {
+  return SFI_EDITORIAL_PUBLICATIONS.find((publication) => publication.slug === slug) ?? null;
+}


### PR DESCRIPTION
## Purpose
Close the observed operational/editorial gaps without adding a second canon or a new workstream.

## OBSERVED defects addressed
- `/api/worldspect/ingest` could execute persistent WorldSpect ingest without authority.
- the frequent GitHub continuity scheduler had an idle wakeup guard, but the heartbeat route itself did not, so the direct Vercel fallback could still execute write-heavy lanes while idle.
- `SFI Self-Development` was triggered after every successful `SFI Continuity Hourly`, coupling institutional continuity to development bookkeeping.
- Discovery Mesh had public routes, feeds and a control plane but `SFI_CANONICAL_OBJECT_REGISTRY` was empty, so there was no real publication to emit.
- `/library` exposed the technical/documentary corpus but did not distinguish or index canonical SFI publications.

## Canonical architecture preflight
SFI PRECHECK

Owner: existing Discovery canonical object registry for publication identity; existing continuity runtime/auth owners for scheduling; existing WorldSpect secret boundary for ingest.

Existing capability inspected: `canonicalObjectRegistry`, `PublicResearchLanding`, `Discovery Emitter`, `/root/discovery`, RSS/Atom/JSON feeds, continuity wakeup/heartbeat routes, GitHub OIDC continuity auth, WorldSpect cron auth, current Library surface.

Absorb vs create decision: absorb. The only new files are a reusable continuity read gate extracted from existing wakeup logic and editorial body content subordinate to the existing publication registry. No second canonical owner, publication state machine, discovery mesh, scheduler or database writer is created.

Authoritative writer: unchanged. Runtime institutional state remains written by existing governed runtime writers only after actionable work is present. Canonical publication admission remains repository-owned by `SFI_CANONICAL_OBJECT_REGISTRY`. Editorial content is not a second publication writer.

Persistence/lineage impact: no schema migration and no synthetic DB rows. Notas Temporales gains explicit repository lineage and evidence identity. Idle heartbeat exits before persistent continuity telemetry. WorldSpect manual ingest is authority-gated before persistence.

Front delta: `/library` becomes Publicaciones + Corpus técnico; `/publications/notas-temporales-v1` gains a full human-readable editorial body. Existing `/root/discovery` remains the internal Discovery control plane.

Back delta: reusable read-only actionable-work gate; heartbeat enforces it internally; manual WorldSpect ingest requires existing secret authority; Self-Development is decoupled from every continuity heartbeat.

DB delta: none. No DDL, migration, reset or canonical-data insertion.

Redundancy removed: duplicated continuity gate logic is centralized; continuity no longer redundantly triggers development bookkeeping. Existing formulas/technical corpus are retained but no longer represent the entire Library.

Execution/ROOT boundary: unchanged. Publishing this explicitly admitted PUBLICATION establishes exposure only. Discovery/Recognition/Interaction/Relation/Propagation/PULL/RETURN require external evidence. No runtime event automatically promotes canon or publication status.

Rollback: revert PR #486. No data migration or destructive state reversal is required.

Verification: SFI Verify, Discovery Emitter, continuity ledger hardening, canonical publication namespace tests, public landing tests, typecheck/build, exact-SHA production deployment and production smoke after merge.

## Delta
- require Bearer authority for manual WorldSpect ingest using the existing WorldSpect/cron secret boundary;
- extract one reusable read-only continuity actionable-work gate;
- enforce that gate inside `/api/cron/continuity-heartbeat` before any continuity run/health/evidence/memory/RETURN write;
- preserve targeted existing-cycle recovery and fail-open-on-gate-read-error semantics;
- remove the `SFI Continuity Hourly -> SFI Self-Development` workflow_run trigger while retaining explicit/manual, bounded push and daily development review;
- admit `Notas Temporales` v1.0 as the first canonical `PUBLICATION` object at `/publications/notas-temporales-v1`;
- materialize its human-readable editorial body, observation method, 16×16 domains, cadence and epistemic boundary;
- make `/library` an institutional index with canonical publications first and the existing technical/formula corpus second;
- include editorial publication and Library paths in the existing Discovery Emitter QA owner.

## Discovery semantics
Publication/deployment can establish `EXPOSURE`. It does **not** establish `DISCOVERY`, `RECOGNITION`, `INTERACTION`, `RELATION`, `PROPAGATION`, `PULL` or `RETURN`; those require later external evidence.

## Canon / authority
- Reuses `SFI-CANONICAL-OBJECT-1.0` and the existing `/publications` namespace owner.
- No second publication registry, sitemap owner, feed owner, URL resolver or publication-state owner.
- No DB migration.
- No automatic publication from runtime events.
- No authority expansion.