### PR TITLE
fix(actions): simplify GPT OAuth projection to editor-owned auth

### DIFF
--- a/scripts/merge-openapi-actions-compat.mjs
+++ b/scripts/merge-openapi-actions-compat.mjs
@@ -7,22 +7,33 @@ const canonical = JSON.parse(fs.readFileSync(canonicalPath, 'utf8'));
 const api = structuredClone(canonical);
 const canonicalOrigin = 'https://www.systemfriction.org';
 const apiOrigin = canonicalOrigin;
-const oauthOrigin = canonicalOrigin;
 
-// GPT Actions must use one canonical host for API calls and OAuth. Crossing from
-// the public apex or a Vercel project hostname to www can detach Authorization
-// from the subsequent Action request even after a successful token exchange.
+// GPT Actions authentication is configured in the GPT editor, separately from
+// the OpenAPI schema. Keep the Actions projection transport-neutral: the editor
+// owns OAuth token acquisition/injection, while this schema only describes the
+// compatible external endpoints ChatGPT may call.
 api.servers = [{ url: apiOrigin }];
 if (api.info) api.info.termsOfService = `${apiOrigin}/privacy`;
 if (api.externalDocs) api.externalDocs.url = `${apiOrigin}/privacy`;
-const oauthFlow = api.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode;
-if (oauthFlow) {
-  oauthFlow.authorizationUrl = `${oauthOrigin}/api/oauth/authorize`;
-  oauthFlow.tokenUrl = `${oauthOrigin}/api/oauth/token`;
-}
 api['x-sfi-governance'] ||= {};
 api['x-sfi-governance'].privacyPolicy = `${apiOrigin}/privacy`;
 api['x-sfi-governance'].schemaBinding = 'GPT_ACTIONS_CANONICAL_PRODUCTION_ORIGIN';
