### PR TITLE
fix(case): make GPT Case object refs transport-safe

### DIFF
--- a/scripts/merge-openapi-cases.mjs
+++ b/scripts/merge-openapi-cases.mjs
@@ -87,6 +87,12 @@ api.components.schemas.CaseWorkspaceRequest = {
     },
     source: { type: 'object', additionalProperties: true },
     kind: { type: 'string' },
+    canonicalRefId: {
+      type: 'string',
+      description: 'Preferred GPT Action transport field for canonicalRef.id when operation=add_object.',
+    },
+    canonicalRefVersion: { type: ['string', 'null'] },
+    canonicalRefHash: { type: ['string', 'null'] },
     canonicalRef: { type: 'object', additionalProperties: true },
     sourceRefs: { type: 'array', items: { type: 'object', additionalProperties: true } },
     recordRefs: { type: 'array', items: { type: 'object', additionalProperties: true } },
@@ -120,11 +126,31 @@ api.components.schemas.CaseResolvedTransportRequest = {
   },
 };
 
+api.components.schemas.CaseObjectTransportRequest = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['caseId', 'kind', 'canonicalRefId', 'payload'],
+  properties: {
+    caseId: { type: 'string' },
+    kind: {
+      type: 'string',
+      enum: ['RECORD', 'OBSERVATION', 'SYSTEM_MODEL', 'HYPOTHESIS', 'ANALYSIS', 'RECOMMENDATION', 'REPORT', 'UNRESOLVED_QUESTION', 'CONTRADICTION'],
+    },
+    canonicalRefId: { type: 'string' },
+    canonicalRefVersion: { type: ['string', 'null'] },
+    canonicalRefHash: { type: ['string', 'null'] },
+    sourceRefIds: { type: 'array', items: { type: 'string' } },
+    recordRefIds: { type: 'array', items: { type: 'string' } },
+    payload: { type: 'object', additionalProperties: true },
+    observedAt: { type: ['string', 'null'] },
+  },
+};
+
 api.paths['/api/external/v1/cases'] = {
   post: {
     operationId: 'operateSfiCaseWorkspace',
     summary: 'Plan, read, create and populate tenant-scoped SFI Case Platform cases',
-    description: 'OAuth Case Platform adapter. Prefer flat systemBoundary* and temporal* fields in GPT Actions; SFI reconstructs canonical nested contracts internally. Cannot admit evidence, make governance decisions, authorize interventions, record RETURN, or create truth claims.',
+    description: 'OAuth Case Platform adapter. Prefer flat systemBoundary*, temporal* and canonicalRef* transport fields. Cannot admit evidence, govern, intervene, record RETURN, or create truth claims.',
     security: [{ sfiOAuth: [] }],
     requestBody: {
       required: true,
@@ -189,6 +215,30 @@ api.paths['/api/external/v1/cases/create'] = {
       '409': { description: 'Required intake context remains incomplete' },
       '401': { description: 'Missing or insufficient cases:write scope' },
       '403': { description: 'User-bound OAuth required or tenant access forbidden' },
+    },
+  },
+};
+
+api.paths['/api/external/v1/cases/object'] = {
+  post: {
+    operationId: 'addSfiCaseObject',
+    summary: 'Persist one bounded Case object through required flat transport',
+    description: 'Dedicated GPT Action for Case objects. canonicalRefId is required and reconstructed inside SFI. Cannot create accepted evidence, governance, intervention, RETURN or truth claims.',
+    security: [{ sfiOAuth: ['cases:write'] }],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: { $ref: '#/components/schemas/CaseObjectTransportRequest' },
+        },
+      },
+    },
+    responses: {
+      '201': { description: 'Bounded Case object persisted' },
+      '400': { description: 'Invalid or authority-forbidden object request' },
+      '401': { description: 'Missing or insufficient cases:write scope' },
+      '403': { description: 'User-bound OAuth required or tenant access forbidden' },
+      '404': { description: 'Case not found in an accessible tenant' },
     },
   },
 };
