### PR TITLE
fix(oauth): serve GPT Actions-specific OpenAPI projection

### DIFF
--- a/scripts/merge-openapi-actions-compat.mjs
+++ b/scripts/merge-openapi-actions-compat.mjs
@@ -5,13 +5,13 @@ const canonicalPath = path.join(process.cwd(), 'public', 'openapi.json');
 const actionsPath = path.join(process.cwd(), 'public', 'openapi-actions.json');
 const canonical = JSON.parse(fs.readFileSync(canonicalPath, 'utf8'));
 const api = structuredClone(canonical);
-const apiOrigin = 'https://systemfriction.org';
-const oauthOrigin = 'https://system-friction.vercel.app';
+const canonicalOrigin = 'https://www.systemfriction.org';
+const apiOrigin = canonicalOrigin;
+const oauthOrigin = canonicalOrigin;
 
-// The public institutional/API surface remains on systemfriction.org. OAuth for
-// ChatGPT Actions stays on the stable Vercel project hostname already registered
-// by the existing GPT client so authorization, issuer and token exchange use one
-// origin end-to-end.
+// GPT Actions must use one canonical host for API calls and OAuth. Crossing from
+// the public apex or a Vercel project hostname to www can detach Authorization
+// from the subsequent Action request even after a successful token exchange.
 api.servers = [{ url: apiOrigin }];
 if (api.info) api.info.termsOfService = `${apiOrigin}/privacy`;
 if (api.externalDocs) api.externalDocs.url = `${apiOrigin}/privacy`;
@@ -20,7 +20,9 @@ if (oauthFlow) {
   oauthFlow.authorizationUrl = `${oauthOrigin}/api/oauth/authorize`;
   oauthFlow.tokenUrl = `${oauthOrigin}/api/oauth/token`;
 }
