### PR TITLE
fix(oauth): route legacy OpenAPI before static-file precedence

### DIFF
--- a/.github/workflows/sfi-production-observatory-smoke.yml
+++ b/.github/workflows/sfi-production-observatory-smoke.yml
@@ -86,6 +86,7 @@ jobs:
           echo "SFI_PRODUCTION_RECEIPT run=$run_id sha=$head_sha url=$run_url"
 
       - name: Verify GPT Actions OAuth/OpenAPI production origin
+        if: github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch'
         shell: bash
         env:
           SFI_PRODUCTION_SMOKE_TARGET: https://www.systemfriction.org

--- a/.github/workflows/sfi-production-observatory-smoke.yml
+++ b/.github/workflows/sfi-production-observatory-smoke.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - .github/workflows/sfi-production-observatory-smoke.yml
       - scripts/qa-sfi-production-observatory-smoke.mjs
+      - scripts/qa-sfi-production-oauth-openapi-smoke.mjs
   workflow_dispatch:
 
 permissions:
@@ -83,6 +84,12 @@ jobs:
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
           echo "run_url=$run_url" >> "$GITHUB_OUTPUT"
           echo "SFI_PRODUCTION_RECEIPT run=$run_id sha=$head_sha url=$run_url"
+
+      - name: Verify GPT Actions OAuth/OpenAPI production origin
+        shell: bash
+        env:
+          SFI_PRODUCTION_SMOKE_TARGET: https://www.systemfriction.org
+        run: node scripts/qa-sfi-production-oauth-openapi-smoke.mjs
 
       - name: Run bounded canonical Observatory production smoke
         id: smoke

--- a/scripts/qa-sfi-host-bound-openapi.ts
+++ b/scripts/qa-sfi-host-bound-openapi.ts
@@ -16,18 +16,21 @@ assert.match(route, /schemaBinding = 'CANONICAL_PRODUCTION_ORIGIN'/, 'actions_sc
 assert.match(route, /'X-SFI-OpenAPI-Origin': origin/, 'actions_schema_must_expose_origin_receipt');
 assert.match(route, /'Cache-Control': 'no-store, max-age=0'/, 'actions_schema_must_not_cache_stale_binding');
 
-const openapiRewrite = Array.isArray(vercel.rewrites)
-  ? vercel.rewrites.find((entry: any) => entry?.source === '/openapi.json')
+const openapiRedirect = Array.isArray(vercel.redirects)
+  ? vercel.redirects.find((entry: any) => entry?.source === '/openapi.json')
   : null;
-assert.equal(openapiRewrite?.destination, '/api/external/openapi', 'legacy_openapi_url_must_route_through_actions_schema');
+assert.equal(openapiRedirect?.destination, '/api/external/openapi', 'legacy_openapi_url_must_redirect_to_actions_schema_before_filesystem');
+assert.equal(openapiRedirect?.permanent, false, 'legacy_openapi_redirect_must_be_temporary_307');
+assert.ok(!Array.isArray(vercel.rewrites) || !vercel.rewrites.some((entry: any) => entry?.source === '/openapi.json'), 'legacy_openapi_must_not_use_filesystem_losing_rewrite');
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-HOST-BOUND-OPENAPI-1.1',
+  contract: 'SFI-HOST-BOUND-OPENAPI-1.2',
   canonicalOrigin: 'https://www.systemfriction.org',
   route: '/api/external/openapi',
   legacyRoute: '/openapi.json',
-  legacyRouteRewritten: true,
+  legacyRouteRedirectedBeforeFilesystem: true,
+  redirectStatus: 307,
   binding: 'CANONICAL_PRODUCTION_ORIGIN',
   canonicalDocumentReused: true,
   oauthUrlsRewritten: true,

--- a/scripts/qa-sfi-production-oauth-openapi-smoke.mjs
+++ b/scripts/qa-sfi-production-oauth-openapi-smoke.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+
+const TARGET = (process.env.SFI_PRODUCTION_SMOKE_TARGET || 'https://www.systemfriction.org').replace(/\/$/, '');
+const EXPECTED_AUTH = `${TARGET}/api/oauth/authorize`;
+const EXPECTED_TOKEN = `${TARGET}/api/oauth/token`;
+const ENDPOINTS = ['/api/external/openapi', '/openapi.json'];
+const TIMEOUT_MS = 12000;
+
+async function read(path) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const response = await fetch(`${TARGET}${path}`, {
+      redirect: 'follow',
+      cache: 'no-store',
+      signal: controller.signal,
+      headers: {
+        accept: 'application/json',
+        'user-agent': 'SFI-production-oauth-openapi-assurance/1.0',
+      },
+    });
+    const text = await response.text();
+    let json = null;
+    try { json = JSON.parse(text); } catch {}
+    return {
+      path,
+      status: response.status,
+      finalUrl: response.url,
+      originReceipt: response.headers.get('x-sfi-openapi-origin'),
+      json,
+      bodyPrefix: text.slice(0, 240),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const observations = [];
+for (const path of ENDPOINTS) observations.push(await read(path));
+
+for (const observation of observations) {
+  assert.equal(observation.status, 200, `${observation.path}:status_must_be_200`);
+  assert.ok(observation.finalUrl.startsWith(TARGET), `${observation.path}:must_finish_on_canonical_origin`);
+  assert.ok(observation.json && typeof observation.json === 'object', `${observation.path}:must_return_json`);
+  assert.equal(observation.json.servers?.[0]?.url, TARGET, `${observation.path}:server_origin_mismatch`);
+  const flow = observation.json.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode;
+  assert.equal(flow?.authorizationUrl, EXPECTED_AUTH, `${observation.path}:authorization_origin_mismatch`);
+  assert.equal(flow?.tokenUrl, EXPECTED_TOKEN, `${observation.path}:token_origin_mismatch`);
+  assert.equal(observation.json['x-sfi-governance']?.schemaBinding, 'CANONICAL_PRODUCTION_ORIGIN', `${observation.path}:schema_binding_missing`);
+  assert.equal(observation.originReceipt, TARGET, `${observation.path}:origin_receipt_mismatch`);
+}
+
+assert.deepEqual(
+  observations.map((item) => item.json.info?.version),
+  [observations[0].json.info?.version, observations[0].json.info?.version],
+  'legacy_and_actions_schema_versions_must_match',
+);
+assert.ok(observations[0].json.info?.version, 'live_openapi_version_required');
+
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-PRODUCTION-OAUTH-OPENAPI-RETURN-1.0',
+  target: TARGET,
+  liveVersion: observations[0].json.info.version,
+  expected: {
+    server: TARGET,
+    authorizationUrl: EXPECTED_AUTH,
+    tokenUrl: EXPECTED_TOKEN,
+    schemaBinding: 'CANONICAL_PRODUCTION_ORIGIN',
+  },
+  observations: observations.map((item) => ({
+    path: item.path,
+    status: item.status,
+    finalUrl: item.finalUrl,
+    originReceipt: item.originReceipt,
+    server: item.json.servers?.[0]?.url,
+    authorizationUrl: item.json.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode?.authorizationUrl,
+    tokenUrl: item.json.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode?.tokenUrl,
+    schemaBinding: item.json['x-sfi-governance']?.schemaBinding,
+  })),
+}, null, 2));

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,11 @@
   "git": {
     "deploymentEnabled": false
   },
