### PR TITLE
fix(oauth): preserve GPT bearer token across canonical origin

### DIFF
--- a/scripts/qa-sfi-host-bound-openapi.ts
+++ b/scripts/qa-sfi-host-bound-openapi.ts
@@ -2,22 +2,33 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const route = readFileSync('src/app/api/external/openapi/route.ts', 'utf8');
+const vercel = JSON.parse(readFileSync('vercel.json', 'utf8')) as Record<string, any>;
 
-assert.match(route, /sourceDocument from ['"]\.\.\/\.\.\/\.\.\/\.\.\/\.\.\/public\/openapi\.json['"]/, 'host_bound_schema_must_reuse_canonical_openapi');
-assert.match(route, /request\.nextUrl\.origin/, 'host_bound_schema_must_bind_to_request_origin');
-assert.match(route, /document\.servers = \[\{ url: origin \}\]/, 'host_bound_schema_must_rewrite_server_origin');
-assert.match(route, /authorizationCode\.authorizationUrl = `\$\{origin\}\/api\/oauth\/authorize`/, 'host_bound_schema_must_rewrite_authorization_url');
-assert.match(route, /authorizationCode\.tokenUrl = `\$\{origin\}\/api\/oauth\/token`/, 'host_bound_schema_must_rewrite_token_url');
-assert.match(route, /document\.info\.termsOfService = `\$\{origin\}\/privacy`/, 'host_bound_schema_must_keep_terms_reachable_on_same_origin');
-assert.match(route, /document\.externalDocs\.url = `\$\{origin\}\/privacy`/, 'host_bound_schema_must_keep_external_docs_reachable_on_same_origin');
-assert.match(route, /schemaBinding = 'REQUEST_ORIGIN'/, 'host_bound_schema_must_publish_binding_mode');
-assert.match(route, /'Cache-Control': 'no-store, max-age=0'/, 'host_bound_schema_must_not_cache_stale_host_binding');
+assert.match(route, /sourceDocument from ['"]\.\.\/\.\.\/\.\.\/\.\.\/\.\.\/public\/openapi\.json['"]/, 'actions_schema_must_reuse_canonical_openapi_base');
+assert.match(route, /const SFI_ACTIONS_ORIGIN = 'https:\/\/www\.systemfriction\.org'/, 'actions_schema_must_bind_to_canonical_production_origin');
+assert.doesNotMatch(route, /request\.nextUrl\.origin/, 'actions_schema_must_not_inherit_apex_or_preview_host');
+assert.match(route, /document\.servers = \[\{ url: origin \}\]/, 'actions_schema_must_rewrite_server_origin');
+assert.match(route, /authorizationCode\.authorizationUrl = `\$\{origin\}\/api\/oauth\/authorize`/, 'actions_schema_must_rewrite_authorization_url');
+assert.match(route, /authorizationCode\.tokenUrl = `\$\{origin\}\/api\/oauth\/token`/, 'actions_schema_must_rewrite_token_url');
+assert.match(route, /document\.info\.termsOfService = `\$\{origin\}\/privacy`/, 'actions_schema_must_keep_terms_reachable_on_canonical_origin');
+assert.match(route, /document\.externalDocs\.url = `\$\{origin\}\/privacy`/, 'actions_schema_must_keep_external_docs_reachable_on_canonical_origin');
+assert.match(route, /schemaBinding = 'CANONICAL_PRODUCTION_ORIGIN'/, 'actions_schema_must_publish_binding_mode');
+assert.match(route, /'X-SFI-OpenAPI-Origin': origin/, 'actions_schema_must_expose_origin_receipt');
+assert.match(route, /'Cache-Control': 'no-store, max-age=0'/, 'actions_schema_must_not_cache_stale_binding');
+
+const openapiRewrite = Array.isArray(vercel.rewrites)
+  ? vercel.rewrites.find((entry: any) => entry?.source === '/openapi.json')
+  : null;
+assert.equal(openapiRewrite?.destination, '/api/external/openapi', 'legacy_openapi_url_must_route_through_actions_schema');
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-HOST-BOUND-OPENAPI-1.0',
+  contract: 'SFI-HOST-BOUND-OPENAPI-1.1',
+  canonicalOrigin: 'https://www.systemfriction.org',
   route: '/api/external/openapi',
-  binding: 'REQUEST_ORIGIN',
+  legacyRoute: '/openapi.json',
+  legacyRouteRewritten: true,
+  binding: 'CANONICAL_PRODUCTION_ORIGIN',
   canonicalDocumentReused: true,
   oauthUrlsRewritten: true,
 }, null, 2));

--- a/src/app/api/external/openapi/route.ts
+++ b/src/app/api/external/openapi/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextResponse } from 'next/server';
 import sourceDocument from '../../../../../public/openapi.json';
 
 export const dynamic = 'force-dynamic';