-if (api['x-sfi-governance']) api['x-sfi-governance'].privacyPolicy = `${apiOrigin}/privacy`;
+api['x-sfi-governance'] ||= {};
+api['x-sfi-governance'].privacyPolicy = `${apiOrigin}/privacy`;
+api['x-sfi-governance'].schemaBinding = 'GPT_ACTIONS_CANONICAL_PRODUCTION_ORIGIN';
 
 const conciseDescriptions = new Map([
   ['POST /api/external/v1/result', 'Persist a structured SFI analysis result without persisting raw binary content. Requires lab:write and preserves provenance/epistemic boundaries.'],
@@ -46,6 +48,10 @@ for (const [route, pathItem] of Object.entries(api.paths || {})) {
 
 const mcp = api.paths?.['/api/mcp/authenticated']?.post;
 if (mcp) {
+  // ChatGPT Actions ignores custom header parameters. Preserve the nonce boundary
+  // in canonical OpenAPI/runtime, but never advertise the unsupported header in
+  // the Actions projection. Executable MCP tools/call therefore remains a
+  // machine-client capability, not something this Action projection can weaken.
   mcp.parameters = (mcp.parameters || []).filter((parameter) => parameter?.in !== 'header');
   mcp['x-sfi-actions-boundary'] = {
     projection: '/openapi-actions.json',
@@ -84,9 +90,10 @@ if (!canonicalMcp?.parameters?.some((parameter) => parameter?.in === 'header' &&
 }
 
 api['x-sfi-actions-compatibility'] = {
-  contract: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.0',
+  contract: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.1',
   canonicalSource: '/openapi.json',
   projection: '/openapi-actions.json',
+  canonicalOrigin,
   apiOrigin,
   oauthOrigin,
   maxOperationDescriptionChars: 300,
@@ -95,4 +102,4 @@ api['x-sfi-actions-compatibility'] = {
 };
 
 fs.writeFileSync(actionsPath, `${JSON.stringify(api, null, 2)}\n`);
-console.log(JSON.stringify({ ok: true, contract: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.0', canonical: 'public/openapi.json', projection: 'public/openapi-actions.json', apiOrigin, oauthOrigin }, null, 2));
+console.log(JSON.stringify({ ok: true, contract: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.1', canonical: 'public/openapi.json', projection: 'public/openapi-actions.json', canonicalOrigin, apiOrigin, oauthOrigin }, null, 2));

--- a/scripts/qa-sfi-oauth-integrations.ts
+++ b/scripts/qa-sfi-oauth-integrations.ts
@@ -18,7 +18,8 @@ assert.match(surface, /method: 'PATCH'/, 'surface_must_update_callbacks_or_rotat
 assert.match(surface, /method: 'DELETE'/, 'surface_must_revoke_clients');
 assert.match(surface, /\/api\/oauth\/authorize/, 'surface_must_emit_authorization_url');
 assert.match(surface, /\/api\/oauth\/token/, 'surface_must_emit_token_url');
-assert.match(surface, /\/api\/external\/openapi/, 'surface_must_emit_host_bound_schema_url');
+assert.match(surface, /\/openapi-actions\.json/, 'surface_must_emit_gpt_actions_compatibility_schema_url');
+assert.doesNotMatch(surface, /Schema URL: \$\{origin\}\/api\/external\/openapi/, 'surface_must_not_configure_gpt_with_machine_openapi');
 assert.match(surface, /ONE TIME ONLY/, 'surface_must_warn_that_client_secret_is_one_time_only');
 assert.match(surface, /No pegues callback/, 'normal_onboarding_must_not_require_callback_round_trip');
 assert.match(surface, /PENDING · AUTO-BIND EN PRIMERA AUTORIZACIÓN/, 'surface_must_explain_pending_first_redirect_state');
@@ -45,8 +46,10 @@ assert.match(session, /href="\/integrations"/, 'authenticated_session_controls_m
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-OAUTH-INTEGRATIONS-1.1',
-  userFlow: 'generate_client -> copy_gpt_config -> first_authorize_auto_binds_exact_redirect -> token -> use',
+  contract: 'SFI-OAUTH-INTEGRATIONS-1.2',
+  userFlow: 'generate_client -> copy_gpt_actions_config -> first_authorize_auto_binds_exact_redirect -> token -> use',
+  gptActionsSchema: '/openapi-actions.json',
+  machineOpenApiUsedForGptActions: false,
   callbackPasteRequiredForNormalOnboarding: false,
   vercelEditRequired: false,
   databaseEditRequired: false,

--- a/scripts/qa-sfi-production-oauth-openapi-smoke.mjs
+++ b/scripts/qa-sfi-production-oauth-openapi-smoke.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 const TARGET = (process.env.SFI_PRODUCTION_SMOKE_TARGET || 'https://www.systemfriction.org').replace(/\/$/, '');
 const EXPECTED_AUTH = `${TARGET}/api/oauth/authorize`;
 const EXPECTED_TOKEN = `${TARGET}/api/oauth/token`;
-const ENDPOINTS = ['/api/external/openapi', '/openapi.json'];
+const ENDPOINTS = ['/api/external/openapi', '/openapi.json', '/openapi-actions.json'];
 const TIMEOUT_MS = 12000;
 
 async function read(path) {
@@ -16,7 +16,7 @@ async function read(path) {
       signal: controller.signal,
       headers: {
         accept: 'application/json',
-        'user-agent': 'SFI-production-oauth-openapi-assurance/1.0',
+        'user-agent': 'SFI-production-oauth-openapi-assurance/1.1',
       },
     });
     const text = await response.text();
@@ -35,6 +35,20 @@ async function read(path) {
   }
 }
 
+function headerParameters(document) {
+  const found = [];
+  for (const [route, pathItem] of Object.entries(document?.paths || {})) {
+    for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
+      const operation = pathItem?.[method];
+      if (!operation) continue;
+      for (const parameter of operation.parameters || []) {
+        if (parameter?.in === 'header') found.push(`${method.toUpperCase()} ${route}:${parameter.name || 'unnamed'}`);
+      }
+    }
+  }
+  return found;
+}
+
 const observations = [];
 for (const path of ENDPOINTS) observations.push(await read(path));
 
@@ -46,27 +60,39 @@ for (const observation of observations) {
   const flow = observation.json.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode;
   assert.equal(flow?.authorizationUrl, EXPECTED_AUTH, `${observation.path}:authorization_origin_mismatch`);
   assert.equal(flow?.tokenUrl, EXPECTED_TOKEN, `${observation.path}:token_origin_mismatch`);
+}
+
+for (const observation of observations.slice(0, 2)) {
   assert.equal(observation.json['x-sfi-governance']?.schemaBinding, 'CANONICAL_PRODUCTION_ORIGIN', `${observation.path}:schema_binding_missing`);
   assert.equal(observation.originReceipt, TARGET, `${observation.path}:origin_receipt_mismatch`);
 }
 
+const actions = observations.find((item) => item.path === '/openapi-actions.json');
+assert.ok(actions, 'actions_projection_required');
+assert.equal(actions.json['x-sfi-governance']?.schemaBinding, 'GPT_ACTIONS_CANONICAL_PRODUCTION_ORIGIN', 'actions_schema_binding_missing');
+assert.equal(actions.json['x-sfi-actions-compatibility']?.customHeaderParametersExcluded, true, 'actions_custom_header_boundary_missing');
+assert.equal(actions.json['x-sfi-actions-compatibility']?.canonicalOrigin, TARGET, 'actions_canonical_origin_mismatch');
+assert.deepEqual(headerParameters(actions.json), [], 'actions_projection_must_not_expose_custom_header_parameters');
+
 assert.deepEqual(
   observations.map((item) => item.json.info?.version),
-  [observations[0].json.info?.version, observations[0].json.info?.version],
-  'legacy_and_actions_schema_versions_must_match',
+  observations.map(() => observations[0].json.info?.version),
+  'canonical_and_actions_schema_versions_must_match',
 );
 assert.ok(observations[0].json.info?.version, 'live_openapi_version_required');
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-PRODUCTION-OAUTH-OPENAPI-RETURN-1.0',
+  contract: 'SFI-PRODUCTION-OAUTH-OPENAPI-RETURN-1.1',
   target: TARGET,
   liveVersion: observations[0].json.info.version,
   expected: {
     server: TARGET,
     authorizationUrl: EXPECTED_AUTH,
     tokenUrl: EXPECTED_TOKEN,
-    schemaBinding: 'CANONICAL_PRODUCTION_ORIGIN',
+    canonicalSchemaBinding: 'CANONICAL_PRODUCTION_ORIGIN',
+    actionsSchemaBinding: 'GPT_ACTIONS_CANONICAL_PRODUCTION_ORIGIN',
+    actionsCustomHeaderParameters: 0,
   },
   observations: observations.map((item) => ({
     path: item.path,
@@ -77,5 +103,6 @@ console.log(JSON.stringify({
     authorizationUrl: item.json.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode?.authorizationUrl,
     tokenUrl: item.json.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode?.tokenUrl,
     schemaBinding: item.json['x-sfi-governance']?.schemaBinding,
+    headerParameters: headerParameters(item.json),
   })),
 }, null, 2));

--- a/scripts/qa-sfi-sovereign-only-human-gates.ts
+++ b/scripts/qa-sfi-sovereign-only-human-gates.ts
@@ -104,26 +104,32 @@ assert.match(openapiMerge, /classify and use as a working source without ROOT ap
 assert.match(openapiMerge, /canonical evidence admission only when an explicit governed promotion boundary is crossed/);
 assert.doesNotMatch(openapiMerge, /ROOT accept\/reject/);
 
-// GPT Actions use the institutional domain for API calls but keep OAuth on the
-// stable Vercel project hostname already registered by the existing GPT client.
-assert.match(actionsProjection, /const apiOrigin = 'https:\/\/systemfriction\.org'/);
-assert.match(actionsProjection, /const oauthOrigin = 'https:\/\/system-friction\.vercel\.app'/);
+// GPT Actions, OAuth metadata and protected-resource metadata must stay on one
+// canonical production origin. Canonical machine OpenAPI/runtime still owns the
+// capability-grant nonce boundary; the Actions projection only removes a header
+// that ChatGPT Actions cannot supply.
+assert.match(actionsProjection, /const canonicalOrigin = 'https:\/\/www\.systemfriction\.org'/);
+assert.match(actionsProjection, /const apiOrigin = canonicalOrigin/);
+assert.match(actionsProjection, /const oauthOrigin = canonicalOrigin/);
 assert.match(actionsProjection, /authorizationUrl = `\$\{oauthOrigin\}\/api\/oauth\/authorize`/);
 assert.match(actionsProjection, /tokenUrl = `\$\{oauthOrigin\}\/api\/oauth\/token`/);
-assert.match(oauthMetadata, /const issuer = 'https:\/\/system-friction\.vercel\.app'/);
-assert.match(protectedResourceMetadata, /const oauthIssuer = 'https:\/\/system-friction\.vercel\.app'/);
-assert.match(protectedResourceMetadata, /const resourceOrigin = 'https:\/\/systemfriction\.org'/);
+assert.match(actionsProjection, /filter\(\(parameter\) => parameter\?\.in !== 'header'\)/);
+assert.match(actionsProjection, /capabilityGrantNonceStillRequiredByMcpRuntimeForExecutableToolsCall: true/);
+assert.match(oauthMetadata, /const issuer = 'https:\/\/www\.systemfriction\.org'/);
+assert.match(protectedResourceMetadata, /const oauthIssuer = 'https:\/\/www\.systemfriction\.org'/);
+assert.match(protectedResourceMetadata, /const resourceOrigin = 'https:\/\/www\.systemfriction\.org'/);
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-SOVEREIGN-ONLY-HUMAN-GATES-1.3',
+  contract: 'SFI-SOVEREIGN-ONLY-HUMAN-GATES-1.4',
   humanApprovalRequiredForRoutineCaseWork: false,
   humanApprovalRequiredForWorkingSources: false,
   humanApprovalRequiredForRoutineLabRun: false,
   duplicateExecutionConfirmationRequired: false,
   obsoleteRoutineHumanGatesPresent: false,
-  actionsApiOrigin: 'https://systemfriction.org',
-  oauthIssuer: 'https://system-friction.vercel.app',
+  actionsApiOrigin: 'https://www.systemfriction.org',
+  oauthIssuer: 'https://www.systemfriction.org',
+  protectedResourceOrigin: 'https://www.systemfriction.org',
   sovereignBoundary: ['INSTITUTIONAL_CHANGE', 'CAPABILITY_IMPLEMENTATION', 'LEARNING_PROMOTION', 'RESERVED_EXTERNAL_OPERATION'],
   plainLanguageDefault: true,
   canonicalPromotionAutomatic: false,

--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -2,7 +2,7 @@ import { SFI_ROOT_SCOPES } from '@/lib/sfi/oauthConfig';
 
 export const dynamic = 'force-dynamic';
 
-const issuer = 'https://system-friction.vercel.app';
+const issuer = 'https://www.systemfriction.org';
 
 export async function GET() {
   return Response.json({

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = 'force-dynamic';
 
-const oauthIssuer = 'https://system-friction.vercel.app';
-const resourceOrigin = 'https://systemfriction.org';
+const oauthIssuer = 'https://www.systemfriction.org';
+const resourceOrigin = 'https://www.systemfriction.org';
 
 export async function GET() {
   return Response.json({

--- a/src/components/sfi/OAuthIntegrationsSurface.tsx
+++ b/src/components/sfi/OAuthIntegrationsSurface.tsx
@@ -143,7 +143,7 @@ export function OAuthIntegrationsSurface() {
       setNotice('Callback actualizada sin tocar Vercel ni redeployar SFI.');
       await reload();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause)));
+      setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
       setBusy(false);
     }
@@ -167,7 +167,7 @@ export function OAuthIntegrationsSurface() {
       setNotice('Client Secret rotado. Sustituye el anterior en el GPT; este valor se muestra una sola vez.');
       await reload();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause)));
+      setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
       setBusy(false);
     }
@@ -186,7 +186,7 @@ export function OAuthIntegrationsSurface() {
       if (disclosure?.client.client_id === clientId) setDisclosure(null);
       await reload();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause)));
+      setError(cause instanceof Error ? cause.message : String(cause));
     } finally {
       setBusy(false);
     }

--- a/src/components/sfi/OAuthIntegrationsSurface.tsx
+++ b/src/components/sfi/OAuthIntegrationsSurface.tsx
@@ -57,7 +57,7 @@ function configText(client: OAuthClient, secret: string, origin: string) {
     `Token URL: ${origin}/api/oauth/token`,
     `Scope: ${client.allowed_scopes.join(' ')}`,
     'Token exchange method: Basic Authorization Header',
-    `Schema URL: ${origin}/api/external/openapi`,
+    `Schema URL: ${origin}/openapi-actions.json`,
   ].join('\n');
 }
 
@@ -143,7 +143,7 @@ export function OAuthIntegrationsSurface() {
       setNotice('Callback actualizada sin tocar Vercel ni redeployar SFI.');
       await reload();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError(cause instanceof Error ? cause.message : String(cause)));
     } finally {
       setBusy(false);
     }
@@ -167,7 +167,7 @@ export function OAuthIntegrationsSurface() {
       setNotice('Client Secret rotado. Sustituye el anterior en el GPT; este valor se muestra una sola vez.');
       await reload();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError(cause instanceof Error ? cause.message : String(cause)));
     } finally {
       setBusy(false);
     }
@@ -186,7 +186,7 @@ export function OAuthIntegrationsSurface() {
       if (disclosure?.client.client_id === clientId) setDisclosure(null);
       await reload();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError(cause instanceof Error ? cause.message : String(cause)));
     } finally {
       setBusy(false);
     }
@@ -243,7 +243,7 @@ export function OAuthIntegrationsSurface() {
               <h2>Copiar al editor del GPT</h2>
               <div className="oauthSecretWarning">CLIENT SECRET · ONE TIME ONLY</div>
               <pre>{configText(disclosure.client, disclosure.clientSecret, origin)}</pre>
-              <p className="oauthMuted">Después de guardar esto en ChatGPT, prueba una Action. El request <code>/authorize</code> traerá la callback generada por OpenAI; SFI la vinculará automáticamente al cliente si la cuenta autenticada es su owner.</p>
+              <p className="oauthMuted">Después de guardar esto en ChatGPT, prueba una Action. Usa el schema específico de GPT Actions; el OpenAPI canónico de máquina conserva cabeceras avanzadas que ChatGPT no admite.</p>
               <div className="oauthActions">
                 <button type="button" onClick={() => copy(configText(disclosure.client, disclosure.clientSecret, origin))}>COPIAR TODO</button>
                 <button type="button" onClick={() => copy(disclosure.client.client_id)}>COPIAR CLIENT ID</button>
@@ -256,7 +256,7 @@ export function OAuthIntegrationsSurface() {
               <p className="oauthMuted">Al crear o rotar una integración, el secreto aparecerá aquí una sola vez. SFI persiste únicamente su hash.</p>
               <dl className="oauthContract">
                 <dt>AUTH</dt><dd>OAuth Authorization Code</dd>
-                <dt>SCHEMA</dt><dd>{origin ? `${origin}/api/external/openapi` : '/api/external/openapi'}</dd>
+                <dt>SCHEMA</dt><dd>{origin ? `${origin}/openapi-actions.json` : '/openapi-actions.json'}</dd>
                 <dt>CALLBACK</dt><dd>Auto-bind first authorization → exact match</dd>
                 <dt>OWNER</dt><dd>Authenticated SFI account</dd>
               </dl>


### PR DESCRIPTION
SFI PRECHECK

Owner: existing SFI OAuth/OpenAPI projection pipeline.

Existing capability inspected: canonical OpenAPI, authenticated MCP adapter, GPT Actions compatibility generator, OAuth integration surface, production OAuth/OpenAPI smoke.

Absorb vs create decision: absorb. No new auth system, route owner, client registry or machine adapter is introduced.

Authoritative writer: unchanged. OAuth tokens remain minted by the existing token endpoint; the canonical machine OpenAPI retains the capability-grant nonce header. GPT Actions receives a compatibility projection only.

Persistence/lineage impact: none. No DB/schema/data changes.

Front delta: OAuth integration UI now instructs GPT users to import `/openapi-actions.json` rather than the canonical machine schema.

Back delta: GPT Actions projection now uses `https://www.systemfriction.org` for API + authorization + token origins and strips unsupported custom header parameters.

DB delta: none.

Redundancy removed: eliminates the contradictory guidance where SFI generated an Actions-safe schema but told users to import the canonical machine schema.

Execution/ROOT boundary: unchanged. `/api/mcp/authenticated` runtime still requires the capability-grant nonce for executable `tools/call`; omitting the header from the GPT Actions schema does not weaken runtime authorization.

Rollback: revert this PR; no data migration required.

Verification: External OAuth CI, typecheck/build, existing Actions-compat QA, and post-deploy production smoke verifying `/openapi-actions.json` has canonical `www` origins and zero `in: header` parameters.

Observed trigger: ChatGPT schema import warned: `parameter X-SFI-Capability-Grant-Nonce has location header; ignoring`. This proves the GPT was consuming canonical machine OpenAPI instead of the Actions projection.