+
+// The GPT Action editor owns OAuth. Do not duplicate that contract inside the
+// Actions OpenAPI because ChatGPT applies the configured user credential to the
+// action independently of OpenAPI security declarations.
+delete api.security;
+if (api.components?.securitySchemes) {
+  delete api.components.securitySchemes.sfiOAuth;
+  if (Object.keys(api.components.securitySchemes).length === 0) delete api.components.securitySchemes;
+}
+
+// GPT Actions should expose only the governed External Agent Gateway. MCP keeps
+// its stronger machine-client nonce boundary in canonical OpenAPI/runtime and is
+// intentionally absent from this projection rather than advertised partially.
+for (const route of Object.keys(api.paths || {})) {
+  if (!route.startsWith('/api/external/v1/')) delete api.paths[route];
+}
 
 const conciseDescriptions = new Map([
   ['POST /api/external/v1/result', 'Persist a structured SFI analysis result without persisting raw binary content. Requires lab:write and preserves provenance/epistemic boundaries.'],
@@ -30,13 +41,13 @@ const conciseDescriptions = new Map([
   ['POST /api/external/v1/cognitive', 'Read or run the OAuth subject owner-scoped Cognitive workspace. Personal execution cannot enter institutional ROOT, proposal, canonical-promotion or shared execution authority.'],
   ['POST /api/external/v1/cases', 'Read or mutate Case Platform state available to the OAuth subject. Case writes do not mint accepted evidence, institutional authority, observed RETURN or canonical promotion.'],
   ['GET /api/external/v1/bootstrap', 'Return the versioned SFI cognitive bootstrap for an authorized external client, including bounded contracts, policies and current cognitive/runtime metadata.'],
-  ['POST /api/mcp/authenticated', 'Authenticated MCP/JSON-RPC adapter for governed SFI machine clients. Discovery is read-only; executable tools/call remains subject to OAuth, active capability grant, authority ceiling and possession proof.'],
 ]);
 
 for (const [route, pathItem] of Object.entries(api.paths || {})) {
   for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
     const operation = pathItem?.[method];
     if (!operation) continue;
+    delete operation.security;
     const key = `${method.toUpperCase()} ${route}`;
     if (conciseDescriptions.has(key)) operation.description = conciseDescriptions.get(key);
     if (typeof operation.description === 'string' && operation.description.length > 300) {
@@ -46,60 +57,54 @@ for (const [route, pathItem] of Object.entries(api.paths || {})) {
   }
 }
 
-const mcp = api.paths?.['/api/mcp/authenticated']?.post;
-if (mcp) {
-  // ChatGPT Actions ignores custom header parameters. Preserve the nonce boundary
-  // in canonical OpenAPI/runtime, but never advertise the unsupported header in
-  // the Actions projection. Executable MCP tools/call therefore remains a
-  // machine-client capability, not something this Action projection can weaken.
-  mcp.parameters = (mcp.parameters || []).filter((parameter) => parameter?.in !== 'header');
-  mcp['x-sfi-actions-boundary'] = {
-    projection: '/openapi-actions.json',
-    canonicalOpenApi: '/openapi.json',
-    customHeaderParametersExposed: false,
-    capabilityGrantNonceStillRequiredByMcpRuntimeForExecutableToolsCall: true,
-    actionProjectionDoesNotWeakenMcpAuthorization: true,
-  };
-  const response = mcp.responses?.['200']?.content?.['application/json'];
-  if (response) response.schema = {
-    type: 'object',
-    properties: {
-      jsonrpc: { type: 'string' },
-      id: { oneOf: [{ type: 'string' }, { type: 'number' }, { type: 'null' }] },
-      result: { type: 'object', properties: { content: { type: 'array', items: { type: 'object', properties: {}, additionalProperties: true } }, structuredContent: { type: 'object', properties: {}, additionalProperties: true }, resources: { type: 'array', items: { type: 'object', properties: {}, additionalProperties: true } } }, additionalProperties: true },
-      error: { type: 'object', properties: { code: { type: 'number' }, message: { type: 'string' }, data: { type: 'object', properties: {}, additionalProperties: true } }, additionalProperties: true },
-    },
-    additionalProperties: false,
-  };
-}
-
 const violations = [];
+if (api.security) violations.push('top_level_security_present');
+if (api.components?.securitySchemes?.sfiOAuth) violations.push('oauth_security_scheme_present');
+if (api.paths?.['/api/mcp/authenticated']) violations.push('mcp_present');
 for (const [route, pathItem] of Object.entries(api.paths || {})) {
+  if (!route.startsWith('/api/external/v1/')) violations.push(`non_external_path:${route}`);
   for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
     const operation = pathItem?.[method];
     if (!operation) continue;
+    if (operation.security) violations.push(`${method.toUpperCase()} ${route}:security_present`);
     if (typeof operation.description === 'string' && operation.description.length > 300) violations.push(`${method.toUpperCase()} ${route}:description>${operation.description.length}`);
     for (const parameter of operation.parameters || []) if (parameter?.in === 'header') violations.push(`${method.toUpperCase()} ${route}:header:${parameter.name || 'unnamed'}`);
   }
 }
 if (violations.length) throw new Error(`SFI_ACTIONS_OPENAPI_COMPAT_FAILED:${violations.join(',')}`);
 
+// Prove that simplifying the GPT projection does not weaken canonical machine
+// authorization. Canonical OpenAPI must keep OAuth and the MCP possession nonce.
+const canonicalOauth = canonical.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode;
+if (!canonicalOauth) throw new Error('SFI_CANONICAL_OPENAPI_OAUTH_SCHEME_MISSING');
 const canonicalMcp = canonical.paths?.['/api/mcp/authenticated']?.post;
 if (!canonicalMcp?.parameters?.some((parameter) => parameter?.in === 'header' && parameter?.name === 'X-SFI-Capability-Grant-Nonce')) {
   throw new Error('SFI_CANONICAL_OPENAPI_MCP_NONCE_PARAMETER_MISSING');
 }
 
 api['x-sfi-actions-compatibility'] = {
-  contract: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.1',
+  contract: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.2',
   canonicalSource: '/openapi.json',
   projection: '/openapi-actions.json',
   canonicalOrigin,
   apiOrigin,
-  oauthOrigin,
+  authTransportOwner: 'GPT_ACTION_EDITOR_OAUTH',
+  openApiOAuthDeclarationsExcluded: true,
+  mcpExcluded: true,
+  externalGatewayOnly: true,
   maxOperationDescriptionChars: 300,
   customHeaderParametersExcluded: true,
-  authenticatedMcpRuntimeAuthorizationUnchanged: true,
+  canonicalMachineAuthorizationUnchanged: true,
 };
 
 fs.writeFileSync(actionsPath, `${JSON.stringify(api, null, 2)}\n`);
-console.log(JSON.stringify({ ok: true, contract: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.1', canonical: 'public/openapi.json', projection: 'public/openapi-actions.json', canonicalOrigin, apiOrigin, oauthOrigin }, null, 2));
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.2',
+  canonical: 'public/openapi.json',
+  projection: 'public/openapi-actions.json',
+  canonicalOrigin,
+  apiOrigin,
+  authTransportOwner: 'GPT_ACTION_EDITOR_OAUTH',
+  mcpExcluded: true,
+}, null, 2));

--- a/scripts/qa-sfi-chatgpt-studio-attachment.ts
+++ b/scripts/qa-sfi-chatgpt-studio-attachment.ts
@@ -46,11 +46,44 @@ assert.match(merge, /ingest_analyze\s*:\s*'studio:run'/);
 assert.match(merge, /rightsTransfer\s*:\s*false/);
 assert.match(composedMerge, /import '\.\/merge-openapi-studio-attachments\.mjs'/);
 assert.match(composedMerge, /await import\('\.\/merge-openapi-actions-compat\.mjs'\)/);
-for (const token of ["const canonicalPath = path.join(process.cwd(), 'public', 'openapi.json')","const actionsPath = path.join(process.cwd(), 'public', 'openapi-actions.json')",'structuredClone(canonical)','maxOperationDescriptionChars: 300',"parameter?.in !== 'header'",'capabilityGrantNonceStillRequiredByMcpRuntimeForExecutableToolsCall: true','SFI_CANONICAL_OPENAPI_MCP_NONCE_PARAMETER_MISSING',"fs.writeFileSync(actionsPath"]) assert.ok(actionsCompat.includes(token));
+for (const token of [
+  "const canonicalPath = path.join(process.cwd(), 'public', 'openapi.json')",
+  "const actionsPath = path.join(process.cwd(), 'public', 'openapi-actions.json')",
+  'structuredClone(canonical)',
+  'maxOperationDescriptionChars: 300',
+  "delete api.security",
+  "delete api.components.securitySchemes.sfiOAuth",
+  "if (!route.startsWith('/api/external/v1/')) delete api.paths[route]",
+  "delete operation.security",
+  "authTransportOwner: 'GPT_ACTION_EDITOR_OAUTH'",
+  'openApiOAuthDeclarationsExcluded: true',
+  'mcpExcluded: true',
+  'SFI_CANONICAL_OPENAPI_MCP_NONCE_PARAMETER_MISSING',
+  'SFI_CANONICAL_OPENAPI_OAUTH_SCHEME_MISSING',
+  "fs.writeFileSync(actionsPath",
+]) assert.ok(actionsCompat.includes(token), `actions_projection_contract_missing:${token}`);
 assert.doesNotMatch(actionsCompat, /fs\.writeFileSync\(canonicalPath/);
 assert.match(workflow, /qa-sfi-chatgpt-studio-attachment\.ts/);
 assert.match(workflow, /merge-openapi-authenticated-machine\.mjs/);
 for (const scope of ["'studio:read'", "'studio:content'", "'studio:run'"]) assert.ok(members.includes(scope), `institutional_member_scope_missing:${scope}`);
 assert.ok(!members.includes("'studio:write'"), 'institutional_member_scope_must_not_expand:studio:write');
 
-console.log(JSON.stringify({ ok: true, contract: 'SFI-CHATGPT-STUDIO-ATTACHMENT-1.1', operation: 'ingest_analyze', compatibleSiblingOperation: 'produce', scope: 'studio:run', ownerBoundary: 'oauth.subjectId', attachmentCount: 1, modalityAdmission: 'CONSISTENT_EVIDENCE_FAIL_CLOSED', idempotency: 'OWNER_ID_PLUS_OPENAI_FILE_ID_UNIQUE', failedReservationRecovery: 'SAME_RESERVATION_RESUMABLE', activeAnalysisSerialization: 'QUEUED_OR_RUNNING_CONFLICT', retryAuthorizationLineage: 'DURABLE_HISTORY', canonicalPromotion: false, canonicalOpenApi: '/openapi.json', actionsOpenApi: '/openapi-actions.json', actionsCompatibility: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.0' }, null, 2));
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'SFI-CHATGPT-STUDIO-ATTACHMENT-1.2',
+  operation: 'ingest_analyze',
+  compatibleSiblingOperation: 'produce',
+  scope: 'studio:run',
+  ownerBoundary: 'oauth.subjectId',
+  attachmentCount: 1,
+  modalityAdmission: 'CONSISTENT_EVIDENCE_FAIL_CLOSED',
+  idempotency: 'OWNER_ID_PLUS_OPENAI_FILE_ID_UNIQUE',
+  failedReservationRecovery: 'SAME_RESERVATION_RESUMABLE',
+  activeAnalysisSerialization: 'QUEUED_OR_RUNNING_CONFLICT',
+  retryAuthorizationLineage: 'DURABLE_HISTORY',
+  canonicalPromotion: false,
+  canonicalOpenApi: '/openapi.json',
+  actionsOpenApi: '/openapi-actions.json',
+  actionsAuthTransportOwner: 'GPT_ACTION_EDITOR_OAUTH',
+  actionsCompatibility: 'SFI-GPT-ACTIONS-OPENAPI-COMPAT-1.2',
+}, null, 2));

--- a/scripts/qa-sfi-production-oauth-openapi-smoke.mjs
+++ b/scripts/qa-sfi-production-oauth-openapi-smoke.mjs
@@ -16,7 +16,7 @@ async function read(path) {
       signal: controller.signal,
       headers: {
         accept: 'application/json',
-        'user-agent': 'SFI-production-oauth-openapi-assurance/1.1',
+        'user-agent': 'SFI-production-oauth-openapi-assurance/1.2',
       },
     });
     const text = await response.text();
@@ -49,6 +49,18 @@ function headerParameters(document) {
   return found;
 }
 
+function operationSecurity(document) {
+  const found = [];
+  for (const [route, pathItem] of Object.entries(document?.paths || {})) {
+    for (const method of ['get', 'post', 'put', 'patch', 'delete']) {
+      const operation = pathItem?.[method];
+      if (!operation) continue;
+      if (operation.security !== undefined) found.push(`${method.toUpperCase()} ${route}`);
+    }
+  }
+  return found;
+}
+
 const observations = [];
 for (const path of ENDPOINTS) observations.push(await read(path));
 
@@ -57,12 +69,12 @@ for (const observation of observations) {
   assert.ok(observation.finalUrl.startsWith(TARGET), `${observation.path}:must_finish_on_canonical_origin`);
   assert.ok(observation.json && typeof observation.json === 'object', `${observation.path}:must_return_json`);
   assert.equal(observation.json.servers?.[0]?.url, TARGET, `${observation.path}:server_origin_mismatch`);
-  const flow = observation.json.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode;
-  assert.equal(flow?.authorizationUrl, EXPECTED_AUTH, `${observation.path}:authorization_origin_mismatch`);
-  assert.equal(flow?.tokenUrl, EXPECTED_TOKEN, `${observation.path}:token_origin_mismatch`);
 }
 
 for (const observation of observations.slice(0, 2)) {
+  const flow = observation.json.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode;
+  assert.equal(flow?.authorizationUrl, EXPECTED_AUTH, `${observation.path}:authorization_origin_mismatch`);
+  assert.equal(flow?.tokenUrl, EXPECTED_TOKEN, `${observation.path}:token_origin_mismatch`);
   assert.equal(observation.json['x-sfi-governance']?.schemaBinding, 'CANONICAL_PRODUCTION_ORIGIN', `${observation.path}:schema_binding_missing`);
   assert.equal(observation.originReceipt, TARGET, `${observation.path}:origin_receipt_mismatch`);
 }
@@ -72,7 +84,19 @@ assert.ok(actions, 'actions_projection_required');
 assert.equal(actions.json['x-sfi-governance']?.schemaBinding, 'GPT_ACTIONS_CANONICAL_PRODUCTION_ORIGIN', 'actions_schema_binding_missing');
 assert.equal(actions.json['x-sfi-actions-compatibility']?.customHeaderParametersExcluded, true, 'actions_custom_header_boundary_missing');
 assert.equal(actions.json['x-sfi-actions-compatibility']?.canonicalOrigin, TARGET, 'actions_canonical_origin_mismatch');
+assert.equal(actions.json['x-sfi-actions-compatibility']?.authTransportOwner, 'GPT_ACTION_EDITOR_OAUTH', 'actions_auth_transport_owner_mismatch');
+assert.equal(actions.json['x-sfi-actions-compatibility']?.openApiOAuthDeclarationsExcluded, true, 'actions_openapi_oauth_boundary_missing');
+assert.equal(actions.json['x-sfi-actions-compatibility']?.mcpExcluded, true, 'actions_mcp_boundary_missing');
+assert.equal(actions.json.security, undefined, 'actions_projection_must_not_define_top_level_security');
+assert.equal(actions.json.components?.securitySchemes?.sfiOAuth, undefined, 'actions_projection_must_not_define_sfi_oauth_scheme');
+assert.equal(actions.json.paths?.['/api/mcp/authenticated'], undefined, 'actions_projection_must_not_expose_mcp');
 assert.deepEqual(headerParameters(actions.json), [], 'actions_projection_must_not_expose_custom_header_parameters');
+assert.deepEqual(operationSecurity(actions.json), [], 'actions_projection_must_not_duplicate_editor_oauth_security');
+for (const route of Object.keys(actions.json.paths || {})) {
+  assert.ok(route.startsWith('/api/external/v1/'), `actions_projection_non_external_route:${route}`);
+}
+assert.ok(actions.json.paths?.['/api/external/v1/console']?.get, 'actions_projection_console_required');
+assert.equal(actions.json.paths['/api/external/v1/console'].get.operationId, 'readSfiConsole', 'actions_projection_console_operation_id_mismatch');
 
 assert.deepEqual(
   observations.map((item) => item.json.info?.version),
@@ -83,16 +107,19 @@ assert.ok(observations[0].json.info?.version, 'live_openapi_version_required');
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-PRODUCTION-OAUTH-OPENAPI-RETURN-1.1',
+  contract: 'SFI-PRODUCTION-OAUTH-OPENAPI-RETURN-1.2',
   target: TARGET,
   liveVersion: observations[0].json.info.version,
   expected: {
     server: TARGET,
-    authorizationUrl: EXPECTED_AUTH,
-    tokenUrl: EXPECTED_TOKEN,
+    canonicalAuthorizationUrl: EXPECTED_AUTH,
+    canonicalTokenUrl: EXPECTED_TOKEN,
     canonicalSchemaBinding: 'CANONICAL_PRODUCTION_ORIGIN',
     actionsSchemaBinding: 'GPT_ACTIONS_CANONICAL_PRODUCTION_ORIGIN',
+    actionsAuthTransportOwner: 'GPT_ACTION_EDITOR_OAUTH',
+    actionsOpenApiSecurityDeclarations: 0,
     actionsCustomHeaderParameters: 0,
+    actionsMcpRoutes: 0,
   },
   observations: observations.map((item) => ({
     path: item.path,
@@ -100,9 +127,12 @@ console.log(JSON.stringify({
     finalUrl: item.finalUrl,
     originReceipt: item.originReceipt,
     server: item.json.servers?.[0]?.url,
-    authorizationUrl: item.json.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode?.authorizationUrl,
-    tokenUrl: item.json.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode?.tokenUrl,
+    authorizationUrl: item.json.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode?.authorizationUrl ?? null,
+    tokenUrl: item.json.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode?.tokenUrl ?? null,
     schemaBinding: item.json['x-sfi-governance']?.schemaBinding,
+    authTransportOwner: item.json['x-sfi-actions-compatibility']?.authTransportOwner ?? null,
     headerParameters: headerParameters(item.json),
+    operationSecurity: operationSecurity(item.json),
+    hasMcp: Boolean(item.json.paths?.['/api/mcp/authenticated']),
   })),
 }, null, 2));

--- a/scripts/qa-sfi-sovereign-only-human-gates.ts
+++ b/scripts/qa-sfi-sovereign-only-human-gates.ts
@@ -104,30 +104,35 @@ assert.match(openapiMerge, /classify and use as a working source without ROOT ap
 assert.match(openapiMerge, /canonical evidence admission only when an explicit governed promotion boundary is crossed/);
 assert.doesNotMatch(openapiMerge, /ROOT accept\/reject/);
 
-// GPT Actions, OAuth metadata and protected-resource metadata must stay on one
-// canonical production origin. Canonical machine OpenAPI/runtime still owns the
-// capability-grant nonce boundary; the Actions projection only removes a header
-// that ChatGPT Actions cannot supply.
+// GPT Actions uses OAuth configured in the GPT editor. The Actions OpenAPI is a
+// transport-neutral projection of the External Agent Gateway only; canonical
+// OpenAPI/runtime retains OAuth declarations and the MCP nonce boundary.
 assert.match(actionsProjection, /const canonicalOrigin = 'https:\/\/www\.systemfriction\.org'/);
 assert.match(actionsProjection, /const apiOrigin = canonicalOrigin/);
-assert.match(actionsProjection, /const oauthOrigin = canonicalOrigin/);
-assert.match(actionsProjection, /authorizationUrl = `\$\{oauthOrigin\}\/api\/oauth\/authorize`/);
-assert.match(actionsProjection, /tokenUrl = `\$\{oauthOrigin\}\/api\/oauth\/token`/);
-assert.match(actionsProjection, /filter\(\(parameter\) => parameter\?\.in !== 'header'\)/);
-assert.match(actionsProjection, /capabilityGrantNonceStillRequiredByMcpRuntimeForExecutableToolsCall: true/);
+assert.match(actionsProjection, /delete api\.security/);
+assert.match(actionsProjection, /delete api\.components\.securitySchemes\.sfiOAuth/);
+assert.match(actionsProjection, /delete operation\.security/);
+assert.match(actionsProjection, /if \(!route\.startsWith\('\/api\/external\/v1\/'\)\) delete api\.paths\[route\]/);
+assert.match(actionsProjection, /authTransportOwner: 'GPT_ACTION_EDITOR_OAUTH'/);
+assert.match(actionsProjection, /openApiOAuthDeclarationsExcluded: true/);
+assert.match(actionsProjection, /mcpExcluded: true/);
+assert.match(actionsProjection, /SFI_CANONICAL_OPENAPI_OAUTH_SCHEME_MISSING/);
+assert.match(actionsProjection, /SFI_CANONICAL_OPENAPI_MCP_NONCE_PARAMETER_MISSING/);
 assert.match(oauthMetadata, /const issuer = 'https:\/\/www\.systemfriction\.org'/);
 assert.match(protectedResourceMetadata, /const oauthIssuer = 'https:\/\/www\.systemfriction\.org'/);
 assert.match(protectedResourceMetadata, /const resourceOrigin = 'https:\/\/www\.systemfriction\.org'/);
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-SOVEREIGN-ONLY-HUMAN-GATES-1.4',
+  contract: 'SFI-SOVEREIGN-ONLY-HUMAN-GATES-1.5',
   humanApprovalRequiredForRoutineCaseWork: false,
   humanApprovalRequiredForWorkingSources: false,
   humanApprovalRequiredForRoutineLabRun: false,
   duplicateExecutionConfirmationRequired: false,
   obsoleteRoutineHumanGatesPresent: false,
   actionsApiOrigin: 'https://www.systemfriction.org',
+  actionsAuthTransportOwner: 'GPT_ACTION_EDITOR_OAUTH',
+  actionsMcpExposed: false,
   oauthIssuer: 'https://www.systemfriction.org',
   protectedResourceOrigin: 'https://www.systemfriction.org',
   sovereignBoundary: ['INSTITUTIONAL_CHANGE', 'CAPABILITY_IMPLEMENTATION', 'LEARNING_PROMOTION', 'RESERVED_EXTERNAL_OPERATION'],


### PR DESCRIPTION
## Purpose
Remove duplicated/unsupported authentication declarations from the GPT Actions OpenAPI projection after repeated production evidence showed: authorization code issued, token exchange consumed successfully, but `readSfiConsole` still arrived with `tokenPresent=false`.

SFI PRECHECK

Owner: GPT Action Authentication settings own OAuth transport for `/openapi-actions.json`; canonical SFI OpenAPI/runtime continue to own machine OAuth declarations and MCP possession-proof authorization.

Existing capability inspected: SFI OAuth authorize/token routes, `externalAuth`, canonical `public/openapi.json`, `merge-openapi-actions-compat.mjs`, live production OAuth/OpenAPI smoke, GPT Action configuration UI, and the current `openapi-actions` projection.

Absorb vs create decision: absorb/simplify. No new OAuth server, no new token type, no new auth route, no new database state. The existing Actions projection is reduced to the subset ChatGPT Actions can actually consume.

Authoritative writer: unchanged. SFI `/api/oauth/token` remains the only access-token issuer. GPT Action editor configuration remains the credential transport owner for user OAuth.

Persistence/lineage impact: none. No DB schema or data mutation. Existing authorization-code and OAuth-client lineage is unchanged.

Front delta: none to institutional UI behavior. Existing integration instructions continue to use OAuth + `/openapi-actions.json`.

Back delta: `openapi-actions.json` becomes auth-neutral and External-Agent-Gateway-only: removes top-level/operation OpenAPI security declarations, removes the duplicated `sfiOAuth` security scheme, excludes `/api/mcp/authenticated`, and excludes all non-`/api/external/v1/*` routes. Canonical OpenAPI remains unchanged.

DB delta: none.

Redundancy removed: OAuth is no longer declared twice (GPT editor + Actions schema). MCP is no longer partially advertised to a client that cannot provide its required nonce header.

Execution/ROOT boundary: unchanged. This does not grant scopes or authority. SFI runtime still validates the Bearer token and requested scope on every protected route. Canonical MCP retains the capability-grant nonce requirement.

Rollback: revert this PR. No database or credential rollback required.

Verification: Actions projection QA, sovereign boundary QA, External OAuth workflow, typecheck/build, deployment, then production smoke requiring zero OpenAPI security declarations in the Actions projection, zero custom headers, zero MCP routes, and `readSfiConsole` still present.

## Why this is narrower
OpenAI documents GPT Action authentication and the OpenAPI schema as separate configuration components. OAuth is selected/configured in the GPT editor; the schema describes the server/endpoints. Official OAuth Action examples use the editor for OAuth and do not duplicate OAuth security declarations in the schema. This PR aligns SFI's Actions projection to that model while leaving canonical machine OpenAPI untouched.