@@ -282,6 +332,7 @@ console.log(JSON.stringify({
   intakePlan: true,
   flatCaseTransportAliases: true,
   dedicatedRequiredCaseActions: true,
+  dedicatedRequiredCaseObjectAction: true,
   actionRevision: api.info?.['x-sfi-action-revision'] ?? null,
   cognitiveRuntime: true,
   cognitiveRuntimeContract: 'SFI-EXTERNAL-COGNITIVE-RUNTIME-1.0',

--- a/scripts/qa-sfi-case-gpt-bridge.ts
+++ b/scripts/qa-sfi-case-gpt-bridge.ts
@@ -55,8 +55,17 @@ assert.equal(objectRoute.includes("epistemicRole: 'GOVERNANCE_DECISION'"), false
 assert.ok(objectRoute.includes("authorizeExternalRequest(request, 'cases:write')"), 'case_object_action_scope_missing');
 assert.ok(objectRoute.includes('canonicalRefId'), 'case_object_action_flat_ref_missing');
 assert.ok(objectRoute.includes('recordOperationalCaseObject'), 'case_object_action_must_reuse_canonical_writer');
+assert.ok(objectRoute.includes("if (!isRow(body.payload)) throw new Error('SFI_CASE_PAYLOAD_REQUIRED')"), 'case_object_action_must_reject_missing_or_non_object_payload');
 
-assert.match(auth, /scope\.startsWith\('cases:'\).*\/api\/external\/v1\/cases/s, 'personal_case_scope_must_be_route_bound');
+for (const pathname of [
+  '/api/external/v1/cases',
+  '/api/external/v1/cases/intake',
+  '/api/external/v1/cases/create',
+  '/api/external/v1/cases/object',
+]) {
+  assert.ok(auth.includes(`'${pathname}'`), `personal_case_route_missing:${pathname}`);
+}
+assert.match(auth, /scope\.startsWith\('cases:'\)[\s\S]*new Set\(\[/, 'personal_case_scope_must_use_explicit_owner_scoped_allowlist');
 assert.match(authorize, /SFI_ROOT_SCOPES/, 'oauth_authorize_must_use_central_scope_registry');
 assert.match(authorize, /SFI_PERSONAL_SCOPES/, 'oauth_authorize_must_use_personal_scope_registry');
 for (const scope of ['cases:read', 'cases:write']) {
@@ -94,6 +103,13 @@ console.log(JSON.stringify({
   objectAction: '/api/external/v1/cases/object',
   objectOperationId: 'addSfiCaseObject',
   flatCanonicalRefRequired: true,
+  payloadRequiredAtRuntime: true,
+  personalCaseRoutes: [
+    '/api/external/v1/cases',
+    '/api/external/v1/cases/intake',
+    '/api/external/v1/cases/create',
+    '/api/external/v1/cases/object',
+  ],
   scopes: ['cases:read', 'cases:write'],
   userBoundOAuth: true,
   tenantIsolation: true,

--- a/scripts/qa-sfi-case-gpt-bridge.ts
+++ b/scripts/qa-sfi-case-gpt-bridge.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 
 const read = (path: string) => readFileSync(path, 'utf8');
 const route = read('src/app/api/external/v1/cases/route.ts');
+const objectRoute = read('src/app/api/external/v1/cases/object/route.ts');
 const auth = read('src/lib/sfi/externalAuth.ts');
 const authorize = read('src/app/api/oauth/authorize/route.ts');
 const oauthConfig = read('src/lib/sfi/oauthConfig.ts');
@@ -24,6 +25,8 @@ for (const token of [
   'normalizeAndRegisterOperationalCaseSource',
   'recordOperationalCaseObject',
   'transitionOperationalCase',
+  'canonicalRefFromAction',
+  'canonicalRefId',
 ]) assert.ok(route.includes(token), `case_gpt_bridge_missing:${token}`);
 
 for (const allowed of [
@@ -36,13 +39,22 @@ for (const allowed of [
   "'REPORT'",
   "'UNRESOLVED_QUESTION'",
   "'CONTRADICTION'",
-]) assert.ok(route.includes(allowed), `case_safe_object_kind_missing:${allowed}`);
+]) {
+  assert.ok(route.includes(allowed), `case_safe_object_kind_missing:${allowed}`);
+  assert.ok(objectRoute.includes(allowed), `case_object_action_safe_kind_missing:${allowed}`);
+}
 
 assert.ok(route.includes("forbiddenAuthority: ['EVIDENCE', 'GOVERNANCE_DECISION', 'INTERVENTION', 'RETURN', 'TRUTH_CLAIM']"), 'case_forbidden_authority_boundary_missing');
+assert.ok(objectRoute.includes("forbiddenAuthority: ['EVIDENCE', 'GOVERNANCE_DECISION', 'INTERVENTION', 'RETURN', 'TRUTH_CLAIM']"), 'case_object_action_forbidden_authority_boundary_missing');
 assert.ok(route.includes("excluded: ['INTERVENING', 'AWAITING_RETURN']"), 'case_external_intervention_return_transition_must_remain_blocked');
 assert.equal(route.includes('generateOperationalReport'), false, 'external_case_bridge_must_not_generate_governed_report_claims');
 assert.equal(route.includes("epistemicRole: 'EVIDENCE'"), false, 'external_case_bridge_must_not_mint_evidence');
 assert.equal(route.includes("epistemicRole: 'GOVERNANCE_DECISION'"), false, 'external_case_bridge_must_not_mint_governance');
+assert.equal(objectRoute.includes("epistemicRole: 'EVIDENCE'"), false, 'case_object_action_must_not_mint_evidence');
+assert.equal(objectRoute.includes("epistemicRole: 'GOVERNANCE_DECISION'"), false, 'case_object_action_must_not_mint_governance');
+assert.ok(objectRoute.includes("authorizeExternalRequest(request, 'cases:write')"), 'case_object_action_scope_missing');
+assert.ok(objectRoute.includes('canonicalRefId'), 'case_object_action_flat_ref_missing');
+assert.ok(objectRoute.includes('recordOperationalCaseObject'), 'case_object_action_must_reuse_canonical_writer');
 
 assert.match(auth, /scope\.startsWith\('cases:'\).*\/api\/external\/v1\/cases/s, 'personal_case_scope_must_be_route_bound');
 assert.match(authorize, /SFI_ROOT_SCOPES/, 'oauth_authorize_must_use_central_scope_registry');
@@ -63,6 +75,13 @@ for (const token of ['sourceRole','verificationState','FRONTERA EPISTÉMICA','IN
 }
 
 assert.ok(openapi.paths?.['/api/external/v1/cases']?.post, 'openapi_case_workspace_path_missing_after_merge');
+assert.equal(openapi.paths?.['/api/external/v1/cases/object']?.post?.operationId, 'addSfiCaseObject', 'openapi_case_object_action_missing_after_merge');
+const objectSchema = openapi.components?.schemas?.CaseObjectTransportRequest ?? {};
+assert.ok(Array.isArray(objectSchema.required), 'case_object_transport_required_fields_missing');
+for (const field of ['caseId', 'kind', 'canonicalRefId', 'payload']) {
+  assert.ok(objectSchema.required.includes(field), `case_object_transport_required_field_missing:${field}`);
+}
+assert.equal(objectSchema.properties?.canonicalRefId?.type, 'string', 'case_object_transport_flat_ref_id_missing');
 const scopes = openapi.components?.securitySchemes?.sfiOAuth?.flows?.authorizationCode?.scopes ?? {};
 assert.ok(scopes['cases:read'], 'openapi_cases_read_scope_missing_after_merge');
 assert.ok(scopes['cases:write'], 'openapi_cases_write_scope_missing_after_merge');
@@ -70,8 +89,11 @@ assert.match(String(openapi['x-sfi-governance']?.caseWorkspaceBoundary ?? ''), /
 
 console.log(JSON.stringify({
   ok: true,
-  contract: 'SFI-GPT-CASE-BRIDGE-1.0',
+  contract: 'SFI-GPT-CASE-BRIDGE-1.1',
   route: '/api/external/v1/cases',
+  objectAction: '/api/external/v1/cases/object',
+  objectOperationId: 'addSfiCaseObject',
+  flatCanonicalRefRequired: true,
   scopes: ['cases:read', 'cases:write'],
   userBoundOAuth: true,
   tenantIsolation: true,

--- a/src/app/api/external/v1/cases/object/route.ts
+++ b/src/app/api/external/v1/cases/object/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from 'next/server';
+import { authorizeExternalRequest, externalAuthError } from '@/lib/sfi/externalAuth';
+import { recordOperationalCaseObject } from '@/lib/sfi/case-platform/repository';
+import { sfiCaseApiFailure } from '@/lib/sfi/case-platform/http';
+import type { SfiCanonicalRef, SfiEpistemicClass } from '@/core/contracts/sfi';
+import type { SfiCaseObjectKind } from '@/core/case-platform';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+type Row = Record<string, unknown>;
+
+const SAFE_OBJECT_KINDS = new Set<SfiCaseObjectKind>([
+  'RECORD',
+  'OBSERVATION',
+  'SYSTEM_MODEL',
+  'HYPOTHESIS',
+  'ANALYSIS',
+  'RECOMMENDATION',
+  'REPORT',
+  'UNRESOLVED_QUESTION',
+  'CONTRADICTION',
+]);
+
+function row(value: unknown): Row {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+}
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function nullableText(value: unknown): string | null {
+  const valueText = text(value);
+  return valueText || null;
+}
+
+function refsFromIds(value: unknown): SfiCanonicalRef[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => text(item))
+    .filter(Boolean)
+    .map((id) => ({ id, version: null, hash: null }));
+}
+
+function epistemicRoleFor(kind: SfiCaseObjectKind): SfiEpistemicClass {
+  if (kind === 'RECORD' || kind === 'OBSERVATION' || kind === 'REPORT') return 'RECORD';
+  if (kind === 'UNRESOLVED_QUESTION' || kind === 'CONTRADICTION') return 'EPISTEMIC_ASSESSMENT';
+  return 'INFERENCE';
+}
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({})) as Row;
+  const auth = authorizeExternalRequest(request, 'cases:write');
+  if (!auth.credential) return NextResponse.json(externalAuthError(auth, 'cases:write'), { status: 401 });
+
+  if (auth.credential.authMethod !== 'oauth' || !auth.credential.subjectId) {
+    return NextResponse.json({
+      ok: false,
+      error: 'user_bound_oauth_required',
+      boundary: 'Case object persistence resolves ownership from OAuth subject_id. Shared/static credentials cannot impersonate a case owner.',
+    }, { status: 403 });
+  }
+
+  try {
+    const caseId = text(body.caseId);
+    if (!caseId) throw new Error('SFI_CASE_ID_REQUIRED');
+
+    const kind = text(body.kind) as SfiCaseObjectKind;
+    if (!SAFE_OBJECT_KINDS.has(kind)) {
+      return NextResponse.json({
+        ok: false,
+        error: 'case_object_kind_not_allowed_for_external_agent',
+        allowed: [...SAFE_OBJECT_KINDS],
+        forbiddenAuthority: ['EVIDENCE', 'GOVERNANCE_DECISION', 'INTERVENTION', 'RETURN', 'TRUTH_CLAIM'],
+      }, { status: 400 });
+    }
+
+    const canonicalRefId = text(body.canonicalRefId);
+    if (!canonicalRefId) throw new Error('SFI_CASE_REF_REQUIRED');
+
+    const object = await recordOperationalCaseObject({
+      caseId,
+      userId: auth.credential.subjectId,
+      kind,
+      epistemicRole: epistemicRoleFor(kind),
+      canonicalRef: {
+        id: canonicalRefId,
+        version: nullableText(body.canonicalRefVersion),
+        hash: nullableText(body.canonicalRefHash),
+      },
+      sourceRefs: refsFromIds(body.sourceRefIds),
+      recordRefs: refsFromIds(body.recordRefIds),
+      evidenceRefs: [],
+      payload: row(body.payload),
+      observedAt: nullableText(body.observedAt),
+    });
+
+    return NextResponse.json({
+      ok: true,
+      operation: 'add_object',
+      object,
+      transportDiagnostics: {
+        canonicalRefTransport: 'FLAT_REQUIRED',
+        canonicalRefId,
+        sourceRefCount: refsFromIds(body.sourceRefIds).length,
+        recordRefCount: refsFromIds(body.recordRefIds).length,
+      },
+      epistemicBoundary: 'This Action persists only bounded Case objects. It cannot create accepted evidence, governance authority, intervention authority, observed RETURN or truth claims.',
+    }, { status: 201 });
+  } catch (error) {
+    return sfiCaseApiFailure(error);
+  }
+}

--- a/src/app/api/external/v1/cases/object/route.ts
+++ b/src/app/api/external/v1/cases/object/route.ts
@@ -22,8 +22,12 @@ const SAFE_OBJECT_KINDS = new Set<SfiCaseObjectKind>([
   'CONTRADICTION',
 ]);
 
+function isRow(value: unknown): value is Row {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
 function row(value: unknown): Row {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value as Row : {};
+  return isRow(value) ? value : {};
 }
 
 function text(value: unknown): string {
@@ -79,6 +83,11 @@ export async function POST(request: Request) {
     const canonicalRefId = text(body.canonicalRefId);
     if (!canonicalRefId) throw new Error('SFI_CASE_REF_REQUIRED');
 
+    if (!isRow(body.payload)) throw new Error('SFI_CASE_PAYLOAD_REQUIRED');
+    const payload = row(body.payload);
+
+    const sourceRefs = refsFromIds(body.sourceRefIds);
+    const recordRefs = refsFromIds(body.recordRefIds);
     const object = await recordOperationalCaseObject({
       caseId,
       userId: auth.credential.subjectId,
@@ -89,10 +98,10 @@ export async function POST(request: Request) {
         version: nullableText(body.canonicalRefVersion),
         hash: nullableText(body.canonicalRefHash),
       },
-      sourceRefs: refsFromIds(body.sourceRefIds),
-      recordRefs: refsFromIds(body.recordRefIds),
+      sourceRefs,
+      recordRefs,
       evidenceRefs: [],
-      payload: row(body.payload),
+      payload,
       observedAt: nullableText(body.observedAt),
     });
 
@@ -103,8 +112,8 @@ export async function POST(request: Request) {
       transportDiagnostics: {
         canonicalRefTransport: 'FLAT_REQUIRED',
         canonicalRefId,
-        sourceRefCount: refsFromIds(body.sourceRefIds).length,
-        recordRefCount: refsFromIds(body.recordRefIds).length,
+        sourceRefCount: sourceRefs.length,
+        recordRefCount: recordRefs.length,
       },
       epistemicBoundary: 'This Action persists only bounded Case objects. It cannot create accepted evidence, governance authority, intervention authority, observed RETURN or truth claims.',
     }, { status: 201 });

--- a/src/app/api/external/v1/cases/route.ts
+++ b/src/app/api/external/v1/cases/route.ts
@@ -80,6 +80,28 @@ function canonicalRef(value: unknown): SfiCanonicalRef {
   };
 }
 
+function canonicalRefFromAction(body: Row): SfiCanonicalRef {
+  const nested = row(body.canonicalRef);
+  const flatId = text(body.canonicalRefId);
+  const nestedId = text(nested.id);
+  const flatVersion = nullableText(body.canonicalRefVersion);
+  const nestedVersion = nullableText(nested.version);
+  const flatHash = nullableText(body.canonicalRefHash);
+  const nestedHash = nullableText(nested.hash);
+
+  if (flatId && nestedId && flatId !== nestedId) throw new Error('SFI_CASE_REF_CONFLICT');
+  if (flatVersion && nestedVersion && flatVersion !== nestedVersion) throw new Error('SFI_CASE_REF_VERSION_CONFLICT');
+  if (flatHash && nestedHash && flatHash !== nestedHash) throw new Error('SFI_CASE_REF_HASH_CONFLICT');
+
+  const id = flatId || nestedId;
+  if (!id) throw new Error('SFI_CASE_REF_REQUIRED');
+  return {
+    id,
+    version: flatVersion ?? nestedVersion,
+    hash: flatHash ?? nestedHash,
+  };
+}
+
 function canonicalRefs(value: unknown): SfiCanonicalRef[] {
   return Array.isArray(value) ? value.map(canonicalRef) : [];
 }
@@ -247,7 +269,7 @@ export async function POST(request: Request) {
         userId,
         kind,
         epistemicRole: epistemicRoleFor(kind),
-        canonicalRef: canonicalRef(body.canonicalRef),
+        canonicalRef: canonicalRefFromAction(body),
         sourceRefs: canonicalRefs(body.sourceRefs),
         recordRefs: canonicalRefs(body.recordRefs),
         evidenceRefs: [],
@@ -258,6 +280,10 @@ export async function POST(request: Request) {
         ok: true,
         operation,
         object,
+        transportDiagnostics: {
+          canonicalRefTransport: text(body.canonicalRefId) ? 'FLAT' : 'NESTED',
+          canonicalRefId: object.canonicalRef.id,
+        },
         epistemicBoundary: 'External case objects preserve assigned epistemic role and cannot create accepted evidence, governance authority, intervention authority, observed return or truth claims.',
       }, { status: 201 });
     }

--- a/src/lib/sfi/externalAuth.ts
+++ b/src/lib/sfi/externalAuth.ts
@@ -46,7 +46,14 @@ function routeAllowsPersonalScope(req: Request, credential: ExternalCredential, 
   // but only on APIs whose implementation is owner-scoped. Scope possession
   // never opens the institutional Method Lab, proposal queue or execution plane.
   if (scope.startsWith('studio:')) return pathname === '/api/external/v1/studio';
-  if (scope.startsWith('cases:')) return pathname === '/api/external/v1/cases';
+  if (scope.startsWith('cases:')) {
+    return new Set([
+      '/api/external/v1/cases',
+      '/api/external/v1/cases/intake',
+      '/api/external/v1/cases/create',
+      '/api/external/v1/cases/object',
+    ]).has(pathname);
+  }
   if (scope.startsWith('lab:')) {
     return pathname === '/api/external/v1/cognitive'
       || pathname === '/api/external/v1/personal-lab';

--- a/src/lib/sfi/externalAuth.ts
+++ b/src/lib/sfi/externalAuth.ts
@@ -42,9 +42,8 @@ function routeAllowsPersonalScope(req: Request, credential: ExternalCredential, 
   if (!isPersonalOAuthCredential(credential)) return true;
   const pathname = new URL(req.url).pathname;
 
-  // A personal token can use the same capability names as institutional OAuth,
-  // but only on APIs whose implementation is owner-scoped. Scope possession
-  // never opens the institutional Method Lab, proposal queue or execution plane.
+  // Personal OAuth is admitted only through explicit owner-scoped route allowlists.
+  // Scope possession never opens institutional Method Lab, proposal queue or execution plane.
   if (scope.startsWith('studio:')) return pathname === '/api/external/v1/studio';
   if (scope.startsWith('cases:')) {
     return new Set([


### PR DESCRIPTION
Observed production failure after the Case transport fixes: `operateSfiCaseWorkspace` with `operation=add_object` returned `SFI_CASE_REF_REQUIRED` even though the requested object included `canonicalRef.id`. The nested `canonicalRef` did not survive the GPT Action transport.

This PR applies the same repair pattern already proven for Case intake in #494/#495, without redesigning the Case Platform or changing authority.

Changes:
- keep the existing generic Case workspace backward-compatible, but accept flat `canonicalRefId` / `canonicalRefVersion` / `canonicalRefHash` aliases and reconstruct the canonical nested ref inside SFI;
- add one dedicated GPT Action `addSfiCaseObject` at `/api/external/v1/cases/object` where `caseId`, `kind`, `canonicalRefId`, and `payload` are required transport fields;
- map optional `sourceRefIds` / `recordRefIds` to canonical refs without granting evidence authority;
- reuse the existing `recordOperationalCaseObject` writer; no second persistence owner or Case engine is introduced;
- explicitly allow the existing owner-scoped personal OAuth Case routes (`/cases`, `/cases/intake`, `/cases/create`, `/cases/object`) without opening institutional execution surfaces;
- reject omitted/non-object `payload` at runtime rather than silently persisting `{}`;
- add regression coverage for flat canonical refs, personal OAuth routing, runtime payload validation, and preserved authority boundaries.

SFI PRECHECK
Owner: existing Case Platform external adapter + canonical Case repository writer.
Existing capability inspected: generic Case Action, dedicated intake/create Actions, Case repository, OAuth subject/tenant boundary, Case GPT bridge QA.
Absorb vs create decision: absorb the existing writer; add only a transport adapter because nested GPT Action object transport is empirically lossy.
Authoritative writer: unchanged (`recordOperationalCaseObject`).
Persistence/lineage impact: none beyond the same Case object write that already existed. No schema migration.
Front delta: none.
Back delta: required flat GPT transport for Case object canonical refs, plus backward-compatible flat aliases on the generic Action and explicit owner-scoped OAuth route admission for existing Case Actions.
DB delta: none.
Redundancy removed: no parallel Case writer, no parallel persistence owner and no alternate Case engine; the dedicated transport route delegates to the canonical repository writer.
Execution/ROOT boundary: unchanged. The external client still cannot mint accepted EVIDENCE, GOVERNANCE_DECISION, INTERVENTION, RETURN or TRUTH_CLAIM authority.
Rollback: revert this PR; no database rollback required.
Verification: GitHub Actions must pass canonical architecture preflight, Case GPT bridge regressions, user-bound OAuth checks, typecheck/build and applicable SFI boundary suites before merge. Netlify legacy preview failures are not treated as production Vercel proof.

Expected retest for CASE-0001 after deployment/schema refresh: call `addSfiCaseObject` with `canonicalRefId=SFI-CASE-0001-SERVICE-PROFILE-MISMATCH`, `canonicalRefVersion=1.0`, `canonicalRefHash=null`, `kind=CONTRADICTION`, and the original payload. Only after that write succeeds should the existing requested lifecycle continue.