-  "rewrites": [
+  "redirects": [
     {
       "source": "/openapi.json",
-      "destination": "/api/external/openapi"
+      "destination": "/api/external/openapi",
+      "permanent": false
     }
   ],
   "crons": [


### PR DESCRIPTION
## Purpose
Close the remaining production defect observed after #487: Vercel served the static `public/openapi.json` before the configured rewrite, so the legacy schema still advertised the apex host and could reintroduce the cross-host Bearer-token boundary.

## OBSERVED production failure
Production assurance against deployment run `34687356684` observed `/openapi.json` returning `servers[0].url = https://systemfriction.org` instead of the canonical `https://www.systemfriction.org`. `/api/external/openapi` remains the intended host-safe projection. The failed smoke is preserved in PR run `34687652529`.

SFI PRECHECK

Owner: existing External Agent Gateway OpenAPI owner + existing production assurance lane. No new authentication subsystem.

Existing capability inspected: host-bound `/api/external/openapi`, legacy static `/openapi.json`, `vercel.json` route precedence, `SFI Production Observatory Smoke`, GPT OAuth/OpenAPI QA.

Absorb vs create decision: absorb. Keep the existing dynamic Actions projection and route legacy discovery to it before filesystem/static resolution. Add one bounded production smoke to the existing post-deploy assurance workflow.

Authoritative writer: unchanged. OAuth authorization codes/access tokens remain owned by the existing OAuth server; gateway auth remains owned by `externalAuth.ts`. The smoke is read-only.

Persistence/lineage impact: no database writes or migrations. GitHub retains deployment/assurance receipts only.

Front delta: none.

Back delta: replace the ineffective `/openapi.json` rewrite with a temporary redirect to `/api/external/openapi`; require both public entry points to converge on the same canonical server/OAuth origin in production.

DB delta: none.

Redundancy removed: legacy static OpenAPI can no longer bypass the host-safe Actions projection through filesystem precedence.

Execution/ROOT boundary: unchanged. No user, OAuth client, scope, tenant, token authority, execution authority or canonical authority change.

Rollback: revert this PR; no data rollback required.

Verification: host-bound OpenAPI QA, SFI Verify/typecheck/build, exact-SHA deploy, then production smoke requiring both `/api/external/openapi` and `/openapi.json` to resolve 200 JSON with `https://www.systemfriction.org` for server/authorize/token, `CANONICAL_PRODUCTION_ORIGIN`, matching versions and `X-SFI-OpenAPI-Origin`.

## Boundary
Passing production schema assurance proves the cross-host configuration defect is removed. It does not fabricate a ChatGPT user-bound token. Final end-to-end proof remains a real GPT reconnect/login followed by `/api/external/v1/console` returning authenticated state instead of `tokenPresent:false`.