@@ -8,6 +8,7 @@ type JsonRecord = Record<string, any>;
 
 const ACTION_DESCRIPTION_LIMIT = 300;
 const OPENAPI_METHODS = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
+const SFI_ACTIONS_ORIGIN = 'https://www.systemfriction.org';
 
 function clipActionDescription(value: string) {
   if (value.length <= ACTION_DESCRIPTION_LIMIT) return value;
@@ -34,8 +35,8 @@ function enforceActionDescriptionLimits(document: JsonRecord) {
   }
 }
 
-export async function GET(request: NextRequest) {
-  const origin = request.nextUrl.origin.replace(/\/$/, '');
+export async function GET() {
+  const origin = SFI_ACTIONS_ORIGIN;
   const document = structuredClone(sourceDocument) as JsonRecord;
 
   document.servers = [{ url: origin }];
@@ -56,7 +57,7 @@ export async function GET(request: NextRequest) {
 
   if (document['x-sfi-governance'] && typeof document['x-sfi-governance'] === 'object') {
     document['x-sfi-governance'].privacyPolicy = `${origin}/privacy`;
-    document['x-sfi-governance'].schemaBinding = 'REQUEST_ORIGIN';
+    document['x-sfi-governance'].schemaBinding = 'CANONICAL_PRODUCTION_ORIGIN';
     document['x-sfi-governance'].actionDescriptionLimit = ACTION_DESCRIPTION_LIMIT;
   }
 
@@ -66,6 +67,7 @@ export async function GET(request: NextRequest) {
     headers: {
       'Cache-Control': 'no-store, max-age=0',
       'Access-Control-Allow-Origin': '*',
+      'X-SFI-OpenAPI-Origin': origin,
     },
   });
 }

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,12 @@
   "git": {
     "deploymentEnabled": false
   },
+  "rewrites": [
+    {
+      "source": "/openapi.json",
+      "destination": "/api/external/openapi"
+    }
+  ],
   "crons": [
     {
       "path": "/api/cron/worldspect",


### PR DESCRIPTION
## Purpose
Fix the observed GPT OAuth transport failure without changing user identity, OAuth client ownership, granted scopes, tenant authority or gateway authorization semantics.

## OBSERVED
- The current ChatGPT OAuth client is ACTIVE and its authorization codes are created and consumed successfully.
- The authenticated principal receives the expected ROOT/institutional scopes.
- The subsequent governed gateway call reports `tokenPresent:false`.
- Production assurance treats `https://www.systemfriction.org` as the canonical host.
- The repository already owns a GPT-safe schema route at `/api/external/openapi`, but legacy discovery still exposes `/openapi.json`, whose checked-in base carries apex-host OAuth/server URLs.

## Canonical architecture preflight
SFI PRECHECK

Owner: existing External Agent Gateway OAuth/OpenAPI owner. No new auth subsystem.

Existing capability inspected: `/api/external/openapi`, `public/openapi.json`, `/api/oauth/authorize`, `/api/oauth/token`, external bearer authorization, OAuth client registry and production canonical-host receipts.

Absorb vs create decision: absorb. Reuse the existing Actions-safe OpenAPI projection instead of creating a second schema or another OAuth mechanism.

Authoritative writer: unchanged. OAuth authorization codes and access tokens remain owned by the existing OAuth server; gateway authorization remains owned by `externalAuth.ts`.

Persistence/lineage impact: none. No database migration or OAuth-client mutation.

Front delta: none.

Back delta: pin the existing Actions OpenAPI projection to `https://www.systemfriction.org`; route legacy `/openapi.json` through that projection; expose an origin receipt header.

DB delta: none.

Redundancy removed: legacy static OpenAPI exposure can no longer bypass the existing host-safe Actions projection.

Execution/ROOT boundary: unchanged. Existing scopes, subject binding, tenant binding and ROOT authority are unchanged.

Rollback: revert this PR. No data rollback required.

Verification: host-bound OpenAPI QA, external OAuth QA, SFI Verify/typecheck/build, exact-SHA production deploy, live schema observation, then real ChatGPT OAuth retry verifying `tokenPresent:true` and `scopeAllowed:true` on `/api/external/v1/console`.

## Files
- `src/app/api/external/openapi/route.ts`
- `vercel.json`
- `scripts/qa-sfi-host-bound-openapi.ts`

## Expected production behavior
Both `/api/external/openapi` and legacy `/openapi.json` resolve an Actions schema whose `servers[0].url`, OAuth authorization URL and OAuth token URL share the canonical production origin `https://www.systemfriction.org`. No cross-host API hop is described to GPT Actions.